### PR TITLE
NFC: Fix comment typo in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -596,7 +596,7 @@ let package = Package(
         ),
 
         .target(
-            /** Test for thread-santizer. */
+            /** Test for thread-sanitizer. */
             name: "tsan_utils",
             dependencies: []
         ),


### PR DESCRIPTION
`santizer` -> `sanitizer`