### PR TITLE
Async file package collections sources storage

### DIFF
--- a/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
@@ -325,6 +325,17 @@ extension LegacyHTTPClient {
         _ url: URL,
         headers: HTTPClientHeaders = .init(),
         options: Request.Options = .init(),
+        observabilityScope: ObservabilityScope? = .none
+    ) async throws -> Response {
+        try await safe_async {
+            self.get(url, headers: headers, options: options, completion: $0)
+        }
+    }
+    @available(*, noasync, message: "Use the async alternative")
+    public func get(
+        _ url: URL,
+        headers: HTTPClientHeaders = .init(),
+        options: Request.Options = .init(),
         observabilityScope: ObservabilityScope? = .none,
         completion: @Sendable @escaping (Result<Response, Error>) -> Void
     ) {

--- a/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
@@ -311,6 +311,17 @@ extension LegacyHTTPClient {
         _ url: URL,
         headers: HTTPClientHeaders = .init(),
         options: Request.Options = .init(),
+        observabilityScope: ObservabilityScope? = .none
+    ) async throws -> Response {
+        try await safe_async {
+            self.head(url, headers: headers, options: options, completion: $0)
+        }
+    }
+    @available(*, noasync, message: "Use the async alternative")
+    public func head(
+        _ url: URL,
+        headers: HTTPClientHeaders = .init(),
+        options: Request.Options = .init(),
         observabilityScope: ObservabilityScope? = .none,
         completion: @Sendable @escaping (Result<Response, Error>) -> Void
     ) {

--- a/Sources/Basics/HTTPClient/LegacyHTTPClientRequest.swift
+++ b/Sources/Basics/HTTPClient/LegacyHTTPClientRequest.swift
@@ -78,7 +78,7 @@ public struct LegacyHTTPClientRequest {
         case download(fileSystem: FileSystem, destination: AbsolutePath)
     }
 
-    public struct Options {
+    public struct Options: Sendable {
         public init(
             addUserAgent: Bool = true,
             validResponseCodes: [Int]? = nil,

--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -192,84 +192,28 @@ public protocol PackageIndexProtocol {
     /// - Parameters:
     ///   - identity: The package identity
     ///   - location: The package location (optional for deduplication)
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
-    func getPackageMetadata(
-        identity: PackageIdentity,
-        location: String?,
-        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
-    )
-
-    /// Finds and returns packages that match the query.
-    ///
-    /// - Parameters:
-    ///   - query: The search query
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
-    func findPackages(
-        _ query: String,
-        callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
-    )
-    
-    /// A paginated list of packages in the index.
-    ///
-    /// - Parameters:
-    ///   - offset: Offset of the first item in the result
-    ///   - limit: Number of items to return in the result. Implementations might impose a threshold for this.
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
-    func listPackages(
-        offset: Int,
-        limit: Int,
-        callback: @escaping (Result<PackageCollectionsModel.PaginatedPackageList, Error>) -> Void
-    )
-}
-
-public extension PackageIndexProtocol {
     func getPackageMetadata(
         identity: PackageIdentity,
         location: String?
-    ) async throws -> PackageCollectionsModel.PackageMetadata {
-        try await safe_async {
-            self.getPackageMetadata(
-                identity: identity,
-                location: location,
-                callback: $0
-            )
-        }
-    }
+    ) async throws -> PackageCollectionsModel.PackageMetadata
 
     /// Finds and returns packages that match the query.
     ///
     /// - Parameters:
     ///   - query: The search query
-    ///   - callback: The closure to invoke when result becomes available
     func findPackages(
         _ query: String
-    ) async throws -> PackageCollectionsModel.PackageSearchResult {
-        try await safe_async {
-            self.findPackages(query, callback: $0)
-        }
-    }
+    ) async throws -> PackageCollectionsModel.PackageSearchResult
 
     /// A paginated list of packages in the index.
     ///
     /// - Parameters:
     ///   - offset: Offset of the first item in the result
     ///   - limit: Number of items to return in the result. Implementations might impose a threshold for this.
-    ///   - callback: The closure to invoke when result becomes available
     func listPackages(
         offset: Int,
         limit: Int
-    ) async throws -> PackageCollectionsModel.PaginatedPackageList {
-        try await safe_async {
-            self.listPackages(
-                offset: offset,
-                limit: limit,
-                callback: $0
-            )
-        }
-    }
+    ) async throws -> PackageCollectionsModel.PaginatedPackageList
 }
 
 public enum PackageIndexError: Equatable, Error {

--- a/Sources/PackageCollections/PackageIndexAndCollections.swift
+++ b/Sources/PackageCollections/PackageIndexAndCollections.swift
@@ -149,16 +149,6 @@ public struct PackageIndexAndCollections: Closable {
         try await self.index.listPackages(offset: offset, limit: limit)
     }
 
-    /// - SeeAlso: `PackageIndexProtocol.listPackages`
-    @available(*, noasync, message: "Use the async alternative")
-    public func listPackagesInIndex(
-        offset: Int,
-        limit: Int,
-        callback: @escaping (Result<PackageCollectionsModel.PaginatedPackageList, Error>) -> Void
-    ) {
-        self.index.listPackages(offset: offset, limit: limit, callback: callback)
-    }
-
 
     // MARK: - APIs that make use of both package index and collections
 
@@ -323,13 +313,12 @@ struct PackageIndexMetadataProvider: PackageMetadataProvider, Closable {
 
     func get(
         identity: PackageIdentity,
-        location: String,
-        callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) -> Void
-    ) {
+        location: String
+    ) async -> (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) {
         if self.index.isEnabled {
-            self.index.get(identity: identity, location: location, callback: callback)
+            return await self.index.get(identity: identity, location: location)
         } else {
-            self.alternative.get(identity: identity, location: location, callback: callback)
+            return await self.alternative.get(identity: identity, location: location)
         }
     }
     

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -72,201 +72,165 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         self.decoder = JSONDecoder.makeWithDefaults()
     }
 
-    func get(_ source: Model.CollectionSource, callback: @escaping (Result<Model.Collection, Error>) -> Void) {
+    func get(_ source: Model.CollectionSource) async throws -> Model.Collection {
         guard case .json = source.type else {
-            return callback(
-                .failure(
-                    InternalError(
-                        "JSONPackageCollectionProvider can only be used for fetching 'json' package collections"
-                    )
-                )
+            throw InternalError(
+                "JSONPackageCollectionProvider can only be used for fetching 'json' package collections"
             )
         }
 
         if let errors = source.validate(fileSystem: fileSystem)?.errors() {
-            return callback(.failure(JSONPackageCollectionProviderError.invalidSource("\(errors)")))
+            throw JSONPackageCollectionProviderError.invalidSource("\(errors)")
         }
 
         // Source is a local file
         if let absolutePath = source.absolutePath {
-            do {
-                let data: Data = try self.fileSystem.readFileContents(absolutePath)
-                return self.decodeAndRunSignatureCheck(
-                    source: source,
-                    data: data,
-                    certPolicyKeys: Self.defaultCertPolicyKeys,
-                    callback: callback
-                )
-            } catch {
-                return callback(.failure(error))
-            }
+            let data: Data = try self.fileSystem.readFileContents(absolutePath)
+            return try await self.decodeAndRunSignatureCheck(
+                source: source,
+                data: data,
+                certPolicyKeys: Self.defaultCertPolicyKeys
+            )
         }
 
         // first do a head request to check content size compared to the maximumSizeInBytes constraint
         let headOptions = self.makeRequestOptions(validResponseCodes: [200])
         let headers = self.makeRequestHeaders()
-        self.httpClient.head(source.url, headers: headers, options: headOptions) { result in
-            switch result {
-            case .failure(HTTPClientError.badResponseStatusCode(let statusCode)):
-                if statusCode == 404 {
-                    return callback(.failure(JSONPackageCollectionProviderError.collectionNotFound(source.url)))
-                } else {
-                    return callback(.failure(
-                        JSONPackageCollectionProviderError
-                            .collectionUnavailable(source.url, statusCode)
-                    ))
-                }
-            case .failure(let error):
-                return callback(.failure(error))
-            case .success(let response):
-                guard let contentLength = response.headers.get("Content-Length").first.flatMap(Int64.init) else {
-                    return callback(.failure(
-                        JSONPackageCollectionProviderError
-                            .invalidResponse(source.url, "Missing Content-Length header")
-                    ))
-                }
-                guard contentLength <= self.configuration.maximumSizeInBytes else {
-                    return callback(.failure(
-                        JSONPackageCollectionProviderError
-                            .responseTooLarge(source.url, contentLength)
-                    ))
-                }
-                // next do a get request to get the actual content
-                var getOptions = self.makeRequestOptions(validResponseCodes: [200])
-                getOptions.maximumResponseSizeInBytes = self.configuration.maximumSizeInBytes
-                self.httpClient.get(source.url, headers: headers, options: getOptions) { result in
-                    switch result {
-                    case .failure(HTTPClientError.badResponseStatusCode(let statusCode)):
-                        if statusCode == 404 {
-                            return callback(.failure(JSONPackageCollectionProviderError.collectionNotFound(source.url)))
-                        } else {
-                            return callback(.failure(
-                                JSONPackageCollectionProviderError
-                                    .collectionUnavailable(source.url, statusCode)
-                            ))
-                        }
-                    case .failure(let error):
-                        return callback(.failure(error))
-                    case .success(let response):
-                        // check content length again so we can record this as a bad actor
-                        // if not returning head and exceeding size
-                        // TODO: store bad actors to prevent server DoS
-                        guard let contentLength = response.headers.get("Content-Length").first.flatMap(Int64.init)
-                        else {
-                            return callback(.failure(
-                                JSONPackageCollectionProviderError
-                                    .invalidResponse(source.url, "Missing Content-Length header")
-                            ))
-                        }
-                        guard contentLength < self.configuration.maximumSizeInBytes else {
-                            return callback(.failure(
-                                JSONPackageCollectionProviderError
-                                    .responseTooLarge(source.url, contentLength)
-                            ))
-                        }
-                        guard let body = response.body else {
-                            return callback(.failure(
-                                JSONPackageCollectionProviderError
-                                    .invalidResponse(source.url, "Body is empty")
-                            ))
-                        }
-
-                        let certPolicyKeys = self.sourceCertPolicy.certificatePolicyKeys(for: source) ?? Self
-                            .defaultCertPolicyKeys
-                        self.decodeAndRunSignatureCheck(
-                            source: source,
-                            data: body,
-                            certPolicyKeys: certPolicyKeys,
-                            callback: callback
-                        )
-                    }
-                }
+        let response: LegacyHTTPClient.Response
+        do {
+            response = try await self.httpClient.head(source.url, headers: headers, options: headOptions)
+        } catch HTTPClientError.badResponseStatusCode(let statusCode) {
+            if statusCode == 404 {
+                throw JSONPackageCollectionProviderError
+                    .collectionNotFound(source.url)
             }
+            throw JSONPackageCollectionProviderError
+                .collectionUnavailable(source.url, statusCode)
         }
+        guard let contentLength = response.headers.get("Content-Length").first.flatMap(Int64.init) else {
+            throw JSONPackageCollectionProviderError
+                .invalidResponse(source.url, "Missing Content-Length header")
+        }
+        guard contentLength <= self.configuration.maximumSizeInBytes else {
+            throw JSONPackageCollectionProviderError
+                .responseTooLarge(source.url, contentLength)
+        }
+        // next do a get request to get the actual content
+        var getOptions = self.makeRequestOptions(validResponseCodes: [200])
+        getOptions.maximumResponseSizeInBytes = self.configuration.maximumSizeInBytes
+
+        let getResponse: LegacyHTTPClient.Response
+        do {
+            getResponse = try await self.httpClient.get(source.url, headers: headers, options: getOptions)
+        } catch HTTPClientError.badResponseStatusCode(let statusCode) {
+            if statusCode == 404 {
+                throw JSONPackageCollectionProviderError
+                    .collectionNotFound(source.url)
+            }
+            throw JSONPackageCollectionProviderError
+                .collectionUnavailable(source.url, statusCode)
+        }
+
+        // check content length again so we can record this as a bad actor
+        // if not returning head and exceeding size
+        // TODO: store bad actors to prevent server DoS
+        guard let contentLength = getResponse.headers.get("Content-Length").first.flatMap(Int64.init)
+        else {
+            throw JSONPackageCollectionProviderError
+                .invalidResponse(source.url, "Missing Content-Length header")
+        }
+        guard contentLength < self.configuration.maximumSizeInBytes else {
+            throw JSONPackageCollectionProviderError
+                .responseTooLarge(source.url, contentLength)
+        }
+        guard let body = getResponse.body else {
+            throw JSONPackageCollectionProviderError
+                .invalidResponse(source.url, "Body is empty")
+        }
+
+        let certPolicyKeys = self.sourceCertPolicy.certificatePolicyKeys(for: source) ?? Self
+            .defaultCertPolicyKeys
+        return try await self.decodeAndRunSignatureCheck(
+            source: source,
+            data: body,
+            certPolicyKeys: certPolicyKeys
+        )
     }
 
     private func decodeAndRunSignatureCheck(
         source: Model.CollectionSource,
         data: Data,
-        certPolicyKeys: [CertificatePolicyKey],
-        callback: @escaping (Result<Model.Collection, Error>) -> Void
-    ) {
+        certPolicyKeys: [CertificatePolicyKey]
+    ) async throws -> Model.Collection {
+        let signedCollection: JSONModel.SignedCollection
         do {
             // This fails if collection is not signed (i.e., no "signature")
-            let signedCollection = try self.decoder.decode(JSONModel.SignedCollection.self, from: data)
-
-            if source.skipSignatureCheck {
-                // Don't validate signature; set isVerified=false
-                callback(self.makeCollection(
-                    from: signedCollection.collection,
-                    source: source,
-                    signature: Model.SignatureData(from: signedCollection.signature, isVerified: false)
-                ))
-            } else if !Self.isSignatureCheckSupported {
-                callback(.failure(StringError("Unsupported platform")))
-            } else {
-                // Check the signature
-                Task {
-                    let signatureResults = await withTaskGroup(of: Result<Void, Error>.self) { group in
-                        for certPolicyKey in certPolicyKeys {
-                            group.addTask {
-                                do {
-                                    try await self.signatureValidator.validate(
-                                        signedCollection: signedCollection,
-                                        certPolicyKey: certPolicyKey
-                                    )
-                                    return .success(())
-                                } catch {
-                                    return .failure(error)
-                                }
-                            }
-                        }
-                        return await group.reduce(into: []) { partialResult, validateResult in
-                            partialResult.append(validateResult)
-                        }
-                    }
-                    
-                    if signatureResults.compactMap(\.success).first != nil {
-                        callback(self.makeCollection(
-                            from: signedCollection.collection,
-                            source: source,
-                            signature: Model.SignatureData(from: signedCollection.signature, isVerified: true)
-                        ))
-                    } else {
-                        guard let error = signatureResults.compactMap(\.failure).first else {
-                            return callback(
-                                .failure(
-                                    InternalError(
-                                        "Expected at least one package collection signature validation failure but got none"
-                                    )
-                                )
-                            )
-                        }
-
-                        self.observabilityScope.emit(
-                            warning: "The signature of package collection [\(source)] is invalid",
-                            underlyingError: error
-                        )
-                        if PackageCollectionSigningError
-                            .noTrustedRootCertsConfigured == error as? PackageCollectionSigningError
-                        {
-                            callback(.failure(PackageCollectionError.cannotVerifySignature))
-                        } else {
-                            callback(.failure(PackageCollectionError.invalidSignature))
-                        }
-                    }
-                }
-            }
+            signedCollection = try self.decoder.decode(JSONModel.SignedCollection.self, from: data)
         } catch {
             // Bad: collection is supposed to be signed but it isn't
             guard !self.sourceCertPolicy.mustBeSigned(source: source) else {
-                return callback(.failure(PackageCollectionError.missingSignature))
+                throw PackageCollectionError.missingSignature
             }
             // Collection is unsigned
             guard let collection = try? self.decoder.decode(JSONModel.Collection.self, from: data) else {
-                return callback(.failure(JSONPackageCollectionProviderError.invalidJSON(source.url)))
+                throw JSONPackageCollectionProviderError.invalidJSON(source.url)
             }
-            callback(self.makeCollection(from: collection, source: source, signature: nil))
+            return try self.makeCollection(from: collection, source: source, signature: nil)
+        }
+        if source.skipSignatureCheck {
+            // Don't validate signature; set isVerified=false
+            return try self.makeCollection(
+                from: signedCollection.collection,
+                source: source,
+                signature: Model.SignatureData(from: signedCollection.signature, isVerified: false)
+            )
+        } else if !Self.isSignatureCheckSupported {
+            throw StringError("Unsupported platform")
+        }
+        // Check the signature
+        do {
+            return try await withThrowingTaskGroup(of: Void.self) { group in
+                for certPolicyKey in certPolicyKeys {
+                    group.addTask {
+                        try await self.signatureValidator.validate(
+                            signedCollection: signedCollection,
+                            certPolicyKey: certPolicyKey
+                        )
+                    }
+                }
+
+                // if there is one valid key return the validated collection
+                // otherwise throw the error for the last key
+                var results = 0
+                while results < certPolicyKeys.count {
+                    results += 1
+                    do {
+                        try await group.next()
+                        break
+                    } catch {
+                        if results == certPolicyKeys.count {
+                            throw error
+                        }
+                    }
+                }
+                return try self.makeCollection(
+                    from: signedCollection.collection,
+                    source: source,
+                    signature: Model.SignatureData(from: signedCollection.signature, isVerified: true)
+                )
+            }
+        } catch {
+            self.observabilityScope.emit(
+                warning: "The signature of package collection [\(source)] is invalid",
+                underlyingError: error
+            )
+            if PackageCollectionSigningError
+                .noTrustedRootCertsConfigured == error as? PackageCollectionSigningError
+            {
+                throw PackageCollectionError.cannotVerifySignature
+            } else {
+                throw PackageCollectionError.invalidSignature
+            }
         }
     }
 
@@ -274,137 +238,133 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         from collection: JSONModel.Collection,
         source: Model.CollectionSource,
         signature: Model.SignatureData?
-    ) -> Result<Model.Collection, Error> {
-        do {
-            if let errors = self.validator.validate(collection: collection)?.errors() {
-                throw JSONPackageCollectionProviderError
-                    .invalidCollection("\(errors.map(\.message).joined(separator: " "))")
-            }
+    ) throws -> Model.Collection {
+        if let errors = self.validator.validate(collection: collection)?.errors() {
+            throw JSONPackageCollectionProviderError
+                .invalidCollection("\(errors.map(\.message).joined(separator: " "))")
+        }
 
-            var serializationOkay = true
-            let packages = try collection.packages.map { package -> Model.Package in
-                let versions = try package.versions.compactMap { version -> Model.Package.Version? in
-                    // note this filters out / ignores missing / bad data in attempt to make the most out of the
-                    // provided set
-                    guard let parsedVersion = TSCUtility.Version(tag: version.version) else {
-                        return nil
-                    }
-
-                    let manifests: [ToolsVersion: Model.Package.Version.Manifest] =
-                        try Dictionary(throwingUniqueKeysWithValues: version.manifests.compactMap { key, value in
-                            guard let keyToolsVersion = ToolsVersion(string: key),
-                                  let manifestToolsVersion = ToolsVersion(string: value.toolsVersion)
-                            else {
-                                return nil
-                            }
-
-                            let targets = value.targets.map { Model.Target(name: $0.name, moduleName: $0.moduleName) }
-                            if targets.count != value.targets.count {
-                                serializationOkay = false
-                            }
-                            let products = value.products
-                                .compactMap { Model.Product(from: $0, packageTargets: targets) }
-                            if products.count != value.products.count {
-                                serializationOkay = false
-                            }
-                            let minimumPlatformVersions: [PackageModel.SupportedPlatform]? = value
-                                .minimumPlatformVersions?
-                                .compactMap { PackageModel.SupportedPlatform(from: $0) }
-                            if minimumPlatformVersions?.count != value.minimumPlatformVersions?.count {
-                                serializationOkay = false
-                            }
-
-                            let manifest = Model.Package.Version.Manifest(
-                                toolsVersion: manifestToolsVersion,
-                                packageName: value.packageName,
-                                targets: targets,
-                                products: products,
-                                minimumPlatformVersions: minimumPlatformVersions
-                            )
-                            return (keyToolsVersion, manifest)
-                        })
-                    if manifests.count != version.manifests.count {
-                        serializationOkay = false
-                    }
-
-                    guard let defaultToolsVersion = ToolsVersion(string: version.defaultToolsVersion) else {
-                        return nil
-                    }
-
-                    let verifiedCompatibility = version.verifiedCompatibility?
-                        .compactMap { Model.Compatibility(from: $0) }
-                    if verifiedCompatibility?.count != version.verifiedCompatibility?.count {
-                        serializationOkay = false
-                    }
-                    let license = version.license.flatMap { Model.License(from: $0) }
-
-                    let signer: Model.Signer?
-                    if let versionSigner = version.signer,
-                       let signerType = Model.SignerType(rawValue: versionSigner.type.lowercased())
-                    {
-                        signer = .init(
-                            type: signerType,
-                            commonName: versionSigner.commonName,
-                            organizationalUnitName: versionSigner.organizationalUnitName,
-                            organizationName: versionSigner.organizationName
-                        )
-                    } else {
-                        signer = nil
-                    }
-
-                    return .init(
-                        version: parsedVersion,
-                        title: nil,
-                        summary: version.summary,
-                        manifests: manifests,
-                        defaultToolsVersion: defaultToolsVersion,
-                        verifiedCompatibility: verifiedCompatibility,
-                        license: license,
-                        author: version.author.map { .init(username: $0.name, url: nil, service: nil) },
-                        signer: signer,
-                        createdAt: version.createdAt
-                    )
+        var serializationOkay = true
+        let packages = try collection.packages.map { package -> Model.Package in
+            let versions = try package.versions.compactMap { version -> Model.Package.Version? in
+                // note this filters out / ignores missing / bad data in attempt to make the most out of the
+                // provided set
+                guard let parsedVersion = TSCUtility.Version(tag: version.version) else {
+                    return nil
                 }
-                if versions.count != package.versions.count {
+
+                let manifests: [ToolsVersion: Model.Package.Version.Manifest] =
+                try Dictionary(throwingUniqueKeysWithValues: version.manifests.compactMap { key, value in
+                    guard let keyToolsVersion = ToolsVersion(string: key),
+                          let manifestToolsVersion = ToolsVersion(string: value.toolsVersion)
+                    else {
+                        return nil
+                    }
+
+                    let targets = value.targets.map { Model.Target(name: $0.name, moduleName: $0.moduleName) }
+                    if targets.count != value.targets.count {
+                        serializationOkay = false
+                    }
+                    let products = value.products
+                        .compactMap { Model.Product(from: $0, packageTargets: targets) }
+                    if products.count != value.products.count {
+                        serializationOkay = false
+                    }
+                    let minimumPlatformVersions: [PackageModel.SupportedPlatform]? = value
+                        .minimumPlatformVersions?
+                        .compactMap { PackageModel.SupportedPlatform(from: $0) }
+                    if minimumPlatformVersions?.count != value.minimumPlatformVersions?.count {
+                        serializationOkay = false
+                    }
+
+                    let manifest = Model.Package.Version.Manifest(
+                        toolsVersion: manifestToolsVersion,
+                        packageName: value.packageName,
+                        targets: targets,
+                        products: products,
+                        minimumPlatformVersions: minimumPlatformVersions
+                    )
+                    return (keyToolsVersion, manifest)
+                })
+                if manifests.count != version.manifests.count {
                     serializationOkay = false
                 }
 
-                // If package identity is set, use that. Otherwise create one from URL.
+                guard let defaultToolsVersion = ToolsVersion(string: version.defaultToolsVersion) else {
+                    return nil
+                }
+
+                let verifiedCompatibility = version.verifiedCompatibility?
+                    .compactMap { Model.Compatibility(from: $0) }
+                if verifiedCompatibility?.count != version.verifiedCompatibility?.count {
+                    serializationOkay = false
+                }
+                let license = version.license.flatMap { Model.License(from: $0) }
+
+                let signer: Model.Signer?
+                if let versionSigner = version.signer,
+                   let signerType = Model.SignerType(rawValue: versionSigner.type.lowercased())
+                {
+                    signer = .init(
+                        type: signerType,
+                        commonName: versionSigner.commonName,
+                        organizationalUnitName: versionSigner.organizationalUnitName,
+                        organizationName: versionSigner.organizationName
+                    )
+                } else {
+                    signer = nil
+                }
+
                 return .init(
-                    identity: package.identity.map { PackageIdentity.plain($0) } ?? PackageIdentity(url: SourceControlURL(package.url)),
-                    location: package.url.absoluteString,
-                    summary: package.summary,
-                    keywords: package.keywords,
-                    versions: versions,
-                    watchersCount: nil,
-                    readmeURL: package.readmeURL,
-                    license: package.license.flatMap { Model.License(from: $0) },
-                    authors: nil,
-                    languages: nil
+                    version: parsedVersion,
+                    title: nil,
+                    summary: version.summary,
+                    manifests: manifests,
+                    defaultToolsVersion: defaultToolsVersion,
+                    verifiedCompatibility: verifiedCompatibility,
+                    license: license,
+                    author: version.author.map { .init(username: $0.name, url: nil, service: nil) },
+                    signer: signer,
+                    createdAt: version.createdAt
                 )
             }
-
-            if !serializationOkay {
-                self.observabilityScope
-                    .emit(
-                        warning: "Some of the information from \(collection.name) could not be deserialized correctly, likely due to invalid format. Contact the collection's author (\(collection.generatedBy?.name ?? "n/a")) to address this issue."
-                    )
+            if versions.count != package.versions.count {
+                serializationOkay = false
             }
 
-            return .success(.init(
-                source: source,
-                name: collection.name,
-                overview: collection.overview,
-                keywords: collection.keywords,
-                packages: packages,
-                createdAt: collection.generatedAt,
-                createdBy: collection.generatedBy.flatMap { Model.Collection.Author(name: $0.name) },
-                signature: signature,
-                lastProcessedAt: Date()
-            ))
-        } catch {
-            return .failure(error)
+            // If package identity is set, use that. Otherwise create one from URL.
+            return .init(
+                identity: package.identity.map { PackageIdentity.plain($0) } ?? PackageIdentity(url: SourceControlURL(package.url)),
+                location: package.url.absoluteString,
+                summary: package.summary,
+                keywords: package.keywords,
+                versions: versions,
+                watchersCount: nil,
+                readmeURL: package.readmeURL,
+                license: package.license.flatMap { Model.License(from: $0) },
+                authors: nil,
+                languages: nil
+            )
         }
+
+        if !serializationOkay {
+            self.observabilityScope
+                .emit(
+                    warning: "Some of the information from \(collection.name) could not be deserialized correctly, likely due to invalid format. Contact the collection's author (\(collection.generatedBy?.name ?? "n/a")) to address this issue."
+                )
+        }
+
+        return .init(
+            source: source,
+            name: collection.name,
+            overview: collection.overview,
+            keywords: collection.keywords,
+            packages: packages,
+            createdAt: collection.generatedAt,
+            createdBy: collection.generatedBy.flatMap { Model.Collection.Author(name: $0.name) },
+            signature: signature,
+            lastProcessedAt: Date()
+        )
     }
 
     private func makeRequestOptions(validResponseCodes: [Int]) -> LegacyHTTPClientRequest.Options {

--- a/Sources/PackageCollections/Providers/PackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageCollectionProvider.swift
@@ -18,16 +18,5 @@ protocol PackageCollectionProvider {
     ///
     /// - Parameters:
     ///   - source: Where the `PackageCollection` is located
-    ///   - callback: The closure to invoke when result becomes available
-    ///
-    @available(*, noasync, message: "Use the async alternative")
-    func get(_ source: PackageCollectionsModel.CollectionSource, callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void)
-}
-
-extension PackageCollectionProvider {
-    func get(_ source: Model.CollectionSource) async throws -> Model.Collection {
-        try await safe_async {
-            self.get(source, callback: $0)
-        }
-    }
+    func get(_ source: Model.CollectionSource) async throws -> Model.Collection
 }

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -19,17 +19,25 @@ import struct TSCUtility.Version
 
 /// `PackageBasicMetadata` provider
 protocol PackageMetadataProvider {
+
+    // TODO: Review if this API is correct
+    // This API is awkward because it unconditionally provides a context
+    // Does it make sense to have a context if you don't have metadata?
+    // The only use of provider on failure is PackageCollections.getPackageMetadata
+    // It would be nice to change the API to
+    // async throw -> (PackageCollectionsModel.PackageBasicMetadata, PackageMetadataProviderContext?)
+    // or even
+    // async throw -> (PackageCollectionsModel.PackageBasicMetadata, PackageMetadataProviderContext)
+
     /// Retrieves metadata for a package with the given identity and repository address.
     ///
     /// - Parameters:
     ///   - identity: The package's identity
     ///   - location: The package's location
-    ///   - callback: The closure to invoke when result becomes available
     func get(
         identity: PackageIdentity,
-        location: String,
-        callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) -> Void
-    )
+        location: String
+    ) async -> (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?)
 }
 
 extension Model {

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -17,6 +17,20 @@ import class Foundation.JSONDecoder
 import class Foundation.JSONEncoder
 import struct Foundation.URL
 
+extension DispatchQueue {
+    func awaitingAsync<T>(_ closure: @escaping () throws -> T) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            self.async {
+                do {
+                    try continuation.resume(returning: closure())
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
 struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     let fileSystem: FileSystem
     let path: AbsolutePath
@@ -32,101 +46,64 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
         self.decoder = JSONDecoder.makeWithDefaults()
     }
 
-    func list(callback: @escaping (Result<[Model.CollectionSource], Error>) -> Void) {
-        DispatchQueue.sharedConcurrent.async {
-            do {
-                let sources = try self.withLock {
-                    try self.loadFromDisk()
-                }
-                callback(.success(sources))
-            } catch {
-                callback(.failure(error))
+    func list() async throws -> [PackageCollectionsModel.CollectionSource] {
+        try await DispatchQueue.sharedConcurrent.awaitingAsync {
+            try self.withLock {
+                try self.loadFromDisk()
             }
         }
     }
 
-    func add(source: Model.CollectionSource,
-             order: Int?,
-             callback: @escaping (Result<Void, Error>) -> Void) {
-        DispatchQueue.sharedConcurrent.async {
-            do {
-                try self.withLock {
-                    var sources = try self.loadFromDisk()
-                    sources = sources.filter { $0 != source }
-                    let order = order.flatMap { $0 >= 0 && $0 < sources.endIndex ? order : sources.endIndex } ?? sources.endIndex
-                    sources.insert(source, at: order)
+    func add(source: PackageCollectionsModel.CollectionSource, order: Int? = nil) async throws {
+        try await DispatchQueue.sharedConcurrent.awaitingAsync {
+            try self.withLock {
+                var sources = try self.loadFromDisk()
+                sources = sources.filter { $0 != source }
+                let order = order.flatMap { $0 >= 0 && $0 < sources.endIndex ? order : sources.endIndex } ?? sources.endIndex
+                sources.insert(source, at: order)
+                try self.saveToDisk(sources)
+            }
+        }
+    }
+
+    func remove(source: PackageCollectionsModel.CollectionSource) async throws {
+        try await DispatchQueue.sharedConcurrent.awaitingAsync {
+            try self.withLock {
+                var sources = try self.loadFromDisk()
+                sources = sources.filter { $0 != source }
+                try self.saveToDisk(sources)
+            }
+        }
+    }
+
+    func move(source: PackageCollectionsModel.CollectionSource, to order: Int) async throws {
+        try await DispatchQueue.sharedConcurrent.awaitingAsync {
+            try self.withLock {
+                var sources = try self.loadFromDisk()
+                sources = sources.filter { $0 != source }
+                let order = order >= 0 && order < sources.endIndex ? order : sources.endIndex
+                sources.insert(source, at: order)
+                try self.saveToDisk(sources)
+            }
+        }
+    }
+
+    func exists(source: PackageCollectionsModel.CollectionSource) async throws -> Bool {
+        try await DispatchQueue.sharedConcurrent.awaitingAsync {
+            try self.withLock {
+                try self.loadFromDisk()
+            }.contains(source)
+        }
+    }
+
+    func update(source: PackageCollectionsModel.CollectionSource) async throws {
+        try await DispatchQueue.sharedConcurrent.awaitingAsync {
+            try self.withLock {
+                var sources = try self.loadFromDisk()
+                if let index = sources.firstIndex(where: { $0 == source }) {
+                    sources[index] = source
                     try self.saveToDisk(sources)
                 }
-                callback(.success(()))
-            } catch {
-                callback(.failure(error))
-            }
-        }
-    }
-
-    func remove(source: Model.CollectionSource,
-                callback: @escaping (Result<Void, Error>) -> Void) {
-        DispatchQueue.sharedConcurrent.async {
-            do {
-                try self.withLock {
-                    var sources = try self.loadFromDisk()
-                    sources = sources.filter { $0 != source }
-                    try self.saveToDisk(sources)
-                }
-                callback(.success(()))
-            } catch {
-                callback(.failure(error))
-            }
-        }
-    }
-
-    func move(source: Model.CollectionSource,
-              to order: Int,
-              callback: @escaping (Result<Void, Error>) -> Void) {
-        DispatchQueue.sharedConcurrent.async {
-            do {
-                try self.withLock {
-                    var sources = try self.loadFromDisk()
-                    sources = sources.filter { $0 != source }
-                    let order = order >= 0 && order < sources.endIndex ? order : sources.endIndex
-                    sources.insert(source, at: order)
-                    try self.saveToDisk(sources)
-                }
-                callback(.success(()))
-            } catch {
-                callback(.failure(error))
-            }
-        }
-    }
-
-    func exists(source: Model.CollectionSource,
-                callback: @escaping (Result<Bool, Error>) -> Void) {
-        DispatchQueue.sharedConcurrent.async {
-            do {
-                let sources = try self.withLock {
-                    try self.loadFromDisk()
-                }
-                callback(.success(sources.contains(source)))
-            } catch {
-                callback(.failure(error))
-            }
-        }
-    }
-
-    func update(source: PackageCollectionsModel.CollectionSource,
-                callback: @escaping (Result<Void, Error>) -> Void) {
-        DispatchQueue.sharedConcurrent.async {
-            do {
-                try self.withLock {
-                    var sources = try self.loadFromDisk()
-                    if let index = sources.firstIndex(where: { $0 == source }) {
-                        sources[index] = source
-                        try self.saveToDisk(sources)
-                    }
-                }
-                callback(.success(()))
-            } catch {
-                callback(.failure(error))
             }
         }
     }

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import Basics
 import Dispatch
 import struct Foundation.Data

--- a/Sources/PackageCollections/Storage/PackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/PackageCollectionsSourcesStorage.swift
@@ -14,11 +14,7 @@ import Basics
 
 public protocol PackageCollectionsSourcesStorage {
     /// Lists all `PackageCollectionSource`s.
-    ///
-    /// - Parameters:
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
-    func list(callback: @escaping (Result<[PackageCollectionsModel.CollectionSource], Error>) -> Void)
+    func list() async throws -> [PackageCollectionsModel.CollectionSource]
 
     /// Adds the given source.
     ///
@@ -26,87 +22,32 @@ public protocol PackageCollectionsSourcesStorage {
     ///   - source: The `PackageCollectionSource` to add
     ///   - order: Optional. The order that the source should take after being added.
     ///            By default the new source is appended to the end (i.e., the least relevant order).
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
     func add(source: PackageCollectionsModel.CollectionSource,
-             order: Int?,
-             callback: @escaping (Result<Void, Error>) -> Void)
+             order: Int?) async throws
 
     /// Removes the given source.
     ///
     /// - Parameters:
     ///   - source: The `PackageCollectionSource` to remove
     ///   - profile: The `Profile` to remove source
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
-    func remove(source: PackageCollectionsModel.CollectionSource,
-                callback: @escaping (Result<Void, Error>) -> Void)
+    func remove(source: PackageCollectionsModel.CollectionSource) async throws
 
     /// Moves source to a different order.
     ///
     /// - Parameters:
     ///   - source: The `PackageCollectionSource` to move
     ///   - order: The order that the source should take.
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
-    func move(source: PackageCollectionsModel.CollectionSource,
-              to order: Int,
-              callback: @escaping (Result<Void, Error>) -> Void)
+    func move(source: PackageCollectionsModel.CollectionSource, to order: Int) async throws
 
     /// Checks if a source has already been added.
     ///
     /// - Parameters:
     ///   - source: The `PackageCollectionSource`
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
-    func exists(source: PackageCollectionsModel.CollectionSource,
-                callback: @escaping (Result<Bool, Error>) -> Void)
+    func exists(source: PackageCollectionsModel.CollectionSource) async throws -> Bool
 
     /// Updates the given source.
     ///
     /// - Parameters:
     ///   - source: The `PackageCollectionSource` to update
-    ///   - callback: The closure to invoke when result becomes available
-    @available(*, noasync, message: "Use the async alternative")
-    func update(source: PackageCollectionsModel.CollectionSource,
-                callback: @escaping (Result<Void, Error>) -> Void)
-}
-
-public extension PackageCollectionsSourcesStorage {
-    func list() async throws -> [PackageCollectionsModel.CollectionSource] {
-        try await safe_async {
-            self.list(callback: $0)
-        }
-    }
-
-    func add(source: PackageCollectionsModel.CollectionSource,
-             order: Int? = nil) async throws {
-        try await safe_async {
-            self.add(source: source, order: order, callback: $0)
-        }
-    }
-
-    func remove(source: PackageCollectionsModel.CollectionSource) async throws {
-        try await safe_async {
-            self.remove(source: source, callback: $0)
-        }
-    }
-
-    func move(source: PackageCollectionsModel.CollectionSource, to order: Int) async throws {
-        try await safe_async {
-            self.move(source: source, to:order, callback: $0)
-        }
-    }
-
-    func exists(source: PackageCollectionsModel.CollectionSource) async throws -> Bool {
-        try await safe_async {
-            self.exists(source: source, callback: $0)
-        }
-    }
-
-    func update(source: PackageCollectionsModel.CollectionSource) async throws {
-        try await safe_async {
-            self.update(source: source, callback: $0)
-        }
-    }
+    func update(source: PackageCollectionsModel.CollectionSource) async throws
 }

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -367,8 +367,6 @@ internal extension GitHubPackageMetadataProvider {
 
 private extension GitHubPackageMetadataProvider {
     func syncGet(identity: PackageIdentity, location: String) async throws -> Model.PackageBasicMetadata {
-        try await safe_async { callback in
-            self.get(identity: identity, location: location) { result, _ in callback(result) }
-        }
+        try await self.get(identity: identity, location: location).0.get()
     }
 }

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -979,19 +979,19 @@ final class PackageCollectionsTests: XCTestCase {
                 self.error = error
             }
 
-            func get(_ source: PackageCollectionsModel.CollectionSource, callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void) {
+            func get(_ source: PackageCollectionsModel.CollectionSource) async throws -> PackageCollectionsModel.Collection {
                 if self.brokenSources.contains(source) {
-                    callback(.failure(self.error))
-                } else {
-                    let signature = PackageCollectionsModel.SignatureData(
-                        certificate: PackageCollectionsModel.SignatureData.Certificate(
-                            subject: .init(userID: nil, commonName: nil, organizationalUnit: nil, organization: nil),
-                            issuer: .init(userID: nil, commonName: nil, organizationalUnit: nil, organization: nil)
-                        ),
-                        isVerified: true
-                    )
-                    callback(.success(PackageCollectionsModel.Collection(source: source, name: "", overview: nil, keywords: nil, packages: [], createdAt: Date(), createdBy: nil, signature: signature)))
+                    throw self.error
                 }
+                let signature = PackageCollectionsModel.SignatureData(
+                    certificate: PackageCollectionsModel.SignatureData.Certificate(
+                        subject: .init(userID: nil, commonName: nil, organizationalUnit: nil, organization: nil),
+                        issuer: .init(userID: nil, commonName: nil, organizationalUnit: nil, organization: nil)
+                    ),
+                    isVerified: true
+                )
+                return PackageCollectionsModel.Collection(source: source, name: "", overview: nil, keywords: nil, packages: [], createdAt: Date(), createdBy: nil, signature: signature)
+
             }
         }
 

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -1413,11 +1413,10 @@ final class PackageCollectionsTests: XCTestCase {
             var name: String = "BrokenMetadataProvider"
 
             func get(
-                identity: PackageIdentity,
-                location: String,
-                callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) -> Void
-            ) {
-                callback(.failure(TerribleThing()), nil)
+                identity: PackageModel.PackageIdentity,
+                location: String
+            ) async -> (Result<PackageCollectionsModel.PackageBasicMetadata, any Error>, PackageMetadataProviderContext?) {
+                return (.failure(TerribleThing()), nil)
             }
 
             struct TerribleThing: Error {}

--- a/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
@@ -700,41 +700,38 @@ private struct MockPackageIndex: PackageIndexProtocol {
         self.url = url
         self.packages = packages
     }
-    
+
     func getPackageMetadata(
         identity: PackageIdentity,
-        location: String?,
-        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
-    ) {
+        location: String?
+    ) async throws -> PackageCollectionsModel.PackageMetadata {
         guard let package = self.packages.first(where: { $0.identity == identity }) else {
-            return callback(.failure(NotFoundError("Package \(identity) not found")))
+            throw NotFoundError("Package \(identity) not found")
         }
-        callback(.success((package: package, collections: [], provider: .init(name: "package index", authTokenType: nil, isAuthTokenConfigured: true))))
+        return (package: package, collections: [], provider: .init(name: "package index", authTokenType: nil, isAuthTokenConfigured: true))
     }
 
     func findPackages(
-        _ query: String,
-        callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
-    ) {
+        _ query: String
+    ) async throws  -> PackageCollectionsModel.PackageSearchResult{
         let items = self.packages.filter { $0.identity.description.contains(query) }
-        callback(.success(.init(items: items.map { .init(package: $0, collections: [], indexes: [self.url]) })))
+        return PackageCollectionsModel.PackageSearchResult(items: items.map { .init(package: $0, collections: [], indexes: [self.url]) })
     }
     
     func listPackages(
         offset: Int,
-        limit: Int,
-        callback: @escaping (Result<PackageCollectionsModel.PaginatedPackageList, Error>) -> Void
-    ) {
+        limit: Int
+    ) async throws -> PackageCollectionsModel.PaginatedPackageList {
         guard !self.packages.isEmpty, offset < self.packages.count, limit > 0 else {
-            return callback(.success(.init(items: [], offset: offset, limit: limit, total: self.packages.count)))
+            return PackageCollectionsModel.PaginatedPackageList(items: [], offset: offset, limit: limit, total: self.packages.count)
         }
 
-        callback(.success(.init(
+        return PackageCollectionsModel.PaginatedPackageList(
             items: Array(self.packages[offset..<min(self.packages.count, offset + limit)]),
             offset: offset,
             limit: limit,
             total: self.packages.count
-        )))
+        )
     }
 }
 
@@ -743,25 +740,22 @@ private struct BrokenPackageIndex: PackageIndexProtocol {
     
     func getPackageMetadata(
         identity: PackageIdentity,
-        location: String?,
-        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
-    ) {
-        callback(.failure(TerribleThing()))
+        location: String?
+    ) async throws -> PackageCollectionsModel.PackageMetadata {
+        throw TerribleThing()
     }
 
     func findPackages(
-        _ query: String,
-        callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
-    ) {
-        callback(.failure(TerribleThing()))
+        _ query: String
+    ) async throws -> PackageCollectionsModel.PackageSearchResult {
+        throw TerribleThing()
     }
     
     func listPackages(
         offset: Int,
-        limit: Int,
-        callback: @escaping (Result<PackageCollectionsModel.PaginatedPackageList, Error>) -> Void
-    ) {
-        callback(.failure(TerribleThing()))
+        limit: Int
+    ) async throws -> PackageCollectionsModel.PaginatedPackageList {
+        throw TerribleThing()
     }
     
     struct TerribleThing: Error {}

--- a/Tests/PackageCollectionsTests/PackageIndexTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexTests.swift
@@ -302,8 +302,6 @@ class PackageIndexTests: XCTestCase {
 
 private extension PackageIndex {
     func syncGet(identity: PackageIdentity, location: String) async throws -> Model.PackageBasicMetadata {
-        try await safe_async { callback in
-            self.get(identity: identity, location: location) { result, _ in callback(result) }
-        }
+        try await self.get(identity: identity, location: location).0.get()
     }
 }

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -158,15 +158,14 @@ struct MockCollectionsProvider: PackageCollectionProvider {
         self.collectionsWithInvalidSignature = collectionsWithInvalidSignature
     }
 
-    func get(_ source: PackageCollectionsModel.CollectionSource, callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void) {
+    func get(_ source: PackageCollectionsModel.CollectionSource) async throws -> PackageCollectionsModel.Collection {
         if let collection = (self.collections.first { $0.source == source }) {
             if self.collectionsWithInvalidSignature?.contains(source) ?? false {
-                return callback(.failure(PackageCollectionError.invalidSignature))
+                throw PackageCollectionError.invalidSignature
             }
-            callback(.success(collection))
-        } else {
-            callback(.failure(NotFoundError("\(source)")))
+            return collection
         }
+        throw NotFoundError("\(source)")
     }
 }
 

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -181,14 +181,12 @@ struct MockMetadataProvider: PackageMetadataProvider {
 
     func get(
         identity: PackageIdentity,
-        location: String,
-        callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) -> Void
-    ) {
-        if let package = self.packages[identity] {
-            callback(.success(package), nil)
-        } else {
-            callback(.failure(NotFoundError("\(identity)")), nil)
+        location: String
+    ) async -> (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) {
+        guard let packageMetadata = self.packages[identity] else {
+            return (.failure(NotFoundError("\(identity)")), nil)
         }
+        return (.success(packageMetadata), nil)
     }
 }
 


### PR DESCRIPTION
Move PackageCollectionsSourcesStorage to async/await

### Motivation:

async/await is more readable than concurrency

### Modifications:

Replace all completionHandler APIs with async/await

### Result:

5 fewer callback APIs
