### PR TITLE
Work around `swift-bootstrap` inability to handle plugins

### DIFF
--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -35,7 +35,9 @@ extension ModulesGraph {
         customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
         testEntryPointPath: AbsolutePath? = nil,
         fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope
+        observabilityScope: ObservabilityScope,
+        productsFilter: ((Product) -> Bool)?,
+        modulesFilter: ((Module) -> Bool)?
     ) throws -> ModulesGraph {
         try Self.load(
             root: root,
@@ -52,7 +54,9 @@ extension ModulesGraph {
             customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
             testEntryPointPath: testEntryPointPath,
             fileSystem: fileSystem,
-            observabilityScope: observabilityScope
+            observabilityScope: observabilityScope,
+            productsFilter: productsFilter,
+            modulesFilter: modulesFilter
         )
     }
 
@@ -72,7 +76,9 @@ extension ModulesGraph {
         customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
         testEntryPointPath: AbsolutePath? = nil,
         fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope
+        observabilityScope: ObservabilityScope,
+        productsFilter: ((Product) -> Bool)? = nil,
+        modulesFilter: ((Module) -> Bool)? = nil
     ) throws -> ModulesGraph {
         let observabilityScope = observabilityScope.makeChildScope(description: "Loading Package Graph")
 
@@ -243,7 +249,9 @@ extension ModulesGraph {
             platformRegistry: customPlatformsRegistry ?? .default,
             platformVersionProvider: platformVersionProvider,
             fileSystem: fileSystem,
-            observabilityScope: observabilityScope
+            observabilityScope: observabilityScope,
+            productsFilter: productsFilter,
+            modulesFilter: modulesFilter
         )
 
         let rootPackages = resolvedPackages.filter { root.manifests.values.contains($0.manifest) }
@@ -372,7 +380,9 @@ private func createResolvedPackages(
     platformRegistry: PlatformRegistry,
     platformVersionProvider: PlatformVersionProvider,
     fileSystem: FileSystem,
-    observabilityScope: ObservabilityScope
+    observabilityScope: ObservabilityScope,
+    productsFilter: ((Product) -> Bool)?,
+    modulesFilter: ((Module) -> Bool)?
 ) throws -> IdentifiableSet<ResolvedPackage> {
 
     // Create package builder objects from the input manifests.
@@ -503,7 +513,13 @@ private func createResolvedPackages(
         )
 
         // Create module builders for each module in the package.
-        let moduleBuilders = package.modules.map {
+        let modules: [Module]
+        if let modulesFilter {
+            modules = package.modules.filter(modulesFilter)
+        } else {
+            modules = package.modules
+        }
+        let moduleBuilders = modules.map {
             ResolvedModuleBuilder(
                 packageIdentity: package.identity,
                 module: $0,
@@ -533,8 +549,15 @@ private func createResolvedPackages(
         }
 
         // Create product builders for each product in the package. A product can only contain a module present in the same package.
-        packageBuilder.products = try package.products.map{
-            try ResolvedProductBuilder(product: $0, packageBuilder: packageBuilder, moduleBuilders: $0.modules.map {
+        let products: [Product]
+        if let productsFilter {
+            products = package.products.filter(productsFilter)
+        } else {
+            products = package.products
+        }
+
+        packageBuilder.products = try products.map { product in
+            try ResolvedProductBuilder(product: product, packageBuilder: packageBuilder, moduleBuilders: product.modules.map {
                 guard let module = modulesMap[$0] else {
                     throw InternalError("unknown target \($0)")
                 }

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -36,8 +36,8 @@ extension ModulesGraph {
         testEntryPointPath: AbsolutePath? = nil,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
-        productsFilter: ((Product) -> Bool)?,
-        modulesFilter: ((Module) -> Bool)?
+        productsFilter: ((Product) -> Bool)? = nil,
+        modulesFilter: ((Module) -> Bool)? = nil
     ) throws -> ModulesGraph {
         try Self.load(
             root: root,

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -554,6 +554,8 @@ public func loadModulesGraph(
         createREPLProduct: createREPLProduct,
         customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
         fileSystem: fileSystem,
-        observabilityScope: observabilityScope
+        observabilityScope: observabilityScope,
+        productsFilter: nil,
+        modulesFilter: nil
     )
 }

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -276,7 +276,6 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
             shouldDisableLocalRpath: Bool,
             logLevel: Basics.Diagnostic.Severity
         ) throws -> BuildSystem {
-
             var buildFlags = buildFlags
             buildFlags.swiftCompilerFlags += Self.additionalSwiftBuildFlags
 
@@ -395,7 +394,14 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
                 },
                 binaryArtifacts: [:],
                 fileSystem: fileSystem,
-                observabilityScope: observabilityScope
+                observabilityScope: observabilityScope,
+                // Plugins can't be used in bootstrap builds, exclude those.
+                productsFilter: {
+                    $0.type != .plugin
+                },
+                modulesFilter: {
+                    $0.type != .plugin
+                }
             )
         }
 


### PR DESCRIPTION
`swift-bootstrap` currently can't handle dependencies with plugins, which prevents us from bumping Swift Argument Parser to a newer version, which did add a dependency on a plugin. The easiest workaround is to exclude plugins from the modules graph only when building with `swift-bootstrap`.