### PR TITLE
Invalidate manifest cache when `-Xbuild-tools-swiftc` changes

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -569,6 +569,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 toolsVersion: toolsVersion,
                 env: Environment.current.cachable,
                 swiftpmVersion: SwiftVersion.current.displayString,
+                extraManifestFlags: self.extraManifestFlags,
                 fileSystem: fileSystem
             )
         } catch {
@@ -1208,6 +1209,7 @@ extension ManifestLoader {
               toolsVersion: ToolsVersion,
               env: Environment,
               swiftpmVersion: String,
+              extraManifestFlags: [String],
               fileSystem: FileSystem
         ) throws {
             let manifestContents = try fileSystem.readFileContents(manifestPath).contents
@@ -1217,6 +1219,7 @@ extension ManifestLoader {
                 manifestContents: manifestContents,
                 toolsVersion: toolsVersion,
                 env: env,
+                extraManifestFlags: extraManifestFlags,
                 swiftpmVersion: swiftpmVersion
             )
 
@@ -1239,6 +1242,7 @@ extension ManifestLoader {
             manifestContents: [UInt8],
             toolsVersion: ToolsVersion,
             env: Environment,
+            extraManifestFlags: [String],
             swiftpmVersion: String
         ) throws -> String {
             let stream = BufferedOutputByteStream()
@@ -1250,6 +1254,9 @@ extension ManifestLoader {
                 stream.send(key.rawValue).send(value)
             }
             stream.send(swiftpmVersion)
+            for flag in extraManifestFlags {
+                stream.send(flag)
+            }
             return stream.bytes.sha256Checksum
         }
     }


### PR DESCRIPTION
The manifest cache key should take into account flags passed to `-Xbuild-tools-swiftc`

### Motivation:

SwiftPM did not re-evaluate manifests even after changing `-Xbuild-tools-swiftc`

### Modifications:

Hash those extra flags into manifest cache key

### Result:

Manifest will be properly re-evaluated after changing `-Xbuild-tools-swiftc`.