### PR TITLE
Remove `experimental` from `--enable-[experimental-]swift-testing`

### DIFF
--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -60,7 +60,8 @@ extension SwiftPackageCommand {
             if testLibraryOptions.enableXCTestSupport {
                 testingLibraries.insert(.xctest)
             }
-            if testLibraryOptions.explicitlyEnableSwiftTestingLibrarySupport == true {
+            if testLibraryOptions.explicitlyEnableSwiftTestingLibrarySupport == true
+                || testLibraryOptions.explicitlyEnableExperimentalSwiftTestingLibrarySupport == true {
                 testingLibraries.insert(.swiftTesting)
             }
             let packageName = self.packageName ?? cwd.basename

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -110,7 +110,8 @@ struct BuildCommandOptions: ParsableArguments {
         // or disable either testing library.
         if !buildTests {
             if testLibraryOptions.explicitlyEnableXCTestSupport != nil
-                || testLibraryOptions.explicitlyEnableSwiftTestingLibrarySupport != nil {
+                || testLibraryOptions.explicitlyEnableSwiftTestingLibrarySupport != nil
+                || testLibraryOptions.explicitlyEnableExperimentalSwiftTestingLibrarySupport != nil {
                 throw StringError("pass --build-tests to build test targets")
             }
         }

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -579,10 +579,16 @@ public struct TestLibraryOptions: ParsableArguments {
     /// Callers (other than `swift package init`) will generally want to use
     /// ``enableSwiftTestingLibrarySupport(swiftCommandState:)`` since it will
     /// take into account whether the package has a dependency on swift-testing.
+    @Flag(name: .customLong("swift-testing"),
+          inversion: .prefixedEnableDisable,
+          help: "Enable support for swift-testing")
+    public var explicitlyEnableSwiftTestingLibrarySupport: Bool?
+
+    /// Deprecated shadow of ``explicitlyEnableSwiftTestingLibrarySupport``.
     @Flag(name: .customLong("experimental-swift-testing"),
           inversion: .prefixedEnableDisable,
-          help: "Enable experimental support for swift-testing")
-    public var explicitlyEnableSwiftTestingLibrarySupport: Bool?
+          help: .hidden)
+    public var explicitlyEnableExperimentalSwiftTestingLibrarySupport: Bool?
 
     /// Whether to enable support for swift-testing.
     public func enableSwiftTestingLibrarySupport(
@@ -590,6 +596,11 @@ public struct TestLibraryOptions: ParsableArguments {
     ) throws -> Bool {
         // Honor the user's explicit command-line selection, if any.
         if let callerSuppliedValue = explicitlyEnableSwiftTestingLibrarySupport {
+            return callerSuppliedValue
+        }
+        
+        // Temporarily honor the experimental flag too.
+        if let callerSuppliedValue = explicitlyEnableExperimentalSwiftTestingLibrarySupport {
             return callerSuppliedValue
         }
 

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -288,6 +288,20 @@ final class TestCommandTests: CommandsTestCase {
 
         try fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
             do {
+                let (stdout, _) = try SwiftPM.Test.execute(["--enable-swift-testing", "--disable-xctest"], packagePath: fixturePath)
+                XCTAssertMatch(stdout, .contains(#"Test "SOME TEST FUNCTION" started"#))
+            }
+        }
+    }
+
+    func testBasicSwiftTestingIntegration_ExperimentalFlag() throws {
+        try XCTSkipUnless(
+            nil != ProcessInfo.processInfo.environment["SWIFT_PM_SWIFT_TESTING_TESTS_ENABLED"],
+            "Skipping \(#function) because swift-testing tests are not explicitly enabled"
+        )
+        
+        try fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
+            do {
                 let (stdout, _) = try SwiftPM.Test.execute(["--enable-experimental-swift-testing", "--disable-xctest"], packagePath: fixturePath)
                 XCTAssertMatch(stdout, .contains(#"Test "SOME TEST FUNCTION" started"#))
             }


### PR DESCRIPTION
This PR removes the word `experimental` from the aforementioned command-line option for `swift package init`, `swift build`, and `swift test`.

This change is speculative.