### PR TITLE
[6.0] Implement `--checksum` option on `swift sdk install`

### DIFF
--- a/Sources/Basics/Archiver/Archiver.swift
+++ b/Sources/Basics/Archiver/Archiver.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import _Concurrency
+import struct Foundation.URL
 
 /// The `Archiver` protocol abstracts away the different operations surrounding archives.
 public protocol Archiver: Sendable {
@@ -94,5 +95,9 @@ extension Archiver {
         try await withCheckedThrowingContinuation { continuation in
             self.validate(path: path, completion: { continuation.resume(with: $0) })
         }
+    }
+
+    package func isFileSupported(_ lastPathComponent: String) -> Bool {
+        self.supportedExtensions.contains(where: { lastPathComponent.hasSuffix($0) })
     }
 }

--- a/Sources/Commands/PackageCommands/ComputeChecksum.swift
+++ b/Sources/Commands/PackageCommands/ComputeChecksum.swift
@@ -28,17 +28,10 @@ struct ComputeChecksum: SwiftCommand {
     var path: AbsolutePath
 
     func run(_ swiftCommandState: SwiftCommandState) throws {
-        let binaryArtifactsManager = try Workspace.BinaryArtifactsManager(
-            fileSystem: swiftCommandState.fileSystem,
-            authorizationProvider: swiftCommandState.getAuthorizationProvider(),
-            hostToolchain: swiftCommandState.getHostToolchain(),
-            checksumAlgorithm: SHA256(),
-            cachePath: .none,
-            customHTTPClient: .none,
-            customArchiver: .none,
-            delegate: .none
+        let checksum = try Workspace.BinaryArtifactsManager.checksum(
+            forBinaryArtifactAt: self.path,
+            fileSystem: swiftCommandState.fileSystem
         )
-        let checksum = try binaryArtifactsManager.checksum(forBinaryArtifactAt: path)
         print(checksum)
     }
 }

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -26,6 +26,12 @@ public enum SwiftSDKError: Swift.Error {
     /// A passed argument is neither a valid file system path nor a URL.
     case invalidPathOrURL(String)
 
+    ///  Bundles installed from remote URLs require a checksum to be provided.
+    case checksumNotProvided(URL)
+
+    /// Computed archive checksum does not match the provided checksum.
+    case checksumInvalid(computed: String, provided: String)
+
     /// Couldn't find the Xcode installation.
     case invalidInstallation(String)
 
@@ -65,6 +71,17 @@ public enum SwiftSDKError: Swift.Error {
 extension SwiftSDKError: CustomStringConvertible {
     public var description: String {
         switch self {
+        case let .checksumInvalid(computed, provided):
+            return """
+            Computed archive checksum `\(computed) does not match the provided checksum `\(provided)`.
+            """
+
+        case .checksumNotProvided(let url):
+            return """
+            Bundles installed from remote URLs (such as \(url)) require their checksum passed via `--checksum` option.
+            The distributor of the bundle must compute it with `swift package compute-checksum` \
+            command and provide it with their Swift SDK installation instructions.
+            """
         case .invalidBundleArchive(let archivePath):
             return """
             Swift SDK archive at `\(archivePath)` does not contain at least one directory with the \

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -73,7 +73,7 @@ extension SwiftSDKError: CustomStringConvertible {
         switch self {
         case let .checksumInvalid(computed, provided):
             return """
-            Computed archive checksum `\(computed) does not match the provided checksum `\(provided)`.
+            Computed archive checksum `\(computed)` does not match the provided checksum `\(provided)`.
             """
 
         case .checksumNotProvided(let url):

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -78,8 +78,8 @@ extension SwiftSDKError: CustomStringConvertible {
 
         case .checksumNotProvided(let url):
             return """
-            Bundles installed from remote URLs (such as \(url)) require their checksum passed via `--checksum` option.
-            The distributor of the bundle must compute it with `swift package compute-checksum` \
+            Bundles installed from remote URLs (`\(url)`) require their checksum passed via `--checksum` option.
+            The distributor of the bundle must compute it with the `swift package compute-checksum` \
             command and provide it with their Swift SDK installation instructions.
             """
         case .invalidBundleArchive(let archivePath):

--- a/Sources/SwiftSDKCommand/Configuration/DeprecatedSwiftSDKConfigurationCommand.swift
+++ b/Sources/SwiftSDKCommand/Configuration/DeprecatedSwiftSDKConfigurationCommand.swift
@@ -14,8 +14,8 @@ import ArgumentParser
 import Basics
 import PackageModel
 
-public struct DeprecatedSwiftSDKConfigurationCommand: ParsableCommand {
-    public static let configuration = CommandConfiguration(
+package struct DeprecatedSwiftSDKConfigurationCommand: ParsableCommand {
+    package static let configuration = CommandConfiguration(
         commandName: "configuration",
         abstract: """
         Deprecated: use `swift sdk configure` instead.
@@ -29,5 +29,5 @@ public struct DeprecatedSwiftSDKConfigurationCommand: ParsableCommand {
         ]
     )
 
-    public init() {}
+    package init() {}
 }

--- a/Sources/SwiftSDKCommand/ListSwiftSDKs.swift
+++ b/Sources/SwiftSDKCommand/ListSwiftSDKs.swift
@@ -16,8 +16,8 @@ import CoreCommands
 import PackageModel
 import SPMBuildCore
 
-public struct ListSwiftSDKs: SwiftSDKSubcommand {
-    public static let configuration = CommandConfiguration(
+package struct ListSwiftSDKs: SwiftSDKSubcommand {
+    package static let configuration = CommandConfiguration(
         commandName: "list",
         abstract:
         """
@@ -28,7 +28,7 @@ public struct ListSwiftSDKs: SwiftSDKSubcommand {
     @OptionGroup()
     var locations: LocationOptions
 
-    public init() {}
+    package init() {}
 
     func run(
         hostTriple: Triple,

--- a/Sources/SwiftSDKCommand/RemoveSwiftSDK.swift
+++ b/Sources/SwiftSDKCommand/RemoveSwiftSDK.swift
@@ -15,8 +15,8 @@ import Basics
 import CoreCommands
 import PackageModel
 
-public struct RemoveSwiftSDK: SwiftSDKSubcommand {
-    public static let configuration = CommandConfiguration(
+package struct RemoveSwiftSDK: SwiftSDKSubcommand {
+    package static let configuration = CommandConfiguration(
         commandName: "remove",
         abstract: """
         Removes a previously installed Swift SDK bundle from the filesystem.

--- a/Sources/SwiftSDKCommand/SwiftSDKCommand.swift
+++ b/Sources/SwiftSDKCommand/SwiftSDKCommand.swift
@@ -12,9 +12,9 @@
 
 import ArgumentParser
 import Basics
-
-public struct SwiftSDKCommand: AsyncParsableCommand {
-    public static let configuration = CommandConfiguration(
+    
+package struct SwiftSDKCommand: AsyncParsableCommand {
+    package static let configuration = CommandConfiguration(
         commandName: "sdk",
         _superCommandName: "swift",
         abstract: "Perform operations on Swift SDKs.",
@@ -29,5 +29,5 @@ public struct SwiftSDKCommand: AsyncParsableCommand {
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)]
     )
 
-    public init() {}
+    package init() {}
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-package-manager/pull/7722.

**Explanation**: This option [was specified in the corresponding proposal for Swift SDKs](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0387-cross-compilation-destinations.md#swift-sdk-installation-and-configuration):

> For Swift SDKs installed from remote URLs an additional `--checksum` option is required, through which users of a Swift SDK can specify a checksum provided by a publisher of the SDK. The latter can produce a checksum by running `swift package compute-checksum command` (introduced in [SE-0272](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0272-swiftpm-binary-dependencies.md)) with the Swift SDK bundle archive as an argument.

**Scope**: the change is isolated to `swift sdk install` and `swift package compute-checksum` subcommands.
**Risk**: low due to isolation to only two rarely used subcommands with corresponding automated test cases provided.
**Testing**: updated existing test cases.
**Issue**: rdar://130590711
**Reviewer**: @bnbarham 