### PR TITLE
Fix Package.swift diagnostics line off by 1 for tools versions <= 5.7

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -769,13 +769,15 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         if toolsVersion >= .v5_8 {
             manifestPreamble = ByteString()
         } else {
-            manifestPreamble = ByteString("import Foundation\n")
+          manifestPreamble = ByteString("\nimport Foundation")
         }
 
         do {
             try withTemporaryDirectory { tempDir, cleanupTempDir in
                 let manifestTempFilePath = tempDir.appending("manifest.swift")
-                try localFileSystem.writeFileContents(manifestTempFilePath, bytes: ByteString(manifestPreamble.contents + manifestContents))
+              // Since this isn't overwriting the original file, postpend Foundation library
+              // import to avoid having diagnostics being displayed on the incorrect line.
+              try localFileSystem.writeFileContents(manifestTempFilePath, bytes: ByteString(manifestContents + manifestPreamble.contents))
 
                 let vfsOverlayTempFilePath = tempDir.appending("vfs.yaml")
                 try VFSOverlay(roots: [

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -769,15 +769,15 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         if toolsVersion >= .v5_8 {
             manifestPreamble = ByteString()
         } else {
-          manifestPreamble = ByteString("\nimport Foundation")
+            manifestPreamble = ByteString("\nimport Foundation")
         }
 
         do {
             try withTemporaryDirectory { tempDir, cleanupTempDir in
                 let manifestTempFilePath = tempDir.appending("manifest.swift")
-              // Since this isn't overwriting the original file, postpend Foundation library
-              // import to avoid having diagnostics being displayed on the incorrect line.
-              try localFileSystem.writeFileContents(manifestTempFilePath, bytes: ByteString(manifestContents + manifestPreamble.contents))
+                // Since this isn't overwriting the original file, append Foundation library
+                // import to avoid having diagnostics being displayed on the incorrect line.
+                try localFileSystem.writeFileContents(manifestTempFilePath, bytes: ByteString(manifestContents + manifestPreamble.contents))
 
                 let vfsOverlayTempFilePath = tempDir.appending("vfs.yaml")
                 try VFSOverlay(roots: [

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -252,7 +252,7 @@ final class WorkspaceTests: XCTestCase {
             testDiagnostics(observability.diagnostics) { result in
                 let diagnostic = result.check(
                     diagnostic: .contains(
-                        "\(pkgDir.appending("Package.swift")):4:8: error: An error in MyPkg"
+                        "\(pkgDir.appending("Package.swift")):3:8: error: An error in MyPkg"
                     ),
                     severity: .error
                 )


### PR DESCRIPTION
Fixes issue #7688

SwiftPM was implicitly prepending the manifest with 'import Foundation' for toolchains using Swift toolchain versions 5.7 and under. The original file itself was never overwritten, thus the diagnostics being reported would always present on the next line.

This is a quick fix that appends the same line to the end of the manifest; doing so assures that the intended behaviour doesn't change, but allows for correct diagnostics to be reported.

### Motivation:

Diagnostics would present on the incorrect line for Package.swift files using tools version 5.7 and under.

### Modifications:

When evaluating the manifest, a temporary directory copies the contents of the manifest to a temporary file; rather than prepending the import to Foundation at the top of the file (causing all lines in the diagnostic reports to be off by one), append the import to the bottom of the temporary manifest when dealing with tools versions 5.7 and under.

### Result:

The intended behaviour that requires users to explicitly import Foundation doesn't change for Swift versions 5.8 and up; diagnostics reported for Package.swift files for those using swift <= 5.7 will now show on the correct line. 