### PR TITLE
[PackageModel] Support swift-testing installed in a toolchain

### DIFF
--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -176,8 +176,11 @@ enum TestingSupport {
         }
         #if !os(macOS)
         #if os(Windows)
-        if let location = toolchain.xctestPath {
-            env.prependPath(key: .path, value: location.pathString)
+        if let xctestLocation = toolchain.xctestPath {
+            env.prependPath(key: .path, value: xctestLocation.pathString)
+        }
+        if let swiftTestingLocation = toolchain.swiftTestingPathOnWindows {
+            env.prependPath(key: .path, value: swiftTestingLocation.pathString)
         }
         #endif
         return env

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -74,20 +74,24 @@ extension Toolchain {
 
     public var hostLibDir: AbsolutePath {
         get throws {
-            return try toolchainLibDir.appending(components: ["swift", "host"])
+            try Self.toolchainLibDir(swiftCompilerPath: self.swiftCompilerPath).appending(
+                components: ["swift", "host"]
+            )
         }
     }
 
     public var macosSwiftStdlib: AbsolutePath {
         get throws {
-            return try AbsolutePath(validating: "../../lib/swift/macosx", relativeTo: resolveSymlinks(swiftCompilerPath))
+            try Self.toolchainLibDir(swiftCompilerPath: self.swiftCompilerPath).appending(
+                components: ["swift", "macosx"]
+            )
         }
     }
 
     public var toolchainLibDir: AbsolutePath {
         get throws {
             // FIXME: Not sure if it's better to base this off of Swift compiler or our own binary.
-            return try AbsolutePath(validating: "../../lib", relativeTo: resolveSymlinks(swiftCompilerPath))
+            try Self.toolchainLibDir(swiftCompilerPath: self.swiftCompilerPath)
         }
     }
 
@@ -109,5 +113,9 @@ extension Toolchain {
     
     public var extraSwiftCFlags: [String] {
         extraFlags.swiftCompilerFlags
+    }
+
+    package static func toolchainLibDir(swiftCompilerPath: AbsolutePath) throws -> AbsolutePath {
+        try AbsolutePath(validating: "../../lib", relativeTo: resolveSymlinks(swiftCompilerPath))
     }
 }

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -42,6 +42,10 @@ public struct ToolchainConfiguration {
     /// This is optional for example on macOS w/o Xcode.
     public var xctestPath: AbsolutePath?
 
+    /// Path to the swift-testing utility.
+    /// Currently computed only for Windows.
+    public var swiftTestingPath: AbsolutePath?
+
     /// Creates the set of manifest resources associated with a `swiftc` executable.
     ///
     /// - Parameters:
@@ -59,7 +63,8 @@ public struct ToolchainConfiguration {
         swiftCompilerEnvironment: Environment = .current,
         swiftPMLibrariesLocation: SwiftPMLibrariesLocation? = nil,
         sdkRootPath: AbsolutePath? = nil,
-        xctestPath: AbsolutePath? = nil
+        xctestPath: AbsolutePath? = nil,
+        swiftTestingPath: AbsolutePath? = nil
     ) {
         let swiftPMLibrariesLocation = swiftPMLibrariesLocation ?? {
             return .init(swiftCompilerPath: swiftCompilerPath)
@@ -72,6 +77,7 @@ public struct ToolchainConfiguration {
         self.swiftPMLibrariesLocation = swiftPMLibrariesLocation
         self.sdkRootPath = sdkRootPath
         self.xctestPath = xctestPath
+        self.swiftTestingPath = swiftTestingPath
     }
 }
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -546,23 +546,25 @@ public final class UserToolchain: Toolchain {
                             xctest.append(contentsOf: ["-L", implib.parentDirectory.pathString])
                         }
 
-                        let swiftTestingInstallation: AbsolutePath =
-                            platform.appending("Developer")
-                                .appending("Library")
-                                .appending("Testing-\(info.defaults.swiftTestingVersion)")
+                        if let swiftTestingVersion = info.defaults.swiftTestingVersion {
+                            let swiftTestingInstallation: AbsolutePath =
+                                platform.appending("Developer")
+                                    .appending("Library")
+                                    .appending("Testing-\(swiftTestingVersion)")
 
-                        swiftTesting = try [
-                            "-I",
-                            AbsolutePath(
-                                validating: "usr/lib/swift/windows",
-                                relativeTo: swiftTestingInstallation
-                            ).pathString,
-                            "-L",
-                            AbsolutePath(
-                                validating: "usr/lib/swift/windows/\(triple.archName)",
-                                relativeTo: swiftTestingInstallation
-                            ).pathString
-                        ]
+                            swiftTesting = try [
+                                "-I",
+                                AbsolutePath(
+                                    validating: "usr/lib/swift/windows",
+                                    relativeTo: swiftTestingInstallation
+                                ).pathString,
+                                "-L",
+                                AbsolutePath(
+                                    validating: "usr/lib/swift/windows/\(triple.archName)",
+                                    relativeTo: swiftTestingInstallation
+                                ).pathString
+                            ]
+                        }
 
                         extraSwiftCFlags = info.defaults.extraSwiftCFlags ?? []
                     }
@@ -1012,10 +1014,14 @@ public final class UserToolchain: Toolchain {
             return nil
         }
 
+        guard let swiftTestingVersion = info.defaults.swiftTestingVersion else {
+            return nil
+        }
+
         let swiftTesting: AbsolutePath =
             platform.appending("Developer")
                 .appending("Library")
-                .appending("Testing-\(info.defaults.swiftTestingVersion)")
+                .appending("Testing-\(swiftTestingVersion)")
 
         let binPath: AbsolutePath? = switch triple.arch {
         case .x86_64: // amd64 x86_64 x86_64h

--- a/Sources/PackageModel/WindowsToolchainInfo.swift
+++ b/Sources/PackageModel/WindowsToolchainInfo.swift
@@ -78,6 +78,10 @@ public struct WindowsPlatformInfo {
         /// specifies the version string of the bundled XCTest.
         public let xctestVersion: String
 
+        /// SWIFT_TESTING_VERSION
+        /// specifies the version string of the bundled swift-testing.
+        public let swiftTestingVersion: String
+
         /// SWIFTC_FLAGS
         /// Specifies extra flags to pass to swiftc from Swift Package Manager.
         public let extraSwiftCFlags: [String]?
@@ -89,6 +93,7 @@ public struct WindowsPlatformInfo {
 extension WindowsPlatformInfo.DefaultProperties: Decodable {
     enum CodingKeys: String, CodingKey {
     case xctestVersion = "XCTEST_VERSION"
+    case swiftTestingVersion = "SWIFT_TESTING_VERSION"
     case extraSwiftCFlags = "SWIFTC_FLAGS"
     }
 }

--- a/Sources/PackageModel/WindowsToolchainInfo.swift
+++ b/Sources/PackageModel/WindowsToolchainInfo.swift
@@ -80,7 +80,7 @@ public struct WindowsPlatformInfo {
 
         /// SWIFT_TESTING_VERSION
         /// specifies the version string of the bundled swift-testing.
-        public let swiftTestingVersion: String
+        public let swiftTestingVersion: String?
 
         /// SWIFTC_FLAGS
         /// Specifies extra flags to pass to swiftc from Swift Package Manager.


### PR DESCRIPTION
Properly handle swift-testing installations in toolchain/SDK.

### Motivation:

On macOS SwiftPM should prefer swift-testing installed into a custom toolchain when used. On Windows we need special logic to discover swift-testing location.

### Modifications:

- Add special swift compiler "extra" flags to favor swift-testing installed in a toolchain.
- Inject `-I`, `-L` on Windows that point to where swift-testing is installed in SDKROOT.
- Inject a path to testing on `PATH` environment variable on Windows to make sure that the library is always discoverable.

Resolves: rdar://132828246

