### PR TITLE
[6.0] Handle `.xcprivacy` files in `TargetSourcesBuilder.swift`

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -723,6 +723,24 @@ public struct FileRuleDescription: Sendable {
         )
     }()
 
+    /// File rule to copy `.xcprivacy` (in the Xcode build system).
+    public static let xcprivacyCopied: FileRuleDescription = {
+        .init(
+            rule: .copyResource,
+            toolsVersion: .v6_0,
+            fileTypes: ["xcprivacy"]
+        )
+    }()
+
+    /// File rule to ignore `.xcprivacy` (in the SwiftPM build system).
+    public static let xcprivacyIgnored: FileRuleDescription = {
+        .init(
+            rule: .ignored,
+            toolsVersion: .v6_0,
+            fileTypes: ["xcprivacy"]
+        )
+    }()
+
     /// List of all the builtin rules.
     public static let builtinRules: [FileRuleDescription] = [
         swift,
@@ -739,11 +757,13 @@ public struct FileRuleDescription: Sendable {
         stringCatalog,
         coredata,
         metal,
+        xcprivacyCopied,
     ]
 
     /// List of file types that apply just to the SwiftPM build system.
     public static let swiftpmFileTypes: [FileRuleDescription] = [
         docc,
+        xcprivacyIgnored,
     ]
 
     /// List of file directory extensions that should be treated as opaque, non source, directories.

--- a/Sources/SPMTestSupport/Observability.swift
+++ b/Sources/SPMTestSupport/Observability.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import func XCTest.XCTAssertTrue
 import func XCTest.XCTAssertEqual
 import func XCTest.XCTFail
 
@@ -165,6 +166,13 @@ public class DiagnosticsTestResult {
 
     init(_ diagnostics: [Basics.Diagnostic]) {
         self.uncheckedDiagnostics = diagnostics
+    }
+
+    package func checkIsEmpty(
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(self.uncheckedDiagnostics.isEmpty, file: file, line: line)
     }
 
     @discardableResult

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -40,6 +40,27 @@ final class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testXCPrivacyIgnored() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/foo/PrivacyInfo.xcprivacy",
+            "/Sources/foo/Foo.swift")
+
+        let manifest = Manifest.createRootManifest(
+            displayName: "pkg",
+            path: .root,
+            targets: [
+                try TargetDescription(name: "foo"),
+            ]
+        )
+        PackageBuilderTester(manifest, in: fs) { package, _ in
+            package.checkModule("foo") { module in
+                module.check(c99name: "foo", type: .library)
+                module.checkSources(root: "/Sources/foo", paths: "Foo.swift")
+                module.checkResources(resources: [])
+            }
+        }
+    }
+
     func testMixedSources() throws {
         let foo: AbsolutePath = "/Sources/foo"
 
@@ -2951,7 +2972,81 @@ final class PackageBuilderTests: XCTestCase {
             }
         }
     }
-    
+
+    func testXcodeResources6_0AndLater() throws {
+        // In SwiftTools 6.0 and later, xcprivacy file types are only supported when explicitly passed via additionalFileRules.
+
+        let root: AbsolutePath = "/Foo"
+        let foo = root.appending(components: "Sources", "Foo")
+
+        let fs = InMemoryFileSystem(emptyFiles:
+            foo.appending(components: "foo.swift").pathString,
+            foo.appending(components: "Foo.xcassets").pathString,
+            foo.appending(components: "Foo.xcstrings").pathString,
+            foo.appending(components: "Foo.xib").pathString,
+            foo.appending(components: "Foo.xcdatamodel").pathString,
+            foo.appending(components: "Foo.metal").pathString,
+            foo.appending(components: "PrivacyInfo.xcprivacy").pathString
+        )
+
+        let manifest = Manifest.createRootManifest(
+            displayName: "Foo",
+            toolsVersion: .v6_0,
+            targets: [
+                try TargetDescription(name: "Foo"),
+            ]
+        )
+
+        PackageBuilderTester(manifest, path: root, supportXCBuildTypes: true, in: fs) { result, diagnostics in
+            result.checkModule("Foo") { result in
+                result.checkSources(sources: ["foo.swift"])
+                result.checkResources(resources: [
+                    foo.appending(components: "Foo.xib").pathString,
+                    foo.appending(components: "Foo.xcdatamodel").pathString,
+                    foo.appending(components: "Foo.xcassets").pathString,
+                    foo.appending(components: "Foo.xcstrings").pathString,
+                    foo.appending(components: "Foo.metal").pathString,
+                    foo.appending(components: "PrivacyInfo.xcprivacy").pathString,
+                ])
+            }
+        }
+    }
+
+    func testXCPrivacyNoDiagnostics() throws {
+        // In SwiftTools 6.0 and later, xcprivacy file types should not produce diagnostics messages when included
+        // as resources and built with `swift build`.
+
+        let root: AbsolutePath = "/Foo"
+        let foo = root.appending(components: "Sources", "Foo")
+
+        let fs = InMemoryFileSystem(emptyFiles:
+            foo.appending(components: "foo.swift").pathString,
+            foo.appending(components: "PrivacyInfo.xcprivacy").pathString
+        )
+
+        let manifest = Manifest.createRootManifest(
+            displayName: "Foo",
+            toolsVersion: .v6_0,
+            targets: [
+                try TargetDescription(
+                    name: "Foo",
+                    resources: [.init(rule: .copy, path: "PrivacyInfo.xcprivacy")]
+                ),
+            ]
+        )
+
+        PackageBuilderTester(manifest, path: root, supportXCBuildTypes: false, in: fs) { result, diagnostics in
+            result.checkModule("Foo") { result in
+                result.checkSources(sources: ["foo.swift"])
+                result.checkResources(resources: [
+                    foo.appending(components: "PrivacyInfo.xcprivacy").pathString,
+                ])
+            }
+
+            diagnostics.checkIsEmpty()
+        }
+    }
+
     func testSnippetsLinkProductLibraries() throws {
         let root = AbsolutePath("/Foo")
         let internalSourcesDir = root.appending(components: "Sources", "Internal")


### PR DESCRIPTION
Cherry-pick of #7807.

**Explanation**:  There should be a file rule to automatically include or ignore privacy manifests, given that we know the file name
**Scope**: isolated in code to a single file, only affects packages that include privacy manifests.
**Risk**: low due to isolated scope.
**Testing**: added new test cases.
**Issue**: rdar://111119227
**Reviewer**: @bnbarham 
