### PR TITLE
[6.0] Invalidate manifest cache when `-Xbuild-tools-swiftc` changes

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -568,6 +568,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 toolsVersion: toolsVersion,
                 env: Environment.current.cachable,
                 swiftpmVersion: SwiftVersion.current.displayString,
+                extraManifestFlags: self.extraManifestFlags,
                 fileSystem: fileSystem
             )
         } catch {
@@ -1207,6 +1208,7 @@ extension ManifestLoader {
               toolsVersion: ToolsVersion,
               env: Environment,
               swiftpmVersion: String,
+              extraManifestFlags: [String],
               fileSystem: FileSystem
         ) throws {
             let manifestContents = try fileSystem.readFileContents(manifestPath).contents
@@ -1216,6 +1218,7 @@ extension ManifestLoader {
                 manifestContents: manifestContents,
                 toolsVersion: toolsVersion,
                 env: env,
+                extraManifestFlags: extraManifestFlags,
                 swiftpmVersion: swiftpmVersion
             )
 
@@ -1238,6 +1241,7 @@ extension ManifestLoader {
             manifestContents: [UInt8],
             toolsVersion: ToolsVersion,
             env: Environment,
+            extraManifestFlags: [String],
             swiftpmVersion: String
         ) throws -> String {
             let stream = BufferedOutputByteStream()
@@ -1249,6 +1253,9 @@ extension ManifestLoader {
                 stream.send(key.rawValue).send(value)
             }
             stream.send(swiftpmVersion)
+            for flag in extraManifestFlags {
+                stream.send(flag)
+            }
             return stream.bytes.sha256Checksum
         }
     }

--- a/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
@@ -269,6 +269,68 @@ final class ManifestLoaderCacheTests: XCTestCase {
         }
     }
 
+    func testCacheInvalidateOnBuildToolsFlags() async throws {
+        try UserToolchain.default.skipUnlessAtLeastSwift6()
+
+        try await testWithTemporaryDirectory { path in
+            let fileSystem = InMemoryFileSystem()
+            let observability = ObservabilitySystem.makeForTesting()
+
+            let manifestPath = path.appending(components: "pkg", "Package.swift")
+            try fileSystem.createDirectory(manifestPath.parentDirectory, recursive: true)
+            try fileSystem.writeFileContents(
+                manifestPath,
+                string: """
+                    import PackageDescription
+                    let package = Package(
+                        name: "Trivial",
+                        targets: [
+                            .target(
+                                name: "foo",
+                                dependencies: []),
+                        ]
+                    )
+                    #if TEST_BUILD_FLAG
+                    package.targets[0].name = "bar"
+                    #endif
+                    """
+            )
+
+            try await check(expectCached: false, extraManifestFlags: [], targetName: "foo")
+            try await check(expectCached: true, extraManifestFlags: [], targetName: "foo")
+            // Cache key should take into account the extra flags.
+            try await check(expectCached: false, extraManifestFlags: ["-DTEST_BUILD_FLAG"], targetName: "bar")
+            try await check(expectCached: true, extraManifestFlags: ["-DTEST_BUILD_FLAG"], targetName: "bar")
+            // Cache should hit after back to original flags.
+            try await check(expectCached: true, extraManifestFlags: [], targetName: "foo")
+
+            func check(expectCached: Bool, extraManifestFlags: [String], targetName: String) async throws {
+                let delegate = ManifestTestDelegate()
+
+                let loader = ManifestLoader(
+                    toolchain: try UserToolchain.default,
+                    cacheDir: path,
+                    extraManifestFlags: extraManifestFlags,
+                    delegate: delegate
+                )
+
+                let manifest = try await XCTAsyncUnwrap(try await loader.load(
+                    manifestPath: manifestPath,
+                    packageKind: .root(manifestPath.parentDirectory),
+                    toolsVersion: .current,
+                    fileSystem: fileSystem,
+                    observabilityScope: observability.topScope
+                ))
+
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)), [manifestPath])
+                try await XCTAssertAsyncEqual(try await delegate.parsed(timeout: .seconds(1)).count, expectCached ? 0 : 1)
+                XCTAssertEqual(manifest.displayName, "Trivial")
+                XCTAssertEqual(manifest.targets[0].name, targetName)
+            }
+        }
+    }
+
     func testCacheInvalidationOnEnv() async throws {
         try UserToolchain.default.skipUnlessAtLeastSwift6()
 
@@ -576,6 +638,7 @@ private func makeMockManifests(
             toolsVersion: ToolsVersion.current,
             env: [:],
             swiftpmVersion: SwiftVersion.current.displayString,
+            extraManifestFlags: [],
             fileSystem: fileSystem
         )
         manifests[key] = ManifestLoader.EvaluationResult(


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-package-manager/pull/7760

**Explanation**: The manifest cache key should take into account flags passed to `-Xbuild-tools-swiftc`, but it didn't. so SwiftPM did not re-evaluate manifests even after changing `-Xbuild-tools-swiftc`. Fix the incorrect cache by hashing those extra flags into manifest cache key.

**Scope**: Affects only when `-Xbuild-tools-swiftc` is used.
**Risk**: low due to isolated less used option
**Testing**: Added a new test case to cover the senario
**Issue**: N/A
**Reviewer**: @xedin