### PR TITLE
Import new Bionic module from Android overlay instead where possible

### DIFF
--- a/Fixtures/DependencyResolution/External/Complex/FisherYates/src/Fisher-Yates_Shuffle.swift
+++ b/Fixtures/DependencyResolution/External/Complex/FisherYates/src/Fisher-Yates_Shuffle.swift
@@ -4,8 +4,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 public extension Collection {

--- a/Sources/Basics/Environment/Environment.swift
+++ b/Sources/Basics/Environment/Environment.swift
@@ -19,6 +19,8 @@ import Musl
 #elseif os(Windows)
 import CRT
 import WinSDK
+#elseif canImport(Bionic)
+import Bionic
 #else
 import Darwin.C
 #endif

--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -132,8 +132,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
         @_exported import WinSDK
         #elseif os(WASI)
         @_exported import WASILibc
-        #elseif canImport(Android)
-        @_exported import Android
+        #elseif canImport(Bionic)
+        @_exported import Bionic
         #else
         @_exported import Darwin.C
         #endif

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -39,8 +39,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 import func TSCBasic.exec


### PR DESCRIPTION
Also, add the import in `Environment.swift` too

@rauhul, you added that last file just after I got these imports in with #7615, so I recently had to add this too to keep it building on Android.