### PR TITLE
Rename `BuildParameters.Testing.Library`.

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -70,6 +70,7 @@ add_library(Basics
   Serialization/SerializedJSON.swift
   SwiftVersion.swift
   SQLiteBackedCache.swift
+  TestingLibrary.swift
   Triple+Basics.swift
   Version+Extensions.swift
   WritableByteStream+Extensions.swift

--- a/Sources/Basics/TestingLibrary.swift
+++ b/Sources/Basics/TestingLibrary.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// The testing libraries supported by the package manager.
+public enum TestingLibrary: Sendable, CustomStringConvertible {
+  /// The XCTest library.
+  ///
+  /// This case represents both the open-source swift-corelibs-xctest
+  /// package and Apple's XCTest framework that ships with Xcode.
+  case xctest
+
+  /// The swift-testing library.
+  case swiftTesting
+
+  public var description: String {
+    switch self {
+    case .xctest:
+      "XCTest"
+    case .swiftTesting:
+      "Swift Testing"
+    }
+  }
+}
+

--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -59,7 +59,7 @@ extension SwiftPackageCommand {
             // Which testing libraries should be used? XCTest is on by default,
             // but Swift Testing must remain off by default until it is present
             // in the Swift toolchain.
-            var supportedTestingLibraries = Set<BuildParameters.Testing.Library>()
+            var supportedTestingLibraries = Set<TestingLibrary>()
             if testLibraryOptions.isEnabled(.xctest) {
                 supportedTestingLibraries.insert(.xctest)
             }

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -449,7 +449,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         additionalArguments: [String],
         productsBuildParameters: BuildParameters,
         swiftCommandState: SwiftCommandState,
-        library: BuildParameters.Testing.Library
+        library: TestingLibrary
     ) async throws -> TestRunner.Result {
         // Pass through all arguments from the command line to Swift Testing.
         var additionalArguments = additionalArguments
@@ -843,7 +843,7 @@ final class TestRunner {
     private let observabilityScope: ObservabilityScope
 
     /// Which testing library to use with this test run.
-    private let library: BuildParameters.Testing.Library
+    private let library: TestingLibrary
 
     /// Get the arguments used on this platform to pass test specifiers to XCTest.
     static func xctestArguments<S>(forTestSpecifiers testSpecifiers: S) -> [String] where S: Collection, S.Element == String {
@@ -873,7 +873,7 @@ final class TestRunner {
         toolchain: UserToolchain,
         testEnv: Environment,
         observabilityScope: ObservabilityScope,
-        library: BuildParameters.Testing.Library
+        library: TestingLibrary
     ) {
         self.bundlePaths = bundlePaths
         self.additionalArguments = additionalArguments

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -150,7 +150,7 @@ enum TestingSupport {
         toolchain: UserToolchain,
         destinationBuildParameters buildParameters: BuildParameters,
         sanitizers: [Sanitizer],
-        library: BuildParameters.Testing.Library
+        library: TestingLibrary
     ) throws -> Environment {
         var env = Environment.current
 

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -14,6 +14,7 @@ import ArgumentParser
 
 import var Basics.localFileSystem
 import struct Basics.AbsolutePath
+import enum Basics.TestingLibrary
 import struct Basics.Triple
 import func Basics.temp_await
 
@@ -597,7 +598,7 @@ public struct TestLibraryOptions: ParsableArguments {
           help: .private)
     public var explicitlyEnableExperimentalSwiftTestingLibrarySupport: Bool?
 
-    private func isEnabled(_ library: BuildParameters.Testing.Library, `default`: Bool) -> Bool {
+    private func isEnabled(_ library: TestingLibrary, `default`: Bool) -> Bool {
         switch library {
         case .xctest:
             explicitlyEnableXCTestSupport ?? `default`
@@ -607,17 +608,17 @@ public struct TestLibraryOptions: ParsableArguments {
     }
 
     /// Test whether or not a given library is enabled.
-    public func isEnabled(_ library: BuildParameters.Testing.Library) -> Bool {
+    public func isEnabled(_ library: TestingLibrary) -> Bool {
         isEnabled(library, default: true)
     }
 
     /// Test whether or not a given library was explicitly enabled by the developer.
-    public func isExplicitlyEnabled(_ library: BuildParameters.Testing.Library) -> Bool {
+    public func isExplicitlyEnabled(_ library: TestingLibrary) -> Bool {
         isEnabled(library, default: false)
     }
 
     /// The list of enabled testing libraries.
-    public var enabledTestingLibraries: [BuildParameters.Testing.Library] {
+    public var enabledTestingLibraries: [TestingLibrary] {
         [.xctest, .swiftTesting].filter(isEnabled)
     }
 }

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Testing.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Testing.swift
@@ -86,22 +86,6 @@ extension BuildParameters {
         /// The style of test product to produce.
         public var testProductStyle: TestProductStyle
 
-        /// The testing libraries supported by the package manager.
-        public enum Library: String, Codable, CustomStringConvertible {
-            /// The XCTest library.
-            ///
-            /// This case represents both the open-source swift-corelibs-xctest
-            /// package and Apple's XCTest framework that ships with Xcode.
-            case xctest = "XCTest"
-
-            /// The swift-testing library.
-            case swiftTesting = "swift-testing"
-
-            public var description: String {
-                rawValue
-            }
-        }
-
         public init(
             configuration: BuildConfiguration,
             targetTriple: Triple,

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -27,7 +27,7 @@ public final class InitPackage {
         public var packageType: PackageType
 
         /// The set of supported testing libraries to include in the package.
-        public var supportedTestingLibraries: Set<BuildParameters.Testing.Library>
+        public var supportedTestingLibraries: Set<TestingLibrary>
 
         /// The list of platforms in the manifest.
         ///
@@ -36,7 +36,7 @@ public final class InitPackage {
 
         public init(
             packageType: PackageType,
-            supportedTestingLibraries: Set<BuildParameters.Testing.Library> = [.xctest],
+            supportedTestingLibraries: Set<TestingLibrary> = [.xctest],
             platforms: [SupportedPlatform] = []
         ) {
             self.packageType = packageType
@@ -93,7 +93,7 @@ public final class InitPackage {
     public convenience init(
         name: String,
         packageType: PackageType,
-        supportedTestingLibraries: Set<BuildParameters.Testing.Library>,
+        supportedTestingLibraries: Set<TestingLibrary>,
         destinationPath: AbsolutePath,
         installedSwiftPMConfiguration: InstalledSwiftPMConfiguration,
         fileSystem: FileSystem
@@ -896,7 +896,7 @@ public final class InitPackage {
 
 private enum InitError: Swift.Error {
     case manifestAlreadyExists
-    case unsupportedTestingLibraryForPackageType(_ testingLibrary: BuildParameters.Testing.Library, _ packageType: InitPackage.PackageType)
+    case unsupportedTestingLibraryForPackageType(_ testingLibrary: TestingLibrary, _ packageType: InitPackage.PackageType)
 }
 
 extension InitError: CustomStringConvertible {

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -432,7 +432,7 @@ extension InitPackage {
     public convenience init(
         name: String,
         packageType: PackageType,
-        supportedTestingLibraries: Set<BuildParameters.Testing.Library> = [.xctest],
+        supportedTestingLibraries: Set<TestingLibrary> = [.xctest],
         destinationPath: AbsolutePath,
         fileSystem: FileSystem
     ) throws {


### PR DESCRIPTION
Since the aforementioned enum no longer has any association with `BuildParameters`, rename it to something less domain-specific and move it to the Basic module.

Since this is a type rename, there's no unit testing to be done. If it compiles, I didn't break it. :)