### PR TITLE
[Traits] Enable trait configuration for `swift-test`

### DIFF
--- a/Fixtures/Traits/Example/Package.swift
+++ b/Fixtures/Traits/Example/Package.swift
@@ -99,5 +99,55 @@ let package = Package(
                 .define("DEFINE3", .when(traits: ["BuildCondition3"])),
             ]
         ),
+        .testTarget(
+            name: "ExampleTests",
+            dependencies: [
+                .product(
+                    name: "Package1Library1",
+                    package: "Package1",
+                    condition: .when(traits: ["Package1"])
+                ),
+                .product(
+                    name: "Package2Library1",
+                    package: "Package2",
+                    condition: .when(traits: ["Package2"])
+                ),
+                .product(
+                    name: "Package3Library1",
+                    package: "Package3",
+                    condition: .when(traits: ["Package3"])
+                ),
+                .product(
+                    name: "Package4Library1",
+                    package: "Package4",
+                    condition: .when(traits: ["Package4"])
+                ),
+                .product(
+                    name: "Package5Library1",
+                    package: "Package5",
+                    condition: .when(traits: ["Package5"])
+                ),
+                .product(
+                    name: "Package7Library1",
+                    package: "Package7",
+                    condition: .when(traits: ["Package7"])
+                ),
+                .product(
+                    name: "Package9Library1",
+                    package: "Package9",
+                    condition: .when(traits: ["Package9"])
+                ),
+                .product(
+                    name: "Package10Library1",
+                    package: "Package10",
+                    condition: .when(traits: ["Package10"])
+                ),
+            ],
+            swiftSettings: [
+                .define("DEFINE1", .when(traits: ["BuildCondition1"])),
+                .define("DEFINE2", .when(traits: ["BuildCondition2"])),
+                .define("DEFINE3", .when(traits: ["BuildCondition3"])),
+            ]
+        )
     ]
 )

--- a/Fixtures/Traits/Example/Tests/ExampleTests/Tests.swift
+++ b/Fixtures/Traits/Example/Tests/ExampleTests/Tests.swift
@@ -1,0 +1,70 @@
+#if Package1
+import Package1Library1
+#endif
+#if Package2
+import Package2Library1
+#endif
+#if Package3
+import Package3Library1
+#endif
+#if Package4
+import Package4Library1
+#endif
+#if Package5
+import Package5Library1
+#endif
+#if Package7
+import Package7Library1
+#endif
+#if Package9
+import Package9Library1
+#endif
+#if Package10
+import Package10Library1
+#endif
+
+import XCTest
+
+final class Tests: XCTestCase {
+    func testTraits() {
+        #if Package1
+        Package1Library1.hello()
+        #endif
+        #if Package2
+        Package2Library1.hello()
+        #endif
+        #if Package3
+        Package3Library1.hello()
+        #endif
+        #if Package4
+        Package4Library1.hello()
+        #endif
+        #if Package5
+        Package5Library1.hello()
+        #endif
+        #if Package7
+        Package7Library1.hello()
+        #endif
+        #if Package9
+        Package9Library1.hello()
+        #endif
+        #if Package10
+        Package10Library1.hello()
+        #endif
+        #if DEFINE1
+        print("DEFINE1 enabled")
+        #else
+        print("DEFINE1 disabled")
+        #endif
+        #if DEFINE2
+        print("DEFINE2 enabled")
+        #else
+        print("DEFINE2 disabled")
+        #endif
+        #if DEFINE3
+        print("DEFINE3 enabled")
+        #else
+        print("DEFINE3 disabled")
+        #endif
+    }
+}

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -170,6 +170,9 @@ struct TestCommandOptions: ParsableArguments {
     @Option(name: .customLong("experimental-event-stream-version"),
             help: .hidden)
     var eventStreamVersion: Int?
+
+    @OptionGroup(visibility: .hidden)
+    package var traits: TraitOptions
 }
 
 /// Tests filtering specifier, which is used to filter tests to run.
