### PR TITLE
Move PackageCollectionsProtocol to async/await

### DIFF
--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -27,30 +27,20 @@ public protocol PackageCollectionsProtocol {
     ///
     /// - Parameters:
     ///   - identifiers: Optional. If specified, only `PackageCollection`s with matching identifiers will be returned.
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
     func listCollections(
-        identifiers: Set<PackageCollectionsModel.CollectionIdentifier>?,
-        callback: @escaping (Result<[PackageCollectionsModel.Collection], Error>) -> Void
-    )
+        identifiers: Set<PackageCollectionsModel.CollectionIdentifier>?
+    ) async throws -> [PackageCollectionsModel.Collection]
 
     /// Refreshes all configured package collections.
-    ///
-    /// - Parameters:
-    ///   - callback: The closure to invoke after triggering a refresh for the configured package collections.
-    @available(*, noasync, message: "Use the async alternative")
-    func refreshCollections(callback: @escaping (Result<[PackageCollectionsModel.CollectionSource], Error>) -> Void)
+    func refreshCollections() async throws -> [PackageCollectionsModel.CollectionSource]
 
     /// Refreshes a package collection.
     ///
     /// - Parameters:
     ///   - source: The package collection to be refreshed
-    ///   - callback: The closure to invoke with the refreshed `PackageCollection`
-    @available(*, noasync, message: "Use the async alternative")
     func refreshCollection(
-        _ source: PackageCollectionsModel.CollectionSource,
-        callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
-    )
+        _ source: PackageCollectionsModel.CollectionSource
+    ) async throws -> PackageCollectionsModel.Collection
 
     /// Adds a package collection.
     ///
@@ -59,77 +49,46 @@ public protocol PackageCollectionsProtocol {
     ///   - order: Optional. The order that the `PackageCollection` should take after being added to the list.
     ///            By default the new collection is appended to the end (i.e., the least relevant order).
     ///   - trustConfirmationProvider: The closure to invoke when the collection is not signed and user confirmation is required to proceed
-    ///   - callback: The closure to invoke with the newly added `PackageCollection`
-    @available(*, noasync, message: "Use the async alternative")
     func addCollection(
         _ source: PackageCollectionsModel.CollectionSource,
         order: Int?,
-        trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)?,
-        callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
-    )
+        trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)?
+    ) async throws -> PackageCollectionsModel.Collection
 
     /// Removes a package collection.
     ///
     /// - Parameters:
     ///   - source: The package collection's source
-    ///   - callback: The closure to invoke with the result becomes available
-    @available(*, noasync, message: "Use the async alternative")
     func removeCollection(
-        _ source: PackageCollectionsModel.CollectionSource,
-        callback: @escaping (Result<Void, Error>) -> Void
-    )
+        _ source: PackageCollectionsModel.CollectionSource
+    ) async throws
 
     /// Moves a package collection to a different order.
     ///
     /// - Parameters:
     ///   - source: The source of the `PackageCollection` to be reordered
     ///   - order: The new order that the `PackageCollection` should be positioned after the move
-    ///   - callback: The closure to invoke with the result becomes available
-    @available(*, noasync, message: "Use the async alternative")
     func moveCollection(
         _ source: PackageCollectionsModel.CollectionSource,
-        to order: Int,
-        callback: @escaping (Result<Void, Error>) -> Void
-    )
+        to order: Int
+    ) async throws
 
     /// Updates settings of a `PackageCollection` source (e.g., if it is trusted or not).
     ///
     /// - Parameters:
     ///   - source: The `PackageCollection` source to be updated
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
     func updateCollection(
-        _ source: PackageCollectionsModel.CollectionSource,
-        callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
-    )
+        _ source: PackageCollectionsModel.CollectionSource
+    ) async throws -> PackageCollectionsModel.Collection
 
     /// Returns information about a package collection. The collection is not required to be in the configured list. If
     /// not found locally, the collection will be fetched from the source.
     ///
     /// - Parameters:
     ///   - source: The package collection's source
-    ///   - callback: The closure to invoke with the `PackageCollection`
-    @available(*, noasync, message: "Use the async alternative")
     func getCollection(
-        _ source: PackageCollectionsModel.CollectionSource,
-        callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
-    )
-
-    /// Returns metadata for the package identified by the given `PackageIdentity`, along with the
-    /// identifiers of `PackageCollection`s where the package is found.
-    ///
-    /// A failure is returned if the package is not found.
-    ///
-    /// - Parameters:
-    ///   - identity: The package identity
-    ///   - location: The package location (optional for deduplication)
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
-    func getPackageMetadata(
-        identity: PackageIdentity,
-        location: String?,
-        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
-    )
+        _ source: PackageCollectionsModel.CollectionSource
+    ) async throws -> PackageCollectionsModel.Collection
 
     /// Returns metadata for the package identified by the given `PackageIdentity`, along with the
     /// identifiers of `PackageCollection`s where the package is found.
@@ -141,25 +100,19 @@ public protocol PackageCollectionsProtocol {
     ///   - location: The package location (optional for deduplication)
     ///   - collections: Optional. If specified, only look for package in these collections. Data from the most recently
     ///                  processed collection will be used.
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
     func getPackageMetadata(
         identity: PackageIdentity,
         location: String?,
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
-        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
-    )
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>?
+    ) async throws -> PackageCollectionsModel.PackageMetadata
 
     /// Lists packages from the specified collections.
     ///
     /// - Parameters:
     ///   - collections: Optional. If specified, only packages in these collections are included.
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
     func listPackages(
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
-        callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
-    )
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>?
+    ) async throws -> PackageCollectionsModel.PackageSearchResult
 
     // MARK: - Target (Module) APIs
 
@@ -171,12 +124,9 @@ public protocol PackageCollectionsProtocol {
     ///
     /// - Parameters:
     ///   - collections: Optional. If specified, only list targets within these collections.
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
     func listTargets(
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
-        callback: @escaping (Result<PackageCollectionsModel.TargetListResult, Error>) -> Void
-    )
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>?
+    ) async throws -> PackageCollectionsModel.TargetListResult
 
     // MARK: - Search APIs
 
@@ -188,13 +138,10 @@ public protocol PackageCollectionsProtocol {
     /// - Parameters:
     ///   - query: The search query
     ///   - collections: Optional. If specified, only search within these collections.
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
     func findPackages(
         _ query: String,
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
-        callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
-    )
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>?
+    ) async throws -> PackageCollectionsModel.PackageSearchResult
 
     /// Finds targets by name and returns the corresponding packages.
     ///
@@ -206,168 +153,13 @@ public protocol PackageCollectionsProtocol {
     ///   - searchType: Optional. Target names must either match exactly or contain the prefix.
     ///                 For more flexibility, use the `findPackages` API instead.
     ///   - collections: Optional. If specified, only search within these collections.
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
     func findTargets(
         _ query: String,
         searchType: PackageCollectionsModel.TargetSearchType?,
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
-        callback: @escaping (Result<PackageCollectionsModel.TargetSearchResult, Error>) -> Void
-    )
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>?
+    ) async throws -> PackageCollectionsModel.TargetSearchResult
 }
 
