### PR TITLE
[6.0] Add back `--enable-experimental-swift-testing` to `swift build` as a no-op.

### DIFF
--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -97,6 +97,13 @@ struct BuildCommandOptions: ParsableArguments {
     @Option(help: "Build the specified product")
     var product: String?
 
+    /// Testing library options.
+    ///
+    /// These options are no longer used but are needed by older versions of the
+    /// Swift VSCode plugin. They will be removed in a future update.
+    @OptionGroup(visibility: .private)
+    var testLibraryOptions: TestLibraryOptions
+
     /// If should link the Swift stdlib statically.
     @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Link Swift stdlib statically")
     public var shouldLinkStaticSwiftStdlib: Bool = false


### PR DESCRIPTION
**Explanation:** Adds back some no-op arguments to `swift build` so that the VSCode plugin stays happy.
**Scope:** Bug fix in `swift build`.
**Issue:** rdar://132408655
**Original PR:** https://github.com/swiftlang/swift-package-manager/pull/7817
**Risk:** Low
**Testing:** N/A (no-op arguments, they do nothing)
**Reviewer:** @MaxDesiatov @bnbarham