@@ -570,7 +573,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             swiftCommandState: swiftCommandState,
             productsBuildParameters: productsBuildParameters,
             toolsBuildParameters: toolsBuildParameters,
-            testProduct: self.options.sharedOptions.testProduct
+            testProduct: self.options.sharedOptions.testProduct,
+            traitConfiguration: .init(traitOptions: self.options.traits)
         )
     }
 
@@ -651,6 +655,9 @@ extension SwiftTestCommand {
         /// Which testing libraries to use (and any related options.)
         @OptionGroup()
         var testLibraryOptions: TestLibraryOptions
+
+        @OptionGroup(visibility: .hidden)
+        package var traits: TraitOptions
 
         // for deprecated passthrough from SwiftTestTool (parse will fail otherwise)
         @Flag(name: [.customLong("list-tests"), .customShort("l")], help: .hidden)
@@ -748,7 +755,8 @@ extension SwiftTestCommand {
                 swiftCommandState: swiftCommandState,
                 productsBuildParameters: productsBuildParameters,
                 toolsBuildParameters: toolsBuildParameters,
-                testProduct: self.sharedOptions.testProduct
+                testProduct: self.sharedOptions.testProduct,
+                traitConfiguration: .init(traitOptions: self.traits)
             )
         }
     }
@@ -1373,11 +1381,11 @@ private func buildTestsIfNeeded(
     swiftCommandState: SwiftCommandState,
     productsBuildParameters: BuildParameters,
     toolsBuildParameters: BuildParameters,
-    testProduct: String?
+    testProduct: String?,
+    traitConfiguration: TraitConfiguration
 ) throws -> [BuiltTestProduct] {
     let buildSystem = try swiftCommandState.createBuildSystem(
-        // TODO: Will support traits in test in a follow up PR
-        traitConfiguration: .init(),
+        traitConfiguration: traitConfiguration,
         productsBuildParameters: productsBuildParameters,
         toolsBuildParameters: toolsBuildParameters
     )

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -174,5 +174,45 @@ final class TraitTests: XCTestCase {
         }
     }
 
+    func testTests_whenNoFlagPassed() async throws {
+        try await fixture(name: "Traits") { fixturePath in
+            let (stdout, _) = try await executeSwiftTest(fixturePath.appending("Example"))
+            let expectedOut = """
+            Package1Library1 trait1 enabled
+            Package2Library1 trait2 enabled
+            Package3Library1 trait3 enabled
+            Package4Library1 trait1 disabled
+            DEFINE1 enabled
+            DEFINE2 disabled
+            DEFINE3 disabled
+
+            """
+            XCTAssertTrue(stdout.contains(expectedOut))
+        }
+    }
+
+    func testTests_whenAllTraitsEnabled_andDefaultTraitsDisabled() async throws {
+        try await fixture(name: "Traits") { fixturePath in
+            let (stdout, _) = try await executeSwiftTest(fixturePath.appending("Example"), extraArgs: ["--experimental-enable-all-traits", "--experimental-disable-default-traits"])
+            let expectedOut = """
+            Package1Library1 trait1 enabled
+            Package2Library1 trait2 enabled
+            Package3Library1 trait3 enabled
+            Package4Library1 trait1 disabled
+            Package5Library1 trait1 enabled
+            Package6Library1 trait1 enabled
+            Package7Library1 trait1 disabled
+            Package10Library1 trait1 enabled
+            Package10Library1 trait2 enabled
+            Package10Library1 trait1 enabled
+            Package10Library1 trait2 enabled
+            DEFINE1 enabled
+            DEFINE2 enabled
+            DEFINE3 enabled
+
+            """
+            XCTAssertTrue(stdout.contains(expectedOut))
+        }
+    }
 }
 #endif


### PR DESCRIPTION
# Motivation

It is useful to be able to configure the traits of the root package when running tests.

# Modification

This PR adds the trait CLI options to the `swift test` command to enable specific traits or all traits, or to disable the default traits.

# Result

`swift test` now supports configuring the root traits.
