### PR TITLE
Add missing nuget case to system package provider docs

### DIFF
--- a/Sources/PackageDescription/PackageDescription.docc/Curation/SystemPackageProvider.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/SystemPackageProvider.md
@@ -4,6 +4,7 @@
 
 ### Providing Hints to Users of System Packages
 
-- ``brew(_:)``
 - ``apt(_:)``
+- ``brew(_:)``
+- ``nuget(_:)``
 - ``yum(_:)``


### PR DESCRIPTION
Fix the docs so "nuget" shows up under the "Providing Hints to Users of System Packages" heading along with the other cases instead of being off by itself.