### PR TITLE
Handle the "abnormal-exit" status kind from the Swift compiler's parseable output

### DIFF
--- a/Sources/Build/LLBuildProgressTracker.swift
+++ b/Sources/Build/LLBuildProgressTracker.swift
@@ -545,7 +545,7 @@ private struct CommandTaskTracker {
             }
 
             self.finishedCount += 1
-        case .unparsableOutput, .signalled, .skipped:
+        case .unparsableOutput, .abnormal, .signalled, .skipped:
             break
         }
     }
@@ -610,7 +610,7 @@ extension SwiftCompilerMessage {
         switch kind {
         case .began(let info):
             ([info.commandExecutable] + info.commandArguments).joined(separator: " ")
-        case .skipped, .finished, .signalled, .unparsableOutput:
+        case .skipped, .finished, .abnormal, .signalled, .unparsableOutput:
             nil
         }
     }
@@ -618,6 +618,7 @@ extension SwiftCompilerMessage {
     fileprivate var standardOutput: String? {
         switch kind {
         case .finished(let info),
+             .abnormal(let info),
              .signalled(let info):
             info.output
         case .unparsableOutput(let output):

--- a/Sources/Build/SwiftCompilerOutputParser.swift
+++ b/Sources/Build/SwiftCompilerOutputParser.swift
@@ -73,6 +73,7 @@ public struct SwiftCompilerMessage {
         case began(BeganInfo)
         case skipped(SkippedInfo)
         case finished(OutputInfo)
+        case abnormal(OutputInfo)
         case signalled(OutputInfo)
         case unparsableOutput(String)
     }
@@ -201,6 +202,8 @@ extension SwiftCompilerMessage.Kind: Decodable, Equatable {
             self = try .skipped(SkippedInfo(from: decoder))
         case "finished":
             self = try .finished(OutputInfo(from: decoder))
+        case "abnormal-exit":
+            self = try .abnormal(OutputInfo(from: decoder))
         case "signalled":
             self = try .signalled(OutputInfo(from: decoder))
         default:


### PR DESCRIPTION
This is used on Windows.