### PR TITLE
Add back `--enable-experimental-swift-testing` to `swift build` as a no-op.

### DIFF
--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -97,6 +97,13 @@ struct BuildCommandOptions: ParsableArguments {
     @Option(help: "Build the specified product")
     var product: String?
 
+    /// Testing library options.
+    ///
+    /// These options are no longer used but are needed by older versions of the
+    /// Swift VSCode plugin. They will be removed in a future update.
+    @OptionGroup(visibility: .private)
+    var testLibraryOptions: TestLibraryOptions
+
     /// Specifies the traits to build.
     @OptionGroup(visibility: .hidden)
     package var traits: TraitOptions


### PR DESCRIPTION
For the benefit of the VSCode Swift plugin, we need to keep this flag around (but as a no-op and hidden from documentation) until the plugin drops support for earlier Swift 6 prereleases.

Resolves rdar://132408655.