### PR TITLE
Add a `--experimental-prepare-for-indexing-no-skipping` command line option to prepare a target without function body skipping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .build
+.index-build
 DerivedData
 /.previous-build
 xcuserdata

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -338,7 +338,7 @@ public final class SwiftModuleBuildDescription {
             return
         }
 
-        guard 
+        guard
             self.buildParameters.triple.isDarwin() &&
             self.buildParameters.testingParameters.experimentalTestOutput
         else {
@@ -541,14 +541,19 @@ public final class SwiftModuleBuildDescription {
             args += ["-emit-module-interface-path", self.parseableModuleInterfaceOutputPath.pathString]
         }
 
-        if self.buildParameters.prepareForIndexing {
+        switch self.buildParameters.prepareForIndexing {
+        case .off:
+            break
+        case .on:
+            args += ["-Xfrontend", "-experimental-lazy-typecheck",]
             if !args.contains("-enable-testing") {
                 // enable-testing needs the non-exportable-decls
                 args += ["-Xfrontend", "-experimental-skip-non-exportable-decls"]
             }
+            fallthrough
+        case .noLazy:
             args += [
                 "-Xfrontend", "-experimental-skip-all-function-bodies",
-                "-Xfrontend", "-experimental-lazy-typecheck",
                 "-Xfrontend", "-experimental-allow-module-with-compiler-errors",
                 "-Xfrontend", "-empty-abi-descriptor"
             ]
@@ -594,7 +599,7 @@ public final class SwiftModuleBuildDescription {
 
         // Pass `-user-module-version` for versioned packages that aren't pre-releases.
         if
-          let version = package.manifest.version, 
+          let version = package.manifest.version,
           version.prereleaseIdentifiers.isEmpty &&
           version.buildMetadataIdentifiers.isEmpty &&
           toolsVersion >= .v6_0
@@ -607,7 +612,7 @@ public final class SwiftModuleBuildDescription {
             isPackageNameSupported: self.buildParameters.driverParameters.isPackageAccessModifierSupported
         )
         args += try self.macroArguments()
-        
+
         // rdar://117578677
         // Pass -fno-omit-frame-pointer to support backtraces
         // this can be removed once the backtracer uses DWARF instead of frame pointers
@@ -621,7 +626,7 @@ public final class SwiftModuleBuildDescription {
 
         return args
     }
-    
+
     /// Determines the arguments needed to run `swift-symbolgraph-extract` for
     /// this module.
     package func symbolGraphExtractArguments() throws -> [String] {

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -1117,9 +1117,9 @@ extension BuildDescription {
             fileSystem: fileSystem,
             observabilityScope: config.observabilityScope
         )
-        let buildManifest = plan.destinationBuildParameters.prepareForIndexing
-            ? try llbuild.generatePrepareManifest(at: config.manifestPath)
-            : try llbuild.generateManifest(at: config.manifestPath)
+        let buildManifest = plan.destinationBuildParameters.prepareForIndexing == .off
+            ? try llbuild.generateManifest(at: config.manifestPath)
+            : try llbuild.generatePrepareManifest(at: config.manifestPath)
 
         let swiftCommands = llbuild.manifest.getCmdToolMap(kind: SwiftCompilerTool.self)
         let swiftFrontendCommands = llbuild.manifest.getCmdToolMap(kind: SwiftFrontendTool.self)

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -439,8 +439,20 @@ public struct BuildOptions: ParsableArguments {
     @Flag(help: "Enable or disable indexing-while-building feature")
     public var indexStoreMode: StoreMode = .autoIndexStore
 
+    /// Instead of building the target, perform the minimal amount of work to prepare it for indexing.
+    ///
+    /// This builds Swift module files for all dependencies but skips generation of object files. It also continues
+    /// building modules in the presence of compilation errors.
     @Flag(name: .customLong("experimental-prepare-for-indexing"), help: .hidden)
     var prepareForIndexing: Bool = false
+
+    /// Don't pass `-experimental-lazy-typecheck` during preparation.
+    ///
+    /// This is intended as a workaround if lazy type checking is causing compiler crashes.
+    ///
+    /// Only applicable in conjunction with `--experimental-prepare-for-indexing`
+    @Flag(name: .customLong("experimental-prepare-for-indexing-no-lazy"), help: .hidden)
+    var prepareForIndexingNoLazy: Bool = false
 
     /// Whether to enable generation of `.swiftinterface`s alongside `.swiftmodule`s.
     @Flag(name: .customLong("enable-parseable-module-interfaces"))

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -773,6 +773,13 @@ public final class SwiftCommandState {
             observabilityScope.emit(warning: Self.entitlementsMacOSWarning)
         }
 
+        let prepareForIndexingMode: BuildParameters.PrepareForIndexingMode =
+            switch (options.build.prepareForIndexing, options.build.prepareForIndexingNoLazy) {
+                case (false, _): .off
+                case (true, false): .on
+                case (true, true): .noLazy
+            }
+
         return try BuildParameters(
             destination: destination,
             dataPath: dataPath,
@@ -786,7 +793,7 @@ public final class SwiftCommandState {
             sanitizers: options.build.enabledSanitizers,
             indexStoreMode: options.build.indexStoreMode.buildParameter,
             isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
-            prepareForIndexing: prepareForIndexing ?? options.build.prepareForIndexing,
+            prepareForIndexing: prepareForIndexingMode,
             debuggingParameters: .init(
                 debugInfoFormat: options.build.debugInfoFormat.buildParameter,
                 triple: triple,

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
@@ -63,7 +63,7 @@ extension BuildParameters {
 
     /// The debugging strategy according to the current build parameters.
     public var debuggingStrategy: DebuggingStrategy? {
-        guard configuration == .debug, !prepareForIndexing else {
+        guard configuration == .debug, prepareForIndexing == .off else {
             return nil
         }
 

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -16,6 +16,17 @@ import PackageModel
 import PackageGraph
 
 public struct BuildParameters: Encodable {
+    public enum PrepareForIndexingMode: Encodable {
+        /// Perform a normal build and don't prepare for indexing
+        case off
+        /// Prepare for indexing but don't pass `-experimental-lazy-typecheck`.
+        ///
+        /// This is intended as a workaround if lazy type checking is causing compiler crashes.
+        case noLazy
+        /// Do minimal build to prepare for indexing
+        case on
+    }
+
     /// Mode for the indexing-while-building feature.
     public enum IndexStoreMode: String, Encodable {
         /// Index store should be enabled.
@@ -115,7 +126,7 @@ public struct BuildParameters: Encodable {
     public var shouldSkipBuilding: Bool
 
     /// Do minimal build to prepare for indexing
-    public var prepareForIndexing: Bool
+    public var prepareForIndexing: PrepareForIndexingMode
 
     /// Build parameters related to debugging.
     public var debuggingParameters: Debugging
@@ -147,7 +158,7 @@ public struct BuildParameters: Encodable {
         indexStoreMode: IndexStoreMode = .auto,
         isXcodeBuildSystemEnabled: Bool = false,
         shouldSkipBuilding: Bool = false,
-        prepareForIndexing: Bool = false,
+        prepareForIndexing: PrepareForIndexingMode = .off,
         debuggingParameters: Debugging? = nil,
         driverParameters: Driver = .init(),
         linkingParameters: Linking = .init(),

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -90,7 +90,7 @@ public func mockBuildParameters(
     linkerDeadStrip: Bool = true,
     linkTimeOptimizationMode: BuildParameters.LinkTimeOptimizationMode? = nil,
     omitFramePointers: Bool? = nil,
-    prepareForIndexing: Bool = false
+    prepareForIndexing: BuildParameters.PrepareForIndexingMode = .off
 ) -> BuildParameters {
     try! BuildParameters(
         destination: destination,


### PR DESCRIPTION
The flags for lazy type checking and function body skipping are still experimental and haven’t been thoroughly tested in the wild yet. In case they are causing issues, add an option to prepare a target without these flags, which users could enable as a workaround.

rdar://130333568
