### PR TITLE
Suppress Swift Testing invocation when XCTMain.swift or LinuxMain.swift is present.

### DIFF
--- a/Sources/Build/LLBuildDescription.swift
+++ b/Sources/Build/LLBuildDescription.swift
@@ -140,7 +140,8 @@ public struct BuildDescription: Codable {
             try BuiltTestProduct(
                 productName: desc.product.name,
                 binaryPath: desc.binaryPath,
-                packagePath: desc.package.path
+                packagePath: desc.package.path,
+                testEntryPointPath: desc.product.underlying.testEntryPointPath
             )
         }
         self.pluginDescriptions = pluginDescriptions

--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -63,7 +63,7 @@ extension SwiftPackageCommand {
             if testLibraryOptions.isEnabled(.xctest) {
                 supportedTestingLibraries.insert(.xctest)
             }
-            if testLibraryOptions.explicitlyEnableSwiftTestingLibrarySupport == true || testLibraryOptions.explicitlyEnableExperimentalSwiftTestingLibrarySupport == true {
+            if testLibraryOptions.isExplicitlyEnabled(.swiftTesting) == true {
                 supportedTestingLibraries.insert(.swiftTesting)
             }
 

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -325,7 +325,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
         // Run Swift Testing (parallel or not, it has a single entry point.)
         if options.testLibraryOptions.isEnabled(.swiftTesting) {
-            if options.testLibraryOptions.isExplicitlyEnabled(.swiftTesting) != true,
+            if let explicitlyEnabled = options.testLibraryOptions.isExplicitlyEnabled(.swiftTesting),
+               explicitlyEnabled,
                let testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first {
                 // Cannot run Swift Testing because an entry point file was used.
                 swiftCommandState.observabilityScope.emit(
@@ -733,7 +734,8 @@ extension SwiftTestCommand {
             }
 
             if testLibraryOptions.isEnabled(.swiftTesting) {
-                if testLibraryOptions.isExplicitlyEnabled(.swiftTesting) != true,
+                if let explicitlyEnabled = testLibraryOptions.isExplicitlyEnabled(.swiftTesting),
+                   explicitlyEnabled,
                    let testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first {
                     // Cannot run Swift Testing because an entry point file was used.
                     swiftCommandState.observabilityScope.emit(

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -325,9 +325,12 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
         // Run Swift Testing (parallel or not, it has a single entry point.)
         if options.testLibraryOptions.isEnabled(.swiftTesting) {
-            if let testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first {
-                // Cannot run Swift Testing because a custom entry point was specified.
-                swiftCommandState.observabilityScope.emit(debug: "Skipping automatic Swift Testing invocation because a test entry point path is present: \(testEntryPointPath)")
+            if options.testLibraryOptions.isExplicitlyEnabled(.swiftTesting) != true,
+               let testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first {
+                // Cannot run Swift Testing because an entry point file was used.
+                swiftCommandState.observabilityScope.emit(
+                    debug: "Skipping automatic Swift Testing invocation because a test entry point path is present: \(testEntryPointPath)"
+                )
             } else {
                 results.append(
                     try await runTestProducts(
@@ -730,9 +733,12 @@ extension SwiftTestCommand {
             }
 
             if testLibraryOptions.isEnabled(.swiftTesting) {
-                if let testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first {
-                    // Cannot run Swift Testing because a custom entry point was specified.
-                    swiftCommandState.observabilityScope.emit(debug: "Skipping automatic Swift Testing invocation (list) because a test entry point path is present: \(testEntryPointPath)")
+                if testLibraryOptions.isExplicitlyEnabled(.swiftTesting) != true,
+                   let testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first {
+                    // Cannot run Swift Testing because an entry point file was used.
+                    swiftCommandState.observabilityScope.emit(
+                        debug: "Skipping automatic Swift Testing invocation (list) because a test entry point path is present: \(testEntryPointPath)"
+                    )
                 } else {
                     let additionalArguments = ["--list-tests"] + CommandLine.arguments.dropFirst()
                     let runner = TestRunner(

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -607,6 +607,16 @@ public struct TestLibraryOptions: ParsableArguments {
         }
     }
 
+    /// Test whether or not a given library was explicitly enabled by the developer.
+    public func isExplicitlyEnabled(_ library: BuildParameters.Testing.Library) -> Bool? {
+        switch library {
+        case .xctest:
+            explicitlyEnableXCTestSupport
+        case .swiftTesting:
+            explicitlyEnableSwiftTestingLibrarySupport ?? explicitlyEnableExperimentalSwiftTestingLibrarySupport
+        }
+    }
+
     /// The list of enabled testing libraries.
     public var enabledTestingLibraries: [BuildParameters.Testing.Library] {
         [.xctest, .swiftTesting].filter(isEnabled)

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -597,17 +597,9 @@ public struct TestLibraryOptions: ParsableArguments {
           help: .private)
     public var explicitlyEnableExperimentalSwiftTestingLibrarySupport: Bool?
 
-    /// Test whether or not a given library is enabled.
-    public func isEnabled(_ library: BuildParameters.Testing.Library) -> Bool {
-        switch library {
-        case .xctest:
-            explicitlyEnableXCTestSupport ?? true
-        case .swiftTesting:
-            explicitlyEnableSwiftTestingLibrarySupport ?? explicitlyEnableExperimentalSwiftTestingLibrarySupport ?? true
-        }
-    }
-
     /// Test whether or not a given library was explicitly enabled by the developer.
+    ///
+    /// If the developer did not specify either way, the result is `nil`.
     public func isExplicitlyEnabled(_ library: BuildParameters.Testing.Library) -> Bool? {
         switch library {
         case .xctest:
@@ -615,6 +607,12 @@ public struct TestLibraryOptions: ParsableArguments {
         case .swiftTesting:
             explicitlyEnableSwiftTestingLibrarySupport ?? explicitlyEnableExperimentalSwiftTestingLibrarySupport
         }
+    }
+
+    /// Test whether or not a given library is enabled.
+    public func isEnabled(_ library: BuildParameters.Testing.Library) -> Bool {
+        // Both libraries are enabled by default.
+        isExplicitlyEnabled(library) ?? true
     }
 
     /// The list of enabled testing libraries.

--- a/Sources/SPMBuildCore/BuiltTestProduct.swift
+++ b/Sources/SPMBuildCore/BuiltTestProduct.swift
@@ -38,14 +38,20 @@ public struct BuiltTestProduct: Codable {
         return bundlePath
     }
 
+    /// The path to the entry point source file (XCTMain.swift, LinuxMain.swift,
+    /// etc.) used, if any.
+    public let testEntryPointPath: AbsolutePath?
+
     /// Creates a new instance.
     /// - Parameters:
     ///   - productName: The test product name.
     ///   - binaryPath: The path of the test binary.
     ///   - packagePath: The path to the package this product was declared in.
-    public init(productName: String, binaryPath: AbsolutePath, packagePath: AbsolutePath) {
+    ///   - mainSourceFilePath: The path to the main source file used, if any.
+    public init(productName: String, binaryPath: AbsolutePath, packagePath: AbsolutePath, testEntryPointPath: AbsolutePath?) {
         self.productName = productName
         self.binaryPath = binaryPath
         self.packagePath = packagePath
+        self.testEntryPointPath = testEntryPointPath
     }
 }

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -58,7 +58,8 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
                         BuiltTestProduct(
                             productName: product.name,
                             binaryPath: binaryPath,
-                            packagePath: package.path
+                            packagePath: package.path,
+                            testEntryPointPath: product.underlying.testEntryPointPath
                         )
                     )
                 }


### PR DESCRIPTION
If a test entry point source file is present in a package, that means our own entry point code won't run, so we can't reliably run Swift Testing. This is a legacy configuration but is still used by a number of packages in the Swift ecosystem.

Further deprecation of this feature is something to consider after Swift 6.0.