### PR TITLE
[Traits] Replace `isDefault` with `default` trait

### DIFF
--- a/Fixtures/Traits/Example/Package.swift
+++ b/Fixtures/Traits/Example/Package.swift
@@ -5,15 +5,24 @@
 let package = Package(
     name: "TraitsExample",
     traits: [
-        Trait(name: "Package1", isDefault: true),
-        Trait(name: "Package2", isDefault: true),
-        Trait(name: "Package3", isDefault: true),
-        Trait(name: "Package4", isDefault: true),
+        .default(
+            enabledTraits: [
+                "Package1",
+                "Package2",
+                "Package3",
+                "Package4",
+                "BuildCondition1",
+            ]
+        ),
+        "Package1",
+        "Package2",
+        "Package3",
+        "Package4",
         "Package5",
         "Package7",
         "Package9",
         "Package10",
-        Trait(name: "BuildCondition1", isDefault: true),
+        "BuildCondition1",
         "BuildCondition2",
         "BuildCondition3",
     ],

--- a/Fixtures/Traits/Package3/Package.swift
+++ b/Fixtures/Traits/Package3/Package.swift
@@ -11,9 +11,10 @@ let package = Package(
         ),
     ],
     traits: [
-        Trait(name: "Package3Trait1", enabledTraits: ["Package3Trait2"]),
-        Trait(name: "Package3Trait2", enabledTraits: ["Package3Trait3"]),
-        Trait(name: "Package3Trait3", isDefault: true),
+        .default(enabledTraits: ["Package3Trait3"]),
+        .trait(name: "Package3Trait1", enabledTraits: ["Package3Trait2"]),
+        .trait(name: "Package3Trait2", enabledTraits: ["Package3Trait3"]),
+        "Package3Trait3",
     ],
     targets: [
         .target(

--- a/Fixtures/Traits/Package4/Package.swift
+++ b/Fixtures/Traits/Package4/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
         ),
     ],
     traits: [
-        Trait(name: "Package4Trait1", isDefault: true),
+        .default(enabledTraits: ["Package4Trait1"]),
+        "Package4Trait1",
     ],
     targets: [
         .target(

--- a/Sources/PackageDescription/PackageDependencyTrait.swift
+++ b/Sources/PackageDescription/PackageDependencyTrait.swift
@@ -16,7 +16,7 @@ extension Package.Dependency {
     @available(_PackageDescription, introduced: 999.0)
     public struct Trait: Hashable, Sendable, ExpressibleByStringLiteral {
         /// Enables all default traits of a package.
-        public static let defaults = Self.init(name: "defaults")
+        public static let defaults = Self.init(name: "default")
 
         /// A condition that limits the application of a dependencies trait.
         public struct Condition: Hashable, Sendable {

--- a/Sources/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerialization.swift
@@ -270,7 +270,6 @@ enum Serialization {
     struct Trait: Hashable, Codable {
         let name: String
         let description: String?
-        let isDefault: Bool
         let enabledTraits: Set<String>
     }
 

--- a/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
@@ -382,7 +382,6 @@ extension Serialization.Trait {
     init(_ trait: PackageDescription.Trait) {
         self.name = trait.name
         self.description = trait.description
-        self.isDefault = trait.isDefault
         self.enabledTraits = trait.enabledTraits
     }
 }

--- a/Sources/PackageDescription/Trait.swift
+++ b/Sources/PackageDescription/Trait.swift
@@ -18,6 +18,15 @@
 @_spi(ExperimentalTraits)
 @available(_PackageDescription, introduced: 999.0)
 public struct Trait: Hashable, ExpressibleByStringLiteral {
+    /// Declares the default traits for this package.
+    public static func `default`(enabledTraits: Set<String>) -> Self {
+        .init(
+            name: "default",
+            description: "The default traits of this package.",
+            enabledTraits: enabledTraits
+        )
+    }
+
     /// The trait's canonical name.
     ///
     /// This is used when enabling the trait or when referring to it from other modifiers in the manifest.
@@ -35,9 +44,6 @@ public struct Trait: Hashable, ExpressibleByStringLiteral {
     /// Use this to explain what functionality this trait enables.
     public var description: String?
 
-    /// A boolean indicating wether the trait is enabled by default.
-    public var isDefault: Bool
-
     /// A set of other traits of this package that this trait enables.
     public var enabledTraits: Set<String>
 
@@ -46,17 +52,14 @@ public struct Trait: Hashable, ExpressibleByStringLiteral {
     /// - Parameters:
     ///   - name: The trait's canonical name.
     ///   - description: The trait's description.
-    ///   - isDefault: A boolean indicating wether the trait is enabled by default.
     ///   - enabledTraits: A set of other traits of this package that this trait enables.
     public init(
         name: String,
         description: String? = nil,
-        isDefault: Bool = false,
         enabledTraits: Set<String> = []
     ) {
         self.name = name
         self.description = description
-        self.isDefault = isDefault
         self.enabledTraits = enabledTraits
     }
 
@@ -69,18 +72,15 @@ public struct Trait: Hashable, ExpressibleByStringLiteral {
     /// - Parameters:
     ///   - name: The trait's canonical name.
     ///   - description: The trait's description.
-    ///   - isDefault: A boolean indicating wether the trait is enabled by default.
     ///   - enabledTraits: A set of other traits of this package that this trait enables.
     public static func trait(
         name: String,
         description: String? = nil,
-        isDefault: Bool = false,
         enabledTraits: Set<String> = []
     ) -> Trait {
         .init(
             name: name,
             description: description,
-            isDefault: isDefault,
             enabledTraits: enabledTraits
         )
     }

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -829,7 +829,7 @@ private func calculateEnabledTraits(
 ) throws -> Set<String> {
     // This the point where we flatten the enabled traits and resolve the recursive traits
     var recursiveEnabledTraits = explictlyEnabledTraits ?? []
-    let areDefaultsEnabled = recursiveEnabledTraits.remove("defaults") != nil
+    let areDefaultsEnabled = recursiveEnabledTraits.remove("default") != nil
 
     // We are going to calculate which traits are actually enabled for a node here. To do this
     // we have to check if default traits should be used and then flatten all the enabled traits.
@@ -843,7 +843,7 @@ private func calculateEnabledTraits(
 
     // We have to enable all default traits if no traits are enabled or the defaults are explicitly enabled
     if explictlyEnabledTraits == nil || areDefaultsEnabled {
-        recursiveEnabledTraits.formUnion(manifest.traits.lazy.filter { $0.isDefault }.map { $0.name })
+        recursiveEnabledTraits.formUnion(manifest.traits.first { $0.name == "default" }?.enabledTraits ?? [])
     }
 
     while true {

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -605,7 +605,6 @@ extension TraitDescription {
         self.init(
             name: trait.name,
             description: trait.description,
-            isDefault: trait.isDefault,
             enabledTraits: trait.enabledTraits
         )
     }

--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -107,11 +107,6 @@ public struct ManifestValidator {
                 continue
             }
 
-            guard traitName.lowercased() != "default" && traitName.lowercased() != "defaults" else {
-                diagnostics.append(.defaultTraitName())
-                continue
-            }
-
             for (index, unicodeScalar) in traitName.unicodeScalars.enumerated() {
                 let properties = unicodeScalar.properties
 
@@ -368,10 +363,6 @@ extension Basics.Diagnostic {
 
     static func emptyTraitName() -> Self {
         .error("Empty strings are not allowed as trait names")
-    }
-
-    static func defaultTraitName() -> Self {
-        .error("Traits are not allowed to be named 'default' or 'defaults' to avoid confusion with default traits")
     }
 
     static func invalidFirstCharacterInTrait(firstCharater: UnicodeScalar, trait: String) -> Self {

--- a/Sources/PackageModel/Manifest/TraitDescription.swift
+++ b/Sources/PackageModel/Manifest/TraitDescription.swift
@@ -19,9 +19,6 @@ public struct TraitDescription: Sendable, Hashable, Codable, ExpressibleByString
     /// The trait's description.
     public var description: String?
 
-    /// A boolean indicating wether the trait is enabled by default.
-    public var isDefault: Bool
-
     /// A set of other traits of this package that this trait enables.
     public var enabledTraits: Set<String>
 
@@ -30,17 +27,14 @@ public struct TraitDescription: Sendable, Hashable, Codable, ExpressibleByString
     /// - Parameters:
     ///   - name: The trait's canonical name.
     ///   - description: The trait's description.
-    ///   - isDefault: A boolean indicating wether the trait is enabled by default.
     ///   - enabledTraits: A set of other traits of this package that this trait enables.
     public init(
         name: String,
         description: String? = nil,
-        isDefault: Bool = false,
         enabledTraits: Set<String> = []
     ) {
         self.name = name
         self.description = description
-        self.isDefault = isDefault
         self.enabledTraits = enabledTraits
     }
 

--- a/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
+++ b/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
@@ -22,7 +22,7 @@ package extension PackageDependency {
         deprecatedName: String? = nil,
         path: AbsolutePath,
         productFilter: ProductFilter = .everything,
-        traits: Set<Trait> = [.init(name: "defaults")]
+        traits: Set<Trait> = [.init(name: "default")]
     ) -> Self {
         let identity = identity ?? PackageIdentity(path: path)
         return .fileSystem(
@@ -40,7 +40,7 @@ package extension PackageDependency {
         path: AbsolutePath,
         requirement: SourceControl.Requirement,
         productFilter: ProductFilter = .everything,
-        traits: Set<Trait> = [.init(name: "defaults")]
+        traits: Set<Trait> = [.init(name: "default")]
     ) -> Self {
         let identity = identity ?? PackageIdentity(path: path)
         return .localSourceControl(
@@ -59,7 +59,7 @@ package extension PackageDependency {
         url: SourceControlURL,
         requirement: SourceControl.Requirement,
         productFilter: ProductFilter = .everything,
-        traits: Set<Trait> = [.init(name: "defaults")]
+        traits: Set<Trait> = [.init(name: "default")]
     ) -> Self {
         let identity = identity ?? PackageIdentity(url: url)
         return .remoteSourceControl(
@@ -76,7 +76,7 @@ package extension PackageDependency {
         identity: String,
         requirement: Registry.Requirement,
         productFilter: ProductFilter = .everything,
-        traits: Set<Trait> = [.init(name: "defaults")]
+        traits: Set<Trait> = [.init(name: "default")]
     ) -> Self {
         return .registry(
             identity: .plain(identity),

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -37,7 +37,7 @@ final class TraitTests: XCTestCase {
 
     func testTraits_whenTraitUnification() async throws {
         try await fixture(name: "Traits") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "defaults,Package9,Package10"])
+            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "default,Package9,Package10"])
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
             XCTAssertFalse(stderr.contains("warning:"))
             XCTAssertEqual(stdout, """
@@ -59,7 +59,7 @@ final class TraitTests: XCTestCase {
 
     func testTraits_whenTraitUnification_whenSecondTraitNotEnabled() async throws {
         try await fixture(name: "Traits") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "defaults,Package9"])
+            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "default,Package9"])
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
             XCTAssertFalse(stderr.contains("warning:"))
             XCTAssertEqual(stdout, """
@@ -79,7 +79,7 @@ final class TraitTests: XCTestCase {
 
     func testTraits_whenIndividualTraitsEnabled_andDefaultTraits() async throws {
         try await fixture(name: "Traits") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "defaults,Package5,Package7,BuildCondition3"])
+            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "default,Package5,Package7,BuildCondition3"])
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
             XCTAssertFalse(stderr.contains("warning:"))
             XCTAssertEqual(stdout, """
@@ -186,7 +186,7 @@ final class TraitTests: XCTestCase {
             let json = try JSON(bytes: ByteString(encodingAsUTF8: dumpOutput))
             guard case let .dictionary(contents) = json else { XCTFail("unexpected result"); return }
             guard case let .array(traits)? = contents["experimentalTraits"] else { XCTFail("unexpected result"); return }
-            XCTAssertEqual(traits.count, 11)
+            XCTAssertEqual(traits.count, 12)
         }
     }
 

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -2919,7 +2919,7 @@ final class ModulesGraphTests: XCTestCase {
                         ),
                     ],
                     traits: [
-                        .init(name: "Trait1", isDefault: true),
+                        .init(name: "default", enabledTraits: ["Trait1"]),
                         "Trait1",
                     ]
                 ),
@@ -2955,7 +2955,8 @@ final class ModulesGraphTests: XCTestCase {
                         ),
                     ],
                     traits: [
-                        .init(name: "Trait1", isDefault: true, enabledTraits: ["Trait2"]),
+                        .init(name: "default", enabledTraits: ["Trait1"]),
+                        .init(name: "Trait1", enabledTraits: ["Trait2"]),
                         .init(name: "Trait2", enabledTraits: ["Trait3", "Trait4"]),
                         "Trait3",
                         .init(name: "Trait4", enabledTraits: ["Trait5"]),
@@ -3004,7 +3005,7 @@ final class ModulesGraphTests: XCTestCase {
                         ),
                     ],
                     traits: [
-                        .init(name: "Package1Trait1", isDefault: true),
+                        .init(name: "default", enabledTraits: ["Package1Trait1"]),
                         "Package1Trait1",
                     ]
                 ),
@@ -3072,7 +3073,8 @@ final class ModulesGraphTests: XCTestCase {
                     ),
                 ],
                 traits: [
-                    .init(name: "Package1Trait1", isDefault: true)
+                    .init(name: "default", enabledTraits: ["Package1Trait1"]),
+                    .init(name: "Package1Trait1")
                 ]
             ),
             Manifest.createFileSystemManifest(
@@ -3164,8 +3166,9 @@ final class ModulesGraphTests: XCTestCase {
                     ),
                 ],
                 traits: [
-                    .init(name: "Package1Trait1", isDefault: true),
-                    .init(name: "Package1Trait2", isDefault: true),
+                    .init(name: "default", enabledTraits: ["Package1Trait1", "Package1Trait2"]),
+                    .init(name: "Package1Trait1"),
+                    .init(name: "Package1Trait2"),
                 ]
             ),
             Manifest.createFileSystemManifest(

--- a/Tests/PackageLoadingTests/TraitLoadingTests.swift
+++ b/Tests/PackageLoadingTests/TraitLoadingTests.swift
@@ -65,27 +65,6 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
         XCTAssertEqual(firstDiagnostic.message, "A package can define a maximum of 300 traits")
     }
 
-    func testTraits_whenDefault() async throws {
-        let traits = ["default", "DEFAULT", "DEfauLT", "defaults", "DEFaulTs", "DEFAULTS"]
-
-        for trait in traits {
-            let content =  """
-            @_spi(ExperimentalTraits) import PackageDescription
-            let package = Package(
-                name: "Foo",
-                traits: ["\(trait)"]
-            )
-            """
-
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            let firstDiagnostic = try XCTUnwrap(validationDiagnostics.first)
-            XCTAssertEqual(firstDiagnostic.severity, .error)
-            XCTAssertEqual(firstDiagnostic.message, "Traits are not allowed to be named 'default' or 'defaults' to avoid confusion with default traits")
-        }
-    }
-
     func testTraits_whenUnknownEnabledTrait() async throws {
         let content =  """
             @_spi(ExperimentalTraits) import PackageDescription
@@ -178,9 +157,10 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
             let package = Package(
                 name: "Foo",
                 traits: [
-                    Trait(name: "Trait1", isDefault: true),
+                    .default(enabledTraits: ["Trait1", "Trait3"]),
+                    Trait(name: "Trait1"),
                     Trait(name: "Trait2"),
-                    .trait(name: "Trait3", isDefault: true, enabledTraits: ["Trait1"]),
+                    .trait(name: "Trait3", enabledTraits: ["Trait1"]),
                 ]
             )
             """
@@ -191,9 +171,10 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
         XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.traits, [
-            TraitDescription(name: "Trait1", isDefault: true),
-            TraitDescription(name: "Trait2", isDefault: false),
-            TraitDescription(name: "Trait3", isDefault: true, enabledTraits: ["Trait1"]),
+            TraitDescription(name: "default", description: "The default traits of this package.", enabledTraits: ["Trait1", "Trait3"]),
+            TraitDescription(name: "Trait1"),
+            TraitDescription(name: "Trait2"),
+            TraitDescription(name: "Trait3", enabledTraits: ["Trait1"]),
         ])
     }
 
@@ -203,8 +184,9 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
             let package = Package(
                 name: "Foo",
                 traits: [
-                    .trait(name: "Trait1", isDefault: true),
-                    .trait(name: "Trait2", isDefault: true),
+                    .default(enabledTraits: ["Trait1", "Trait2"]),
+                    .trait(name: "Trait1"),
+                    .trait(name: "Trait2"),
                 ],
                 dependencies: [
                     .package(
@@ -268,8 +250,9 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
         XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.traits, [
-            TraitDescription(name: "Trait1", isDefault: true),
-            TraitDescription(name: "Trait2", isDefault: true),
+            TraitDescription(name: "default", description: "The default traits of this package.", enabledTraits: ["Trait1", "Trait2"]),
+            TraitDescription(name: "Trait1"),
+            TraitDescription(name: "Trait2"),
         ])
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
         XCTAssertEqual(
@@ -278,7 +261,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
                 .init(name: "FooTrait1"),
                 .init(name: "FooTrait2", condition: .init(traits: ["Trait1"])),
                 .init(name: "FooTrait3", condition: .init(traits: ["Trait2"])),
-                .init(name: "defaults"),
+                .init(name: "default"),
             ]
         )
         XCTAssertEqual(
@@ -287,7 +270,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
                 .init(name: "BarTrait1"),
                 .init(name: "BarTrait2", condition: .init(traits: ["Trait1"])),
                 .init(name: "BarTrait3", condition: .init(traits: ["Trait2"])),
-                .init(name: "defaults"),
+                .init(name: "default"),
             ]
         )
         XCTAssertEqual(
@@ -296,7 +279,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
                 .init(name: "FooBarTrait1"),
                 .init(name: "FooBarTrait2", condition: .init(traits: ["Trait1"])),
                 .init(name: "FooBarTrait3", condition: .init(traits: ["Trait2"])),
-                .init(name: "defaults"),
+                .init(name: "default"),
             ]
         )
         XCTAssertEqual(


### PR DESCRIPTION
# Motivation

The current spelling uses `isDefault` per trait to declare the default traits. This makes it hard to see which traits are actually the default traits.

# Modification

Instead of using an explicit `isDefault` per trait this PR now uses a `.defaults(enabledTraits:)` overload which just uses the `"default"` trait under the hood. This simplifies the logic tremendously to handle default traits.

# Result

Nicer spelling for default traits and easier implementation.
