### PR TITLE
[6.0] Use bearer auth for `binaryTarget` or packages from a package registry

### DIFF
--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -71,6 +71,9 @@ extension AuthorizationProvider {
         guard let (user, password) = self.authentication(for: url) else {
             return nil
         }
+        guard user != "token" else {
+            return "Bearer \(password)"
+        }
         let authString = "\(user):\(password)"
         let authData = Data(authString.utf8)
         return "Basic \(authData.base64EncodedString())"

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -63,6 +63,15 @@ final class AuthorizationProviderTests: XCTestCase {
         }
     }
 
+    func testBasicAPIsBearerToken() {
+        let url = URL("http://\(UUID().uuidString)")
+        let user = "token"
+        let token = UUID().uuidString
+
+        let provider = TestProvider(map: [url: (user: user, password: token)])
+        self.assertBearerAuthentication(provider, for: url, expected: token)
+    }
+
     func testProtocolHostPort() throws {
         #if !canImport(Security)
         try XCTSkipIf(true)
@@ -256,6 +265,20 @@ final class AuthorizationProviderTests: XCTestCase {
         XCTAssertEqual(
             provider.httpAuthorizationHeader(for: url),
             "Basic " + Data("\(expected.user):\(expected.password)".utf8).base64EncodedString()
+        )
+    }
+
+    private func assertBearerAuthentication(
+        _ provider: AuthorizationProvider,
+        for url: URL,
+        expected: String
+    ) {
+        let authentication = provider.authentication(for: url)
+        XCTAssertEqual(authentication?.user, "token")
+        XCTAssertEqual(authentication?.password, expected)
+        XCTAssertEqual(
+            provider.httpAuthorizationHeader(for: url),
+            "Bearer \(expected)"
         )
     }
 }


### PR DESCRIPTION
**Explanation**:  Use bearer auth when pulling binary targets or a package from a package registry and the user is `token`. The issue is that `package-registry` and `binaryArtifact` have an auth logic that behaves differently.
**Scope**: Authorization Header generation when pulling dependencies
**Original PR:** [#7662](https://github.com/apple/swift-package-manager/pull/7662)
**Risk:** Users named `token` can't use basic auth anymore
**Testing:** Unit Test for testing correct Auth Header is generated
**Reviewer:** @MaxDesiatov