### PR TITLE
Detect if XCTest is installed on Darwin

### DIFF
--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -60,10 +60,10 @@ extension SwiftPackageCommand {
             // but Swift Testing must remain off by default until it is present
             // in the Swift toolchain.
             var supportedTestingLibraries = Set<TestingLibrary>()
-            if testLibraryOptions.isEnabled(.xctest) {
+            if testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
                 supportedTestingLibraries.insert(.xctest)
             }
-            if testLibraryOptions.isExplicitlyEnabled(.swiftTesting) {
+            if testLibraryOptions.isExplicitlyEnabled(.swiftTesting, swiftCommandState: swiftCommandState) {
                 supportedTestingLibraries.insert(.swiftTesting)
             }
 

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -256,8 +256,10 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         var results = [TestRunner.Result]()
 
         // Run XCTest.
-        if options.testLibraryOptions.isEnabled(.xctest) {
-            // validate XCTest available on darwin based systems
+        if options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
+            // Validate XCTest available on Darwin-based systems. If it's not available and we're hitting this code
+            // path, that means the developer must have explicitly passed --enable-xctest (or the toolchain is
+            // corrupt, I suppose.)
             let toolchain = try swiftCommandState.getTargetToolchain()
             if case let .unsupported(reason) = try swiftCommandState.getHostToolchain().swiftSDK.xctestSupport {
                 if let reason {
@@ -278,7 +280,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                     swiftCommandState: swiftCommandState,
                     library: .xctest
                 )
-                if result == .success, let testCount, testCount == 0 {
+                if result == .success, testCount == 0 {
                     results.append(.noMatchingTests)
                 } else {
                     results.append(result)
@@ -324,9 +326,9 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         }
 
         // Run Swift Testing (parallel or not, it has a single entry point.)
-        if options.testLibraryOptions.isEnabled(.swiftTesting) {
+        if options.testLibraryOptions.isEnabled(.swiftTesting, swiftCommandState: swiftCommandState) {
             lazy var testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first
-            if options.testLibraryOptions.isExplicitlyEnabled(.swiftTesting) || testEntryPointPath == nil {
+            if options.testLibraryOptions.isExplicitlyEnabled(.swiftTesting, swiftCommandState: swiftCommandState) || testEntryPointPath == nil {
                 results.append(
                     try await runTestProducts(
                         testProducts,
@@ -412,7 +414,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     public func run(_ swiftCommandState: SwiftCommandState) async throws {
         do {
             // Validate commands arguments
-            try self.validateArguments(observabilityScope: swiftCommandState.observabilityScope)
+            try self.validateArguments(swiftCommandState: swiftCommandState)
         } catch {
             swiftCommandState.observabilityScope.emit(error)
             throw ExitCode.failure
@@ -466,7 +468,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
             additionalArguments += commandLineArguments
 
-            if var xunitPath = options.xUnitOutput, options.testLibraryOptions.isEnabled(.xctest) {
+            if var xunitPath = options.xUnitOutput, options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
                 // We are running Swift Testing, XCTest is also running in this session, and an xUnit path
                 // was specified. Make sure we don't stomp on XCTest's XML output by having Swift Testing
                 // write to a different path.
@@ -634,7 +636,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     /// Private function that validates the commands arguments
     ///
     /// - Throws: if a command argument is invalid
-    private func validateArguments(observabilityScope: ObservabilityScope) throws {
+    private func validateArguments(swiftCommandState: SwiftCommandState) throws {
         // Validation for --num-workers.
         if let workers = options.numberOfWorkers {
 
@@ -649,13 +651,13 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                 throw StringError("'--num-workers' must be greater than zero")
             }
 
-            guard options.testLibraryOptions.isEnabled(.xctest) else {
+            guard options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) else {
                 throw StringError("'--num-workers' is only supported when testing with XCTest")
             }
         }
 
         if options._deprecated_shouldListTests {
-            observabilityScope.emit(warning: "'--list-tests' option is deprecated; use 'swift test list' instead")
+            swiftCommandState.observabilityScope.emit(warning: "'--list-tests' option is deprecated; use 'swift test list' instead")
         }
     }
 
@@ -739,7 +741,7 @@ extension SwiftTestCommand {
                 library: .swiftTesting
             )
 
-            if testLibraryOptions.isEnabled(.xctest) {
+            if testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
                 let testSuites = try TestingSupport.getTestSuites(
                     in: testProducts,
                     swiftCommandState: swiftCommandState,
@@ -755,9 +757,9 @@ extension SwiftTestCommand {
                 }
             }
 
-            if testLibraryOptions.isEnabled(.swiftTesting) {
+            if testLibraryOptions.isEnabled(.swiftTesting, swiftCommandState: swiftCommandState) {
                 lazy var testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first
-                if testLibraryOptions.isExplicitlyEnabled(.swiftTesting) || testEntryPointPath == nil {
+                if testLibraryOptions.isExplicitlyEnabled(.swiftTesting, swiftCommandState: swiftCommandState) || testEntryPointPath == nil {
                     let additionalArguments = ["--list-tests"] + CommandLine.arguments.dropFirst()
                     let runner = TestRunner(
                         bundlePaths: testProducts.map(\.binaryPath),

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -257,7 +257,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
         // Run XCTest.
         if options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
-            // Validate XCTest available on Darwin-based systems. If it's not available and we're hitting this code
+            // Validate XCTest is available on Darwin-based systems. If it's not available and we're hitting this code
             // path, that means the developer must have explicitly passed --enable-xctest (or the toolchain is
             // corrupt, I suppose.)
             let toolchain = try swiftCommandState.getTargetToolchain()

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -599,6 +599,11 @@ public struct TestLibraryOptions: ParsableArguments {
           help: .private)
     public var explicitlyEnableExperimentalSwiftTestingLibrarySupport: Bool?
 
+    /// The common implementation for `isEnabled()` and `isExplicitlyEnabled()`.
+    ///
+    /// It is intentional that `isEnabled()` is not simply this function with a
+    /// default value for the `default` argument. There's no "true" default
+    /// value to use; it depends on the semantics the caller is interested in.
     private func isEnabled(_ library: TestingLibrary, `default`: Bool, swiftCommandState: SwiftCommandState) -> Bool {
         switch library {
         case .xctest:


### PR DESCRIPTION
This PR checks if XCTest is available before invoking XCTest-based tests on Darwin. There are three possible outcomes:

1. If XCTest is available, we will run XCTest-based tests (as we have historically.)
2. If XCTest is not available and the user explicitly passed `--enable-xctest`, we will attempt to run XCTest-based tests, but in general this code path will continue to fail as `swift test` has historically done when XCTest is not available.
3. If XCTest is not available and the user did not pass `--enable-xctest`, we skip running any XCTest logic.

On Linux/Windows/etc., XCTest is always present via swift-corelibs-xctest and so this change has no practical effect there. On Darwin, XCTest may be missing if the user has installed the Xcode Command Line Tools, but not the full Xcode IDE. XCTest is not included with the Xcode Command Line Tools package.

The purpose of this change is to allow running `swift test` when XCTest is unavailable but Swift Testing _is_ available.
