### PR TITLE
Improve cross-compilation when using experimental XCBuild support

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -473,13 +473,8 @@ public struct BuildOptions: ParsableArguments {
     public var debugInfoFormat: DebugInfoFormat = .dwarf
 
     public var buildSystem: BuildSystemProvider.Kind {
-        #if os(macOS)
         // Force the Xcode build system if we want to build more than one arch.
         return self.architectures.count > 1 ? .xcode : self._buildSystem
-        #else
-        // Force building with the native build system on other platforms than macOS.
-        return .native
-        #endif
     }
 
     /// Whether to enable test discovery on platforms without Objective-C runtime.

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -233,8 +233,8 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
     func createBuildParametersFile() throws -> AbsolutePath {
         // Generate the run destination parameters.
         let runDestination = XCBBuildParameters.RunDestination(
-            platform: "macosx",
-            sdk: "macosx",
+            platform: self.buildParameters.triple.osNameUnversioned,
+            sdk: self.buildParameters.triple.osNameUnversioned,
             sdkVariant: nil,
             targetArchitecture: buildParameters.triple.archName,
             supportedArchitectures: [],

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -182,13 +182,13 @@ final class BuildCommandTests: CommandsTestCase {
             )
 
             // Print correct path when building with XCBuild.
+            #if os(macOS)
             let xcodeDebugOutput = try await execute(["--build-system", "xcode", "--show-bin-path"], packagePath: fullPath)
                 .stdout
             let xcodeReleaseOutput = try await execute(
                 ["--build-system", "xcode", "-c", "release", "--show-bin-path"],
                 packagePath: fullPath
             ).stdout
-            #if os(macOS)
             XCTAssertEqual(
                 xcodeDebugOutput,
                 "\(xcbuildTargetPath.appending(components: "Products", "Debug").pathString)\n"
@@ -197,9 +197,6 @@ final class BuildCommandTests: CommandsTestCase {
                 xcodeReleaseOutput,
                 "\(xcbuildTargetPath.appending(components: "Products", "Release").pathString)\n"
             )
-            #else
-            XCTAssertEqual(xcodeDebugOutput, "\(targetPath.appending("debug").pathString)\n")
-            XCTAssertEqual(xcodeReleaseOutput, "\(targetPath.appending("release").pathString)\n")
             #endif
 
             // Test symlink.


### PR DESCRIPTION
This allows e.g. `swift build --build-system xcode --triple arm64-apple-iphoneos` to work, slightly improving the ergonomics here and reducing hard-coded values.
