### PR TITLE
[6.0] NFC: Make 'FileRuleDescription.Rule' conform to `Sendable`

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -567,7 +567,7 @@ public struct FileRuleDescription: Sendable {
     /// A rule semantically describes a file/directory in a target.
     ///
     /// It is up to the build system to translate a rule into a build command.
-    public enum Rule: Equatable {
+    public enum Rule: Sendable, Equatable {
         /// The compile rule for `sources` in a package.
         case compile
 


### PR DESCRIPTION
**Explanation**: `TargetSourcesBuilder.swift`: Stored property 'rule' of 'Sendable'-conforming struct 'FileRuleDescription' has non-sendable type 'FileRuleDescription.Rule'; this is an error in the Swift 6 language mode.
**Scope**: Non-functional change.
**Risk**: Very low as it's an NFC change removing a compiler warning.
**Testing**: Manually verified that the warning is resolved.
**Issue**: rdar://131439553
**Reviewer**: @bnbarham
