### PR TITLE
Revert "Fix: use bearer auth when pulling binaryTarget or packages from a package registry"

### DIFF
--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -71,9 +71,6 @@ extension AuthorizationProvider {
         guard let (user, password) = self.authentication(for: url) else {
             return nil
         }
-        guard user != "token" else {
-            return "Bearer \(password)"
-        }
         let authString = "\(user):\(password)"
         let authData = Data(authString.utf8)
         return "Basic \(authData.base64EncodedString())"

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -63,15 +63,6 @@ final class AuthorizationProviderTests: XCTestCase {
         }
     }
 
-    func testBasicAPIsBearerToken() {
-        let url = URL("http://\(UUID().uuidString)")
-        let user = "token"
-        let token = UUID().uuidString
-
-        let provider = TestProvider(map: [url: (user: user, password: token)])
-        self.assertBearerAuthentication(provider, for: url, expected: token)
-    }
-
     func testProtocolHostPort() throws {
         #if !canImport(Security)
         try XCTSkipIf(true)
@@ -265,20 +256,6 @@ final class AuthorizationProviderTests: XCTestCase {
         XCTAssertEqual(
             provider.httpAuthorizationHeader(for: url),
             "Basic " + Data("\(expected.user):\(expected.password)".utf8).base64EncodedString()
-        )
-    }
-
-    private func assertBearerAuthentication(
-        _ provider: AuthorizationProvider,
-        for url: URL,
-        expected: String
-    ) {
-        let authentication = provider.authentication(for: url)
-        XCTAssertEqual(authentication?.user, "token")
-        XCTAssertEqual(authentication?.password, expected)
-        XCTAssertEqual(
-            provider.httpAuthorizationHeader(for: url),
-            "Bearer \(expected)"
         )
     }
 }


### PR DESCRIPTION
Reverts swiftlang/swift-package-manager#7662

It would be a breaking change if someone is using `token` as their username, and we don't have a migration path or any other means to clarify this breaking change to the users.