### PR TITLE
[Linux] Teach SwiftPM how to handle actor-isolated test functions

### DIFF
--- a/Tests/BasicsTests/ActorIsolatedTestCaseTests.swift
+++ b/Tests/BasicsTests/ActorIsolatedTestCaseTests.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+// The tests in this file are used to check that test cases with actor isolation
+// are correctly seen and ingested during testing.
+
+@globalActor
+final actor TestActor {
+    static let shared = TestActor()
+}
+
+@TestActor
+class ActorIsolatedTestCaseTests: XCTestCase {
+    func test_actorIsolatedByClass() { }
+    func test_actorIsolatedByClassAndAsync() async { }
+}
+
+class IndividuallyActorIsolatedTestCaseTests: XCTestCase {
+    @TestActor
+    func test_actorIsolatedByClass() { }
+
+    @TestActor
+    func test_actorIsolatedByClassAndAsync() async { }
+}
+
+class MainActorIsolatedTestCaseTests: XCTestCase {
+    @MainActor
+    func test_actorIsolatedToMain() { }
+}


### PR DESCRIPTION
This change teaches SwiftPM how to handle actor-isolated test cases in a package on Linux.

### Motivation:

Given the following `XCTestCase` subclass:

```swift
@MainActor
class Tests1: XCTestCase {
  func testX() { }
}
```

Or this one:

```swift
class Tests1: XCTestCase {
  @MainActor
  func testX() { }
}
```

SwiftPM currently does not handle them properly, leading to a build error when compiling the test suite of the form:

```
error: converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'
  testCase(Tests1.__allTests__Tests1),
error: cannot convert value of type '[Any]' to expected argument type '[(String, (XCTestCase) -> () -> Void)]'
  testCase(ObserverTests.__allTests__Tests1),
```

### Modifications:

This change emits a helper function into the synthesized test binary that takes either a synchronous or asynchronous member function of a test case class and returns a function of the appropriate form. It then uses that function when synthesizing the `__allTests__` array instead of trying to check if a function `isAsync`.

Since a function of the form `@MainActor func testX() { }` lives in the twilight zone between sync and `async`, but can be trivially converted to an `async` function (with a synthesized thunk), this allows such functions to be added to the array in question.

### Result:

This change should allow test suites with actor-isolated tests to build and be tested successfully.