### PR TITLE
Use `release` build configuration in `experimental-install`

### DIFF
--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(Commands
   PackageCommands/EditCommands.swift
   PackageCommands/Format.swift
   PackageCommands/Init.swift
-  PackageCommands/InstalledPackages.swift
+  PackageCommands/Install.swift
   PackageCommands/Learn.swift
   PackageCommands/PluginCommand.swift
   PackageCommands/ResetCommands.swift

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -313,7 +313,7 @@ public struct BuildOptions: ParsableArguments {
 
     /// Build configuration.
     @Option(name: .shortAndLong, help: "Build with configuration")
-    public var configuration: BuildConfiguration = .debug
+    public var configuration: BuildConfiguration?
 
     @Option(
         name: .customLong("Xcc", withSingleDash: true),

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -800,7 +800,7 @@ public final class SwiftCommandState {
                 debugInfoFormat: options.build.debugInfoFormat.buildParameter,
                 triple: triple,
                 shouldEnableDebuggingEntitlement:
-                    options.build.getTaskAllowEntitlement ?? (options.build.configuration == .debug),
+                    options.build.getTaskAllowEntitlement ?? (options.build.configuration ?? self.preferredBuildConfiguration == .debug),
                 omitFramePointers: options.build.omitFramePointers
             ),
             driverParameters: .init(

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -271,6 +271,8 @@ public final class SwiftCommandState {
 
     private let hostTriple: Basics.Triple?
 
+    package var preferredBuildConfiguration = BuildConfiguration.debug
+
     /// Create an instance of this tool.
     ///
     /// - parameter options: The command line options to be passed to this tool.
@@ -783,7 +785,7 @@ public final class SwiftCommandState {
         return try BuildParameters(
             destination: destination,
             dataPath: dataPath,
-            configuration: options.build.configuration,
+            configuration: options.build.configuration ?? self.preferredBuildConfiguration,
             toolchain: toolchain,
             triple: triple,
             flags: options.build.buildFlags,
@@ -825,7 +827,7 @@ public final class SwiftCommandState {
                 isVerbose: self.logLevel <= .info
             ),
             testingParameters: .init(
-                configuration: options.build.configuration,
+                configuration: options.build.configuration ?? self.preferredBuildConfiguration,
                 targetTriple: triple,
                 forceTestDiscovery: options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
                 testEntryPointPath: options.build.testEntryPointPath


### PR DESCRIPTION
One would almost always install the release binary, as opposed to debugging binaries when building locally for development. Thus `release` should be the default for `swift package experimental-install`.

rdar://130922365
