### PR TITLE
chore: remove unused Tests (PackageLoadingPerformanceTests)

### DIFF
--- a/xcode/SwiftPM-Package.xctestplan
+++ b/xcode/SwiftPM-Package.xctestplan
@@ -116,14 +116,6 @@
       "parallelizable" : true,
       "target" : {
         "containerPath" : "container:",
-        "identifier" : "PackageLoadingPerformanceTests",
-        "name" : "PackageLoadingPerformanceTests"
-      }
-    },
-    {
-      "parallelizable" : true,
-      "target" : {
-        "containerPath" : "container:",
         "identifier" : "PackageLoadingTests",
         "name" : "PackageLoadingTests"
       }


### PR DESCRIPTION
As title said.

### Motivation:
If you look at SwiftPM-Package.xctestplan in Xcode, you can see PackageLoadingPerformanveTests is no longer needed. 

![image](https://github.com/swiftlang/swift-package-manager/assets/39183069/488f07ec-d0f3-4d92-a38b-1dccc318cb6a)

### Modifications:
So I removed it from xctestplan.

### Result:
Nothing
