### PR TITLE
NFC: Fix doc comment link in `UndirectedGraph.swift`

### DIFF
--- a/Sources/Basics/Graph/UndirectedGraph.swift
+++ b/Sources/Basics/Graph/UndirectedGraph.swift
@@ -12,7 +12,7 @@
 
 import struct DequeModule.Deque
 
-/// Undirected graph that stores edges in an [adjacency matrix](https://en.wikipedia.org/wiki/Adjacency_list).
+/// Undirected graph that stores edges in an [adjacency matrix](https://en.wikipedia.org/wiki/Adjacency_matrix).
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 public struct UndirectedGraph<Node> {
     public init(nodes: [Node]) {


### PR DESCRIPTION
`UndirectedGraph` uses an adjacency matrix not adjacency list for edges representation. The link in its doc comment should be corrected.
