### PR TITLE
[6.0][PackageLoading] Support deserialization of manifests that used `swif…

### DIFF
--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -535,7 +535,7 @@ extension TargetBuildSettingDescription.Kind {
         case "unsafeFlags":
             return .unsafeFlags(values)
 
-        case "swiftLanguageMode":
+        case "swiftLanguageVersion", "swiftLanguageMode":
             guard let rawVersion = values.first else {
                 throw InternalError("invalid (empty) build settings value")
             }


### PR DESCRIPTION
…tLanguageVersion`

- Explanation:

  Follow-up to https://github.com/swiftlang/swift-package-manager/pull/7620

  This is important for the manifest cache - make sure that older manifests that used original spelling of the build setting are still deserializable.

- Main Branch PR: https://github.com/swiftlang/swift-package-manager/pull/7827

- Resolves: rdar://132484168

- Risk: Very Low (This change is very narrow and affects only people who adopted `swiftLanguagVersion` while building with 6.0 snapshot and had their manifests cached).

- Reviewed By: @bnbarham 

- Testing: Local testing only since there are no convenient affordances to test this.

(cherry picked from commit 51890861666d6c2835b1c3dc38f79c21997b2c34)
