### PR TITLE
Add a comment to explain why we don't process code coverage on test fail

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -438,7 +438,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
             try await run(swiftCommandState, buildParameters: productsBuildParameters, testProducts: testProducts)
 
-            // process code Coverage if request
+            // Process code coverage if requested. We do not process it if the test run failed.
+            // See https://github.com/swiftlang/swift-package-manager/pull/6894 for more info.
             if self.options.enableCodeCoverage, swiftCommandState.executionStatus != .failure {
                 try await processCodeCoverage(testProducts, swiftCommandState: swiftCommandState)
             }


### PR DESCRIPTION
In #6894, code coverage processing was disabled because it produces spurious output. This PR just adds a comment to the current source that links back to that one for future reference.