### PR TITLE
[PackageDescription] NFC: Address a deprecation warning about SwiftVe…

### DIFF
--- a/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
@@ -107,7 +107,7 @@ extension Serialization.CXXLanguageStandard {
 }
 
 extension Serialization.SwiftVersion {
-    init(_ swiftVersion: PackageDescription.SwiftVersion) {
+    init(_ swiftVersion: PackageDescription.SwiftLanguageMode) {
         switch swiftVersion {
         case .v3: self = .v3
         case .v4: self = .v4


### PR DESCRIPTION
…rsion

Resolves: rdar://132532650

### Motivation:

`SwiftVersion` has been renamed to `SwiftLanguageMode`, but there was still one spot in the code base left using it.

### Modifications:

- Replace `SwiftVersion` with `SwiftLanguageMode` in PackageDescriptionSerializationConversion.swift

### Result:

No more deprecation warnings about `SwiftVersion`.
