### PR TITLE
[6.0] Fix checksum computation for Swift SDK bundles

### DIFF
--- a/Sources/Basics/Archiver/Archiver.swift
+++ b/Sources/Basics/Archiver/Archiver.swift
@@ -95,4 +95,8 @@ extension Archiver {
             self.validate(path: path, completion: { continuation.resume(with: $0) })
         }
     }
+
+    package func isFileSupported(_ lastPathComponent: String) -> Bool {
+        self.supportedExtensions.contains(where: { lastPathComponent.hasSuffix($0) })
+    }
 }

--- a/Sources/Commands/PackageCommands/ComputeChecksum.swift
+++ b/Sources/Commands/PackageCommands/ComputeChecksum.swift
@@ -28,17 +28,10 @@ struct ComputeChecksum: SwiftCommand {
     var path: AbsolutePath
 
     func run(_ swiftCommandState: SwiftCommandState) throws {
-        let binaryArtifactsManager = try Workspace.BinaryArtifactsManager(
-            fileSystem: swiftCommandState.fileSystem,
-            authorizationProvider: swiftCommandState.getAuthorizationProvider(),
-            hostToolchain: swiftCommandState.getHostToolchain(),
-            checksumAlgorithm: SHA256(),
-            cachePath: .none,
-            customHTTPClient: .none,
-            customArchiver: .none,
-            delegate: .none
+        let checksum = try Workspace.BinaryArtifactsManager.checksum(
+            forBinaryArtifactAt: self.path,
+            fileSystem: swiftCommandState.fileSystem
         )
-        let checksum = try binaryArtifactsManager.checksum(forBinaryArtifactAt: path)
         print(checksum)
     }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-package-manager/pull/7748.

**Explanation**: This feature [was specified in the corresponding proposal for Swift SDKs](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0387-cross-compilation-destinations.md#swift-sdk-installation-and-configuration):

> For Swift SDKs installed from remote URLs an additional `--checksum` option is required, through which users of a Swift SDK can specify a checksum provided by a publisher of the SDK. The latter can produce a checksum by running `swift package compute-checksum` command (introduced in [SE-0272](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0272-swiftpm-binary-dependencies.md)) with the Swift SDK bundle archive as an argument.

Currently, `swift package compute-checksum` is unable to handle `.tar.gz` bundles, which is a commonly used format for Swift SDKs. We're fixing that here by adding correct and unified handling for archive extensions.

This change is isolated to the `swift package compute-checksum` subcommand. The `--checksum` option is added in a subsequent PR: https://github.com/swiftlang/swift-package-manager/pull/7722.

**Scope**: Isolated to `swift package compute-checksum` subcommand.
**Risk**: Low, no existing behavior is 
**Testing**: Automated test cases modified/added and passing in a subsequent PR: https://github.com/swiftlang/swift-package-manager/pull/7723
**Issue**: rdar://130590711
**Reviewer**: @bnbarham 
