### PR TITLE
Enable swift-testing by default.

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -593,42 +593,8 @@ public struct TestLibraryOptions: ParsableArguments {
             return callerSuppliedValue
         }
 
-        // If the active package has a dependency on swift-testing, automatically enable support for it so that extra steps are not needed.
-        let workspace = try swiftCommandState.getActiveWorkspace()
-        let root = try swiftCommandState.getWorkspaceRoot()
-        let rootManifests = try temp_await {
-            workspace.loadRootManifests(
-                packages: root.packages,
-                observabilityScope: swiftCommandState.observabilityScope,
-                completion: $0
-            )
-        }
-
-        // Is swift-testing among the dependencies of the package being built?
-        // If so, enable support.
-        let isEnabledByDependency = rootManifests.values.lazy
-            .flatMap(\.dependencies)
-            .map(\.identity)
-            .map(String.init(describing:))
-            .contains("swift-testing")
-        if isEnabledByDependency {
-            swiftCommandState.observabilityScope.emit(debug: "Enabling swift-testing support due to its presence as a package dependency.")
-            return true
-        }
-
-        // Is swift-testing the package being built itself (unlikely)? If so,
-        // enable support.
-        let isEnabledByName = root.packages.lazy
-            .map(PackageIdentity.init(path:))
-            .map(String.init(describing:))
-            .contains("swift-testing")
-        if isEnabledByName {
-            swiftCommandState.observabilityScope.emit(debug: "Enabling swift-testing support because it is a root package.")
-            return true
-        }
-
-        // Default to disabled since swift-testing is experimental (opt-in.)
-        return false
+        // Default to enabled.
+        return true
     }
 
     /// Get the set of enabled testing libraries.

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -25,6 +25,7 @@ import struct PackageModel.EnabledSanitizers
 import struct PackageModel.PackageIdentity
 import class PackageModel.Manifest
 import enum PackageModel.Sanitizer
+import struct PackageModel.SupportedPlatform
 
 import struct SPMBuildCore.BuildParameters
 import struct SPMBuildCore.BuildSystemProvider
@@ -591,6 +592,32 @@ public struct TestLibraryOptions: ParsableArguments {
         // Honor the user's explicit command-line selection, if any.
         if let callerSuppliedValue = explicitlyEnableSwiftTestingLibrarySupport {
             return callerSuppliedValue
+        }
+
+        let root = try swiftCommandState.getWorkspaceRoot()
+        let workspace = try swiftCommandState.getActiveWorkspace()
+        let rootManifests = try temp_await {
+            workspace.loadRootManifests(
+                packages: root.packages,
+                observabilityScope: swiftCommandState.observabilityScope,
+                completion: $0
+            )
+        }
+
+        let minimumPlatformsWithAsync: [String: SupportedPlatform] = [
+            "macos": SupportedPlatform(platform: .macOS, version: "10.15"),
+            "ios": SupportedPlatform(platform: .iOS, version: "13.0"),
+            "watchOS": SupportedPlatform(platform: .watchOS, version: "6.0"),
+            "tvOS": SupportedPlatform(platform: .tvOS, version: "13.0"),
+        ]
+        for platformReq in rootManifests.values.lazy.flatMap(\.platforms) {
+            if let minimumPlatform = minimumPlatformsWithAsync[platformReq.platformName],
+               minimumPlatform.version > .init(platformReq.version) {
+                // The minimum platform version specified by the package does
+                // not support Swift Concurrency, so it cannot use swift-testing
+                // automatically.
+                return false
+            }
         }
 
         // Default to enabled.


### PR DESCRIPTION
This PR sets the default state of `--{enable,disable}-experimental-swift-testing` to enabled.

This PR is speculative.