### PR TITLE
NFC: enable `InferSendableFromCaptures` on almost all modules

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -856,7 +856,6 @@ for target in package.targets where target.type == .regular && target.name != "S
         updatedSwiftSettings = swiftSettings
     } else {
         updatedSwiftSettings = [sendableFromCaptures]
-
     }
 
     target.swiftSettings = updatedSwiftSettings

--- a/Package.swift
+++ b/Package.swift
@@ -847,7 +847,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
 }
 
 // FIXME: `SourceControl` module needs to be updated to support `InferSendableFromCaptures`.
-for target in package.targets where target.type == .regular && target.name != "SourceControl" {
+for target in package.targets where [.regular, .test].contains(target.type) && target.name != "SourceControl" {
     let sendableFromCaptures = SwiftSetting.enableUpcomingFeature("InferSendableFromCaptures")
     let updatedSwiftSettings: [SwiftSetting]
 

--- a/Package.swift
+++ b/Package.swift
@@ -845,3 +845,19 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-certificates"),
     ]
 }
+
+// FIXME: `SourceControl` module needs to be updated to support `InferSendableFromCaptures`.
+for target in package.targets where target.type == .regular && target.name != "SourceControl" {
+    let sendableFromCaptures = SwiftSetting.enableUpcomingFeature("InferSendableFromCaptures")
+    let updatedSwiftSettings: [SwiftSetting]
+
+    if var swiftSettings = target.swiftSettings {
+        swiftSettings.append(sendableFromCaptures)
+        updatedSwiftSettings = swiftSettings
+    } else {
+        updatedSwiftSettings = [sendableFromCaptures]
+
+    }
+
+    target.swiftSettings = updatedSwiftSettings
+}

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1876,7 +1876,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Load the graph with one root.
-        try await workspace.checkPackageGraph(roots: ["Root1"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root1"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(packages: "Foo", "Root1")
             }


### PR DESCRIPTION
`SourceControl` is excluded for now as it triggers concurrency errors when this feature is enabled.
