### PR TITLE
SwiftTestTool: run `fflush` after `print`

### DIFF
--- a/Fixtures/Miscellaneous/HangingTest/.gitignore
+++ b/Fixtures/Miscellaneous/HangingTest/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Fixtures/Miscellaneous/HangingTest/Package.swift
+++ b/Fixtures/Miscellaneous/HangingTest/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "HangingTest",
+    products: [
+        .library(
+            name: "HangingTest",
+            targets: ["HangingTest"]),
+    ],
+    targets: [
+        .target(
+            name: "HangingTest"),
+        .testTarget(
+            name: "HangingTestTests",
+            dependencies: ["HangingTest"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
+++ b/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class aaaaTests: XCTestCase {
     func testExample() throws {
         while true {
-            Thread.sleep(for: 1)
+            Thread.sleep(forTimeInterval: 1)
         }
     }
 }

--- a/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
+++ b/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
@@ -1,15 +1,10 @@
-#if os(Windows)
-import CRT
-#elseif canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
+import Foundation
+import XCTest
 
 final class aaaaTests: XCTestCase {
     func testExample() throws {
         while true {
-            sleep(1)
+            Thread.sleep(for: 1)
         }
     }
 }

--- a/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
+++ b/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+import Darwin
+
+final class aaaaTests: XCTestCase {
+    func testExample() throws {
+        while true {
+            sleep(1)
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
+++ b/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
@@ -1,5 +1,10 @@
-import XCTest
+#if os(Windows)
+import CRT
+#elseif canImport(Darwin)
 import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 final class aaaaTests: XCTestCase {
     func testExample() throws {

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -34,6 +34,14 @@ import class TSCUtility.NinjaProgressAnimation
 import class TSCUtility.PercentProgressAnimation
 import protocol TSCUtility.ProgressAnimationProtocol
 
+#if canImport(Darwin)
+import func Darwin.fflush
+import let Darwin.stdout
+#elseif canImport(Glibc)
+import func Glibc.fflush
+import let Glibc.stdout
+#endif
+
 private enum TestError: Swift.Error {
     case invalidListTestJSONData
     case testsExecutableNotFound

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -251,6 +251,7 @@ public struct SwiftTestTool: SwiftCommand {
                 // command's result output goes on stdout
                 // ie "swift test" should output to stdout
                 print($0)
+                fflush(stdout)
             })
             if !ranSuccessfully {
                 swiftTool.executionStatus = .failure

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -37,7 +37,7 @@ import protocol TSCUtility.ProgressAnimationProtocol
 #if os(Windows)
 import func CRT.fflush
 import let CRT.stdout
-#if canImport(Darwin)
+#elseif canImport(Darwin)
 import func Darwin.fflush
 import let Darwin.stdout
 #elseif canImport(Glibc)

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -34,6 +34,9 @@ import class TSCUtility.NinjaProgressAnimation
 import class TSCUtility.PercentProgressAnimation
 import protocol TSCUtility.ProgressAnimationProtocol
 
+#if os(Windows)
+import func CRT.fflush
+import let CRT.stdout
 #if canImport(Darwin)
 import func Darwin.fflush
 import let Darwin.stdout

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -260,6 +260,7 @@ final class TestToolTests: CommandsTestCase {
 
     func testOutputLineBuffering() async throws {
         try fixture(name: "Miscellaneous/HangingTest") { fixturePath in
+            // Pre-build tests so that `swift test` command takes as little time as possible to start the hanging test.
             _ = try SwiftPM.Build.execute(["--build-tests"], packagePath: fixturePath)
 
             let completeArgs = [SwiftPM.Test.path.pathString, "--package-path", fixturePath.pathString]

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -282,7 +282,7 @@ final class TestToolTests: CommandsTestCase {
             try process.launch()
 
             // This time interval should be enough for the test to start and get its output into the pipe.
-            Thread.sleep(forTimeInterval: 2)
+            Thread.sleep(forTimeInterval: 5)
 
             process.signal(9)
 

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -263,42 +263,20 @@ final class TestToolTests: CommandsTestCase {
     }
 
     func testOutputLineBuffering() async throws {
-        defer {
-            print(#line); fflush(stdout)
-        }
-
-        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global())
-        timer.setEventHandler(handler: {
-            write(1, String(repeating: "=", count: 9000), 9000);
-            write(1, "\n",1)
-            _ = timer
-        })
-        timer.schedule(deadline: .now()+1, repeating: .seconds(1))
-        timer.resume()
-
-        defer {
-            timer.cancel()
-        }
-
-        DispatchQueue.global().asyncAfter(deadline: .now() + 1800) {
-            print(#line); fflush(stdout)
-
-            fatalError()
-        }
-
-        print(#line); fflush(stdout)
-        write(1, "\nfoo\n", 5)
+        #if os(macOS)
+        // This test hangs on macOS on CI for an unknown reason, and only when running `swift test --parallel`,
+        // it does pass sequentially. Potentially could be a bug in the `TSC.Process` implementation, rdar://110021665.
+        try XCTSkipIf(true, "this test hangs on macOS")
+        #endif
 
         try fixture(name: "Miscellaneous/HangingTest") { fixturePath in
             // Pre-build tests so that `swift test` command takes as little time as possible to start the hanging test.
             _ = try SwiftPM.Build.execute(["--build-tests"], packagePath: fixturePath)
-            print(#line); fflush(stdout)
 
             let completeArgs = [SwiftPM.Test.path.pathString, "--package-path", fixturePath.pathString]
-            print(#line); fflush(stdout)
 
             var output = [UInt8]()
-            let lock = Lock()
+            let lock = NSLock()
             let outputRedirection = TSCBasic.Process.OutputRedirection.stream(
                 stdout: { bytes in
                     lock.withLock {
@@ -311,29 +289,22 @@ final class TestToolTests: CommandsTestCase {
                     }
                 }
             )
-            print(#line); fflush(stdout)
 
             let process = TSCBasic.Process(
                 arguments: completeArgs,
                 outputRedirection: outputRedirection
             )
-            print(#line); fflush(stdout)
             try process.launch()
-            print(#line); fflush(stdout)
 
             // This time interval should be enough for the test to start and get its output into the pipe.
             Thread.sleep(forTimeInterval: 10)
-            print(#line); fflush(stdout)
 
             process.signal(9)
-            print(#line); fflush(stdout)
 
             let outputString = lock.withLock {
                 String(bytes: output, encoding: .utf8)
             }
             XCTAssertMatch(outputString, .and(.contains("Test Suite"), .contains(" started at ")))
-            print(#line); fflush(stdout)
-
         }
     }
 }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -282,7 +282,7 @@ final class TestToolTests: CommandsTestCase {
             try process.launch()
 
             // This time interval should be enough for the test to start and get its output into the pipe.
-            Thread.sleep(forTimeInterval: 5)
+            Thread.sleep(forTimeInterval: 10)
 
             process.signal(9)
 

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -266,7 +266,20 @@ final class TestToolTests: CommandsTestCase {
         defer {
             print(#line); fflush(stdout)
         }
-        
+
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global())
+        timer.setEventHandler(handler: {
+            write(1, String(repeating: "=", count: 9000), 9000);
+            write(1, "\n",1)
+            _ = timer
+        })
+        timer.schedule(deadline: .now()+1, repeating: .seconds(1))
+        timer.resume()
+
+        defer {
+            timer.cancel()
+        }
+
         DispatchQueue.global().asyncAfter(deadline: .now() + 1800) {
             print(#line); fflush(stdout)
 

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -26,7 +26,7 @@ set -x
 # Perform package update in order to get the latest commits for the dependencies.
 swift package update
 swift build -c $CONFIGURATION
-swift test -c $CONFIGURATION
+swift test -c $CONFIGURATION --parallel
 
 # Run the integration tests with just built SwiftPM.
 export SWIFTPM_BIN_DIR=$(swift build -c $CONFIGURATION --show-bin-path)

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -26,7 +26,7 @@ set -x
 # Perform package update in order to get the latest commits for the dependencies.
 swift package update
 swift build -c $CONFIGURATION
-swift test -c $CONFIGURATION --parallel
+swift test -c $CONFIGURATION
 
 # Run the integration tests with just built SwiftPM.
 export SWIFTPM_BIN_DIR=$(swift build -c $CONFIGURATION --show-bin-path)


### PR DESCRIPTION
This makes sure that the output of `swift test` is line-buffered, which is crucial when a test crashes or hangs. `swift test` should be able to output information about tests it's currently running with its output piped (e.g. on CI) through line-size buffers. 

Resolves https://github.com/apple/swift-package-manager/issues/6592.
