### PR TITLE
[PackageDescription] Deprecated `swiftLanguageVersion` should result …

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -422,7 +422,7 @@ public struct SwiftSetting: Sendable {
       _ condition: BuildSettingCondition? = nil
     ) -> SwiftSetting {
         return SwiftSetting(
-            name: "swiftLanguageVersion", value: [.init(describing: version)], condition: condition)
+            name: "swiftLanguageMode", value: [.init(describing: version)], condition: condition)
     }
 
     /// Defines a `-language-mode` to pass  to the

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -589,7 +589,7 @@ final class ManifestSourceGenerationTests: XCTestCase {
         try await testManifestWritingRoundTrip(manifestContents: contents, toolsVersion: .v5_9)
     }
 
-    func testManifestGenerationWithSwiftLanguageVersion() async throws {
+    func testManifestGenerationWithSwiftLanguageMode() async throws {
         try UserToolchain.default.skipUnlessAtLeastSwift6()
         let manifest = Manifest.createRootManifest(
             displayName: "pkg",


### PR DESCRIPTION
…in `swiftLanguageMode` setting

Otherwise manifest loading is going to fail because `swiftLanguageVersion` has been removed.

Resolves: https://github.com/swiftlang/swift-package-manager/issues/7823
Resolves: rdar://132484168