### PR TITLE
[6.0] Fix warning in `OSSignpost.swift` w/ `@preconcurrency import`

### DIFF
--- a/Sources/Basics/OSSignpost.swift
+++ b/Sources/Basics/OSSignpost.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(os)
-import os
+@preconcurrency import os
 #endif
 
 #if canImport(os)


### PR DESCRIPTION
Cherry-pick of #7785.

**Explanation**: Fixes a Swift Concurrency warning for an import of a preconcurrency module.
**Scope**: Isolated to a warning in a single file.
**Risk**: Very low, change is NFC.
**Testing**: Manually verified that the warning is gone.
**Issue**: rdar://131432130
**Reviewer**: @xedin 
