### PR TITLE
[6.0] Add the formalized Swift Testing event stream arguments to `swift test`.

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -80,6 +80,38 @@ struct SharedOptions: ParsableArguments {
     var testProduct: String?
 }
 
+struct TestEventStreamOptions: ParsableArguments {
+    /// Legacy equivalent of ``configurationPath``.
+    @Option(name: .customLong("experimental-configuration-path"),
+            help: .private)
+    var experimentalConfigurationPath: AbsolutePath?
+
+    /// Path where swift-testing's JSON configuration should be read.
+    @Option(name: .customLong("configuration-path"),
+            help: .hidden)
+    var configurationPath: AbsolutePath?
+
+    /// Legacy equivalent of ``eventStreamOutputPath``.
+    @Option(name: .customLong("experimental-event-stream-output"),
+            help: .private)
+    var experimentalEventStreamOutputPath: AbsolutePath?
+
+    /// Path where swift-testing's JSON output should be written.
+    @Option(name: .customLong("event-stream-output-path"),
+            help: .hidden)
+    var eventStreamOutputPath: AbsolutePath?
+
+    /// Legacy equivalent of ``eventStreamVersion``.
+    @Option(name: .customLong("experimental-event-stream-version"),
+            help: .private)
+    var experimentalEventStreamVersion: Int?
+
+    /// The schema version of swift-testing's JSON input/output.
+    @Option(name: .customLong("event-stream-version"),
+            help: .hidden)
+    var eventStreamVersion: Int?
+}
+
 struct TestCommandOptions: ParsableArguments {
     @OptionGroup()
     var globalOptions: GlobalOptions
@@ -90,6 +122,10 @@ struct TestCommandOptions: ParsableArguments {
     /// Which testing libraries to use (and any related options.)
     @OptionGroup()
     var testLibraryOptions: TestLibraryOptions
+
+    /// Options for Swift Testing's event stream.
+    @OptionGroup()
+    var testEventStreamOptions: TestEventStreamOptions
 
     /// If tests should run in parallel mode.
     @Flag(name: .customLong("parallel"),
@@ -155,21 +191,6 @@ struct TestCommandOptions: ParsableArguments {
     var enableExperimentalTestOutput: Bool {
         return testOutput == .experimentalSummary
     }
-
-    /// Path where swift-testing's JSON configuration should be read.
-    @Option(name: .customLong("experimental-configuration-path"),
-            help: .hidden)
-    var configurationPath: AbsolutePath?
-
-    /// Path where swift-testing's JSON output should be written.
-    @Option(name: .customLong("experimental-event-stream-output"),
-            help: .hidden)
-    var eventStreamOutputPath: AbsolutePath?
-
-    /// The schema version of swift-testing's JSON input/output.
-    @Option(name: .customLong("experimental-event-stream-version"),
-            help: .hidden)
-    var eventStreamVersion: Int?
 }
 
 /// Tests filtering specifier, which is used to filter tests to run.
@@ -652,6 +673,10 @@ extension SwiftTestCommand {
         /// Which testing libraries to use (and any related options.)
         @OptionGroup()
         var testLibraryOptions: TestLibraryOptions
+
+        /// Options for Swift Testing's event stream.
+        @OptionGroup()
+        var testEventStreamOptions: TestEventStreamOptions
 
         // for deprecated passthrough from SwiftTestTool (parse will fail otherwise)
         @Flag(name: [.customLong("list-tests"), .customShort("l")], help: .hidden)


### PR DESCRIPTION
Cherry-picks #7768 to release/6.0.

**Explanation**: Adds tools-facing command-line arguments for Swift Testing to `swift test` and `swift test list`. These arguments are passed through verbatim to Swift Testing and are not directly used by SwiftPM.
**Scope**: Affects `swift test` and `swift test list`.
**Risk**: Low—these arguments are wholly ignored by SwiftPM, and just need to be allowed through.
**Testing**: Existing test coverage for `swift test`, plus tests on the Swift Testing side for actually handling the arguments. Since SwiftPM ignores them, additional unit testing on the SwiftPM side would be tautological.
**Issue**: https://github.com/apple/swift-testing/pull/479
**Reviewer**: @bnbarham, @briancroom, @stmontgomery, @dennisweissmann