### PR TITLE
Fix warning in `OSSignpost.swift` w/ `@preconcurrency import`

### DIFF
--- a/Sources/Basics/OSSignpost.swift
+++ b/Sources/Basics/OSSignpost.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(os)
-import os
+@preconcurrency import os
 #endif
 
 #if canImport(os)


### PR DESCRIPTION
rdar://131432130