### PR TITLE
[6.0] Update `CODEOWNERS` after `swiftlang` transfer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # For the release branch @apple/swift-branch-managers needs to approve the changes
-* @apple/swift-branch-managers
+* @swiftlang/swift-branch-managers


### PR DESCRIPTION
Current `CODEOWNERS` file is invalid, as `@apple/swift-branch-managers` is an invalid codeowner team after a transfer to the `swiftlang` org.
