### PR TITLE
Add destination directory as argument to `swift package init`

### DIFF
--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -434,12 +434,14 @@ extension InitPackage {
         packageType: PackageType,
         supportedTestingLibraries: Set<BuildParameters.Testing.Library> = [.xctest],
         destinationPath: AbsolutePath,
+        isDestinationCurrentWorkingDirectory: Bool,
         fileSystem: FileSystem
     ) throws {
         try self.init(
             name: name,
             options: InitPackageOptions(packageType: packageType, supportedTestingLibraries: supportedTestingLibraries),
             destinationPath: destinationPath,
+            isDestinationCurrentWorkingDirectory: isDestinationCurrentWorkingDirectory,
             installedSwiftPMConfiguration: .default,
             fileSystem: fileSystem
         )

--- a/Tests/CommandsTests/PackageRegistryCommandTests.swift
+++ b/Tests/CommandsTests/PackageRegistryCommandTests.swift
@@ -349,6 +349,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
                 name: "MyPackage",
                 packageType: .executable,
                 destinationPath: packageDirectory,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -381,6 +382,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
                 name: "MyPackage",
                 packageType: .executable,
                 destinationPath: packageDirectory,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -410,6 +412,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
                 name: "MyPackage",
                 packageType: .executable,
                 destinationPath: packageDirectory,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -470,6 +473,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
                 name: "MyPackage",
                 packageType: .executable,
                 destinationPath: packageDirectory,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -513,6 +517,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
                 name: "MyPackage",
                 packageType: .executable,
                 destinationPath: packageDirectory,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -544,6 +549,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
                 name: "MyPackage",
                 packageType: .executable,
                 destinationPath: packageDirectory,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -598,6 +604,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
                 name: "MyPackage",
                 packageType: .executable,
                 destinationPath: packageDirectory,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -642,6 +649,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
                 name: "MyPackage",
                 packageType: .executable,
                 destinationPath: packageDirectory,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -685,6 +693,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
                 name: "MyPackage",
                 packageType: .executable,
                 destinationPath: packageDirectory,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -765,6 +774,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
                 name: "MyPackage",
                 packageType: .executable,
                 destinationPath: packageDirectory,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -876,6 +886,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
                 name: "MyPackage",
                 packageType: .executable,
                 destinationPath: packageDirectory,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -986,6 +997,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
                 name: "MyPackage",
                 packageType: .executable,
                 destinationPath: packageDirectory,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -32,6 +32,7 @@ final class InitTests: XCTestCase {
                 name: name,
                 packageType: .empty,
                 destinationPath: path,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             var progressMessages = [String]()
@@ -68,6 +69,7 @@ final class InitTests: XCTestCase {
                 name: name,
                 packageType: .executable,
                 destinationPath: path,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             var progressMessages = [String]()
@@ -114,6 +116,7 @@ final class InitTests: XCTestCase {
                 name: name,
                 packageType: .library,
                 destinationPath: path,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             var progressMessages = [String]()
@@ -166,6 +169,7 @@ final class InitTests: XCTestCase {
                 packageType: .library,
                 supportedTestingLibraries: [.swiftTesting],
                 destinationPath: path,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -209,6 +213,7 @@ final class InitTests: XCTestCase {
                 packageType: .library,
                 supportedTestingLibraries: [.swiftTesting, .xctest],
                 destinationPath: path,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -254,6 +259,7 @@ final class InitTests: XCTestCase {
                 packageType: .library,
                 supportedTestingLibraries: [],
                 destinationPath: path,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
@@ -287,6 +293,7 @@ final class InitTests: XCTestCase {
                 name: name,
                 packageType: .commandPlugin,
                 destinationPath: path,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             ).writePackageStructure()
 
@@ -322,6 +329,7 @@ final class InitTests: XCTestCase {
                 name: name,
                 packageType: .buildToolPlugin,
                 destinationPath: path,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             ).writePackageStructure()
 
@@ -362,6 +370,7 @@ final class InitTests: XCTestCase {
                 name: packageName,
                 packageType: .library,
                 destinationPath: packageRoot,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             initPackage.progressReporter = { message in }
@@ -415,6 +424,7 @@ final class InitTests: XCTestCase {
                 name: "Foo",
                 options: options,
                 destinationPath: packageRoot,
+                isDestinationCurrentWorkingDirectory: false,
                 installedSwiftPMConfiguration: .default,
                 fileSystem: localFileSystem
             )

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -5261,6 +5261,7 @@ final class WorkspaceTests: XCTestCase {
                 name: packagePath.basename,
                 packageType: .executable,
                 destinationPath: packagePath,
+                isDestinationCurrentWorkingDirectory: false,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()


### PR DESCRIPTION
Closes #7791

This allows for specifying the directory to create a new package within. If no argument is supplied, matching the current supported command options, then the package will be created in the current working directory. If an argument is supplied, then the package will be created in the directory at the path specified.

### Motivation:

The goal is to make the creation of new packages more predictable based on the arguments passed in, as well as to give more control to developers to specify the location of new packages, rather than relying on current working directory contexts and forcing the developer to `mkdir` and `cd` a bunch while using this command.

### Modifications:

- Added a single argument to `swift package init` to take in the directory to create the package at
- Modified the progress `print` statements during creation to specify the relative directories that the package is being created in

### Result:

- The existing syntax for commands to `swift package init` is unchanged, where if no arguments are specified, the package will be created in the current working directory.
- If an argument _is_ specified, the package will be created at that destination path instead.