### PR TITLE
[6.0] Don't log "no matching tests" diagnostic when running XCTest only.

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -276,7 +276,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                     swiftCommandState: swiftCommandState,
                     library: .xctest
                 )
-                if result == .success && testCount == 0 {
+                if result == .success, let testCount, testCount == 0 {
                     results.append(.noMatchingTests)
                 } else {
                     results.append(result)
@@ -357,13 +357,13 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         }
     }
 
-    private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState) throws -> (arguments: [String], testCount: Int) {
+    private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState) throws -> (arguments: [String], testCount: Int?) {
         switch options.testCaseSpecifier {
         case .none:
             if case .skip = options.skippedTests(fileSystem: swiftCommandState.fileSystem) {
                 fallthrough
             } else {
-                return ([], 0)
+                return ([], nil)
             }
 
         case .regex, .specific, .skip:

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -307,4 +307,11 @@ final class TestCommandTests: CommandsTestCase {
             await XCTAssertAsyncNoThrow(try await SwiftPM.Test.execute(packagePath: fixturePath))
         }
     }
+
+    func testXCTestOnlyDoesNotLogAboutNoMatchingTests() async throws {
+        try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (_, stderr) = try await SwiftPM.Test.execute(["--disable-swift-testing"], packagePath: fixturePath)
+            XCTAssertNoMatch(stderr, .contains("No matching test cases were run"))
+        }
+    }
 }


### PR DESCRIPTION
**Explanation:** Fixes a logic error in deciding when to log the "no matching test cases were run" diagnostic if `--disable-swift-testing` is passed.
**Scope:** Bug fix in `swift test`.
**Issue:** N/A (noticed locally, opened PR)
**Original PR:** https://github.com/swiftlang/swift-package-manager/pull/7803
**Risk:** Low
**Testing:** Added unit test.
**Reviewer:** @MaxDesiatov @bnbarham