### PR TITLE
[PackageLoading] Support deserialization of manifests that used `swif…

### DIFF
--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -540,7 +540,7 @@ extension TargetBuildSettingDescription.Kind {
         case "unsafeFlags":
             return .unsafeFlags(values)
 
-        case "swiftLanguageMode":
+        case "swiftLanguageVersion", "swiftLanguageMode":
             guard let rawVersion = values.first else {
                 throw InternalError("invalid (empty) build settings value")
             }


### PR DESCRIPTION
…tLanguageVersion`

Follow-up to https://github.com/swiftlang/swift-package-manager/pull/7620

This is important for the manifest cache - make sure that older manifests that used original spelling of the build setting are still deserializable.
