### PR TITLE
[DNM] Testing swiftpm-testing-helper tool discovery for tests on Darwin platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -738,6 +738,14 @@ let package = Package(
     swiftLanguageVersions: [.v5]
 )
 
+#if canImport(Darwin)
+package.targets.append(contentsOf: [
+    .executableTarget(
+        name: "swiftpm-testing-helper"
+    )
+])
+#endif
+
 // Workaround SPM's attempt to link in executables which does not work on all
 // platforms.
 #if !os(Windows)

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -112,9 +112,7 @@ public class LLBuildManifestBuilder {
             }
         }
 
-        if self.plan.destinationBuildParameters.testingParameters.library == .xctest {
-            try self.addTestDiscoveryGenerationCommand()
-        }
+        try self.addTestDiscoveryGenerationCommand()
         try self.addTestEntryPointGenerationCommand()
 
         // Create command for all products in the plan.
@@ -310,9 +308,7 @@ extension LLBuildManifestBuilder {
 
             let outputs = testEntryPointTarget.target.sources.paths
 
-            let mainFileName = TestEntryPointTool.mainFileName(
-                for: self.plan.destinationBuildParameters.testingParameters.library
-            )
+            let mainFileName = TestEntryPointTool.mainFileName
             guard let mainOutput = (outputs.first { $0.basename == mainFileName }) else {
                 throw InternalError("main output (\(mainFileName)) not found")
             }

--- a/Sources/Build/LLBuildCommands.swift
+++ b/Sources/Build/LLBuildCommands.swift
@@ -247,6 +247,7 @@ final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
             #endif
 
             @main
+            @available(macOS 10.15.0, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
             @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
             struct Runner {
                 private static func testingLibrary() -> String {

--- a/Sources/Build/LLBuildCommands.swift
+++ b/Sources/Build/LLBuildCommands.swift
@@ -275,7 +275,7 @@ final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
                 private static func _runAsyncMain(_ asyncFun: @Sendable @escaping () async throws -> ())
                 #endif
 
-                static func main() \(asyncMainKeyword) {
+                static func main() \#(asyncMainKeyword) {
                     let testingLibrary = Self.testingLibrary()
                     #if \#(swiftTestingImportCondition)
                     if testingLibrary == "swift-testing" {

--- a/Sources/Build/LLBuildCommands.swift
+++ b/Sources/Build/LLBuildCommands.swift
@@ -242,9 +242,9 @@ final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
 
         // FIXME: work around crash on Amazon Linux 2 when main function is async (rdar://128303921)
         let asyncMainKeyword = if context.productsBuildParameters.triple.isLinux() {
-            "async"
+          ""
         } else {
-            ""
+          "async"
         }
 
         stream.send(

--- a/Sources/Build/LLBuildDescription.swift
+++ b/Sources/Build/LLBuildDescription.swift
@@ -140,8 +140,7 @@ public struct BuildDescription: Codable {
             try BuiltTestProduct(
                 productName: desc.product.name,
                 binaryPath: desc.binaryPath,
-                packagePath: desc.package.path,
-                library: desc.buildParameters.testingParameters.library
+                packagePath: desc.package.path
             )
         }
         self.pluginDescriptions = pluginDescriptions

--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -54,20 +54,11 @@ extension SwiftPackageCommand {
                 throw InternalError("Could not find the current working directory")
             }
 
-            // NOTE: Do not use testLibraryOptions.enabledTestingLibraries(swiftCommandState:) here
-            // because the package doesn't exist yet, so there are no dependencies for it to query.
-            var testingLibraries: Set<BuildParameters.Testing.Library> = []
-            if testLibraryOptions.enableXCTestSupport {
-                testingLibraries.insert(.xctest)
-            }
-            if testLibraryOptions.explicitlyEnableSwiftTestingLibrarySupport == true {
-                testingLibraries.insert(.swiftTesting)
-            }
             let packageName = self.packageName ?? cwd.basename
             let initPackage = try InitPackage(
                 name: packageName,
                 packageType: initMode,
-                supportedTestingLibraries: testingLibraries,
+                supportedTestingLibraries: Set(testLibraryOptions.enabledTestingLibraries),
                 destinationPath: cwd,
                 installedSwiftPMConfiguration: swiftCommandState.getHostToolchain().installedSwiftPMConfiguration,
                 fileSystem: swiftCommandState.fileSystem

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -175,7 +175,7 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
         }
 
         if case .allIncludingTests = subset {
-            func updateTestingParameters(of buildParameters: inout BuildParameters, library: BuildParameters.Testing.Library) {
+            func updateTestingParameters(of buildParameters: inout BuildParameters) {
                 buildParameters.testingParameters = .init(
                     configuration: buildParameters.configuration,
                     targetTriple: buildParameters.triple,
@@ -183,15 +183,12 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
                     enableTestability: buildParameters.testingParameters.enableTestability,
                     experimentalTestOutput: buildParameters.testingParameters.experimentalTestOutput,
                     forceTestDiscovery: globalOptions.build.enableTestDiscovery,
-                    testEntryPointPath: globalOptions.build.testEntryPointPath,
-                    library: library
+                    testEntryPointPath: globalOptions.build.testEntryPointPath
                 )
             }
-            for library in try options.testLibraryOptions.enabledTestingLibraries(swiftCommandState: swiftCommandState) {
-                updateTestingParameters(of: &productsBuildParameters, library: library)
-                updateTestingParameters(of: &toolsBuildParameters, library: library)
-                try build(swiftCommandState, subset: subset, productsBuildParameters: productsBuildParameters, toolsBuildParameters: toolsBuildParameters)
-            }
+            updateTestingParameters(of: &productsBuildParameters)
+            updateTestingParameters(of: &toolsBuildParameters)
+            try build(swiftCommandState, subset: subset, productsBuildParameters: productsBuildParameters, toolsBuildParameters: toolsBuildParameters)
         } else {
             try build(swiftCommandState, subset: subset, productsBuildParameters: productsBuildParameters, toolsBuildParameters: toolsBuildParameters)
         }

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -847,13 +847,8 @@ final class TestRunner {
             }
             args += [xctestPath.pathString]
         case .swiftTesting:
-            // FIXME: better way to get path to self
-            let toolPath = String(unsafeUninitializedCapacity: 2048) { buffer in
-                var count = UInt32(buffer.count)
-                _NSGetExecutablePath(buffer.baseAddress!, &count)
-                return Int(count)
-            }
-            args += [toolPath, "--test-bundle-path", testPath.pathString]
+            let helper = try self.toolchain.getSwiftTestingHelper()
+            args += [helper.pathString, "--test-bundle-path", testPath.pathString]
         }
         args += additionalArguments
         args += [testPath.pathString]

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -118,8 +118,7 @@ enum TestingSupport {
                 destinationBuildParameters: swiftCommandState.buildParametersForTest(
                     enableCodeCoverage: enableCodeCoverage,
                     shouldSkipBuilding: shouldSkipBuilding,
-                    experimentalTestOutput: experimentalTestOutput,
-                    library: .xctest
+                    experimentalTestOutput: experimentalTestOutput
                 ).productsBuildParameters,
                 sanitizers: sanitizers,
                 library: .xctest
@@ -134,8 +133,7 @@ enum TestingSupport {
             toolchain: try swiftCommandState.getTargetToolchain(),
             destinationBuildParameters: swiftCommandState.buildParametersForTest(
                 enableCodeCoverage: enableCodeCoverage,
-                shouldSkipBuilding: shouldSkipBuilding,
-                library: .xctest
+                shouldSkipBuilding: shouldSkipBuilding
             ).productsBuildParameters,
             sanitizers: sanitizers,
             library: .xctest
@@ -164,10 +162,6 @@ enum TestingSupport {
             env["NO_COLOR"] = "1"
         }
 
-        // Set an environment variable to indicate which library's test product
-        // is being executed.
-        env["SWIFT_PM_TEST_LIBRARY"] = String(describing: library)
-
         // Add the code coverage related variables.
         if buildParameters.testingParameters.enableCodeCoverage {
             // Defines the path at which the profraw files will be written on test execution.
@@ -177,7 +171,7 @@ enum TestingSupport {
             // execution but is required when the tests are running in parallel as
             // SwiftPM repeatedly invokes the test binary with the test case name as
             // the filter.
-            let codecovProfile = buildParameters.buildPath.appending(components: "codecov", "default%m.profraw")
+            let codecovProfile = buildParameters.buildPath.appending(components: "codecov", "\(library)%m.profraw")
             env["LLVM_PROFILE_FILE"] = codecovProfile.pathString
         }
         #if !os(macOS)
@@ -193,6 +187,11 @@ enum TestingSupport {
             // appending since we prefer the user setting (if set) to the one we inject
             env.appendPath(key: "DYLD_FRAMEWORK_PATH", value: sdkPlatformFrameworksPath.fwk.pathString)
             env.appendPath(key: "DYLD_LIBRARY_PATH", value: sdkPlatformFrameworksPath.lib.pathString)
+        }
+
+        // We aren't using XCTest's harness logic to run Swift Testing tests.
+        if library == .xctest {
+            env["SWIFT_TESTING_ENABLED"] = "0"
         }
 
         // Fast path when no sanitizers are enabled.
@@ -221,24 +220,21 @@ extension SwiftCommandState {
         enableCodeCoverage: Bool,
         enableTestability: Bool? = nil,
         shouldSkipBuilding: Bool = false,
-        experimentalTestOutput: Bool = false,
-        library: BuildParameters.Testing.Library
+        experimentalTestOutput: Bool = false
     ) throws -> (productsBuildParameters: BuildParameters, toolsBuildParameters: BuildParameters) {
         let productsBuildParameters = buildParametersForTest(
             modifying: try productsBuildParameters,
             enableCodeCoverage: enableCodeCoverage,
             enableTestability: enableTestability,
             shouldSkipBuilding: shouldSkipBuilding,
-            experimentalTestOutput: experimentalTestOutput,
-            library: library
+            experimentalTestOutput: experimentalTestOutput
         )
         let toolsBuildParameters = buildParametersForTest(
             modifying: try toolsBuildParameters,
             enableCodeCoverage: enableCodeCoverage,
             enableTestability: enableTestability,
             shouldSkipBuilding: shouldSkipBuilding,
-            experimentalTestOutput: experimentalTestOutput,
-            library: library
+            experimentalTestOutput: experimentalTestOutput
         )
         return (productsBuildParameters, toolsBuildParameters)
     }
@@ -248,8 +244,7 @@ extension SwiftCommandState {
         enableCodeCoverage: Bool,
         enableTestability: Bool?,
         shouldSkipBuilding: Bool,
-        experimentalTestOutput: Bool,
-        library: BuildParameters.Testing.Library
+        experimentalTestOutput: Bool
     ) -> BuildParameters {
         var parameters = parameters
 
@@ -266,8 +261,7 @@ extension SwiftCommandState {
             configuration: parameters.configuration,
             targetTriple: parameters.triple,
             forceTestDiscovery: explicitlyEnabledDiscovery,
-            testEntryPointPath: explicitlySpecifiedPath,
-            library: library
+            testEntryPointPath: explicitlySpecifiedPath
         )
 
         parameters.testingParameters.enableCodeCoverage = enableCodeCoverage

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -586,7 +586,7 @@ public struct TestLibraryOptions: ParsableArguments {
     /// have the correct default value if the user didn't specify one.
     @Flag(name: .customLong("swift-testing"),
           inversion: .prefixedEnableDisable,
-          help: "Enable support for swift-testing")
+          help: "Enable support for Swift Testing")
     public var explicitlyEnableSwiftTestingLibrarySupport: Bool?
 
     /// Legacy experimental equivalent of ``explicitlyEnableSwiftTestingLibrarySupport``.
@@ -594,7 +594,7 @@ public struct TestLibraryOptions: ParsableArguments {
     /// This option will be removed in a future update.
     @Flag(name: .customLong("experimental-swift-testing"),
           inversion: .prefixedEnableDisable,
-          help: .hidden)
+          help: .private)
     public var explicitlyEnableExperimentalSwiftTestingLibrarySupport: Bool?
 
     /// Test whether or not a given library is enabled.
@@ -609,7 +609,7 @@ public struct TestLibraryOptions: ParsableArguments {
 
     /// The list of enabled testing libraries.
     public var enabledTestingLibraries: [BuildParameters.Testing.Library] {
-        [.xctest, .swiftTesting].lazy.filter(isEnabled)
+        [.xctest, .swiftTesting].filter(isEnabled)
     }
 }
 

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -580,83 +580,36 @@ public struct TestLibraryOptions: ParsableArguments {
           help: "Enable support for XCTest")
     public var explicitlyEnableXCTestSupport: Bool?
 
-    /// Whether to enable support for XCTest.
-    public var enableXCTestSupport: Bool {
-        // Default to enabled.
-        explicitlyEnableXCTestSupport ?? true
-    }
-
-    /// Whether to enable support for swift-testing (as explicitly specified by the user.)
+    /// Whether to enable support for Swift Testing (as explicitly specified by the user.)
     ///
-    /// Callers (other than `swift package init`) will generally want to use
-    /// ``enableSwiftTestingLibrarySupport(swiftCommandState:)`` since it will
-    /// take into account whether the package has a dependency on swift-testing.
-    @Flag(name: .customLong("experimental-swift-testing"),
+    /// Callers will generally want to use ``enableSwiftTestingLibrarySupport`` since it will
+    /// have the correct default value if the user didn't specify one.
+    @Flag(name: .customLong("swift-testing"),
           inversion: .prefixedEnableDisable,
-          help: "Enable experimental support for swift-testing")
+          help: "Enable support for swift-testing")
     public var explicitlyEnableSwiftTestingLibrarySupport: Bool?
 
-    /// Whether to enable support for swift-testing.
-    public func enableSwiftTestingLibrarySupport(
-        swiftCommandState: SwiftCommandState
-    ) throws -> Bool {
-        // Honor the user's explicit command-line selection, if any.
-        if let callerSuppliedValue = explicitlyEnableSwiftTestingLibrarySupport {
-            return callerSuppliedValue
-        }
+    /// Legacy experimental equivalent of ``explicitlyEnableSwiftTestingLibrarySupport``.
+    ///
+    /// This option will be removed in a future update.
+    @Flag(name: .customLong("experimental-swift-testing"),
+          inversion: .prefixedEnableDisable,
+          help: .hidden)
+    public var explicitlyEnableExperimentalSwiftTestingLibrarySupport: Bool?
 
-        // If the active package has a dependency on swift-testing, automatically enable support for it so that extra steps are not needed.
-        let workspace = try swiftCommandState.getActiveWorkspace()
-        let root = try swiftCommandState.getWorkspaceRoot()
-        let rootManifests = try temp_await {
-            workspace.loadRootManifests(
-                packages: root.packages,
-                observabilityScope: swiftCommandState.observabilityScope,
-                completion: $0
-            )
+    /// Test whether or not a given library is enabled.
+    public func isEnabled(_ library: BuildParameters.Testing.Library) -> Bool {
+        switch library {
+        case .xctest:
+            explicitlyEnableXCTestSupport ?? true
+        case .swiftTesting:
+            explicitlyEnableSwiftTestingLibrarySupport ?? explicitlyEnableExperimentalSwiftTestingLibrarySupport ?? true
         }
-
-        // Is swift-testing among the dependencies of the package being built?
-        // If so, enable support.
-        let isEnabledByDependency = rootManifests.values.lazy
-            .flatMap(\.dependencies)
-            .map(\.identity)
-            .map(String.init(describing:))
-            .contains("swift-testing")
-        if isEnabledByDependency {
-            swiftCommandState.observabilityScope.emit(debug: "Enabling swift-testing support due to its presence as a package dependency.")
-            return true
-        }
-
-        // Is swift-testing the package being built itself (unlikely)? If so,
-        // enable support.
-        let isEnabledByName = root.packages.lazy
-            .map(PackageIdentity.init(path:))
-            .map(String.init(describing:))
-            .contains("swift-testing")
-        if isEnabledByName {
-            swiftCommandState.observabilityScope.emit(debug: "Enabling swift-testing support because it is a root package.")
-            return true
-        }
-
-        // Default to disabled since swift-testing is experimental (opt-in.)
-        return false
     }
 
-    /// Get the set of enabled testing libraries.
-    public func enabledTestingLibraries(
-        swiftCommandState: SwiftCommandState
-    ) throws -> Set<BuildParameters.Testing.Library> {
-        var result = Set<BuildParameters.Testing.Library>()
-
-        if enableXCTestSupport {
-            result.insert(.xctest)
-        }
-        if try enableSwiftTestingLibrarySupport(swiftCommandState: swiftCommandState) {
-            result.insert(.swiftTesting)
-        }
-
-        return result
+    /// The list of enabled testing libraries.
+    public var enabledTestingLibraries: [BuildParameters.Testing.Library] {
+        [.xctest, .swiftTesting].lazy.filter(isEnabled)
     }
 }
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -387,6 +387,22 @@ public final class UserToolchain: Toolchain {
         )
     }
 
+    public func getSwiftTestingHelper() throws -> AbsolutePath {
+        // The helper would be located in `.build/<config>` directory when
+        // SwiftPM is built locally and `usr/libexec/swift/pm` directory in
+        // installed version.
+        let binDirectories = self.swiftSDK.toolset.rootPaths +
+            self.swiftSDK.toolset.rootPaths.map {
+                $0.parentDirectory.appending(components: ["libexec", "swift", "pm"])
+            }
+
+        return try UserToolchain.getTool(
+            "swiftpm-testing-helper",
+            binDirectories: binDirectories,
+            fileSystem: self.fileSystem
+        )
+    }
+
     internal static func deriveSwiftCFlags(
         triple: Triple,
         swiftSDK: SwiftSDK,

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Testing.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Testing.swift
@@ -40,13 +40,9 @@ extension BuildParameters {
 
         /// Whether this test product style requires additional, derived test targets, i.e. there must be additional test targets, beyond those
         /// listed explicitly in the package manifest, created in order to add additional behavior (such as entry point logic).
+        /// FIXME: remove this property since it's always true now.
         public var requiresAdditionalDerivedTestTargets: Bool {
-            switch self {
-            case .loadableBundle:
-                return false
-            case .entryPointExecutable:
-                return true
-            }
+            true
         }
 
         /// The explicitly-specified entry point file path, if this style of test product supports it and a path was specified.
@@ -113,9 +109,6 @@ extension BuildParameters {
             }
         }
 
-        /// Which testing library to use for this build.
-        public var library: Library
-
         public init(
             configuration: BuildConfiguration,
             targetTriple: Triple,
@@ -123,8 +116,7 @@ extension BuildParameters {
             enableTestability: Bool? = nil,
             experimentalTestOutput: Bool = false,
             forceTestDiscovery: Bool = false,
-            testEntryPointPath: AbsolutePath? = nil,
-            library: Library = .xctest
+            testEntryPointPath: AbsolutePath? = nil
         ) {
             self.enableCodeCoverage = enableCodeCoverage
             self.experimentalTestOutput = experimentalTestOutput
@@ -136,11 +128,10 @@ extension BuildParameters {
             // when building and testing in release mode, one can use the '--disable-testable-imports' flag
             // to disable testability in `swift test`, but that requires that the tests do not use the testable imports feature
             self.enableTestability =  enableTestability ?? (.debug == configuration)
-            self.testProductStyle = (targetTriple.isDarwin() && library == .xctest) ? .loadableBundle : .entryPointExecutable(
+            self.testProductStyle = targetTriple.isDarwin() ? .loadableBundle : .entryPointExecutable(
                 explicitlyEnabledDiscovery: forceTestDiscovery,
                 explicitlySpecifiedPath: testEntryPointPath
             )
-            self.library = library
         }
     }
 }

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -293,16 +293,11 @@ public struct BuildParameters: Encodable {
             guard !self.triple.isWasm else {
                 return try RelativePath(validating: "\(product.name).wasm")
             }
-            switch testingParameters.library {
-            case .xctest:
-                let base = "\(product.name).xctest"
-                if self.triple.isDarwin() {
-                    return try RelativePath(validating: "\(base)/Contents/MacOS/\(product.name)")
-                } else {
-                    return try RelativePath(validating: base)
-                }
-            case .swiftTesting:
-                return try RelativePath(validating: "\(product.name).swift-testing")
+            let base = "\(product.name).xctest"
+            if self.triple.isDarwin() {
+                return try RelativePath(validating: "\(base)/Contents/MacOS/\(product.name)")
+            } else {
+                return try RelativePath(validating: base)
             }
         case .macro:
             #if BUILD_MACROS_AS_DYLIBS

--- a/Sources/SPMBuildCore/BuiltTestProduct.swift
+++ b/Sources/SPMBuildCore/BuiltTestProduct.swift
@@ -28,15 +28,8 @@ public struct BuiltTestProduct: Codable {
     /// When the test product is not bundled (for instance, when using XCTest on
     /// non-Darwin targets), this path is equal to ``binaryPath``.
     public var bundlePath: AbsolutePath {
-        // Go up the folder hierarchy until we find the .xctest or
-        // .swift-testing bundle.
-        let pathExtension: String
-        switch library {
-        case .xctest:
-            pathExtension = ".xctest"
-        case .swiftTesting:
-            pathExtension = ".swift-testing"
-        }
+        // Go up the folder hierarchy until we find the .xctest bundle.
+        let pathExtension = ".xctest"
         let hierarchySequence = sequence(first: binaryPath, next: { $0.isRoot ? nil : $0.parentDirectory })
         guard let bundlePath = hierarchySequence.first(where: { $0.basename.hasSuffix(pathExtension) }) else {
             fatalError("could not find test bundle path from '\(binaryPath)'")
@@ -45,18 +38,14 @@ public struct BuiltTestProduct: Codable {
         return bundlePath
     }
 
-    /// The library used to build this test product.
-    public var library: BuildParameters.Testing.Library
-
     /// Creates a new instance.
     /// - Parameters:
     ///   - productName: The test product name.
     ///   - binaryPath: The path of the test binary.
     ///   - packagePath: The path to the package this product was declared in.
-    public init(productName: String, binaryPath: AbsolutePath, packagePath: AbsolutePath, library: BuildParameters.Testing.Library) {
+    public init(productName: String, binaryPath: AbsolutePath, packagePath: AbsolutePath) {
         self.productName = productName
         self.binaryPath = binaryPath
         self.packagePath = packagePath
-        self.library = library
     }
 }

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -58,8 +58,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
                         BuiltTestProduct(
                             productName: product.name,
                             binaryPath: binaryPath,
-                            packagePath: package.path,
-                            library: buildParameters.testingParameters.library
+                            packagePath: package.path
                         )
                     )
                 }

--- a/Sources/swift-test/Entrypoint.swift
+++ b/Sources/swift-test/Entrypoint.swift
@@ -11,10 +11,40 @@
 //===----------------------------------------------------------------------===//
 
 import Commands
+#if canImport(Darwin.C)
+private import Darwin.C
+#endif
 
 @main
 struct Entrypoint {
-    static func main() async {
+    static func main() async throws {
+#if canImport(Darwin.C)
+      // HACK: use the swift-test executable as a host for the .xctest bundle
+      // when running Swift Testing tests.
+      let args = CommandLine.arguments
+      if args.count >= 3, args[1] == "--test-bundle-path" {
+        let bundlePath = args[2]
+        guard let image = dlopen(bundlePath, RTLD_LAZY) else {
+          let errorMessage: String = dlerror().flatMap {
+            String(validatingCString: $0)
+          } ?? "An unknown error occurred."
+          fatalError("Failed to open test bundle at path \(bundlePath): \(errorMessage)")
+        }
+        defer {
+          dlclose(image)
+        }
+
+        // Find and call the main function from the image. This function may
+        // link to the copy of Swift Testing included with Xcode, or may link to
+        // a copy that's included as a package dependency.
+        let main = dlsym(image, "main").map {
+          unsafeBitCast($0, to: (@convention(c) (CInt, UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) -> CInt).self)
+        }
+        if let main {
+          exit(main(CommandLine.argc, CommandLine.unsafeArgv))
+        }
+      }
+#endif
         await SwiftTestCommand.main()
     }
 }

--- a/Sources/swift-test/Entrypoint.swift
+++ b/Sources/swift-test/Entrypoint.swift
@@ -12,7 +12,7 @@
 
 import Commands
 #if canImport(Darwin.C)
-private import Darwin.C
+import Darwin.C
 #endif
 
 @main
@@ -26,7 +26,11 @@ struct Entrypoint {
         let bundlePath = args[2]
         guard let image = dlopen(bundlePath, RTLD_LAZY) else {
           let errorMessage: String = dlerror().flatMap {
+#if compiler(>=6)
             String(validatingCString: $0)
+#else
+            String(validatingUTF8: $0)
+#endif
           } ?? "An unknown error occurred."
           fatalError("Failed to open test bundle at path \(bundlePath): \(errorMessage)")
         }

--- a/Sources/swiftpm-testing-helper/Entrypoint.swift
+++ b/Sources/swiftpm-testing-helper/Entrypoint.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Darwin.C
+
+@main
+struct Entrypoint {
+    static func main() throws {
+        let args = CommandLine.arguments
+        if args.count >= 3, args[1] == "--test-bundle-path" {
+            let bundlePath = args[2]
+            guard let image = dlopen(bundlePath, RTLD_LAZY) else {
+                let errorMessage: String = dlerror().flatMap {
+                    #if compiler(>=6)
+                    String(validatingCString: $0)
+                    #else
+                    String(validatingUTF8: $0)
+                    #endif
+                } ?? "An unknown error occurred."
+                fatalError("Failed to open test bundle at path \(bundlePath): \(errorMessage)")
+            }
+            defer {
+                dlclose(image)
+            }
+
+            // Find and call the main function from the image. This function may
+            // link to the copy of Swift Testing included with Xcode, or may link to
+            // a copy that's included as a package dependency.
+            let main = dlsym(image, "main").map {
+                unsafeBitCast(
+                    $0,
+                    to: (@convention(c) (CInt, UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) -> CInt).self
+                )
+            }
+            if let main {
+                exit(main(CommandLine.argc, CommandLine.unsafeArgv))
+            }
+        }
+    }
+}

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1146,9 +1146,6 @@ final class BuildPlanTests: XCTestCase {
         ))
 
         XCTAssertEqual(Set(result.productMap.keys.map(\.productName)), ["APackageTests"])
-        #if os(macOS)
-        XCTAssertEqual(Set(result.targetMap.keys.map(\.moduleName)), ["ATarget", "BTarget", "ATargetTests"])
-        #else
         XCTAssertEqual(Set(result.targetMap.keys.map(\.moduleName)), [
             "APackageTests",
             "APackageDiscoveredTests",
@@ -1156,7 +1153,6 @@ final class BuildPlanTests: XCTestCase {
             "ATargetTests",
             "BTarget",
         ])
-        #endif
     }
 
     func testBasicReleasePackage() throws {
@@ -2213,13 +2209,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         ))
         result.checkProductsCount(1)
-        #if os(macOS)
-        result.checkTargetsCount(2)
-        #else
-        // On non-Apple platforms, when a custom entry point file is present (e.g. XCTMain.swift), there is one
-        // additional target for the synthesized test entry point.
         result.checkTargetsCount(3)
-        #endif
 
         let buildPath = result.plan.productsBuildPath
 
@@ -2288,6 +2278,8 @@ final class BuildPlanTests: XCTestCase {
                 buildPath.appending(components: "Modules", "Foo.swiftmodule").pathString,
                 "-Xlinker", "-add_ast_path", "-Xlinker",
                 buildPath.appending(components: "Modules", "FooTests.swiftmodule").pathString,
+                "-Xlinker", "-add_ast_path", "-Xlinker",
+                buildPath.appending(components: "PkgPackageTests.build", "PkgPackageTests.swiftmodule").pathString,
                 "-g",
             ]
         )

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -197,7 +197,6 @@ final class TestCommandTests: CommandsTestCase {
             XCTAssertNoMatch(stdout, .contains("testExample2"))
             XCTAssertNoMatch(stdout, .contains("testExample3"))
             XCTAssertNoMatch(stdout, .contains("testExample4"))
-            XCTAssertMatch(stderr, .contains("No matching test cases were run"))
         }
     }
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -435,7 +435,14 @@ def install(args):
 def install_swiftpm(prefix, args):
     # Install the swift-package-manager tool and create symlinks to it.
     cli_tool_dest = os.path.join(prefix, "bin")
+    aux_tool_dest = os.path.join(prefix, "libexec", "swift", "pm")
+
     install_binary(args, "swift-package-manager", os.path.join(cli_tool_dest, "swift-package"), destination_is_directory=False)
+
+    # `swiftpm-testing-helper` only exists on Darwin platforms
+    if os.path.exists(os.path.join(args.bin_dir, "swiftpm-testing-helper")):
+        install_binary(args, "swiftpm-testing-helper", aux_tool_dest)
+
     for tool in ["swift-build", "swift-test", "swift-run", "swift-package-collection", "swift-package-registry", "swift-sdk", "swift-experimental-sdk"]:
         src = "swift-package"
         dest = os.path.join(cli_tool_dest, tool)


### PR DESCRIPTION
Testing some changes to https://github.com/swiftlang/swift-package-manager/pull/7766

- Introduce `swiftpm-testing-helper` and install it into toolchain
- Use SwiftSDK rootpaths to discover the tool while running tests - it would either be in `.build/<config>` if it's a local build or in `usr/libexec/swift/pm` if it's an installed toolchain.