### PR TITLE
Don't stomp on xUnit output from XCTest when running Swift Testing.

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -466,7 +466,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
             additionalArguments += commandLineArguments
 
-            if var xunitPath, options.testLibraryOptions.isEnabled(.xctest) {
+            if var xunitPath = options.xUnitOutput, options.testLibraryOptions.isEnabled(.xctest) {
                 // We are running Swift Testing, XCTest is also running in this session, and an xUnit path
                 // was specified. Make sure we don't stomp on XCTest's XML output by having Swift Testing
                 // write to a different path.


### PR DESCRIPTION
This PR forces Swift Testing to write its xUnit output to a different path from what the user specifies.

In the future, we should have the two testing libraries collate their XML output into a single file, but that requires the ability to parse and reformat XML output and that's a little beyond the capabilities of this feature right now. Since we expect most uses of xUnit output right now are existing ones with existing XCTest-based tests, moving Swift Testing aside seems like the right call.

(If XCTest is explicitly disabled, the exact specified path is used.)