### PR TITLE
6.0: [NFC] Expose `platformVersionProvider` with `@_spi(SwiftPMInternal)`

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -16,9 +16,16 @@ import struct Basics.AbsolutePath
 import struct LLBuildManifest.TestDiscoveryTool
 import struct LLBuildManifest.TestEntryPointTool
 import struct PackageGraph.ModulesGraph
+
+@_spi(SwiftPMInternal)
 import struct PackageGraph.ResolvedPackage
+
+@_spi(SwiftPMInternal)
 import struct PackageGraph.ResolvedProduct
+
+@_spi(SwiftPMInternal)
 import struct PackageGraph.ResolvedModule
+
 import struct PackageModel.Sources
 import class PackageModel.SwiftModule
 import class PackageModel.Module

--- a/Sources/PackageGraph/Resolution/ResolvedModule.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedModule.swift
@@ -144,7 +144,8 @@ public struct ResolvedModule {
     /// The list of platforms that are supported by this module.
     public let supportedPlatforms: [SupportedPlatform]
 
-    private let platformVersionProvider: PlatformVersionProvider
+    @_spi(SwiftPMInternal)
+    public let platformVersionProvider: PlatformVersionProvider
 
     /// Triple for which this resolved module should be compiled for.
     public package(set) var buildTriple: BuildTriple {

--- a/Sources/PackageGraph/Resolution/ResolvedPackage.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedPackage.swift
@@ -51,7 +51,8 @@ public struct ResolvedPackage {
     /// If the given package's source is a registry release, this provides additional metadata and signature information.
     public let registryMetadata: RegistryReleaseMetadata?
 
-    private let platformVersionProvider: PlatformVersionProvider
+    @_spi(SwiftPMInternal)
+    public let platformVersionProvider: PlatformVersionProvider
 
     public init(
         underlying: Package,

--- a/Sources/PackageGraph/Resolution/ResolvedProduct.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedProduct.swift
@@ -47,6 +47,7 @@ public struct ResolvedProduct {
     /// The list of platforms that are supported by this product.
     public let supportedPlatforms: [SupportedPlatform]
 
+    @_spi(SwiftPMInternal)
     public let platformVersionProvider: PlatformVersionProvider
 
     /// Triple for which this resolved product should be compiled for.


### PR DESCRIPTION
(cherry picked from https://github.com/swiftlang/swift-package-manager/pull/7819)

**Explanation**: NFC changes to expose a few properties with `@_spi(SwiftPMInternal)`.
**Scope**: limited to a few property declarations.
**Risk**: very low, the change is NFC
**Testing**: N/A
**Issue**: N/A
**Reviewer**: @francescomikulis 