### PR TITLE
Move getPackageMetadata to async/await

### DIFF
--- a/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
@@ -325,6 +325,17 @@ extension LegacyHTTPClient {
         _ url: URL,
         headers: HTTPClientHeaders = .init(),
         options: Request.Options = .init(),
+        observabilityScope: ObservabilityScope? = .none
+    ) async throws -> Response {
+        try await safe_async {
+            self.get(url, headers: headers, options: options, completion: $0)
+        }
+    }
+    @available(*, noasync, message: "Use the async alternative")
+    public func get(
+        _ url: URL,
+        headers: HTTPClientHeaders = .init(),
+        options: Request.Options = .init(),
         observabilityScope: ObservabilityScope? = .none,
         completion: @Sendable @escaping (Result<Response, Error>) -> Void
     ) {

--- a/Sources/Basics/HTTPClient/LegacyHTTPClientRequest.swift
+++ b/Sources/Basics/HTTPClient/LegacyHTTPClientRequest.swift
@@ -78,7 +78,7 @@ public struct LegacyHTTPClientRequest {
         case download(fileSystem: FileSystem, destination: AbsolutePath)
     }
 
-    public struct Options {
+    public struct Options: Sendable {
         public init(
             addUserAgent: Bool = true,
             validResponseCodes: [Int]? = nil,

--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -192,84 +192,28 @@ public protocol PackageIndexProtocol {
     /// - Parameters:
     ///   - identity: The package identity
     ///   - location: The package location (optional for deduplication)
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
-    func getPackageMetadata(
-        identity: PackageIdentity,
-        location: String?,
-        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
-    )
-
-    /// Finds and returns packages that match the query.
-    ///
-    /// - Parameters:
-    ///   - query: The search query
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
-    func findPackages(
-        _ query: String,
-        callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
-    )
-    
-    /// A paginated list of packages in the index.
-    ///
-    /// - Parameters:
-    ///   - offset: Offset of the first item in the result
-    ///   - limit: Number of items to return in the result. Implementations might impose a threshold for this.
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
-    func listPackages(
-        offset: Int,
-        limit: Int,
-        callback: @escaping (Result<PackageCollectionsModel.PaginatedPackageList, Error>) -> Void
-    )
-}
-
-public extension PackageIndexProtocol {
     func getPackageMetadata(
         identity: PackageIdentity,
         location: String?
-    ) async throws -> PackageCollectionsModel.PackageMetadata {
-        try await safe_async {
-            self.getPackageMetadata(
-                identity: identity,
-                location: location,
-                callback: $0
-            )
-        }
-    }
+    ) async throws -> PackageCollectionsModel.PackageMetadata
 
     /// Finds and returns packages that match the query.
     ///
     /// - Parameters:
     ///   - query: The search query
-    ///   - callback: The closure to invoke when result becomes available
     func findPackages(
         _ query: String
-    ) async throws -> PackageCollectionsModel.PackageSearchResult {
-        try await safe_async {
-            self.findPackages(query, callback: $0)
-        }
-    }
+    ) async throws -> PackageCollectionsModel.PackageSearchResult
 
     /// A paginated list of packages in the index.
     ///
     /// - Parameters:
     ///   - offset: Offset of the first item in the result
     ///   - limit: Number of items to return in the result. Implementations might impose a threshold for this.
-    ///   - callback: The closure to invoke when result becomes available
     func listPackages(
         offset: Int,
         limit: Int
-    ) async throws -> PackageCollectionsModel.PaginatedPackageList {
-        try await safe_async {
-            self.listPackages(
-                offset: offset,
-                limit: limit,
-                callback: $0
-            )
-        }
-    }
+    ) async throws -> PackageCollectionsModel.PaginatedPackageList
 }
 
 public enum PackageIndexError: Equatable, Error {

--- a/Sources/PackageCollections/PackageIndexAndCollections.swift
+++ b/Sources/PackageCollections/PackageIndexAndCollections.swift
@@ -149,16 +149,6 @@ public struct PackageIndexAndCollections: Closable {
         try await self.index.listPackages(offset: offset, limit: limit)
     }
 
-    /// - SeeAlso: `PackageIndexProtocol.listPackages`
-    @available(*, noasync, message: "Use the async alternative")
-    public func listPackagesInIndex(
-        offset: Int,
-        limit: Int,
-        callback: @escaping (Result<PackageCollectionsModel.PaginatedPackageList, Error>) -> Void
-    ) {
-        self.index.listPackages(offset: offset, limit: limit, callback: callback)
-    }
-
 
     // MARK: - APIs that make use of both package index and collections
 
@@ -323,13 +313,12 @@ struct PackageIndexMetadataProvider: PackageMetadataProvider, Closable {
 
     func get(
         identity: PackageIdentity,
-        location: String,
-        callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) -> Void
-    ) {
+        location: String
+    ) async -> (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) {
         if self.index.isEnabled {
-            self.index.get(identity: identity, location: location, callback: callback)
+            return await self.index.get(identity: identity, location: location)
         } else {
-            self.alternative.get(identity: identity, location: location, callback: callback)
+            return await self.alternative.get(identity: identity, location: location)
         }
     }
     

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -19,17 +19,25 @@ import struct TSCUtility.Version
 
 /// `PackageBasicMetadata` provider
 protocol PackageMetadataProvider {
+
+    // TODO: Review if this API is correct
+    // This API is awkward because it unconditionally provides a context
+    // Does it make sense to have a context if you don't have metadata?
+    // The only use of provider on failure is PackageCollections.getPackageMetadata
+    // It would be nice to change the API to
+    // async throw -> (PackageCollectionsModel.PackageBasicMetadata, PackageMetadataProviderContext?)
+    // or even
+    // async throw -> (PackageCollectionsModel.PackageBasicMetadata, PackageMetadataProviderContext)
+
     /// Retrieves metadata for a package with the given identity and repository address.
     ///
     /// - Parameters:
     ///   - identity: The package's identity
     ///   - location: The package's location
-    ///   - callback: The closure to invoke when result becomes available
     func get(
         identity: PackageIdentity,
-        location: String,
-        callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) -> Void
-    )
+        location: String
+    ) async -> (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?)
 }
 
 extension Model {

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -367,8 +367,6 @@ internal extension GitHubPackageMetadataProvider {
 
 private extension GitHubPackageMetadataProvider {
     func syncGet(identity: PackageIdentity, location: String) async throws -> Model.PackageBasicMetadata {
-        try await safe_async { callback in
-            self.get(identity: identity, location: location) { result, _ in callback(result) }
-        }
+        try await self.get(identity: identity, location: location).0.get()
     }
 }

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -1413,11 +1413,10 @@ final class PackageCollectionsTests: XCTestCase {
             var name: String = "BrokenMetadataProvider"
 
             func get(
-                identity: PackageIdentity,
-                location: String,
-                callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) -> Void
-            ) {
-                callback(.failure(TerribleThing()), nil)
+                identity: PackageModel.PackageIdentity,
+                location: String
+            ) async -> (Result<PackageCollectionsModel.PackageBasicMetadata, any Error>, PackageMetadataProviderContext?) {
+                return (.failure(TerribleThing()), nil)
             }
 
             struct TerribleThing: Error {}

--- a/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
@@ -700,41 +700,38 @@ private struct MockPackageIndex: PackageIndexProtocol {
         self.url = url
         self.packages = packages
     }
-    
+
     func getPackageMetadata(
         identity: PackageIdentity,
-        location: String?,
-        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
-    ) {
+        location: String?
+    ) async throws -> PackageCollectionsModel.PackageMetadata {
         guard let package = self.packages.first(where: { $0.identity == identity }) else {
-            return callback(.failure(NotFoundError("Package \(identity) not found")))
+            throw NotFoundError("Package \(identity) not found")
         }
-        callback(.success((package: package, collections: [], provider: .init(name: "package index", authTokenType: nil, isAuthTokenConfigured: true))))
+        return (package: package, collections: [], provider: .init(name: "package index", authTokenType: nil, isAuthTokenConfigured: true))
     }
 
     func findPackages(
-        _ query: String,
-        callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
-    ) {
+        _ query: String
+    ) async throws  -> PackageCollectionsModel.PackageSearchResult{
         let items = self.packages.filter { $0.identity.description.contains(query) }
-        callback(.success(.init(items: items.map { .init(package: $0, collections: [], indexes: [self.url]) })))
+        return PackageCollectionsModel.PackageSearchResult(items: items.map { .init(package: $0, collections: [], indexes: [self.url]) })
     }
     
     func listPackages(
         offset: Int,
-        limit: Int,
-        callback: @escaping (Result<PackageCollectionsModel.PaginatedPackageList, Error>) -> Void
-    ) {
+        limit: Int
+    ) async throws -> PackageCollectionsModel.PaginatedPackageList {
         guard !self.packages.isEmpty, offset < self.packages.count, limit > 0 else {
-            return callback(.success(.init(items: [], offset: offset, limit: limit, total: self.packages.count)))
+            return PackageCollectionsModel.PaginatedPackageList(items: [], offset: offset, limit: limit, total: self.packages.count)
         }
 
-        callback(.success(.init(
+        return PackageCollectionsModel.PaginatedPackageList(
             items: Array(self.packages[offset..<min(self.packages.count, offset + limit)]),
             offset: offset,
             limit: limit,
             total: self.packages.count
-        )))
+        )
     }
 }
 
@@ -743,25 +740,22 @@ private struct BrokenPackageIndex: PackageIndexProtocol {
     
     func getPackageMetadata(
         identity: PackageIdentity,
-        location: String?,
-        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
-    ) {
-        callback(.failure(TerribleThing()))
+        location: String?
+    ) async throws -> PackageCollectionsModel.PackageMetadata {
+        throw TerribleThing()
     }
 
     func findPackages(
-        _ query: String,
-        callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
-    ) {
-        callback(.failure(TerribleThing()))
+        _ query: String
+    ) async throws -> PackageCollectionsModel.PackageSearchResult {
+        throw TerribleThing()
     }
     
     func listPackages(
         offset: Int,
-        limit: Int,
-        callback: @escaping (Result<PackageCollectionsModel.PaginatedPackageList, Error>) -> Void
-    ) {
-        callback(.failure(TerribleThing()))
+        limit: Int
+    ) async throws -> PackageCollectionsModel.PaginatedPackageList {
+        throw TerribleThing()
     }
     
     struct TerribleThing: Error {}

--- a/Tests/PackageCollectionsTests/PackageIndexTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexTests.swift
@@ -302,8 +302,6 @@ class PackageIndexTests: XCTestCase {
 
 private extension PackageIndex {
     func syncGet(identity: PackageIdentity, location: String) async throws -> Model.PackageBasicMetadata {
-        try await safe_async { callback in
-            self.get(identity: identity, location: location) { result, _ in callback(result) }
-        }
+        try await self.get(identity: identity, location: location).0.get()
     }
 }

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -181,14 +181,12 @@ struct MockMetadataProvider: PackageMetadataProvider {
 
     func get(
         identity: PackageIdentity,
-        location: String,
-        callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) -> Void
-    ) {
-        if let package = self.packages[identity] {
-            callback(.success(package), nil)
-        } else {
-            callback(.failure(NotFoundError("\(identity)")), nil)
+        location: String
+    ) async -> (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) {
+        guard let packageMetadata = self.packages[identity] else {
+            return (.failure(NotFoundError("\(identity)")), nil)
         }
+        return (.success(packageMetadata), nil)
     }
 }
 


### PR DESCRIPTION
Move more of the PackageCollection APIs to native async/await

### Motivation:

More modern code that will be able to adopt swift 6 data race safety eventually

### Modifications:

PackageMetadataProvider APIs are all now async/await
PackageIndexProtocol APIs are all now async/await
Added question about the need for returning PackageMetadataProviderContext when PackageBasicMetadata can not be read

### Result:

More readable code