### PR TITLE
[6.0] Remove unused options from `add-product` subcommand

### DIFF
--- a/Sources/Commands/PackageCommands/AddProduct.swift
+++ b/Sources/Commands/PackageCommands/AddProduct.swift
@@ -51,15 +51,6 @@ extension SwiftPackageCommand {
         )
         var targets: [String] = []
 
-        @Option(help: "The URL for a remote binary target")
-        var url: String?
-
-        @Option(help: "The path to a local binary target")
-        var path: String?
-
-        @Option(help: "The checksum for a remote binary target")
-        var checksum: String?
-
         func run(_ swiftCommandState: SwiftCommandState) throws {
             let workspace = try swiftCommandState.getActiveWorkspace()
 


### PR DESCRIPTION
Cherry-pick of #7693 

**Explanation**: I removed the mistakenly implemented options (`url`, `path`, `checksum`) that were not used in the `add-product` subcommand.
**Scope**: `add-product` subcommand.
**Issue**: N/A
**Original PR**: #7693 
**Risk**: No risk. Because it just removes unreferenced code.
**Testing**: covered by existing tests
**Reviewer**: @bnbarham 