### PR TITLE
Clarify unsupported direct macro module imports in `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ Swift 6.0
   `--experimental-swift-sdks-path` options on `swift build` are deprecated with replacements that don't have the
   `experimental` prefix.
 
-* [#7535] The `swift sdk configuration` subcommand is deprecated with a replacement named `configure` that has options that exactly match
+* [#7535]
+
+  The `swift sdk configuration` subcommand is deprecated with a replacement named `configure` that has options that exactly match
   [SE-0387 proposal text].
 
 * [#7202]
@@ -33,6 +35,9 @@ Swift 6.0
 * [#7118]
 
   Macros cross-compiled by SwiftPM with Swift SDKs are now correctly built, loaded, and evaluated for the host triple.
+
+  Packages with modules that incorrectly imported macro modules directly instead of importing macro interface modules will no longer build
+  with `swift build`.
 
 Swift 5.10
 -----------


### PR DESCRIPTION
Importing macro modules directly to use those macros was never supposed to work, and now with macro modules built for the host triple, importing such macro modules in modules built for the target triple will fail.
