### PR TITLE
Update link to Swift system requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For release notes with information about changes between versions, see the [rele
 
 ## System Requirements
 
-The package manager’s system requirements are the same as [those for Swift](https://github.com/apple/swift#system-requirements) with the caveat that the package manager requires Git at runtime as well as build-time.
+The package manager’s system requirements are the same as [those for Swift](https://github.com/swiftlang/swift/blob/main/docs/HowToGuides/GettingStarted.md#system-requirements) with the caveat that the package manager requires Git at runtime as well as build-time.
 
 ---
 


### PR DESCRIPTION
As the title says.

### Motivation:

Due to the original documentation link becoming invalid, there is a need to update it to ensure users have access to the most current and accurate system requirements.

### Modifications:

Replaced the link as follows:

- Old: https://github.com/apple/swift#system-requirements
- New: https://github.com/swiftlang/swift/blob/main/docs/HowToGuides/GettingStarted.md#system-requirements

### Result:

The link correction ensures access to accurate system requirements.