-public extension PackageCollectionsProtocol {
-    func listCollections(
-        identifiers: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
-    ) async throws -> [PackageCollectionsModel.Collection]  {
-        try await safe_async {
-            self.listCollections(identifiers: identifiers, callback: $0)
-        }
-    }
-
-    func refreshCollections() async throws -> [PackageCollectionsModel.CollectionSource] {
-        try await safe_async {
-            self.refreshCollections(callback: $0)
-        }
-    }
-
-    func refreshCollection(
-        _ source: PackageCollectionsModel.CollectionSource
-    ) async throws -> PackageCollectionsModel.Collection {
-        try await safe_async {
-            self.refreshCollection(
-                source,
-                callback: $0
-            )
-        }
-    }
-
-    func addCollection(
-        _ source: PackageCollectionsModel.CollectionSource,
-        order: Int? = nil,
-        trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)? = nil
-    ) async throws -> PackageCollectionsModel.Collection {
-        try await safe_async {
-            self.addCollection(
-                source,
-                order: order,
-                trustConfirmationProvider:trustConfirmationProvider,
-                callback: $0
-            )
-        }
-    }
-
-    func removeCollection(
-        _ source: PackageCollectionsModel.CollectionSource
-    ) async throws {
-        try await safe_async {
-            self.removeCollection(
-                source,
-                callback: $0
-            )
-        }
-    }
-
-    func moveCollection(
-        _ source: PackageCollectionsModel.CollectionSource,
-        to order: Int
-    ) async throws {
-        try await safe_async {
-            self.moveCollection(
-                source,
-                to: order,
-                callback: $0
-            )
-        }
-    }
-
-    func updateCollection(
-        _ source: PackageCollectionsModel.CollectionSource
-    ) async throws -> PackageCollectionsModel.Collection {
-        try await safe_async {
-            self.updateCollection(
-                source,
-                callback: $0
-            )
-        }
-    }
-
-    func getCollection(
-        _ source: PackageCollectionsModel.CollectionSource
-    ) async throws -> PackageCollectionsModel.Collection {
-        try await safe_async {
-            self.getCollection(
-                source,
-                callback: $0
-            )
-        }
-    }
-
-    func getPackageMetadata(
-        identity: PackageIdentity,
-        location: String? = nil,
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
-    ) async throws -> PackageCollectionsModel.PackageMetadata {
-        try await safe_async {
-            self.getPackageMetadata(
-                identity: identity,
-                location: location,
-                collections: collections,
-                callback: $0
-            )
-        }
-    }
-
-    func listPackages(
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
-    ) async throws -> PackageCollectionsModel.PackageSearchResult {
-        try await safe_async {
-            self.listPackages(
-                collections: collections,
-                callback: $0
-            )
-        }
-    }
-
-    func listTargets(
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
-    ) async throws -> PackageCollectionsModel.TargetListResult {
-        try await safe_async {
-            self.listTargets(
-                collections: collections,
-                callback: $0
-            )
-        }
-    }
-
-    func findPackages(
-        _ query: String,
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
-    ) async throws -> PackageCollectionsModel.PackageSearchResult {
-        try await safe_async {
-            self.findPackages(
-                query,
-                collections: collections,
-                callback: $0
-            )
-        }
-    }
-
-    func findTargets(
-        _ query: String,
-        searchType: PackageCollectionsModel.TargetSearchType? = nil,
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
-    ) async throws -> PackageCollectionsModel.TargetSearchResult {
-        try await safe_async {
-            self.findTargets(
-                query,
-                searchType: searchType,
-                collections: collections,
-                callback: $0
-            )
-        }
-    }
-}
 
 public enum PackageCollectionError: Equatable, Error {
     /// Package collection is not signed and there is no record of user's trust selection

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import Basics
 import PackageModel
 
@@ -121,322 +122,244 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
 
     // MARK: - Collections
 
-    public func listCollections(identifiers: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
-                                callback: @escaping (Result<[PackageCollectionsModel.Collection], Error>) -> Void) {
+    public func listCollections(identifiers: Set<PackageCollectionsModel.CollectionIdentifier>? = nil) async throws -> [PackageCollectionsModel.Collection] {
         guard Self.isSupportedPlatform else {
-            return callback(.failure(PackageCollectionError.unsupportedPlatform))
+            throw PackageCollectionError.unsupportedPlatform
         }
 
-        self.storage.sources.list { result in
-            switch result {
-            case .failure(let error):
-                callback(.failure(error))
-            case .success(let sources):
-                let identiferSource = sources.reduce(into: [PackageCollectionsModel.CollectionIdentifier: PackageCollectionsModel.CollectionSource]()) { result, source in
-                    result[.init(from: source)] = source
-                }
-                let identifiersToFetch = identiferSource.keys.filter { identifiers?.contains($0) ?? true }
+        let sources = try await self.storage.sources.list()
+        let identiferSource = sources.reduce(into: [PackageCollectionsModel.CollectionIdentifier: PackageCollectionsModel.CollectionSource]()) { result, source in
+            result[.init(from: source)] = source
+        }
+        let identifiersToFetch = identiferSource.keys.filter { identifiers?.contains($0) ?? true }
 
-                if identifiersToFetch.isEmpty {
-                    return callback(.success([]))
-                }
+        if identifiersToFetch.isEmpty {
+            return []
+        }
 
-                self.storage.collections.list(identifiers: identifiersToFetch) { result in
-                    switch result {
-                    case .failure(let error):
-                        callback(.failure(error))
-                    case .success(var collections):
-                        let sourceOrder = sources.enumerated().reduce(into: [Model.CollectionIdentifier: Int]()) { result, item in
-                            result[.init(from: item.element)] = item.offset
-                        }
+        var collections = try await self.storage.collections.list(identifiers: identifiersToFetch)
 
-                        // re-order by profile order which reflects the user's election
-                        let sort = { (lhs: PackageCollectionsModel.Collection, rhs: PackageCollectionsModel.Collection) -> Bool in
-                            sourceOrder[lhs.identifier] ?? 0 < sourceOrder[rhs.identifier] ?? 0
-                        }
+        let sourceOrder = sources.enumerated().reduce(into: [Model.CollectionIdentifier: Int]()) { result, item in
+            result[.init(from: item.element)] = item.offset
+        }
 
-                        // We've fetched all the wanted collections and we're done
-                        if collections.count == identifiersToFetch.count {
-                            collections.sort(by: sort)
-                            return callback(.success(collections))
-                        }
+        // re-order by profile order which reflects the user's election
+        let sort = { (lhs: PackageCollectionsModel.Collection, rhs: PackageCollectionsModel.Collection) -> Bool in
+            sourceOrder[lhs.identifier] ?? 0 < sourceOrder[rhs.identifier] ?? 0
+        }
 
-                        // Some of the results are missing. This happens when deserialization of stored collections fail,
-                        // so we will try refreshing the missing collections to update data in storage.
-                        let missingSources = Set(identifiersToFetch.compactMap { identiferSource[$0] }).subtracting(Set(collections.map { $0.source }))
-                        let refreshResults = ThreadSafeArrayStore<Result<Model.Collection, Error>>()
-                        missingSources.forEach { source in
-                            self.refreshCollectionFromSource(source: source, trustConfirmationProvider: nil) { refreshResult in
-                                let count = refreshResults.append(refreshResult)
-                                if count == missingSources.count {
-                                    var result = collections + refreshResults.compactMap { $0.success } // best-effort; not returning errors
-                                    result.sort(by: sort)
-                                    callback(.success(result))
-                                }
-                            }
-                        }
-                    }
-                }
+        // We've fetched all the wanted collections and we're done
+        if collections.count == identifiersToFetch.count {
+            collections.sort(by: sort)
+            return collections
+        }
+
+        // Some of the results are missing. This happens when deserialization of stored collections fail,
+        // so we will try refreshing the missing collections to update data in storage.
+        let missingSources = Set(identifiersToFetch.compactMap { identiferSource[$0] }).subtracting(Set(collections.map { $0.source }))
+        var refreshResults = [Model.Collection]()
+        for source in missingSources {
+            guard let refreshResult = try? await self.refreshCollectionFromSource(source: source, trustConfirmationProvider: nil) else {
+                continue
             }
+            refreshResults.append(refreshResult)
         }
+        var result = collections + refreshResults
+        result.sort(by: sort)
+        return result
     }
 
-    public func refreshCollections(callback: @escaping (Result<[PackageCollectionsModel.CollectionSource], Error>) -> Void) {
+    public func refreshCollections() async throws -> [PackageCollectionsModel.CollectionSource] {
         guard Self.isSupportedPlatform else {
-            return callback(.failure(PackageCollectionError.unsupportedPlatform))
+            throw PackageCollectionError.unsupportedPlatform
         }
 
-        self.storage.sources.list { result in
-            switch result {
-            case .failure(let error):
-                callback(.failure(error))
-            case .success(let sources):
-                if sources.isEmpty {
-                    return callback(.success([]))
-                }
-                let refreshResults = ThreadSafeArrayStore<Result<Model.Collection, Error>>()
-                sources.forEach { source in
-                    self.refreshCollectionFromSource(source: source, trustConfirmationProvider: nil) { refreshResult in
-                        let count = refreshResults.append(refreshResult)
-                        if count == sources.count {
-                            let errors = refreshResults.compactMap { $0.failure }
-                            callback(errors.isEmpty ? .success(sources) : .failure(MultipleErrors(errors)))
-                        }
-                    }
-                }
+        let sources = try await self.storage.sources.list()
+        guard !sources.isEmpty else {
+            return []
+        }
+
+        var refreshResults = [Result<Model.Collection, Error>]()
+        for source in sources {
+            do {
+                try await refreshResults.append(.success(self.refreshCollectionFromSource(source: source, trustConfirmationProvider: nil)))
+            } catch {
+                refreshResults.append(.failure(error))
             }
         }
+        let failures = refreshResults.compactMap { $0.failure }
+        guard failures.isEmpty else {
+            throw MultipleErrors(failures)
+        }
+        return sources
     }
 
-    public func refreshCollection(_ source: PackageCollectionsModel.CollectionSource,
-                                  callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void) {
+    public func refreshCollection(_ source: PackageCollectionsModel.CollectionSource) async throws -> PackageCollectionsModel.Collection {
         guard Self.isSupportedPlatform else {
-            return callback(.failure(PackageCollectionError.unsupportedPlatform))
+            throw PackageCollectionError.unsupportedPlatform
         }
 
-        self.storage.sources.list { result in
-            switch result {
-            case .failure(let error):
-                callback(.failure(error))
-            case .success(let sources):
-                guard let savedSource = sources.first(where: { $0 == source }) else {
-                    return callback(.failure(NotFoundError("\(source)")))
-                }
-                self.refreshCollectionFromSource(source: savedSource, trustConfirmationProvider: nil, callback: callback)
-            }
+        let sources = try await self.storage.sources.list()
+        guard let savedSource = sources.first(where: { $0 == source }) else {
+            throw NotFoundError("\(source)")
         }
+        return try await self.refreshCollectionFromSource(source: savedSource, trustConfirmationProvider: nil)
     }
 
-    public func addCollection(_ source: PackageCollectionsModel.CollectionSource,
-                              order: Int? = nil,
-                              trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)? = nil,
-                              callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void) {
+    public func addCollection(_ source: PackageCollectionsModel.CollectionSource, order: Int? = nil, trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)? = nil) async throws -> PackageCollectionsModel.Collection {
         guard Self.isSupportedPlatform else {
-            return callback(.failure(PackageCollectionError.unsupportedPlatform))
+            throw PackageCollectionError.unsupportedPlatform
         }
 
         if let errors = source.validate(fileSystem: self.fileSystem)?.errors() {
-            return callback(.failure(MultipleErrors(errors)))
+            throw MultipleErrors(errors)
         }
 
         // first record the registration
-        self.storage.sources.add(source: source, order: order) { result in
-            switch result {
-            case .failure(let error):
-                callback(.failure(error))
-            case .success:
-                // next try to fetch the collection from the network and store it locally so future operations dont need to access the network
-                self.refreshCollectionFromSource(source: source, trustConfirmationProvider: trustConfirmationProvider) { collectionResult in
-                    switch collectionResult {
-                    case .failure(let error):
-                        // Don't delete the source if we are either pending user confirmation or have recorded user's preference.
-                        // It is also possible that we can't verify signature (yet) due to config issue, which user can fix and we retry later.
-                        if let error = error as? PackageCollectionError, error == .trustConfirmationRequired || error == .untrusted || error == .cannotVerifySignature {
-                            return callback(.failure(error))
-                        }
-                        // Otherwise remove source since it fails to be fetched
-                        self.storage.sources.remove(source: source) { _ in
-                            // Whether removal succeeds or not, return the refresh error
-                            callback(.failure(error))
-                        }
-                    case .success(let collection):
-                        callback(.success(collection))
-                    }
-                }
+        try await self.storage.sources.add(source: source, order: order)
+        // next try to fetch the collection from the network and store it locally so future operations dont need to access the network
+        do {
+            return try await self.refreshCollectionFromSource(source: source, trustConfirmationProvider: trustConfirmationProvider)
+        } catch {
+            // Don't delete the source if we are either pending user confirmation or have recorded user's preference.
+            // It is also possible that we can't verify signature (yet) due to config issue, which user can fix and we retry later.
+            if let error = error as? PackageCollectionError, error == .trustConfirmationRequired || error == .untrusted || error == .cannotVerifySignature {
+                throw error
             }
+            // Otherwise remove source since it fails to be fetched
+            try? await self.storage.sources.remove(source: source)
+            // Whether removal succeeds or not, return the refresh error
+            throw error
         }
+
     }
 
-    public func removeCollection(_ source: PackageCollectionsModel.CollectionSource,
-                                 callback: @escaping (Result<Void, Error>) -> Void) {
+    public func removeCollection(_ source: PackageCollectionsModel.CollectionSource) async throws {
         guard Self.isSupportedPlatform else {
-            return callback(.failure(PackageCollectionError.unsupportedPlatform))
+            throw PackageCollectionError.unsupportedPlatform
         }
 
-        self.storage.sources.remove(source: source) { result in
-            switch result {
-            case .failure(let error):
-                callback(.failure(error))
-            case .success:
-                self.storage.collections.remove(identifier: .init(from: source), callback: callback)
-            }
-        }
+        try await self.storage.sources.remove(source: source)
+        try await self.storage.collections.remove(identifier: .init(from: source))
     }
 
-    public func moveCollection(_ source: PackageCollectionsModel.CollectionSource,
-                               to order: Int,
-                               callback: @escaping (Result<Void, Error>) -> Void) {
+    public func moveCollection(_ source: PackageCollectionsModel.CollectionSource, to order: Int) async throws {
         guard Self.isSupportedPlatform else {
-            return callback(.failure(PackageCollectionError.unsupportedPlatform))
+            throw PackageCollectionError.unsupportedPlatform
         }
 
-        self.storage.sources.move(source: source, to: order, callback: callback)
+        try await self.storage.sources.move(source: source, to: order)
     }
 
-    public func updateCollection(_ source: PackageCollectionsModel.CollectionSource,
-                                 callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void) {
+    public func updateCollection(_ source: PackageCollectionsModel.CollectionSource) async throws -> PackageCollectionsModel.Collection {
         guard Self.isSupportedPlatform else {
-            return callback(.failure(PackageCollectionError.unsupportedPlatform))
+            throw PackageCollectionError.unsupportedPlatform
         }
 
-        self.storage.sources.update(source: source) { result in
-            switch result {
-            case .failure(let error):
-                callback(.failure(error))
-            case .success:
-                self.refreshCollectionFromSource(source: source, trustConfirmationProvider: nil, callback: callback)
-            }
-        }
+        try await self.storage.sources.update(source: source)
+        return try await self.refreshCollectionFromSource(source: source, trustConfirmationProvider: nil)
     }
 
     // Returns information about a package collection.
     // The collection is not required to be in the configured list.
     // If not found locally (storage), the collection will be fetched from the source.
-    public func getCollection(_ source: PackageCollectionsModel.CollectionSource,
-                              callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void) {
+    public func getCollection(_ source: PackageCollectionsModel.CollectionSource) async throws -> PackageCollectionsModel.Collection {
         guard Self.isSupportedPlatform else {
-            return callback(.failure(PackageCollectionError.unsupportedPlatform))
+            throw PackageCollectionError.unsupportedPlatform
         }
 
-        self.storage.collections.get(identifier: .init(from: source)) { result in
-            switch result {
-            case .failure:
-                // The collection is not in storage. Validate the source before fetching it.
-                if let errors = source.validate(fileSystem: self.fileSystem)?.errors() {
-                    return callback(.failure(MultipleErrors(errors)))
-                }
-                guard let provider = self.collectionProviders[source.type] else {
-                    return callback(.failure(UnknownProvider(source.type)))
-                }
-                provider.get(source, callback: callback)
-            case .success(let collection):
-                callback(.success(collection))
+        do {
+            return try await self.storage.collections.get(identifier: .init(from: source))
+        } catch {
+            // The collection is not in storage. Validate the source before fetching it.
+            if let errors = source.validate(fileSystem: self.fileSystem)?.errors() {
+                throw MultipleErrors(errors)
             }
+            guard let provider = self.collectionProviders[source.type] else {
+                throw UnknownProvider(source.type)
+            }
+            return try await provider.get(source)
         }
     }
 
     // MARK: - Packages
 
-    public func findPackages(_ query: String,
-                             collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
-                             callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void) {
+    public func findPackages(
+        _ query: String,
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.PackageSearchResult{
         guard Self.isSupportedPlatform else {
-            return callback(.failure(PackageCollectionError.unsupportedPlatform))
+            throw PackageCollectionError.unsupportedPlatform
         }
+        let sources = try await self.storage.sources.list()
 
-        self.storage.sources.list { result in
-            switch result {
-            case .failure(let error):
-                callback(.failure(error))
-            case .success(let sources):
-                let identifiers = sources.map { .init(from: $0) }.filter { collections?.contains($0) ?? true }
-                if identifiers.isEmpty {
-                    return callback(.success(Model.PackageSearchResult(items: [])))
-                }
-                self.storage.collections.searchPackages(identifiers: identifiers, query: query, callback: callback)
-            }
+        let identifiers = sources.map { .init(from: $0) }.filter { collections?.contains($0) ?? true }
+        if identifiers.isEmpty {
+            return Model.PackageSearchResult(items: [])
         }
+        return try await self.storage.collections.searchPackages(identifiers: identifiers, query: query)
     }
 
-    public func listPackages(collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
-                             callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void) {
-        self.listCollections(identifiers: collections) { result in
-            switch result {
-            case .failure(let error):
-                callback(.failure(error))
-            case .success(let collections):
-                var packageCollections = [PackageIdentity: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
-                // Use package data from the most recently processed collection
-                collections.sorted(by: { $0.lastProcessedAt > $1.lastProcessedAt }).forEach { collection in
-                    collection.packages.forEach { package in
-                        var entry = packageCollections.removeValue(forKey: package.identity)
-                        if entry == nil {
-                            entry = (package, .init())
-                        }
+    public func listPackages(collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil) async throws -> PackageCollectionsModel.PackageSearchResult {
+        let collections = try await self.listCollections(identifiers: collections)
 
-                        if var entry = entry {
-                            entry.collections.insert(collection.identifier)
-                            packageCollections[package.identity] = entry
-                        }
-                    }
+        var packageCollections = [PackageIdentity: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
+        // Use package data from the most recently processed collection
+        collections.sorted(by: { $0.lastProcessedAt > $1.lastProcessedAt }).forEach { collection in
+            collection.packages.forEach { package in
+                var entry = packageCollections.removeValue(forKey: package.identity)
+                if entry == nil {
+                    entry = (package, .init())
                 }
 
-                let result = PackageCollectionsModel.PackageSearchResult(
-                    items: packageCollections.sorted { $0.value.package.displayName < $1.value.package.displayName }
-                        .map { entry in
-                        .init(package: entry.value.package, collections: Array(entry.value.collections))
-                        }
-                )
-                callback(.success(result))
+                if var entry = entry {
+                    entry.collections.insert(collection.identifier)
+                    packageCollections[package.identity] = entry
+                }
             }
         }
+
+        return PackageCollectionsModel.PackageSearchResult(
+            items: packageCollections.sorted { $0.value.package.displayName < $1.value.package.displayName }
+                .map { entry in
+                .init(package: entry.value.package, collections: Array(entry.value.collections))
+                }
+        )
     }
 
     // MARK: - Package Metadata
 
-    public func getPackageMetadata(identity: PackageIdentity,
-                                   location: String? = .none,
-                                   callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {
-        self.getPackageMetadata(identity: identity, location: location, collections: .none, callback: callback)
-    }
-
-    public func getPackageMetadata(identity: PackageIdentity,
-                                   location: String? = .none,
-                                   collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
-                                   callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {
+    public func getPackageMetadata(
+        identity: PackageModel.PackageIdentity,
+        location: String? = nil,
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.PackageMetadata {
         guard Self.isSupportedPlatform else {
-            return callback(.failure(PackageCollectionError.unsupportedPlatform))
+            throw PackageCollectionError.unsupportedPlatform
         }
 
         // first find in storage
-        self.findPackage(identity: identity, location: location, collections: collections) { result in
-            switch result {
-            case .failure(let error):
-                callback(.failure(error))
-            case .success(let packageSearchResult):
-                // then try to get more metadata from provider (optional)
-                self.metadataProvider.get(identity: packageSearchResult.package.identity, location: packageSearchResult.package.location) { result, provider in
-                    switch result {
-                    case .failure(let error):
-                        self.observabilityScope.emit(
-                            warning: "Failed fetching information about \(identity) from \(self.metadataProvider.self)",
-                            underlyingError: error
-                        )
-                        let metadata = Model.PackageMetadata(
-                            package: Self.mergedPackageMetadata(package: packageSearchResult.package, basicMetadata: nil),
-                            collections: packageSearchResult.collections,
-                            provider: provider
-                        )
-                        callback(.success(metadata))
-                    case .success(let basicMetadata):
-                        // finally merge the results
-                        let metadata = Model.PackageMetadata(
-                            package: Self.mergedPackageMetadata(package: packageSearchResult.package, basicMetadata: basicMetadata),
-                            collections: packageSearchResult.collections,
-                            provider: provider
-                        )
-                        callback(.success(metadata))
-                    }
+        let packageSearchResult = try await self.findPackage(identity: identity, location: location, collections: collections)
+        // then try to get more metadata from provider (optional)
+        return await withCheckedContinuation { continuation in
+            self.metadataProvider.get(identity: packageSearchResult.package.identity, location: packageSearchResult.package.location) { result, provider in
+                switch result {
+                case .success(let basicMetadata):
+                    continuation.resume(returning: Model.PackageMetadata(
+                        package: Self.mergedPackageMetadata(package: packageSearchResult.package, basicMetadata: basicMetadata),
+                        collections: packageSearchResult.collections,
+                        provider: provider
+                    ))
+                case .failure(let error):
+                    self.observabilityScope.emit(
+                        warning: "Failed fetching information about \(identity) from \(self.metadataProvider.self)",
+                        underlyingError: error
+                    )
+                    continuation.resume(returning: Model.PackageMetadata(
+                        package: Self.mergedPackageMetadata(package: packageSearchResult.package, basicMetadata: nil),
+                        collections: packageSearchResult.collections,
+                        provider: provider
+                    ))
                 }
             }
         }
@@ -444,45 +367,32 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
 
     // MARK: - Targets
 
-    public func listTargets(collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
-                            callback: @escaping (Result<PackageCollectionsModel.TargetListResult, Error>) -> Void) {
+    public func listTargets(collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil) async throws -> PackageCollectionsModel.TargetListResult {
         guard Self.isSupportedPlatform else {
-            return callback(.failure(PackageCollectionError.unsupportedPlatform))
+            throw PackageCollectionError.unsupportedPlatform
         }
 
-        self.listCollections(identifiers: collections) { result in
-            switch result {
-            case .failure(let error):
-                callback(.failure(error))
-            case .success(let collections):
-                let targets = self.targetListResultFromCollections(collections)
-                callback(.success(targets))
-            }
-        }
+        let collections = try await self.listCollections(identifiers: collections)
+        return self.targetListResultFromCollections(collections)
     }
 
-    public func findTargets(_ query: String,
-                            searchType: PackageCollectionsModel.TargetSearchType? = nil,
-                            collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
-                            callback: @escaping (Result<PackageCollectionsModel.TargetSearchResult, Error>) -> Void) {
+    public func findTargets(
+        _ query: String,
+        searchType: PackageCollectionsModel.TargetSearchType? = nil,
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.TargetSearchResult {
         guard Self.isSupportedPlatform else {
-            return callback(.failure(PackageCollectionError.unsupportedPlatform))
+            throw PackageCollectionError.unsupportedPlatform
         }
 
         let searchType = searchType ?? .exactMatch
 
-        self.storage.sources.list { result in
-            switch result {
-            case .failure(let error):
-                callback(.failure(error))
-            case .success(let sources):
-                let identifiers = sources.map { .init(from: $0) }.filter { collections?.contains($0) ?? true }
-                if identifiers.isEmpty {
-                    return callback(.success(.init(items: [])))
-                }
-                self.storage.collections.searchTargets(identifiers: identifiers, query: query, type: searchType, callback: callback)
-            }
+        let sources = try await self.storage.sources.list()
+        let identifiers = sources.map { .init(from: $0) }.filter { collections?.contains($0) ?? true }
+        if identifiers.isEmpty {
+            return PackageCollectionsModel.TargetSearchResult(items: [])
         }
+        return try await self.storage.collections.searchTargets(identifiers: identifiers, query: query, type: searchType)
     }
 
     // MARK: - Private
@@ -491,115 +401,103 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
     // This helps avoid network access in normal operations
     private func refreshCollectionFromSource(
         source: PackageCollectionsModel.CollectionSource,
-        trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)?,
-        callback: @escaping (Result<Model.Collection, Error>) -> Void
-    ) {
+        trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)? = nil
+    ) async throws -> Model.Collection {
         guard let provider = self.collectionProviders[source.type] else {
-            return callback(.failure(UnknownProvider(source.type)))
+            throw UnknownProvider(source.type)
         }
-        provider.get(source) { result in
-            switch result {
-            case .failure(let error):
-                // Remove the unavailable/invalid collection (if previously saved) from storage before calling back
-                self.storage.collections.remove(identifier: PackageCollectionsModel.CollectionIdentifier(from: source)) { _ in
-                    callback(.failure(error))
-                }
-            case .success(let collection):
-                // If collection is signed and signature is valid, save to storage. `provider.get`
-                // would have failed if signature were invalid.
-                if collection.isSigned {
-                    return self.storage.collections.put(collection: collection, callback: callback)
-                }
+        var collection: Model.Collection
+        do {
+            collection = try await provider.get(source)
+        } catch {
+            // Remove the unavailable/invalid collection (if previously saved) from storage before calling back
+            try? await self.storage.collections.remove(identifier: PackageCollectionsModel.CollectionIdentifier(from: source))
+            throw error
+        }
+        // If collection is signed and signature is valid, save to storage. `provider.get`
+        // would have failed if signature were invalid.
+        if collection.isSigned {
+            return try await self.storage.collections.put(collection: collection)
+        }
 
-                // If collection is not signed, check if it's trusted by user and prompt user if needed.
-                if let isTrusted = source.isTrusted {
-                    if isTrusted {
-                        return self.storage.collections.put(collection: collection, callback: callback)
-                    } else {
-                        // Try to remove the untrusted collection (if previously saved) from storage before calling back
-                        return self.storage.collections.remove(identifier: collection.identifier) { _ in
-                            callback(.failure(PackageCollectionError.untrusted))
-                        }
-                    }
-                }
+        // If collection is not signed, check if it's trusted by user and prompt user if needed.
+        if let isTrusted = source.isTrusted {
+            guard isTrusted else {
+                // Try to remove the untrusted collection (if previously saved) from storage before calling back
+                try? await self.storage.collections.remove(identifier: collection.identifier)
+                throw PackageCollectionError.untrusted
+            }
+            return try await self.storage.collections.put(collection: collection)
+        }
 
-                // No user preference recorded, so we need to prompt if we can.
-                guard let trustConfirmationProvider = trustConfirmationProvider else {
-                    // Try to remove the untrusted collection (if previously saved) from storage before calling back
-                    return self.storage.collections.remove(identifier: collection.identifier) { _ in
-                        callback(.failure(PackageCollectionError.trustConfirmationRequired))
-                    }
-                }
 
-                trustConfirmationProvider(collection) { userTrusted in
-                    var source = source
-                    source.isTrusted = userTrusted
-                    // Record user preference then save collection to storage
-                    self.storage.sources.update(source: source) { updateSourceResult in
-                        switch updateSourceResult {
-                        case .failure(let error):
-                            callback(.failure(error))
-                        case .success:
-                            if userTrusted {
-                                var collection = collection
-                                collection.source = source
-                                self.storage.collections.put(collection: collection, callback: callback)
-                            } else {
-                                // Try to remove the untrusted collection (if previously saved) from storage before calling back
-                                return self.storage.collections.remove(identifier: collection.identifier) { _ in
-                                    callback(.failure(PackageCollectionError.untrusted))
-                                }
-                            }
-                        }
-                    }
-                }
+        // No user preference recorded, so we need to prompt if we can.
+        guard let trustConfirmationProvider else {
+            // Try to remove the untrusted collection (if previously saved) from storage before calling back
+            try? await self.storage.collections.remove(identifier: collection.identifier)
+            throw PackageCollectionError.trustConfirmationRequired
+        }
+        let userTrusted = await withCheckedContinuation { continuation in
+            trustConfirmationProvider(collection) { result in
+                continuation.resume(returning: result)
             }
         }
+        var source = source
+        source.isTrusted = userTrusted
+        // Record user preference then save collection to storage
+        try await self.storage.sources.update(source: source)
+
+        guard userTrusted else {
+            // Try to remove the untrusted collection (if previously saved) from storage before calling back
+            try? await self.storage.collections.remove(identifier: collection.identifier)
+            throw PackageCollectionError.untrusted
+        }
+        collection.source = source
+        return try await self.storage.collections.put(collection: collection)
     }
 
     func findPackage(identity: PackageIdentity,
-                     location: String?,
-                     collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
-                     callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult.Item, Error>) -> Void) {
-        self.storage.sources.list { result in
-            let notFoundError = NotFoundError("identity: \(identity), location: \(location ?? "none")")
-            
-            switch result {
-            case .failure(is NotFoundError):
-                callback(.failure(notFoundError))
-            case .failure(let error):
-                callback(.failure(error))
-            case .success(let sources):
-                var collectionIdentifiers = sources.map { Model.CollectionIdentifier(from: $0) }
-                if let collections {
-                    collectionIdentifiers = collectionIdentifiers.filter { collections.contains($0) }
-                }
-                if collectionIdentifiers.isEmpty {
-                    return callback(.failure(notFoundError))
-                }
-                self.storage.collections.findPackage(identifier: identity, collectionIdentifiers: collectionIdentifiers) { findPackageResult in
-                    switch findPackageResult {
-                    case .failure(is NotFoundError):
-                        callback(.failure(notFoundError))
-                    case .failure(let error):
-                        callback(.failure(error))
-                    case .success(let packagesCollections):
-                        let matches: [PackageCollectionsModel.Package]
-                        if let location {
-                            // A package identity can be associated with multiple repository URLs
-                            matches = packagesCollections.packages.filter { CanonicalPackageLocation($0.location) == CanonicalPackageLocation(location) }
-                        }
-                        else {
-                            matches = packagesCollections.packages
-                        }
-                        guard let package = matches.first else {
-                            return callback(.failure(notFoundError))
-                        }
-                        callback(.success(.init(package: package, collections: packagesCollections.collections)))
-                    }
-                }
-            }
+                     location: String? = nil,
+                     collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.PackageSearchResult.Item {
+        let notFoundError = NotFoundError("identity: \(identity), location: \(location ?? "none")")
+
+        let sources: [PackageCollectionsModel.CollectionSource]
+        do {
+            sources = try await self.storage.sources.list()
+        } catch is NotFoundError {
+            throw notFoundError
         }
+
+        var collectionIdentifiers = sources.map { Model.CollectionIdentifier(from: $0) }
+        if let collections {
+            collectionIdentifiers = collectionIdentifiers.filter { collections.contains($0) }
+        }
+        guard !collectionIdentifiers.isEmpty else {
+            throw notFoundError
+        }
+        let packagesCollections: (packages: [PackageCollectionsModel.Package], collections: [PackageCollectionsModel.CollectionIdentifier])
+        do {
+            packagesCollections = try await self.storage.collections.findPackage(identifier: identity, collectionIdentifiers: collectionIdentifiers)
+        } catch is NotFoundError {
+            throw notFoundError
+        }
+
+        let matches: [PackageCollectionsModel.Package]
+        if let location {
+            // A package identity can be associated with multiple repository URLs
+            matches = packagesCollections.packages.filter { CanonicalPackageLocation($0.location) == CanonicalPackageLocation(location) }
+        }
+        else {
+            matches = packagesCollections.packages
+        }
+        guard let package = matches.first else {
+            throw notFoundError
+        }
+        return PackageCollectionsModel.PackageSearchResult.Item(
+            package: package,
+            collections: packagesCollections.collections)
+
     }
 
     private func targetListResultFromCollections(_ collections: [Model.Collection]) -> Model.TargetListResult {

--- a/Sources/PackageCollections/PackageIndexAndCollections.swift
+++ b/Sources/PackageCollections/PackageIndexAndCollections.swift
@@ -77,36 +77,13 @@ public struct PackageIndexAndCollections: Closable {
         try await self.collections.listCollections(identifiers: identifiers)
     }
 
-    /// - SeeAlso: `PackageCollectionsProtocol.listCollections`
-    @available(*, noasync, message: "Use the async alternative")
-    public func listCollections(
-        identifiers: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
-        callback: @escaping (Result<[PackageCollectionsModel.Collection], Error>) -> Void
-    ) {
-        self.collections.listCollections(identifiers: identifiers, callback: callback)
-    }
     
     public func refreshCollections() async throws -> [PackageCollectionsModel.CollectionSource] {
         try await self.collections.refreshCollections()
     }
 
-    /// - SeeAlso: `PackageCollectionsProtocol.refreshCollections`
-    @available(*, noasync, message: "Use the async alternative")
-    public func refreshCollections(callback: @escaping (Result<[PackageCollectionsModel.CollectionSource], Error>) -> Void) {
-        self.collections.refreshCollections(callback: callback)
-    }
-
     public func refreshCollection(_ source: PackageCollectionsModel.CollectionSource) async throws -> PackageCollectionsModel.Collection {
         try await self.collections.refreshCollection(source)
-    }
-
-    /// - SeeAlso: `PackageCollectionsProtocol.refreshCollection`
-    @available(*, noasync, message: "Use the async alternative")
-    public func refreshCollection(
-        _ source: PackageCollectionsModel.CollectionSource,
-        callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
-    ) {
-        self.collections.refreshCollection(source, callback: callback)
     }
 
     public func addCollection(
@@ -120,31 +97,11 @@ public struct PackageIndexAndCollections: Closable {
             trustConfirmationProvider: trustConfirmationProvider
         )
     }
-
-    /// - SeeAlso: `PackageCollectionsProtocol.addCollection`
-    @available(*, noasync, message: "Use the async alternative")
-    public func addCollection(
-        _ source: PackageCollectionsModel.CollectionSource,
-        order: Int? = nil,
-        trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)? = nil,
-        callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
-    ) {
-        self.collections.addCollection(source, order: order, trustConfirmationProvider: trustConfirmationProvider, callback: callback)
-    }
     
     public func removeCollection(
         _ source: PackageCollectionsModel.CollectionSource
     ) async throws {
         try await self.collections.removeCollection(source)
-    }
-
-    /// - SeeAlso: `PackageCollectionsProtocol.removeCollection`
-    @available(*, noasync, message: "Use the async alternative")
-    public func removeCollection(
-        _ source: PackageCollectionsModel.CollectionSource,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
-        self.collections.removeCollection(source, callback: callback)
     }
 
     public func getCollection(
@@ -153,28 +110,10 @@ public struct PackageIndexAndCollections: Closable {
         try await self.collections.getCollection(source)
     }
 
-    /// - SeeAlso: `PackageCollectionsProtocol.getCollection`
-    @available(*, noasync, message: "Use the async alternative")
-    public func getCollection(
-        _ source: PackageCollectionsModel.CollectionSource,
-        callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
-    ) {
-        self.collections.getCollection(source, callback: callback)
-    }
-    
     public func listPackages(
         collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
     ) async throws -> PackageCollectionsModel.PackageSearchResult {
         try await self.collections.listPackages(collections: collections)
-    }
-
-    /// - SeeAlso: `PackageCollectionsProtocol.listPackages`
-    @available(*, noasync, message: "Use the async alternative")
-    public func listPackages(
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
-        callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
-    ) {
-        self.collections.listPackages(collections: collections, callback: callback)
     }
     
     public func listTargets(
@@ -183,15 +122,6 @@ public struct PackageIndexAndCollections: Closable {
         try await self.collections.listTargets(collections: collections)
     }
 
-    /// - SeeAlso: `PackageCollectionsProtocol.listTargets`
-    @available(*, noasync, message: "Use the async alternative")
-    public func listTargets(
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
-        callback: @escaping (Result<PackageCollectionsModel.TargetListResult, Error>) -> Void
-    ) {
-        self.collections.listTargets(collections: collections, callback: callback)
-    }
-    
     public func findTargets(
         _ query: String,
         searchType: PackageCollectionsModel.TargetSearchType? = nil,
@@ -204,17 +134,7 @@ public struct PackageIndexAndCollections: Closable {
         )
     }
 
-    /// - SeeAlso: `PackageCollectionsProtocol.findTargets`
-    @available(*, noasync, message: "Use the async alternative")
-    public func findTargets(
-        _ query: String,
-        searchType: PackageCollectionsModel.TargetSearchType? = nil,
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
-        callback: @escaping (Result<PackageCollectionsModel.TargetSearchResult, Error>) -> Void
-    ) {
-        self.collections.findTargets(query, searchType: searchType, collections: collections, callback: callback)
-    }
-    
+
     // MARK: - Package index specific APIs
 
     /// Indicates if package index is configured.
@@ -238,22 +158,9 @@ public struct PackageIndexAndCollections: Closable {
     ) {
         self.index.listPackages(offset: offset, limit: limit, callback: callback)
     }
-    
+
+
     // MARK: - APIs that make use of both package index and collections
-    public func getPackageMetadata(
-        identity: PackageIdentity,
-        location: String? = nil,
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
-    ) async throws -> PackageCollectionsModel.PackageMetadata {
-        try await safe_async {
-            self.getPackageMetadata(
-                identity: identity,
-                location: location,
-                collections: collections,
-                callback: $0
-            )
-        }
-    }
 
     /// Returns metadata for the package identified by the given `PackageIdentity`, using package index (if configured)
     /// and collections data.
@@ -264,78 +171,40 @@ public struct PackageIndexAndCollections: Closable {
     ///   - identity: The package identity
     ///   - location: The package location (optional for deduplication)
     ///   - collections: Optional. If specified, only these collections are used to construct the result.
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
     public func getPackageMetadata(
         identity: PackageIdentity,
         location: String? = nil,
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
-        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
-    ) {
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.PackageMetadata {
         // Package index not available - fallback to collections
         guard self.index.isEnabled else {
-            return self.collections.getPackageMetadata(identity: identity, location: location, collections: collections, callback: callback)
+            return try await self.collections.getPackageMetadata(identity: identity, location: location, collections: collections)
         }
-                
-        // Get metadata using both package index and collections
-        let sync = DispatchGroup()
-        let results = ThreadSafeKeyValueStore<Source, Result<PackageCollectionsModel.PackageMetadata, Error>>()
 
-        sync.enter()
         // This uses package index only
-        self.index.getPackageMetadata(identity: identity, location: location) { result in
-            defer { sync.leave() }
-            results[.index] = result
-        }
+        async let indexResult = self.index.getPackageMetadata(identity: identity, location: location)
 
-        sync.enter()
         // This uses either package index or "alternative" (e.g., GitHub) as metadata provider,
         // then merge the supplementary metadata with data coming from collections. The package
         // must belong to at least one collection.
-        self.collections.getPackageMetadata(identity: identity, location: location, collections: collections) { result in
-            defer { sync.leave() }
-            results[.collections] = result
-        }
-        
-        sync.notify(queue: .sharedConcurrent) {
-            guard let indexResult = results[.index], let collectionsResult = results[.collections] else {
-                return callback(.failure(InternalError("Should contain results from package index and collections")))
-            }
+        async let collectionsResult = self.collections.getPackageMetadata(identity: identity, location: location, collections: collections)
 
-            switch (indexResult, collectionsResult) {
-            case (.success(let metadataResult), _):
-                // Metadata from `PackageIndex`
-                callback(.success(
-                    PackageCollectionsModel.PackageMetadata(
-                        package: metadataResult.package,
-                        collections: collectionsResult.success?.collections ?? [],
-                        provider: metadataResult.provider
-                    )
-                ))
-            case (.failure(let indexError), .success(let metadataResult)):
-                self.observabilityScope.emit(warning: "PackageIndex.getPackageMetadata failed: \(indexError)")
-                // Metadata from `PackageCollections`, which is a combination of
-                // package index/alternative (e.g., GitHub) and collection data.
-                callback(.success(metadataResult))
-            case (.failure(let indexError), .failure(let collectionsError)):
-                // Failed to get metadata through `PackageIndex` and `PackageCollections`.
-                // Return index's error.
-                self.observabilityScope.emit(warning: "PackageCollections.getPackageMetadata failed: \(collectionsError)")
-                callback(.failure(indexError))
-            }
-        }
-    }
 
-    public func findPackages(
-        _ query: String,
-        in searchIn: SearchIn = .both(collections: nil)
-    ) async throws -> PackageCollectionsModel.PackageSearchResult {
-        try await safe_async {
-            self.findPackages(
-                query,
-                in: searchIn,
-                callback: $0
+        do {
+            let indexPackageMetadata = try await indexResult
+            return PackageCollectionsModel.PackageMetadata(
+                package: indexPackageMetadata.package,
+                collections: (try? await collectionsResult)?.collections ?? [],
+                provider: indexPackageMetadata.provider
             )
+        } catch {
+            self.observabilityScope.emit(warning: "PackageIndex.getPackageMetadata failed: \(error)")
+            do {
+                return try await collectionsResult
+            } catch let collectionsError {
+                self.observabilityScope.emit(warning: "PackageCollections.getPackageMetadata failed: \(collectionsError)")
+            }
+            throw error
         }
     }
 
@@ -345,53 +214,36 @@ public struct PackageIndexAndCollections: Closable {
     ///   - query: The search query
     ///   - in: Indicates whether to search in the index only, collections only, or both.
     ///         The optional `Set<CollectionIdentifier>` in some enum cases restricts search within those collections only.
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
     public func findPackages(
         _ query: String,
-        in searchIn: SearchIn = .both(collections: nil),
-        callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
-    ) {
+        in searchIn: SearchIn = .both(collections: nil)
+    ) async throws -> PackageCollectionsModel.PackageSearchResult {
         switch searchIn {
         case .index:
             guard self.index.isEnabled else {
                 self.observabilityScope.emit(debug: "Package index is not enabled. Returning empty result.")
-                return callback(.success(.init(items: [])))
+                return PackageCollectionsModel.PackageSearchResult(items: [])
             }
-            self.index.findPackages(query, callback: callback)
+            return try await self.index.findPackages(query)
         case .collections(let collections):
-            self.collections.findPackages(query, collections: collections, callback: callback)
+            return try await self.collections.findPackages(query, collections: collections)
         case .both(let collections):
             // Find packages in both package index and collections
-            let sync = DispatchGroup()
-            let results = ThreadSafeKeyValueStore<Source, Result<PackageCollectionsModel.PackageSearchResult, Error>>()
+            async let pendingIndexPackages = self.index.findPackages(query)
+            async let pendingcollectionPackages = self.collections.findPackages(query, collections: collections)
 
-            sync.enter()
-            self.index.findPackages(query) { result in
-                defer { sync.leave() }
-                results[.index] = result
-            }
+            do {
+                let indexSearchResult = try await pendingIndexPackages
+                do {
+                    let collectionsSearchResult = try await pendingcollectionPackages
 
-            sync.enter()
-            self.collections.findPackages(query, collections: collections) { result in
-                defer { sync.leave() }
-                results[.collections] = result
-            }
-            
-            sync.notify(queue: .sharedConcurrent) {
-                guard let indexResult = results[.index], let collectionsResult = results[.collections] else {
-                    return callback(.failure(InternalError("Should contain results from package index and collections")))
-                }
-
-                switch (indexResult, collectionsResult) {
-                case (.success(let indexSearchResult), .success(let collectionsSearchResult)):
                     let indexItems = Dictionary(uniqueKeysWithValues: indexSearchResult.items.map {
                         (SearchResultItemKey(identity: $0.package.identity, location: $0.package.location), $0)
                     })
                     let collectionItems = Dictionary(uniqueKeysWithValues: collectionsSearchResult.items.map {
                         (SearchResultItemKey(identity: $0.package.identity, location: $0.package.location), $0)
                     })
-                    
+
                     // An array of combined results, with index items listed first.
                     var items = [PackageCollectionsModel.PackageSearchResult.Item]()
                     // Iterating through the dictionary would simplify the code, but we want to keep the ordering of the search result.
@@ -412,36 +264,37 @@ public struct PackageIndexAndCollections: Closable {
                         }
                         items.append($0)
                     }
-                    
-                    callback(.success(PackageCollectionsModel.PackageSearchResult(items: items)))
-                case (.success(let indexSearchResult), .failure(let collectionsError)):
+                    return PackageCollectionsModel.PackageSearchResult(items: items)
+
+                } catch let collectionsError {
                     self.observabilityScope.emit(warning: "PackageCollections.findPackages failed: \(collectionsError)")
+
                     // Collections query failed, try another way to find the collections that an item belongs to.
-                    self.collections.listPackages(collections: collections) { collectionsResult in
-                        switch collectionsResult {
-                        case .failure:
-                            callback(.success(indexSearchResult))
-                        case .success(let collectionsSearchResult):
-                            let items = indexSearchResult.items.map { item in
-                                PackageCollectionsModel.PackageSearchResult.Item(
-                                    package: item.package,
-                                    collections: collectionsSearchResult.items.first(where: {
-                                        item.package.identity == $0.package.identity && item.package.location == $0.package.location
-                                    })?.collections ?? [],
-                                    indexes: item.indexes
-                                )
-                            }
-                            callback(.success(PackageCollectionsModel.PackageSearchResult(items: items)))
+                    do {
+                        let collectionsSearchResult = try await self.collections.listPackages(collections: collections)
+                        let items = indexSearchResult.items.map { item in
+                            PackageCollectionsModel.PackageSearchResult.Item(
+                                package: item.package,
+                                collections: collectionsSearchResult.items.first(where: {
+                                    item.package.identity == $0.package.identity && item.package.location == $0.package.location
+                                })?.collections ?? [],
+                                indexes: item.indexes
+                            )
                         }
+                        return PackageCollectionsModel.PackageSearchResult(items: items)
+                    } catch {
+                        return indexSearchResult
                     }
-                case (.failure(let indexError), .success(let searchResult)):
-                    self.observabilityScope.emit(warning: "PackageIndex.findPackages failed: \(indexError)")
-                    callback(.success(searchResult))
-                case (.failure(let indexError), .failure(let collectionsError)):
+                }
+            } catch let indexError {
+                self.observabilityScope.emit(warning: "PackageIndex.findPackages failed: \(indexError)")
+                do {
+                    return try await pendingcollectionPackages
+                } catch let collectionsError {
                     // Failed to find packages through `PackageIndex` and `PackageCollections`.
                     // Return index's error.
                     self.observabilityScope.emit(warning: "PackageCollections.findPackages failed: \(collectionsError)")
-                    callback(.failure(indexError))
+                    throw indexError
                 }
             }
 

--- a/Sources/PackageCollections/Storage/PackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/PackageCollectionsStorage.swift
@@ -69,6 +69,7 @@ public protocol PackageCollectionsStorage {
     ///   - identifier: The package identifier
     ///   - collectionIdentifiers: Optional. The identifiers of the `PackageCollection`s
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func findPackage(identifier: PackageIdentity,
                      collectionIdentifiers: [PackageCollectionsModel.CollectionIdentifier]?,
                      callback: @escaping (Result<(packages: [PackageCollectionsModel.Package], collections: [PackageCollectionsModel.CollectionIdentifier]), Error>) -> Void)
@@ -106,6 +107,23 @@ public extension PackageCollectionsStorage {
     func list(identifiers: [PackageCollectionsModel.CollectionIdentifier]? = nil) async throws -> [PackageCollectionsModel.Collection] {
         try await safe_async {
             self.list(identifiers: identifiers, callback: $0)
+        }
+    }
+
+    func searchPackages(
+        identifiers: [PackageCollectionsModel.CollectionIdentifier]? = nil,
+        query: String
+    ) async throws -> PackageCollectionsModel.PackageSearchResult {
+        try await safe_async {
+            self.searchPackages(identifiers: identifiers, query: query, callback: $0)
+        }
+    }
+    func findPackage(
+        identifier: PackageIdentity,
+        collectionIdentifiers: [PackageCollectionsModel.CollectionIdentifier]? = nil
+    ) async throws -> (packages: [PackageCollectionsModel.Package], collections: [PackageCollectionsModel.CollectionIdentifier]) {
+        try await safe_async {
+            self.findPackage(identifier: identifier, collectionIdentifiers: collectionIdentifiers, callback: $0)
         }
     }
 

--- a/Sources/PackageCollectionsCommand/PackageCollectionsCommand.swift
+++ b/Sources/PackageCollectionsCommand/PackageCollectionsCommand.swift
@@ -287,7 +287,7 @@ public struct PackageCollectionsCommand: AsyncParsableCommand {
                 let identity = PackageIdentity(urlString: self.packageURL)
 
                 do { // assume URL is for a package in an imported collection
-                    let result = try await collections.getPackageMetadata(identity: identity, location: self.packageURL)
+                    let result = try await collections.getPackageMetadata(identity: identity, location: self.packageURL, collections: nil)
 
                     if let versionString = version {
                         guard let version = TSCUtility.Version(versionString), let result = result.package.versions.first(where: { $0.version == version }), let printedResult = printVersion(result) else {

--- a/Sources/PackageMetadata/PackageMetadata.swift
+++ b/Sources/PackageMetadata/PackageMetadata.swift
@@ -82,12 +82,12 @@ public struct Package {
         versions: [Version],
         licenseURL: URL? = nil,
         readmeURL: URL? = nil,
-        repositoryURLs: [SourceControlURL]?,
-        resources: [Resource],
-        author: Author?,
-        description: String?,
-        publishedAt: Date?,
-        signingEntity: SigningEntity?,
+        repositoryURLs: [SourceControlURL]? = nil,
+        resources: [Resource] = [],
+        author: Author? = nil,
+        description: String? = nil,
+        publishedAt: Date? = nil,
+        signingEntity: SigningEntity? = nil,
         latestVersion: Version? = nil,
         source: Source
     ) {
@@ -168,127 +168,111 @@ public struct PackageSearchClient {
 
     private func getVersionMetadata(
         package: PackageIdentity,
-        version: Version,
-        callback: @escaping (Result<Metadata, Error>) -> Void
-    ) {
-        self.registryClient.getPackageVersionMetadata(
+        version: Version
+    ) async throws -> Metadata {
+        let metadata = try await self.registryClient.getPackageVersionMetadata(
             package: package,
             version: version,
             fileSystem: self.fileSystem,
             observabilityScope: observabilityScope,
-            callbackQueue: DispatchQueue.sharedConcurrent
-        ) { result in
-            callback(result.tryMap { metadata in
-                Metadata(
-                    licenseURL: metadata.licenseURL,
-                    readmeURL: metadata.readmeURL,
-                    repositoryURLs: metadata.repositoryURLs,
-                    resources: metadata.resources.map { .init($0) },
-                    author: metadata.author.map { .init($0) },
-                    description: metadata.description,
-                    publishedAt: metadata.publishedAt,
-                    signingEntity: metadata.sourceArchive?.signingEntity
-                )
-            })
-        }
+            callbackQueue: DispatchQueue.sharedConcurrent)
+
+        return Metadata(
+            licenseURL: metadata.licenseURL,
+            readmeURL: metadata.readmeURL,
+            repositoryURLs: metadata.repositoryURLs,
+            resources: metadata.resources.map { .init($0) },
+            author: metadata.author.map { .init($0) },
+            description: metadata.description,
+            publishedAt: metadata.publishedAt,
+            signingEntity: metadata.sourceArchive?.signingEntity
+        )
     }
 
     public func findPackages(
-        _ query: String,
-        callback: @escaping (Result<[Package], Error>) -> Void
-    ) {
+        _ query: String
+    ) async throws -> [Package] {
         let identity = PackageIdentity.plain(query)
 
         // Search the package index and collections for a search term.
-        let search = { (error: Error?) in
-            self.indexAndCollections.findPackages(query) { result in
-                do {
-                    let packages = try result.get().items.map {
-                        let versions = $0.package.versions.sorted(by: >)
-                        let latestVersion = versions.first
-                        
-                        return Package(
-                            identity: $0.package.identity,
-                            location: $0.package.location,
-                            versions: $0.package.versions.map(\.version),
-                            licenseURL: $0.package.license?.url,
-                            readmeURL: $0.package.readmeURL,
-                            repositoryURLs: nil,
-                            resources: [],
-                            author: latestVersion?.author.map { .init($0) },
-                            description: latestVersion?.summary,
-                            publishedAt: latestVersion?.createdAt,
-                            signingEntity: latestVersion?.signer.map { SigningEntity(signer: $0) },
-                            latestVersion: latestVersion?.version,
-                            // this only makes sense in connection with providing versioned metadata
-                            source: .indexAndCollections(collections: $0.collections, indexes: $0.indexes)
-                        )
-                    }
-                    if packages.isEmpty, let error {
-                        // If the search result is empty and we had a previous error, emit it now.
-                        return callback(.failure(error))
-                    } else {
-                        return callback(.success(packages))
-                    }
-                } catch {
-                    return callback(.failure(error))
-                }
+        let search = { (error: Error?) async throws -> [Package] in
+            let result = try await self.indexAndCollections.findPackages(query)
+            let packages = result.items.map {
+                let versions = $0.package.versions.sorted(by: >)
+                let latestVersion = versions.first
+
+                return Package(
+                    identity: $0.package.identity,
+                    location: $0.package.location,
+                    versions: $0.package.versions.map(\.version),
+                    licenseURL: $0.package.license?.url,
+                    readmeURL: $0.package.readmeURL,
+                    repositoryURLs: nil,
+                    resources: [],
+                    author: latestVersion?.author.map { .init($0) },
+                    description: latestVersion?.summary,
+                    publishedAt: latestVersion?.createdAt,
+                    signingEntity: latestVersion?.signer.map { SigningEntity(signer: $0) },
+                    latestVersion: latestVersion?.version,
+                    // this only makes sense in connection with providing versioned metadata
+                    source: .indexAndCollections(collections: $0.collections, indexes: $0.indexes)
+                )
             }
+            if packages.isEmpty, let error {
+                // If the search result is empty and we had a previous error, emit it now.
+                throw error
+            }
+            return packages
         }
 
         // Interpret the given search term as a URL and fetch the corresponding Git repository to
         // determine the available version tags and branches. If the search term cannot be interpreted
         // as a URL or there are any errors during the process, we fall back to searching the configured
         // index or package collections.
-        let fetchStandalonePackageByURL = { (error: Error?) in
+        let fetchStandalonePackageByURL = { (error: Error?) async throws -> [Package] in
             let url = SourceControlURL(query)
-
             do {
-                try withTemporaryDirectory(removeTreeOnDeinit: true) { (tempDir: AbsolutePath) in
+                return try withTemporaryDirectory(removeTreeOnDeinit: true) { (tempDir: AbsolutePath) in
                     let tempPath = tempDir.appending(component: url.lastPathComponent)
-                    do {
-                        let repositorySpecifier = RepositorySpecifier(url: url)
-                        try self.repositoryProvider.fetch(
-                            repository: repositorySpecifier,
-                            to: tempPath,
-                            progressHandler: nil
-                        )
-                        if try self.repositoryProvider.isValidDirectory(tempPath),
-                           let repository = try self.repositoryProvider.open(
-                               repository: repositorySpecifier,
-                               at: tempPath
-                           ) as? GitRepository
-                        {
-                            let branches = try repository.getBranches()
-                            let versions = try repository.getTags().compactMap { Version($0) }
-                            let package = Package(
-                                identity: .init(url: url),
-                                location: url.absoluteString,
-                                branches: branches,
-                                versions: versions,
-                                licenseURL: nil,
-                                readmeURL: self.guessReadMeURL(
-                                    baseURL: url,
-                                    defaultBranch: try repository.getDefaultBranch()
-                                ),
-                                repositoryURLs: nil,
-                                resources: [],
-                                author: nil,
-                                description: nil,
-                                publishedAt: nil,
-                                signingEntity: nil,
-                                latestVersion: nil,
-                                // this only makes sense in connection with providing versioned metadata
-                                source: .sourceControl(url: url)
-                            )
-                            return callback(.success([package]))
-                        }
-                    } catch {
-                        return search(error)
+                    let repositorySpecifier = RepositorySpecifier(url: url)
+                    try self.repositoryProvider.fetch(
+                        repository: repositorySpecifier,
+                        to: tempPath,
+                        progressHandler: nil
+                    )
+                    guard try self.repositoryProvider.isValidDirectory(tempPath), let repository = try self.repositoryProvider.open(
+                        repository: repositorySpecifier,
+                        at: tempPath
+                    ) as? GitRepository else {
+                        return []
                     }
+
+                    let branches = try repository.getBranches()
+                    let versions = try repository.getTags().compactMap { Version($0) }
+                    let package = Package(
+                        identity: .init(url: url),
+                        location: url.absoluteString,
+                        branches: branches,
+                        versions: versions,
+                        licenseURL: nil,
+                        readmeURL: self.guessReadMeURL(
+                            baseURL: url,
+                            defaultBranch: try repository.getDefaultBranch()
+                        ),
+                        repositoryURLs: nil,
+                        resources: [],
+                        author: nil,
+                        description: nil,
+                        publishedAt: nil,
+                        signingEntity: nil,
+                        latestVersion: nil,
+                        // this only makes sense in connection with providing versioned metadata
+                        source: .sourceControl(url: url)
+                    )
+                    return [package]
                 }
             } catch {
-                return search(error)
+                return try await search(error)
             }
         }
 
@@ -296,87 +280,45 @@ public struct PackageSearchClient {
         // package metadata for it from the configured registry. If there are any errors
         // or the search term does not work as a registry identity, we will fall back on
         // `fetchStandalonePackageByURL`.
-        if identity.isRegistry {
-            return self.registryClient.getPackageMetadata(
-                package: identity,
-                observabilityScope: observabilityScope,
-                callbackQueue: DispatchQueue.sharedConcurrent
-            ) { result in
-                do {
-                    let metadata = try result.get()
-                    let versions = metadata.versions.sorted(by: >)
-
-                    // See if the latest package version has readmeURL set
-                    if let version = versions.first {
-                        self.getVersionMetadata(package: identity, version: version) { result in
-                            let licenseURL: URL?
-                            let readmeURL: URL?
-                            let repositoryURLs: [SourceControlURL]?
-                            let resources: [Package.Resource]
-                            let author: Package.Author?
-                            let description: String?
-                            let publishedAt: Date?
-                            let signingEntity: SigningEntity?
-                            if case .success(let metadata) = result {
-                                licenseURL = metadata.licenseURL
-                                readmeURL = metadata.readmeURL
-                                repositoryURLs = metadata.repositoryURLs
-                                resources = metadata.resources
-                                author = metadata.author
-                                description = metadata.description
-                                publishedAt = metadata.publishedAt
-                                signingEntity = metadata.signingEntity
-                            } else {
-                                licenseURL = nil
-                                readmeURL = self.guessReadMeURL(alternateLocations: metadata.alternateLocations)
-                                repositoryURLs = nil
-                                resources = []
-                                author = nil
-                                description = nil
-                                publishedAt = nil
-                                signingEntity = nil
-                            }
-
-                            return callback(.success([Package(
-                                identity: identity,
-                                versions: metadata.versions,
-                                licenseURL: licenseURL,
-                                readmeURL: readmeURL,
-                                repositoryURLs: repositoryURLs,
-                                resources: resources,
-                                author: author,
-                                description: description,
-                                publishedAt: publishedAt,
-                                signingEntity: signingEntity,
-                                latestVersion: version,
-                                source: .registry(url: metadata.registry.url)
-                            )]))
-                        }
-                    } else {
-                        let readmeURL: URL? = self.guessReadMeURL(alternateLocations: metadata.alternateLocations)
-                        return callback(.success([Package(
-                            identity: identity,
-                            versions: metadata.versions,
-                            licenseURL: nil,
-                            readmeURL: readmeURL,
-                            repositoryURLs: nil,
-                            resources: [],
-                            author: nil,
-                            description: nil,
-                            publishedAt: nil,
-                            signingEntity: nil,
-                            latestVersion: nil,
-                            // this only makes sense in connection with providing versioned metadata
-                            source: .registry(url: metadata.registry.url)
-                        )]))
-                    }
-                } catch {
-                    return fetchStandalonePackageByURL(error)
-                }
-            }
-        } else {
-            return fetchStandalonePackageByURL(nil)
+        guard identity.isRegistry else {
+            return try await fetchStandalonePackageByURL(nil)
         }
+        let metadata: RegistryClient.PackageMetadata
+        do {
+            metadata = try await self.registryClient.getPackageMetadata(package: identity, observabilityScope: observabilityScope, callbackQueue: DispatchQueue.sharedConcurrent)
+        } catch {
+            return try await fetchStandalonePackageByURL(error)
+        }
+
+        let versions = metadata.versions.sorted(by: >)
+
+        // See if the latest package version has readmeURL set
+        guard let version = versions.first else {
+            let readmeURL: URL? = self.guessReadMeURL(alternateLocations: metadata.alternateLocations)
+            return [Package(
+                identity: identity,
+                versions: versions,
+                readmeURL: readmeURL,
+                // this only makes sense in connection with providing versioned metadata
+                source: .registry(url: metadata.registry.url)
+            )]
+        }
+
+        let versionMetadata = try? await self.getVersionMetadata(package: identity, version: version)
+        return [Package(
+            identity: identity,
+            versions: versions,
+            licenseURL: versionMetadata?.licenseURL,
+            readmeURL: versionMetadata?.readmeURL,
+            repositoryURLs: versionMetadata?.repositoryURLs,
+            resources: versionMetadata?.resources ?? [],
+            author: versionMetadata?.author,
+            description: versionMetadata?.description,
+            publishedAt: versionMetadata?.publishedAt,
+            signingEntity: versionMetadata?.signingEntity,
+            latestVersion: version,
+            source: .registry(url: metadata.registry.url)
+        )]
     }
 
     public func lookupIdentities(


### PR DESCRIPTION
Move PackageCollectionsProtocol to async/await

### Motivation:

async/await is easier to read and reason about then the callback APIs

### Modifications:

PackageCollectionsProtocol is now expressed in terms of async methods instead of callbacks 
callback to async bridge methods are removed
Replaced usage of DispatchGroup with async let
PackageMetadata init has default values for optional and array values

### Result:

More readable code