### PR TITLE
Ensure code coverage is output correctly when `--parallel` is specified.

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1115,6 +1115,11 @@ final class ParallelTestRunner {
             let thread = Thread {
                 // Dequeue a specifier and run it till we encounter nil.
                 while let test = self.pendingTests.dequeue() {
+                    var testEnv = testEnv
+                    TestingSupport.randomizeCodeCovPath(
+                        in: &testEnv,
+                        destinationBuildParameters: self.productsBuildParameters
+                    )
                     let additionalArguments = TestRunner.xctestArguments(forTestSpecifiers: CollectionOfOne(test.specifier))
                     let testRunner = TestRunner(
                         bundlePaths: [test.productPath],


### PR DESCRIPTION
The documentation for "LLVM_PROFILE_FILE" suggests, but does not state outright, that `%m` is unreliable when used with concurrently running processes. This PR changes the paths we use for code coverage .profraw files to be unique per invocation using `UUID`. That means that when `--parallel` is specified, the various processes don't stomp on each other's output.
    
Resolves #7069.
Resolves rdar://131971679.