### PR TITLE
Fix a bunch of concurrency related warnings

### DIFF
--- a/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
@@ -48,7 +48,7 @@ public final class LegacyHTTPClient: Cancellable {
     private var outstandingRequests = ThreadSafeKeyValueStore<UUID, OutstandingRequest>()
 
     // static to share across instances of the http client
-    private static var hostsErrorsLock = NSLock()
+    private static let hostsErrorsLock = NSLock()
     private static var hostsErrors = [String: [Date]]()
 
     public init(configuration: LegacyHTTPClientConfiguration = .init(), handler: Handler? = nil) {

--- a/Sources/Basics/Vendor/Triple+Platforms.swift
+++ b/Sources/Basics/Vendor/Triple+Platforms.swift
@@ -350,9 +350,9 @@ extension Triple {
   /// `tripleVersion >= featureVersion`.
   ///
   /// - SeeAlso: `Triple.supports(_:)`
-  public struct FeatureAvailability {
-    
-    public enum Availability {
+public struct FeatureAvailability: Sendable {
+
+    public enum Availability: Sendable {
       case unavailable
       case available(since: Version)
       case availableInAllVersions

--- a/Sources/Basics/Vendor/Triple.swift
+++ b/Sources/Basics/Vendor/Triple.swift
@@ -43,7 +43,7 @@
 ///
 /// This is a port of https://github.com/apple/swift-llvm/blob/stable/include/llvm/ADT/Triple.h
 @dynamicMemberLookup
-public struct Triple {
+public struct Triple: Sendable {
   /// `Triple` proxies predicates from `Triple.OS`, returning `false` for an unknown OS.
   public subscript(dynamicMember predicate: KeyPath<OS, Bool>) -> Bool {
     os?[keyPath: predicate] ?? false
@@ -71,7 +71,7 @@ public struct Triple {
   public let objectFormat: ObjectFormat?
 
   /// Represents a version that may be present in the target triple.
-  public struct Version: Equatable, Comparable, CustomStringConvertible {
+    public struct Version: Equatable, Comparable, CustomStringConvertible, Sendable {
     public static let zero = Version(0, 0, 0)
 
     public var major: Int
@@ -426,7 +426,7 @@ extension Triple {
     }
   }
 
-  public enum Arch: String, CaseIterable, Decodable {
+public enum Arch: String, CaseIterable, Decodable, Sendable {
     /// ARM (little endian): arm, armv.*, xscale
     case arm
     // ARM (big endian): armeb
@@ -844,9 +844,9 @@ extension Triple {
 // MARK: - Parse SubArch
 
 extension Triple {
-  public enum SubArch: Hashable {
+    public enum SubArch: Hashable, Sendable {
 
-    public enum ARM {
+    public enum ARM: Sendable {
 
       public enum Profile {
         case a, r, m
@@ -916,13 +916,13 @@ extension Triple {
       }
     }
 
-    public enum Kalimba {
+    public enum Kalimba: Sendable {
       case v3
       case v4
       case v5
     }
 
-    public enum MIPS {
+    public enum MIPS: Sendable {
       case r6
     }
 
@@ -1022,7 +1022,7 @@ extension Triple {
 // MARK: - Parse Vendor
 
 extension Triple {
-  public enum Vendor: String, CaseIterable, TripleComponent {
+    public enum Vendor: String, CaseIterable, TripleComponent, Sendable {
     case apple
     case pc
     case scei
@@ -1084,7 +1084,7 @@ extension Triple {
 // MARK: - Parse OS
 
 extension Triple {
-  public enum OS: String, CaseIterable, TripleComponent {
+  public enum OS: String, CaseIterable, TripleComponent, Sendable {
     case ananas
     case cloudABI = "cloudabi"
     case darwin
@@ -1258,7 +1258,7 @@ extension Triple {
     }
   }
 
-  public enum Environment: String, CaseIterable, Equatable {
+  public enum Environment: String, CaseIterable, Equatable, Sendable {
     case eabihf
     case eabi
     case elfv1
@@ -1354,7 +1354,7 @@ extension Triple {
 // MARK: - Parse Object Format
 
 extension Triple {
-  public enum ObjectFormat {
+  public enum ObjectFormat: Sendable {
     case coff
     case elf
     case macho


### PR DESCRIPTION
Fixed Sendable warnings

### Motivation:

Get SPM ready to adopt swift 6 mode

### Modifications:

Added Sendable annotations to several clearly Sendable/safe types

### Result:

Fewer warnings that will be errors in Swift 6
