### PR TITLE
Remove use of `NSString.replacingOccurrences(of:with:)`

### DIFF
--- a/Sources/Basics/Concurrency/AsyncProcess.swift
+++ b/Sources/Basics/Concurrency/AsyncProcess.swift
@@ -1316,7 +1316,8 @@ extension AsyncProcessResult.Error: CustomStringConvertible {
                 let indentation = "    "
                 str.append(contentsOf: " output:\n")
                 str.append(contentsOf: indentation)
-                str.append(contentsOf: output.replacingOccurrences(of: "\n", with: "\n" + indentation))
+                str.append(contentsOf: output.split(whereSeparator: { $0.isNewline })
+                                             .joined(separator: "\n\(indentation)"))
                 if !output.hasSuffix("\n") {
                     str.append(contentsOf: "\n")
                 }

--- a/Sources/Basics/FileSystem/AbsolutePath.swift
+++ b/Sources/Basics/FileSystem/AbsolutePath.swift
@@ -321,7 +321,7 @@ extension AbsolutePath {
 
 extension AbsolutePath {
     public var escapedPathString: String {
-        self.pathString.replacingOccurrences(of: "\\", with: "\\\\")
+        self.pathString.replacing("\\", with: "\\\\")
     }
 }
 

--- a/Sources/Basics/FileSystem/NativePathExtensions.swift
+++ b/Sources/Basics/FileSystem/NativePathExtensions.swift
@@ -20,7 +20,7 @@ extension AbsolutePath {
         return URL(fileURLWithPath: self.pathString).withUnsafeFileSystemRepresentation {
             let repr = String(cString: $0!)
             if escaped {
-                return repr.replacingOccurrences(of: "\\", with: "\\\\")
+                return repr.replacing("\\", with: "\\\\")
             }
             return repr
         }

--- a/Sources/Basics/Netrc.swift
+++ b/Sources/Basics/Netrc.swift
@@ -135,7 +135,7 @@ public struct NetrcParser {
             let matchedString = nsString.substring(with: $0.range)
             if !matchedString.starts(with: "\"") {
                 trimmedCommentsText = trimmedCommentsText
-                    .replacingOccurrences(of: matchedString, with: "")
+                    .replacing(matchedString, with: "")
             }
         }
         return trimmedCommentsText

--- a/Sources/Basics/Sandbox.swift
+++ b/Sources/Basics/Sandbox.swift
@@ -241,8 +241,8 @@ extension AbsolutePath {
     /// Private computed property that returns a version of the path as a string quoted for use as a subpath in a .sb sandbox profile.
     fileprivate var quotedAsSubpathForSandboxProfile: String {
         "\"" + self.pathString
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacing("\\", with: "\\\\")
+            .replacing("\"", with: "\\\"")
             + "\""
     }
 }

--- a/Sources/Basics/Serialization/SerializedJSON.swift
+++ b/Sources/Basics/Serialization/SerializedJSON.swift
@@ -31,7 +31,7 @@ extension SerializedJSON: ExpressibleByStringInterpolation {
         fileprivate var value: String = ""
 
         private func escape(_ string: String) -> String {
-            string.replacingOccurrences(of: #"\"#, with: #"\\"#)
+            string.replacing(#"\"#, with: #"\\"#)
         }
 
         public init(literalCapacity: Int, interpolationCount: Int) {

--- a/Sources/Commands/Utilities/DOTManifestSerializer.swift
+++ b/Sources/Commands/Utilities/DOTManifestSerializer.swift
@@ -38,8 +38,8 @@ struct DOTManifestSerializer {
 
     /// Quote the name and escape the quotes and backslashes
     func quoteName(_ name: String) -> String {
-        "\"" + name.replacingOccurrences(of: "\"", with: "\\\"")
-            .replacingOccurrences(of: "\\", with: "\\\\") + "\""
+        "\"" + name.replacing("\"", with: "\\\"")
+                   .replacing("\\", with: "\\\\") + "\""
     }
 
     mutating func writeDOT(to stream: OutputByteStream) {

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -785,7 +785,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 let vfsOverlayTempFilePath = tempDir.appending("vfs.yaml")
                 try VFSOverlay(roots: [
                     VFSOverlay.File(
-                        name: manifestPath._normalized.replacingOccurrences(of: #"\"#, with: #"\\"#),
+                        name: manifestPath._normalized.replacing(#"\"#, with: #"\\"#),
                         externalContents: manifestTempFilePath._nativePathString(escaped: true)
                     )
                 ]).write(to: vfsOverlayTempFilePath, fileSystem: localFileSystem)
@@ -1061,7 +1061,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
                         var environment = Environment.current
                         #if os(Windows)
-                        let windowsPathComponent = runtimePath.pathString.replacingOccurrences(of: "/", with: "\\")
+                        let windowsPathComponent = runtimePath.pathString.replacing("/", with: "\\")
                         environment.prependPath(key: .path, value: windowsPathComponent)
                         #endif
 

--- a/Sources/PackageLoading/ModuleMapGenerator.swift
+++ b/Sources/PackageLoading/ModuleMapGenerator.swift
@@ -19,7 +19,7 @@ public let moduleMapFilename = "module.modulemap"
 
 extension AbsolutePath {
   fileprivate var moduleEscapedPathString: String {
-    return self.pathString.replacingOccurrences(of: "\\", with: "\\\\")
+    return self.pathString.replacing("\\", with: "\\\\")
   }
 }
 

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -695,8 +695,8 @@ extension TargetBuildSettingDescription.Kind {
 extension String {
     fileprivate var quotedForPackageManifest: String {
         return "\"" + self
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacing("\\", with: "\\\\")
+            .replacing("\"", with: "\\\"")
             + "\""
     }
 }

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -2493,7 +2493,7 @@ extension HTTPClientHeaders {
             return nil
         }
 
-        return parts[1].replacingOccurrences(of: "\"", with: "")
+        return parts[1].replacing("\"", with: "")
     }
 }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -778,7 +778,7 @@ public final class GitRepository: Repository, WorkingCheckout {
             }
 
             return stringPaths.map(output.split(whereSeparator: { $0.isNewline }).map {
-                let string = String($0).replacingOccurrences(of: "\\\\", with: "\\")
+                let string = String($0).replacing("\\\\", with: "\\")
                 if string.utf8.first == UInt8(ascii: "\"") {
                     return String(string.dropFirst(1).dropLast(1))
                 }

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -58,10 +58,10 @@ public func testWithTemporaryDirectory<Result>(
     body: (AbsolutePath) async throws -> Result
 ) async throws -> Result {
     let cleanedFunction = function.description
-        .replacingOccurrences(of: "(", with: "")
-        .replacingOccurrences(of: ")", with: "")
-        .replacingOccurrences(of: ".", with: "")
-        .replacingOccurrences(of: ":", with: "_")
+        .replacing("(", with: "")
+        .replacing(")", with: "")
+        .replacing(".", with: "")
+        .replacing(":", with: "_")
     return try await withTemporaryDirectory(prefix: "spm-tests-\(cleanedFunction)") { tmpDirPath in
         defer {
             // Unblock and remove the tmp dir on deinit.


### PR DESCRIPTION
Prefer to use `String.replacing(_:with:)` instead of the `NSString` operations for the strings.  This should avoid an unnecessary use of Foundation API and a dispatch to the `NSString` API.