### PR TITLE
[6.0][PackageDescription] SE-0441: Rename `swiftLanguageVersion` to `swift…

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/DependentPlugins/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/DependentPlugins/Package.swift
@@ -35,5 +35,5 @@ let package = Package(
             ]
         ),
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageModes: [.v5]
 )

--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -396,13 +396,30 @@ public struct SwiftSetting: Sendable {
     /// - Parameters:
     ///   - version: The Swift language version to use.
     ///   - condition: A condition that restricts the application of the build setting.
-    @available(_PackageDescription, introduced: 6.0)
+    @available(_PackageDescription, introduced: 6.0, deprecated: 6.0, renamed: "swiftLanguageMode(_:_:)")
     public static func swiftLanguageVersion(
       _ version: SwiftVersion,
       _ condition: BuildSettingCondition? = nil
     ) -> SwiftSetting {
         return SwiftSetting(
             name: "swiftLanguageVersion", value: [.init(describing: version)], condition: condition)
+    }
+
+    /// Defines a `-language-mode` to pass  to the
+    /// corresponding build tool.
+    ///
+    /// - Since: First available in PackageDescription 6.0.
+    ///
+    /// - Parameters:
+    ///   - mode: The Swift language mode to use.
+    ///   - condition: A condition that restricts the application of the build setting.
+    @available(_PackageDescription, introduced: 6.0)
+    public static func swiftLanguageMode(
+      _ mode: SwiftLanguageMode,
+      _ condition: BuildSettingCondition? = nil
+    ) -> SwiftSetting {
+        return SwiftSetting(
+            name: "swiftLanguageMode", value: [.init(describing: mode)], condition: condition)
     }
 }
 

--- a/Sources/PackageDescription/LanguageStandardSettings.swift
+++ b/Sources/PackageDescription/LanguageStandardSettings.swift
@@ -148,9 +148,8 @@ public enum CXXLanguageStandard: String {
     case gnucxx2b = "gnu++2b"
 }
 
-/// The version of the Swift language you use to compile Swift sources in the
-/// package.
-public enum SwiftVersion {
+/// The Swift language mode used to compile Swift sources in the package
+public enum SwiftLanguageMode {
     /// The identifier for the Swift 3 language version.
     @available(_PackageDescription, introduced: 4, obsoleted: 5)
     case v3
@@ -177,7 +176,7 @@ public enum SwiftVersion {
     case version(String)
 }
 
-extension SwiftVersion: CustomStringConvertible {
+extension SwiftLanguageMode: CustomStringConvertible {
     public var description: String {
         switch self {
         case .v3: "3"
@@ -189,3 +188,7 @@ extension SwiftVersion: CustomStringConvertible {
         }
     }
 }
+
+/// Type alias to previous name for backward source compatibility
+@available(_PackageDescription, deprecated: 6, renamed:"SwiftLanguageMode")
+public typealias SwiftVersion = SwiftLanguageMode

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -252,8 +252,9 @@ public final class Package {
     ///   - swiftLanguageVersions: The list of Swift versions with which this package is compatible.
     ///   - cLanguageStandard: The C language standard to use for all C targets in this package.
     ///   - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
+    @_disfavoredOverload
     @available(_PackageDescription, introduced: 5.3)
-    @available(_PackageDescription, obsoleted: 6, renamed:"init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageModes:cLanguageStandard:cxxLanguageStandard:)")
+    @available(_PackageDescription, deprecated: 6, renamed:"init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageModes:cLanguageStandard:cxxLanguageStandard:)")
     public init(
         name: String,
         defaultLocalization: LanguageTag? = nil,

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -103,8 +103,15 @@ public final class Package {
     /// The list of package dependencies.
     public var dependencies: [Dependency]
 
-    /// The list of Swift versions with which this package is compatible.
-    public var swiftLanguageVersions: [SwiftVersion]?
+    /// The list of Swift language modes with which this package is compatible.
+    public var swiftLanguageModes: [SwiftLanguageMode]?
+    
+    /// Legacy property name, accesses value of `swiftLanguageModes`
+    @available(_PackageDescription, deprecated: 6, renamed: "swiftLanguageModes")
+    public var swiftLanguageVersions: [SwiftVersion]? {
+        get { swiftLanguageModes }
+        set { swiftLanguageModes = newValue }
+    }
 
     /// The C language standard to use for all C targets in this package.
     public var cLanguageStandard: CLanguageStandard?
@@ -145,7 +152,7 @@ public final class Package {
         self.products = products
         self.dependencies = dependencies
         self.targets = targets
-        self.swiftLanguageVersions = swiftLanguageVersions.map{ $0.map{ .version("\($0)") } }
+        self.swiftLanguageModes = swiftLanguageVersions.map{ $0.map{ .version("\($0)") } }
         self.cLanguageStandard = cLanguageStandard
         self.cxxLanguageStandard = cxxLanguageStandard
         registerExitHandler()
@@ -183,7 +190,7 @@ public final class Package {
         self.products = products
         self.dependencies = dependencies
         self.targets = targets
-        self.swiftLanguageVersions = swiftLanguageVersions
+        self.swiftLanguageModes = swiftLanguageVersions
         self.cLanguageStandard = cLanguageStandard
         self.cxxLanguageStandard = cxxLanguageStandard
         registerExitHandler()
@@ -224,7 +231,7 @@ public final class Package {
         self.products = products
         self.dependencies = dependencies
         self.targets = targets
-        self.swiftLanguageVersions = swiftLanguageVersions
+        self.swiftLanguageModes = swiftLanguageVersions
         self.cLanguageStandard = cLanguageStandard
         self.cxxLanguageStandard = cxxLanguageStandard
         registerExitHandler()
@@ -246,6 +253,7 @@ public final class Package {
     ///   - cLanguageStandard: The C language standard to use for all C targets in this package.
     ///   - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
     @available(_PackageDescription, introduced: 5.3)
+    @available(_PackageDescription, obsoleted: 6, renamed:"init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageModes:cLanguageStandard:cxxLanguageStandard:)")
     public init(
         name: String,
         defaultLocalization: LanguageTag? = nil,
@@ -267,7 +275,50 @@ public final class Package {
         self.products = products
         self.dependencies = dependencies
         self.targets = targets
-        self.swiftLanguageVersions = swiftLanguageVersions
+        self.swiftLanguageModes = swiftLanguageVersions
+        self.cLanguageStandard = cLanguageStandard
+        self.cxxLanguageStandard = cxxLanguageStandard
+        registerExitHandler()
+    }
+    
+    /// Initializes a Swift package with configuration options you provide.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the Swift package, or `nil` to use the package's Git URL to deduce the name.
+    ///   - defaultLocalization: The default localization for resources.
+    ///   - platforms: The list of supported platforms with a custom deployment target.
+    ///   - pkgConfig: The name to use for C modules. If present, Swift Package Manager searches for a
+    ///   `<name>.pc` file to get the additional flags required for a system target.
+    ///   - providers: The package providers for a system target.
+    ///   - products: The list of products that this package makes available for clients to use.
+    ///   - dependencies: The list of package dependencies.
+    ///   - targets: The list of targets that are part of this package.
+    ///   - swiftLanguageModes: The list of Swift language modes with which this package is compatible.
+    ///   - cLanguageStandard: The C language standard to use for all C targets in this package.
+    ///   - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
+    @available(_PackageDescription, introduced: 6)
+    public init(
+        name: String,
+        defaultLocalization: LanguageTag? = nil,
+        platforms: [SupportedPlatform]? = nil,
+        pkgConfig: String? = nil,
+        providers: [SystemPackageProvider]? = nil,
+        products: [Product] = [],
+        dependencies: [Dependency] = [],
+        targets: [Target] = [],
+        swiftLanguageModes: [SwiftLanguageMode]? = nil,
+        cLanguageStandard: CLanguageStandard? = nil,
+        cxxLanguageStandard: CXXLanguageStandard? = nil
+    ) {
+        self.name = name
+        self.defaultLocalization = defaultLocalization
+        self.platforms = platforms
+        self.pkgConfig = pkgConfig
+        self.providers = providers
+        self.products = products
+        self.dependencies = dependencies
+        self.targets = targets
+        self.swiftLanguageModes = swiftLanguageModes
         self.cLanguageStandard = cLanguageStandard
         self.cxxLanguageStandard = cxxLanguageStandard
         registerExitHandler()

--- a/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
@@ -372,7 +372,7 @@ extension Serialization.Package {
         self.targets = package.targets.map { .init($0) }
         self.products = package.products.map { .init($0) }
         self.dependencies = package.dependencies.map { .init($0) }
-        self.swiftLanguageVersions = package.swiftLanguageVersions?.map { .init($0) }
+        self.swiftLanguageVersions = package.swiftLanguageModes?.map { .init($0) }
         self.cLanguageStandard = package.cLanguageStandard.map { .init($0) }
         self.cxxLanguageStandard = package.cxxLanguageStandard.map { .init($0) }
     }

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -535,7 +535,7 @@ extension TargetBuildSettingDescription.Kind {
         case "unsafeFlags":
             return .unsafeFlags(values)
 
-        case "swiftLanguageVersion":
+        case "swiftLanguageMode":
             guard let rawVersion = values.first else {
                 throw InternalError("invalid (empty) build settings value")
             }
@@ -548,7 +548,7 @@ extension TargetBuildSettingDescription.Kind {
                 throw InternalError("unknown swift language version: \(rawVersion)")
             }
 
-            return .swiftLanguageVersion(version)
+            return .swiftLanguageMode(version)
         default:
             throw InternalError("invalid build setting \(name)")
         }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1162,7 +1162,7 @@ public final class PackageBuilder {
 
                 values = ["-enable-experimental-feature", value]
 
-            case .swiftLanguageVersion(let version):
+            case .swiftLanguageMode(let version):
                 switch setting.tool {
                 case .c, .cxx, .linker:
                     throw InternalError("only Swift supports swift language version")

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -39,7 +39,7 @@ public enum TargetBuildSettingDescription {
 
         case unsafeFlags([String])
 
-        case swiftLanguageVersion(SwiftLanguageVersion)
+        case swiftLanguageMode(SwiftLanguageVersion)
 
         public var isUnsafeFlags: Bool {
             switch self {
@@ -47,7 +47,7 @@ public enum TargetBuildSettingDescription {
                 // If `.unsafeFlags` is used, but doesn't specify any flags, we treat it the same way as not specifying it.
                 return !flags.isEmpty
             case .headerSearchPath, .define, .linkedLibrary, .linkedFramework, .interoperabilityMode,
-                 .enableUpcomingFeature, .enableExperimentalFeature, .swiftLanguageVersion:
+                 .enableUpcomingFeature, .enableExperimentalFeature, .swiftLanguageMode:
                 return false
             }
         }

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -525,7 +525,7 @@ fileprivate extension SourceCodeFragment {
                 params.append(SourceCodeFragment(from: condition))
             }
             self.init(enum: setting.kind.name, subnodes: params)
-        case .swiftLanguageVersion(let version):
+        case .swiftLanguageMode(let version):
             params.append(SourceCodeFragment(from: version))
             if let condition = setting.condition {
                 params.append(SourceCodeFragment(from: condition))
@@ -683,8 +683,8 @@ extension TargetBuildSettingDescription.Kind {
             return "enableUpcomingFeature"
         case .enableExperimentalFeature:
             return "enableExperimentalFeature"
-        case .swiftLanguageVersion:
-            return "swiftLanguageVersion"
+        case .swiftLanguageMode:
+            return "swiftLanguageMode"
         }
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4151,12 +4151,12 @@ final class BuildPlanTests: XCTestCase {
                         ),
                         .init(
                             tool: .swift,
-                            kind: .swiftLanguageVersion(.v4),
+                            kind: .swiftLanguageMode(.v4),
                             condition: .init(platformNames: ["macos"])
                         ),
                         .init(
                             tool: .swift,
-                            kind: .swiftLanguageVersion(.v5),
+                            kind: .swiftLanguageMode(.v5),
                             condition: .init(platformNames: ["linux"])
                         ),
                         .init(tool: .linker, kind: .linkedLibrary("sqlite3")),
@@ -4189,8 +4189,8 @@ final class BuildPlanTests: XCTestCase {
                     name: "t1",
                     settings: [
                         .init(tool: .swift, kind: .define("DEP")),
-                        .init(tool: .swift, kind: .swiftLanguageVersion(.v4), condition: .init(platformNames: ["linux"])),
-                        .init(tool: .swift, kind: .swiftLanguageVersion(.v5), condition: .init(platformNames: ["macos"])),
+                        .init(tool: .swift, kind: .swiftLanguageMode(.v4), condition: .init(platformNames: ["linux"])),
+                        .init(tool: .swift, kind: .swiftLanguageMode(.v5), condition: .init(platformNames: ["macos"])),
                         .init(tool: .linker, kind: .linkedLibrary("libz")),
                     ]
                 ),

--- a/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
@@ -414,7 +414,8 @@ final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
                     products: [],
                     targets: [
                         .target(name: "Foo"),
-                    ]
+                    ],
+                    swiftLanguageVersions: [.v5]
                 )
                 """
 

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -3040,14 +3040,14 @@ final class PackageBuilderTests: XCTestCase {
                 try TargetDescription(
                     name: "foo",
                     settings: [
-                        .init(tool: .swift, kind: .swiftLanguageVersion(.v5))
+                        .init(tool: .swift, kind: .swiftLanguageMode(.v5))
                     ]
                 ),
                 try TargetDescription(
                     name: "bar",
                     settings: [
-                        .init(tool: .swift, kind: .swiftLanguageVersion(.v3), condition: .init(platformNames: ["linux"])),
-                        .init(tool: .swift, kind: .swiftLanguageVersion(.v4), condition: .init(platformNames: ["macos"], config: "debug"))
+                        .init(tool: .swift, kind: .swiftLanguageMode(.v3), condition: .init(platformNames: ["linux"])),
+                        .init(tool: .swift, kind: .swiftLanguageMode(.v4), condition: .init(platformNames: ["macos"], config: "debug"))
                     ]
                 ),
             ]

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -601,22 +601,22 @@ final class ManifestSourceGenerationTests: XCTestCase {
                     name: "v5",
                     type: .executable,
                     settings: [
-                        .init(tool: .swift, kind: .swiftLanguageVersion(.v6))
+                        .init(tool: .swift, kind: .swiftLanguageMode(.v6))
                     ]
                 ),
                 try TargetDescription(
                     name: "custom",
                     type: .executable,
                     settings: [
-                        .init(tool: .swift, kind: .swiftLanguageVersion(.init(string: "5.10")!))
+                        .init(tool: .swift, kind: .swiftLanguageMode(.init(string: "5.10")!))
                     ]
                 ),
                 try TargetDescription(
                     name: "conditional",
                     type: .executable,
                     settings: [
-                        .init(tool: .swift, kind: .swiftLanguageVersion(.v5), condition: .init(platformNames: ["linux"])),
-                        .init(tool: .swift, kind: .swiftLanguageVersion(.v4), condition: .init(platformNames: ["macos"], config: "debug"))
+                        .init(tool: .swift, kind: .swiftLanguageMode(.v5), condition: .init(platformNames: ["linux"])),
+                        .init(tool: .swift, kind: .swiftLanguageMode(.v4), condition: .init(platformNames: ["macos"], config: "debug"))
                     ]
                 )
             ])

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -2928,7 +2928,7 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "bar", dependencies: [], settings: [
                             .init(
                                 tool: .swift,
-                                kind: .swiftLanguageVersion(.v4_2),
+                                kind: .swiftLanguageMode(.v4_2),
                                 condition: .init(platformNames: ["linux"])
                             ),
                         ]),
@@ -2995,24 +2995,24 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "foo", dependencies: [], settings: [
                             .init(
                                 tool: .swift,
-                                kind: .swiftLanguageVersion(.v4_2)
+                                kind: .swiftLanguageMode(.v4_2)
                             ),
                         ]),
                         .init(name: "bar", dependencies: [], settings: [
                             .init(
                                 tool: .swift,
-                                kind: .swiftLanguageVersion(.v6)
+                                kind: .swiftLanguageMode(.v6)
                             ),
                         ]),
                         .init(name: "baz", dependencies: [], settings: [
                             .init(
                                 tool: .swift,
-                                kind: .swiftLanguageVersion(.v3),
+                                kind: .swiftLanguageMode(.v3),
                                 condition: .init(platformNames: ["linux"])
                             ),
                             .init(
                                 tool: .swift,
-                                kind: .swiftLanguageVersion(.v4_2),
+                                kind: .swiftLanguageMode(.v4_2),
                                 condition: .init(platformNames: ["macOS"])
                             ),
                         ]),


### PR DESCRIPTION
…LanguageMode`

- Explanation:

  Implementation of SE-0441.

  - Deprecates `swiftLanguageVersion` API to maintain source compatibility with existing manifests;
  - Introduces new PackageDescription API - `swiftLanguageMode` (available from PackageDescription 6 on);
  - Renames multiple internal APIs to use `mode` instead of `version` when appropriate;
  - Build setting is still `-swift-version` but would be changed to use `mode` when it becomes available.

- Main Branch PR: https://github.com/swiftlang/swift-package-manager/pull/7620

- Risk: Low (Diagnoses invalid code instead of crashing and allows more uses of init accessors in accordance with the proposal).

- Reviewed By: @MaxDesiatov @xedin @bnbarham 

- Testing: Existing test-cases were modified and new tests were added.

(cherry picked from commit 844156b1e5f2d219541f7487f0d6e3d33890f139)
