### PR TITLE
[6.0] Add support for new Bionic module from Android overlay (`import Bionic`) (#7615)

### DIFF
--- a/Fixtures/DependencyResolution/External/Complex/FisherYates/src/Fisher-Yates_Shuffle.swift
+++ b/Fixtures/DependencyResolution/External/Complex/FisherYates/src/Fisher-Yates_Shuffle.swift
@@ -4,6 +4,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 public extension Collection {

--- a/Fixtures/DependencyResolution/External/Complex/FisherYates/src/Fisher-Yates_Shuffle.swift
+++ b/Fixtures/DependencyResolution/External/Complex/FisherYates/src/Fisher-Yates_Shuffle.swift
@@ -4,8 +4,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 public extension Collection {

--- a/Fixtures/Miscellaneous/EchoExecutable/Sources/secho/main.swift
+++ b/Fixtures/Miscellaneous/EchoExecutable/Sources/secho/main.swift
@@ -2,6 +2,8 @@
 	import Glibc
 #elseif canImport(Musl)
 	import Musl
+#elseif canImport(Android)
+	import Android
 #else
 	import Darwin.C
 #endif

--- a/Sources/Basics/Environment/Environment.swift
+++ b/Sources/Basics/Environment/Environment.swift
@@ -19,6 +19,8 @@ import Musl
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif canImport(Bionic)
+import Bionic
 #else
 import Darwin.C
 #endif

--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -132,8 +132,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
         @_exported import WinSDK
         #elseif os(WASI)
         @_exported import WASILibc
-        #elseif canImport(Android)
-        @_exported import Android
+        #elseif canImport(Bionic)
+        @_exported import Bionic
         #else
         @_exported import Darwin.C
         #endif

--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -132,6 +132,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
         @_exported import WinSDK
         #elseif os(WASI)
         @_exported import WASILibc
+        #elseif canImport(Android)
+        @_exported import Android
         #else
         @_exported import Darwin.C
         #endif

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -39,8 +39,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 import func TSCBasic.exec

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -39,6 +39,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 import func TSCBasic.exec

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -10,13 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Glibc)
-@_implementationOnly import Glibc
-#elseif canImport(Musl)
-@_implementationOnly import Musl
-#elseif canImport(Darwin)
-@_implementationOnly import Darwin.C
-#elseif canImport(ucrt) && canImport(WinSDK)
+#if canImport(ucrt) && canImport(WinSDK)
 @_implementationOnly import ucrt
 @_implementationOnly import struct WinSDK.HANDLE
 #endif

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -505,17 +505,6 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
 
     func testNonZeroExitStatusDoesNotAssert() async throws {
         let content = """
-            #if canImport(Glibc)
-            import Glibc
-            #elseif canImport(Musl)
-            import Musl
-            #elseif os(Windows)
-            import MSVCRT
-            import WinSDK
-            #else
-            import Darwin.C
-            #endif
-
             print("crash")
             exit(1)
             """


### PR DESCRIPTION
__Explanation:__ Now that this new overlay was merged into the 6.0 compiler too in swiftlang/swift#74758, this adds the overlay to five of the seven files that currently `import Glibc`, with those last two showing no difference if this _wasn't_ added, like `PackageDescription.swift`, so remove most of those imports.

__Scope:__ Add imports on Android and remove a handful in two files that were unused

__Issue:__ None

__Original PRs:__ #7615 and #7755

__Risk:__ Very low

__Testing:__ Passed all CI on trunk, plus on my daily Android CI

__Reviewer:__ @bnbarham