### PR TITLE
[6.0] NFC: Expose `Environment` with `@_spi`

### DIFF
--- a/Sources/Basics/Environment/Environment.swift
+++ b/Sources/Basics/Environment/Environment.swift
@@ -64,7 +64,8 @@ extension Environment {
 // MARK: - Conversions between Dictionary<String, String>
 
 extension Environment {
-    package init(_ dictionary: [String: String]) {
+    @_spi(SwiftPMInternal)
+    public init(_ dictionary: [String: String]) {
         self.storage = .init()
         let sorted = dictionary.sorted { $0.key < $1.key }
         for (key, value) in sorted {
@@ -74,7 +75,8 @@ extension Environment {
 }
 
 extension [String: String] {
-    package init(_ environment: Environment) {
+    @_spi(SwiftPMInternal)
+    public init(_ environment: Environment) {
         self.init()
         let sorted = environment.sorted { $0.key < $1.key }
         for (key, value) in sorted {

--- a/Sources/DriverSupport/DriverSupportUtils.swift
+++ b/Sources/DriverSupport/DriverSupportUtils.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(SwiftPMInternal)
 import Basics
+
 import PackageModel
 import SwiftDriver
 import class TSCBasic.Process

--- a/Sources/DriverSupport/SPMSwiftDriverExecutor.swift
+++ b/Sources/DriverSupport/SPMSwiftDriverExecutor.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(SwiftPMInternal)
 import Basics
+
 import SwiftDriver
 
 import class TSCBasic.Process

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(SwiftPMInternal)
 import Basics
+
 import Foundation
 import PackageModel
 import PackageLoading

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(SwiftPMInternal)
 import Basics
+
 import Foundation
 import PackageGraph
 import PackageModel

--- a/Tests/BasicsTests/Environment/EnvironmentTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentTests.swift
@@ -10,7 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+@_spi(SwiftPMInternal)
+@testable
+import Basics
+
 import XCTest
 
 final class EnvironmentTests: XCTestCase {

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(SwiftPMInternal)
 import Basics
 @testable import PackageGraph
 import PackageLoading


### PR DESCRIPTION
Cherry-pick of #7780.

**Explanation**: Initializers for this type should be available via `@_spi` for clients to consume.
**Scope**: Limited to a single type and relevant initializers.
**Risk**: Very low, change is NFC.
**Testing**: Verified through existing test suite.
**Issue**: rdar://131407852
**Reviewer**: @bnbarham 
