### PR TITLE
Don't log "no matching tests" diagnostic when running XCTest only.

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -278,7 +278,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                     swiftCommandState: swiftCommandState,
                     library: .xctest
                 )
-                if result == .success && testCount == 0 {
+                if result == .success, let testCount, testCount == 0 {
                     results.append(.noMatchingTests)
                 } else {
                     results.append(result)
@@ -359,13 +359,13 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         }
     }
 
-    private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState) throws -> (arguments: [String], testCount: Int) {
+    private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState) throws -> (arguments: [String], testCount: Int?) {
         switch options.testCaseSpecifier {
         case .none:
             if case .skip = options.skippedTests(fileSystem: swiftCommandState.fileSystem) {
                 fallthrough
             } else {
-                return ([], 0)
+                return ([], nil)
             }
 
         case .regex, .specific, .skip:

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -317,4 +317,11 @@ final class TestCommandTests: CommandsTestCase {
             await XCTAssertAsyncNoThrow(try await SwiftPM.Test.execute(packagePath: fixturePath))
         }
     }
+
+    func testXCTestOnlyDoesNotLogAboutNoMatchingTests() async throws {
+        try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (_, stderr) = try await SwiftPM.Test.execute(["--disable-swift-testing"], packagePath: fixturePath)
+            XCTAssertNoMatch(stderr, .contains("No matching test cases were run"))
+        }
+    }
 }


### PR DESCRIPTION
Fixes a logic error in deciding when to log the "no matching test cases were run" diagnostic if `--disable-swift-testing` is passed.