### PR TITLE
[Build/Plugins] Separate plugin tool builds from plugin invocations

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -1020,8 +1020,6 @@ extension BuildOperation {
 }
 
 extension BuildOperation {
-    fileprivate typealias PluginTool = (path: AbsolutePath, triples: [String]?)
-
     private func buildPluginTools(
         graph: ModulesGraph,
         pluginsPerModule: [ResolvedModule.ID: [ResolvedModule]],

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -184,6 +184,9 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     /// Build parameters used for tools.
     public let toolsBuildParameters: BuildParameters
 
+    package let llbuildManifestPath: AbsolutePath
+    package let buildDescriptionPath: AbsolutePath
+
     /// The package graph.
     public let graph: ModulesGraph
 
@@ -257,6 +260,8 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     public init(
         destinationBuildParameters: BuildParameters,
         toolsBuildParameters: BuildParameters,
+        customLLBuildManifestPath: AbsolutePath? = nil,
+        customBuildDescriptionPath: AbsolutePath? = nil,
         graph: ModulesGraph,
         additionalFileRules: [FileRuleDescription] = [],
         buildToolPluginInvocationResults: [ResolvedModule.ID: [BuildToolPluginInvocationResult]] = [:],
@@ -267,6 +272,8 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     ) throws {
         self.destinationBuildParameters = destinationBuildParameters
         self.toolsBuildParameters = toolsBuildParameters
+        self.llbuildManifestPath = customLLBuildManifestPath ?? destinationBuildParameters.llbuildManifest
+        self.buildDescriptionPath = customBuildDescriptionPath ?? destinationBuildParameters.buildDescriptionPath
         self.graph = graph
         self.buildToolPluginInvocationResults = buildToolPluginInvocationResults
         self.prebuildCommandResults = prebuildCommandResults

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -184,9 +184,6 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     /// Build parameters used for tools.
     public let toolsBuildParameters: BuildParameters
 
-    package let llbuildManifestPath: AbsolutePath
-    package let buildDescriptionPath: AbsolutePath
-
     /// The package graph.
     public let graph: ModulesGraph
 
@@ -260,8 +257,6 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     public init(
         destinationBuildParameters: BuildParameters,
         toolsBuildParameters: BuildParameters,
-        customLLBuildManifestPath: AbsolutePath? = nil,
-        customBuildDescriptionPath: AbsolutePath? = nil,
         graph: ModulesGraph,
         additionalFileRules: [FileRuleDescription] = [],
         buildToolPluginInvocationResults: [ResolvedModule.ID: [BuildToolPluginInvocationResult]] = [:],
@@ -272,8 +267,6 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     ) throws {
         self.destinationBuildParameters = destinationBuildParameters
         self.toolsBuildParameters = toolsBuildParameters
-        self.llbuildManifestPath = customLLBuildManifestPath ?? destinationBuildParameters.llbuildManifest
-        self.buildDescriptionPath = customBuildDescriptionPath ?? destinationBuildParameters.buildDescriptionPath
         self.graph = graph
         self.buildToolPluginInvocationResults = buildToolPluginInvocationResults
         self.prebuildCommandResults = prebuildCommandResults

--- a/Sources/PackageGraph/Resolution/ResolvedModule.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedModule.swift
@@ -12,7 +12,7 @@
 
 import PackageModel
 
-import struct OrderedCollections.OrderedSet
+import struct Basics.IdentifiableSet
 
 @available(*, deprecated, renamed: "ResolvedModule")
 public typealias ResolvedTarget = ResolvedModule
@@ -106,22 +106,22 @@ public struct ResolvedModule {
     }
 
     /// Collect all of the plugins that the current target depends on.
-    package func pluginDependencies(satisfying environment: BuildEnvironment) -> [PluginModule] {
-        var plugins = OrderedSet<PluginModule>()
+    package func pluginDependencies(satisfying environment: BuildEnvironment) -> [ResolvedModule] {
+        var plugins = IdentifiableSet<ResolvedModule>()
         for dependency in self.dependencies(satisfying: environment) {
             switch dependency {
             case .module(let module, _):
                 if let plugin = module.underlying as? PluginModule {
                     assert(plugin.capability == .buildTool)
-                    plugins.append(plugin)
+                    plugins.insert(module)
                 }
             case .product(let product, _):
-                for plugin in product.modules.compactMap({ $0.underlying as? PluginModule }) {
-                    plugins.append(plugin)
+                for plugin in product.modules.filter({ $0.underlying is PluginModule }) {
+                    plugins.insert(plugin)
                 }
             }
         }
-        return plugins.elements
+        return Array(plugins)
     }
 
     /// The language-level module name.

--- a/Sources/SPMTestSupport/MockBuildTestHelper.swift
+++ b/Sources/SPMTestSupport/MockBuildTestHelper.swift
@@ -254,6 +254,29 @@ public func mockBuildPlan(
         observabilityScope: observabilityScope
     )
 }
+
+package func mockPluginTools(
+    plugins: IdentifiableSet<ResolvedModule>,
+    fileSystem: any FileSystem,
+    buildParameters: BuildParameters,
+    hostTriple: Basics.Triple
+) throws -> [ResolvedModule.ID: [String: (path: AbsolutePath, triples: [String]?)]] {
+    var accessibleToolsPerPlugin: [ResolvedModule.ID: [String: (path: AbsolutePath, triples: [String]?)]] = [:]
+    for plugin in plugins where accessibleToolsPerPlugin[plugin.id] == nil {
+        let accessibleTools = try plugin.preparePluginTools(
+            fileSystem: fileSystem,
+            environment: buildParameters.buildEnvironment,
+            for: hostTriple
+        ) { name, path in
+            buildParameters.buildPath.appending(path)
+        }
+
+        accessibleToolsPerPlugin[plugin.id] = accessibleTools
+    }
+
+    return accessibleToolsPerPlugin
+}
+
 enum BuildError: Swift.Error {
     case error(String)
 }

--- a/Sources/SPMTestSupport/MockBuildTestHelper.swift
+++ b/Sources/SPMTestSupport/MockBuildTestHelper.swift
@@ -260,8 +260,8 @@ package func mockPluginTools(
     fileSystem: any FileSystem,
     buildParameters: BuildParameters,
     hostTriple: Basics.Triple
-) throws -> [ResolvedModule.ID: [String: (path: AbsolutePath, triples: [String]?)]] {
-    var accessibleToolsPerPlugin: [ResolvedModule.ID: [String: (path: AbsolutePath, triples: [String]?)]] = [:]
+) throws -> [ResolvedModule.ID: [String: PluginTool]] {
+    var accessibleToolsPerPlugin: [ResolvedModule.ID: [String: PluginTool]] = [:]
     for plugin in plugins where accessibleToolsPerPlugin[plugin.id] == nil {
         let accessibleTools = try plugin.preparePluginTools(
             fileSystem: fileSystem,

--- a/Tests/BuildTests/PluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/PluginsBuildPlanTests.swift
@@ -21,7 +21,9 @@ final class PluginsBuildPlanTests: XCTestCase {
         try await fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath)
             XCTAssertMatch(stdout, .contains("Build complete!"))
-            XCTAssertTrue(localFileSystem.exists(fixturePath.appending(RelativePath(".build/plugins/tools/build.db"))))
+            // FIXME: This is temporary until build of plugin tools is extracted into its own command.
+            XCTAssertTrue(localFileSystem.exists(fixturePath.appending(RelativePath(".build/plugin-tools.db"))))
+            XCTAssertTrue(localFileSystem.exists(fixturePath.appending(RelativePath(".build/build.db"))))
         }
     }
 

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -213,15 +213,14 @@ final class PluginInvocationTests: XCTestCase {
             destination: .host,
             environment: BuildEnvironment(platform: .macOS, configuration: .debug)
         )
-        let results = try graph.invokeBuildToolPlugins(
-            outputDir: outputDir,
+
+        let results = try invokeBuildToolPlugins(
+            graph: graph,
             buildParameters: buildParameters,
-            additionalFileRules: [],
-            toolSearchDirectories: [UserToolchain.default.swiftCompilerPath.parentDirectory],
-            pkgConfigDirectories: [],
+            fileSystem: fileSystem,
+            outputDir: outputDir,
             pluginScriptRunner: pluginRunner,
-            observabilityScope: observability.topScope,
-            fileSystem: fileSystem
+            observabilityScope: observability.topScope
         )
         let builtToolsDir = AbsolutePath("/path/to/build/\(buildParameters.triple)/debug")
 
@@ -514,8 +513,8 @@ final class PluginInvocationTests: XCTestCase {
                 }
                 """)
 
-            // NTFS does not have nanosecond granularity (nor is this is a guaranteed file 
-            // system feature on all file systems). Add a sleep before the execution to ensure that we have sufficient 
+            // NTFS does not have nanosecond granularity (nor is this is a guaranteed file
+            // system feature on all file systems). Add a sleep before the execution to ensure that we have sufficient
             // precision to read a difference.
             try await Task.sleep(nanoseconds: UInt64(SendableTimeInterval.seconds(1).nanoseconds()!))
 
@@ -907,18 +906,18 @@ final class PluginInvocationTests: XCTestCase {
             // Invoke build tool plugin
             do {
                 let outputDir = packageDir.appending(".build")
-                let result = try packageGraph.invokeBuildToolPlugins(
+                let buildParameters = mockBuildParameters(
+                    destination: .host,
+                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                )
+
+                let result = try invokeBuildToolPlugins(
+                    graph: packageGraph,
+                    buildParameters: buildParameters,
+                    fileSystem: localFileSystem,
                     outputDir: outputDir,
-                    buildParameters: mockBuildParameters(
-                        destination: .host,
-                        environment: BuildEnvironment(platform: .macOS, configuration: .debug)
-                    ),
-                    additionalFileRules: [],
-                    toolSearchDirectories: [UserToolchain.default.swiftCompilerPath.parentDirectory],
-                    pkgConfigDirectories: [],
                     pluginScriptRunner: pluginScriptRunner,
-                    observabilityScope: observability.topScope,
-                    fileSystem: localFileSystem
+                    observabilityScope: observability.topScope
                 )
 
                 let diags = result.flatMap(\.value.results).flatMap(\.diagnostics)
@@ -1261,18 +1260,18 @@ final class PluginInvocationTests: XCTestCase {
 
             // Invoke build tool plugin
             let outputDir = packageDir.appending(".build")
-            return try packageGraph.invokeBuildToolPlugins(
+            let buildParameters = mockBuildParameters(
+                destination: .host,
+                environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+            )
+
+            return try invokeBuildToolPlugins(
+                graph: packageGraph,
+                buildParameters: buildParameters,
+                fileSystem: localFileSystem,
                 outputDir: outputDir,
-                buildParameters: mockBuildParameters(
-                    destination: .host,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
-                ),
-                additionalFileRules: [],
-                toolSearchDirectories: [UserToolchain.default.swiftCompilerPath.parentDirectory],
-                pkgConfigDirectories: [],
                 pluginScriptRunner: pluginScriptRunner,
-                observabilityScope: observability.topScope,
-                fileSystem: localFileSystem
+                observabilityScope: observability.topScope
             ).mapValues(\.results)
         }
     }
@@ -1320,5 +1319,40 @@ final class PluginInvocationTests: XCTestCase {
                 XCTAssertEqual($0.buildCommands.first?.configuration.executable.basename, "LocalBinaryTool\(hostTriple.tripleString).sh")
             }
         }
+    }
+
+    private func invokeBuildToolPlugins(
+        graph: ModulesGraph,
+        buildParameters: BuildParameters,
+        fileSystem: any FileSystem,
+        outputDir: AbsolutePath,
+        pluginScriptRunner: PluginScriptRunner,
+        observabilityScope: ObservabilityScope
+    ) throws -> [ResolvedModule.ID: (target: ResolvedModule, results: [BuildToolPluginInvocationResult])] {
+        let pluginsPerModule = graph.pluginsPerModule(
+            satisfying: buildParameters.buildEnvironment
+        )
+
+        let plugins = pluginsPerModule.values.reduce(into: IdentifiableSet<ResolvedModule>()) { result, plugins in
+            plugins.forEach { result.insert($0) }
+        }
+
+        return try graph.invokeBuildToolPlugins(
+            pluginsPerTarget: pluginsPerModule,
+            pluginTools: mockPluginTools(
+                plugins: plugins,
+                fileSystem: fileSystem,
+                buildParameters: buildParameters,
+                hostTriple: hostTriple
+            ),
+            outputDir: outputDir,
+            buildParameters: buildParameters,
+            additionalFileRules: [],
+            toolSearchDirectories: [UserToolchain.default.swiftCompilerPath.parentDirectory],
+            pkgConfigDirectories: [],
+            pluginScriptRunner: pluginScriptRunner,
+            observabilityScope: observabilityScope,
+            fileSystem: fileSystem
+        )
     }
 }


### PR DESCRIPTION
An attempt to simplify `invokeBuildToolPlugins` and avoid having to use a separate BuildOperation to build plugin accessible tools.

### Motivation:

This is the first step towards the world where plugins are going to be invoked during BuildPlan construction as the modules/products are discovered.

### Modifications:

- Instead of having to pass PluginModule around together with ModulesGraph, refactor accessible tool inference to be based on ResolvedModules.
- BuildOperation: organize various build options and configurations into `LLBuildSystemConfiguration`
- Extract build of plugin tools from `invokeBuildToolPlugins` into a separate method on `BuildOperation`

### Result:

Better concern separation for plugins which enabled further refactoring and plugin integration into the build plan.
