### PR TITLE
Add 'any' to generated test runner code

### DIFF
--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -34,14 +34,14 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
                 return "\(buildParameters.testOutputPath)"
             }
 
-            private func write(record: Encodable) {
+            private func write(record: any Encodable) {
                 let lock = FileLock(at: URL(fileURLWithPath: self.testOutputPath + ".lock"))
                 _ = try? lock.withLock {
                     self._write(record: record)
                 }
             }
 
-            private func _write(record: Encodable) {
+            private func _write(record: any Encodable) {
                 if let data = try? JSONEncoder().encode(record) {
                     if let fileHandle = FileHandle(forWritingAtPath: self.testOutputPath) {
                         defer { fileHandle.closeFile() }
@@ -435,7 +435,7 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
         }
 
         extension TestErrorInfo {
-            init(_ error: Swift.Error) {
+            init(_ error: any Swift.Error) {
                 self.init(description: "\\(error)", type: "\\(Swift.type(of: error))")
             }
         }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -20,7 +20,7 @@ final class TestCommandTests: CommandsTestCase {
     private func execute(_ args: [String], packagePath: AbsolutePath? = nil) async throws -> (stdout: String, stderr: String) {
         try await SwiftPM.Test.execute(args, packagePath: packagePath)
     }
-    
+
     func testUsage() async throws {
         let stdout = try await execute(["-help"]).stdout
         XCTAssert(stdout.contains("USAGE: swift test"), "got stdout:\n" + stdout)
@@ -47,7 +47,7 @@ final class TestCommandTests: CommandsTestCase {
             }
         }
     }
-    
+
     func testNumWorkersValue() async throws {
         #if !os(macOS)
         // Running swift-test fixtures on linux is not yet possible.
@@ -299,6 +299,16 @@ final class TestCommandTests: CommandsTestCase {
         try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             let (_, stderr) = try await SwiftPM.Test.execute(strictConcurrencyFlags, packagePath: fixturePath)
             XCTAssertNoMatch(stderr, .contains("is not concurrency-safe"))
+        }
+    }
+#endif
+
+#if !canImport(Darwin)
+    func testGeneratedMainIsExistentialAnyClean() async throws {
+        let existentialAnyFlags = ["-Xswiftc", "-enable-upcoming-feature", "-Xswiftc", "ExistentialAny"]
+        try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (_, stderr) = try await SwiftPM.Test.execute(existentialAnyFlags, packagePath: fixturePath)
+            XCTAssertNoMatch(stderr, .contains("error: use of protocol"))
         }
     }
 #endif


### PR DESCRIPTION
Using the upcoming existential any feature via
'-Xswiftc -enable-upcoming-feature -Xswiftc ExistentialAny' causes build failures on non-Darwin platforms as a test observer class is generated which doesn't use explicit 'any'.

This is an issue for library maintainers who want to enforce this in CI.