### PR TITLE
[6.0] Use `release` build configuration in `experimental-install`

### DIFF
--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(Commands
   PackageCommands/EditCommands.swift
   PackageCommands/Format.swift
   PackageCommands/Init.swift
-  PackageCommands/InstalledPackages.swift
+  PackageCommands/Install.swift
   PackageCommands/Learn.swift
   PackageCommands/PluginCommand.swift
   PackageCommands/ResetCommands.swift

--- a/Sources/Commands/PackageCommands/Install.swift
+++ b/Sources/Commands/PackageCommands/Install.swift
@@ -30,13 +30,13 @@ extension SwiftPackageCommand {
         @Option(help: "The name of the executable product to install")
         var product: String?
 
-        func run(_ tool: SwiftCommandState) throws {
-            let swiftpmBinDir = try tool.fileSystem.getOrCreateSwiftPMInstalledBinariesDirectory()
+        func run(_ commandState: SwiftCommandState) throws {
+            let swiftpmBinDir = try commandState.fileSystem.getOrCreateSwiftPMInstalledBinariesDirectory()
 
             let env = Environment.current
 
             if let path = env[.path], !path.contains(swiftpmBinDir.pathString), !globalOptions.logging.quiet {
-                tool.observabilityScope.emit(
+                commandState.observabilityScope.emit(
                     warning: """
                     PATH doesn't include \(swiftpmBinDir.pathString)! This means you won't be able to access \
                     the installed executables by default, and will need to specify the full path.
@@ -44,14 +44,14 @@ extension SwiftPackageCommand {
                 )
             }
 
-            let alreadyExisting = (try? InstalledPackageProduct.installedProducts(tool.fileSystem)) ?? []
+            let alreadyExisting = (try? InstalledPackageProduct.installedProducts(commandState.fileSystem)) ?? []
 
-            let workspace = try tool.getActiveWorkspace()
-            let packageRoot = try tool.getPackageRoot()
+            let workspace = try commandState.getActiveWorkspace()
+            let packageRoot = try commandState.getPackageRoot()
 
             let packageGraph = try workspace.loadPackageGraph(
                 rootPath: packageRoot,
-                observabilityScope: tool.observabilityScope
+                observabilityScope: commandState.observabilityScope
             )
 
             let possibleCandidates = packageGraph.rootPackages.flatMap(\.products)
@@ -81,12 +81,16 @@ extension SwiftPackageCommand {
                 throw StringError("\(productToInstall.name) is already installed at \(existingPkg.path)")
             }
 
+            if commandState.options.build.configuration == nil {
+                commandState.preferredBuildConfiguration = .release
+            }
+
             try tool.createBuildSystem(explicitProduct: productToInstall.name)
                 .build(subset: .product(productToInstall.name))
 
-            let binPath = try tool.productsBuildParameters.buildPath.appending(component: productToInstall.name)
+            let binPath = try commandState.productsBuildParameters.buildPath.appending(component: productToInstall.name)
             let finalBinPath = swiftpmBinDir.appending(component: binPath.basename)
-            try tool.fileSystem.copy(from: binPath, to: finalBinPath)
+            try commandState.fileSystem.copy(from: binPath, to: finalBinPath)
 
             print("Executable product `\(productToInstall.name)` was successfully installed to \(finalBinPath).")
         }

--- a/Sources/Commands/PackageCommands/Install.swift
+++ b/Sources/Commands/PackageCommands/Install.swift
@@ -85,7 +85,7 @@ extension SwiftPackageCommand {
                 commandState.preferredBuildConfiguration = .release
             }
 
-            try tool.createBuildSystem(explicitProduct: productToInstall.name)
+            try commandState.createBuildSystem(explicitProduct: productToInstall.name)
                 .build(subset: .product(productToInstall.name))
 
             let binPath = try commandState.productsBuildParameters.buildPath.appending(component: productToInstall.name)

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -312,7 +312,7 @@ public struct BuildOptions: ParsableArguments {
 
     /// Build configuration.
     @Option(name: .shortAndLong, help: "Build with configuration")
-    public var configuration: BuildConfiguration = .debug
+    public var configuration: BuildConfiguration?
 
     @Option(
         name: .customLong("Xcc", withSingleDash: true),

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -770,7 +770,7 @@ public final class SwiftCommandState {
                 debugInfoFormat: options.build.debugInfoFormat.buildParameter,
                 triple: triple,
                 shouldEnableDebuggingEntitlement:
-                    options.build.getTaskAllowEntitlement ?? (options.build.configuration == .debug),
+                    options.build.getTaskAllowEntitlement ?? (options.build.configuration ?? self.preferredBuildConfiguration == .debug),
                 omitFramePointers: options.build.omitFramePointers
             ),
             driverParameters: .init(

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -269,6 +269,8 @@ public final class SwiftCommandState {
 
     private let hostTriple: Basics.Triple?
 
+    package var preferredBuildConfiguration = BuildConfiguration.debug
+
     /// Create an instance of this tool.
     ///
     /// - parameter options: The command line options to be passed to this tool.
@@ -753,7 +755,7 @@ public final class SwiftCommandState {
         return try BuildParameters(
             destination: destination,
             dataPath: dataPath,
-            configuration: options.build.configuration,
+            configuration: options.build.configuration ?? self.preferredBuildConfiguration,
             toolchain: toolchain,
             triple: triple,
             flags: options.build.buildFlags,
@@ -795,7 +797,7 @@ public final class SwiftCommandState {
                 isVerbose: self.logLevel <= .info
             ),
             testingParameters: .init(
-                configuration: options.build.configuration,
+                configuration: options.build.configuration ?? self.preferredBuildConfiguration,
                 targetTriple: triple,
                 forceTestDiscovery: options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
                 testEntryPointPath: options.build.testEntryPointPath


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-package-manager/pull/7744.

**Explanation**: One would almost always install the release binary, as opposed to debugging binaries when building locally for development. Thus `release` should be the default for `swift package experimental-install`.
**Scope**: Changes are isolated to an experimental and hidden subcommand.
**Risk**: Very low, since changes are isolated to an experimental and hidden subcommand.
**Testing**: Tested manually end-to-end, also covered by existing tests, which caught a regression during development.
**Issue**: rdar://130922365
**Reviewer**: @bnbarham 