### PR TITLE
Pass through the toolchain to use for manifest loading

### DIFF
--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -43,6 +43,9 @@ public protocol Toolchain {
     /// The root path to the Swift SDK used by this toolchain.
     var sdkRootPath: AbsolutePath? { get }
 
+    /// The manifest and library locations used by this toolchain.
+    var swiftPMLibrariesLocation: ToolchainConfiguration.SwiftPMLibrariesLocation { get }
+
     /// Path of the `clang` compiler.
     func getClangCompiler() throws -> AbsolutePath
 

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -24,6 +24,7 @@ import class Build.SwiftModuleBuildDescription
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ModulesGraph
 import enum PackageGraph.BuildTriple
+internal import class PackageModel.UserToolchain
 
 public typealias BuildTriple = PackageGraph.BuildTriple
 
@@ -133,6 +134,7 @@ public struct BuildDescription {
                 return PluginTargetBuildDescription(
                     target: target,
                     toolsVersion: package.manifest.toolsVersion,
+                    toolchain: buildPlan.toolsBuildParameters.toolchain,
                     isPartOfRootPackage: modulesGraph.rootPackages.map(\.id).contains(package.id)
                 )
             }

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -40,6 +40,9 @@ public struct MockToolchain: PackageModel.Toolchain {
     public let extraFlags = PackageModel.BuildFlags()
     public let installedSwiftPMConfiguration = InstalledSwiftPMConfiguration.default
     public let providedLibraries = [ProvidedLibrary]()
+    public let swiftPMLibrariesLocation = ToolchainConfiguration.SwiftPMLibrariesLocation(
+        manifestLibraryPath: AbsolutePath("/fake/manifestLib/path"), pluginLibraryPath: AbsolutePath("/fake/pluginLibrary/path")
+    )
 
     public func getClangCompiler() throws -> AbsolutePath {
         "/fake/path/to/clang"


### PR DESCRIPTION
Prefer the toolchain provided in the build plan rather than the default host toolchain so that the returned arguments align with the toolchain used to construct the build plan.