### PR TITLE
Handle `.xcprivacy` files in `TargetSourcesBuilder.swift`

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -723,6 +723,15 @@ public struct FileRuleDescription: Sendable {
         )
     }()
 
+    /// File rule to ignore `.xcprivacy` (in the SwiftPM build system).
+    public static let xcprivacy: FileRuleDescription = {
+        .init(
+            rule: .ignored,
+            toolsVersion: .v6_0,
+            fileTypes: ["xcprivacy"]
+        )
+    }()
+
     /// List of all the builtin rules.
     public static let builtinRules: [FileRuleDescription] = [
         swift,
@@ -744,6 +753,7 @@ public struct FileRuleDescription: Sendable {
     /// List of file types that apply just to the SwiftPM build system.
     public static let swiftpmFileTypes: [FileRuleDescription] = [
         docc,
+        xcprivacy,
     ]
 
     /// List of file directory extensions that should be treated as opaque, non source, directories.

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -723,8 +723,17 @@ public struct FileRuleDescription: Sendable {
         )
     }()
 
+    /// File rule to copy `.xcprivacy` (in the Xcode build system).
+    public static let xcprivacyCopied: FileRuleDescription = {
+        .init(
+            rule: .copyResource,
+            toolsVersion: .v6_0,
+            fileTypes: ["xcprivacy"]
+        )
+    }()
+
     /// File rule to ignore `.xcprivacy` (in the SwiftPM build system).
-    public static let xcprivacy: FileRuleDescription = {
+    public static let xcprivacyIgnored: FileRuleDescription = {
         .init(
             rule: .ignored,
             toolsVersion: .v6_0,
@@ -748,12 +757,13 @@ public struct FileRuleDescription: Sendable {
         stringCatalog,
         coredata,
         metal,
+        xcprivacyCopied,
     ]
 
     /// List of file types that apply just to the SwiftPM build system.
     public static let swiftpmFileTypes: [FileRuleDescription] = [
         docc,
-        xcprivacy,
+        xcprivacyIgnored,
     ]
 
     /// List of file directory extensions that should be treated as opaque, non source, directories.

--- a/Sources/_InternalTestSupport/Observability.swift
+++ b/Sources/_InternalTestSupport/Observability.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import func XCTest.XCTAssertTrue
 import func XCTest.XCTAssertEqual
 import func XCTest.XCTFail
 
@@ -161,6 +162,13 @@ public class DiagnosticsTestResult {
 
     init(_ diagnostics: [Basics.Diagnostic]) {
         self.uncheckedDiagnostics = diagnostics
+    }
+
+    package func checkIsEmpty(
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(self.uncheckedDiagnostics.isEmpty, file: file, line: line)
     }
 
     @discardableResult

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -3033,7 +3033,7 @@ final class PackageBuilderTests: XCTestCase {
             ]
         )
 
-        PackageBuilderTester(manifest, path: root, supportXCBuildTypes: true, in: fs) { result, diagnostics in
+        PackageBuilderTester(manifest, path: root, supportXCBuildTypes: false, in: fs) { result, diagnostics in
             result.checkModule("Foo") { result in
                 result.checkSources(sources: ["foo.swift"])
                 result.checkResources(resources: [

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -38,6 +38,27 @@ final class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testXCPrivacyIgnored() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/foo/PrivacyInfo.xcprivacy",
+            "/Sources/foo/Foo.swift")
+
+        let manifest = Manifest.createRootManifest(
+            displayName: "pkg",
+            path: .root,
+            targets: [
+                try TargetDescription(name: "foo"),
+            ]
+        )
+        PackageBuilderTester(manifest, in: fs) { package, _ in
+            package.checkModule("foo") { module in
+                module.check(c99name: "foo", type: .library)
+                module.checkSources(root: "/Sources/foo", paths: "Foo.swift")
+                module.checkResources(resources: [])
+            }
+        }
+    }
+
     func testMixedSources() throws {
         let foo: AbsolutePath = "/Sources/foo"
 


### PR DESCRIPTION
rdar://111119227
