### PR TITLE
Remove `temp_await` [part 2]

### DIFF
--- a/Examples/package-info/Sources/package-info/example.swift
+++ b/Examples/package-info/Sources/package-info/example.swift
@@ -26,8 +26,8 @@ struct Example {
 
         let package = try await workspace.loadRootPackage(at: packagePath, observabilityScope: observability.topScope)
 
-        let graph = try workspace.loadPackageGraph(rootPath: packagePath, observabilityScope: observability.topScope)
-        
+        let graph = try await workspace.loadPackageGraph(rootPath: packagePath, observabilityScope: observability.topScope)
+
         // EXAMPLES
         // ========
 

--- a/Sources/Basics/Graph/GraphAlgorithms.swift
+++ b/Sources/Basics/Graph/GraphAlgorithms.swift
@@ -55,3 +55,34 @@ public func depthFirstSearch<T: Hashable>(
         }
     }
 }
+
+public func depthFirstSearch<T: Hashable>(
+    _ nodes: [T],
+    successors: (T) async throws -> [T],
+    onUnique: (T) -> Void,
+    onDuplicate: (T, T) -> Void
+) async rethrows {
+    var stack = OrderedSet<T>()
+    var visited = Set<T>()
+
+    for node in nodes {
+        precondition(stack.isEmpty)
+        stack.append(node)
+
+        while !stack.isEmpty {
+            let curr = stack.removeLast()
+
+            let visitResult = visited.insert(curr)
+            if visitResult.inserted {
+                onUnique(curr)
+            } else {
+                onDuplicate(visitResult.memberAfterInsert, curr)
+                continue
+            }
+
+            for succ in try await successors(curr) {
+                stack.append(succ)
+            }
+        }
+    }
+}

--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -250,11 +250,37 @@ extension DiagnosticsEmitterProtocol {
         }
     }
 
+    public func trap<T>(_ closure: () async throws -> T) async -> T? {
+        do {
+            return try await closure()
+        } catch Diagnostics.fatalError {
+            // FIXME: (diagnostics) deprecate this with Diagnostics.fatalError
+            return nil
+        } catch {
+            self.emit(error)
+            return nil
+        }
+    }
+
     /// trap a throwing closure, emitting diagnostics on error and returning boolean representing success
     @discardableResult
     public func trap(_ closure: () throws -> Void) -> Bool {
         do {
             try closure()
+            return true
+        } catch Diagnostics.fatalError {
+            // FIXME: (diagnostics) deprecate this with Diagnostics.fatalError
+            return false
+        } catch {
+            self.emit(error)
+            return false
+        }
+    }
+
+    @discardableResult
+    public func trap(_ closure: () async throws -> Void) async -> Bool {
+        do {
+            try await closure()
             return true
         } catch Diagnostics.fatalError {
             // FIXME: (diagnostics) deprecate this with Diagnostics.fatalError

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -266,6 +266,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         self.pkgConfigDirectories = pkgConfigDirectories
     }
 
+    @available(*, noasync, message: "This must only be called from a dispatch queue")
     public func getPackageGraph() throws -> ModulesGraph {
         try self.packageGraph.memoize {
             try self.packageGraphLoader()

--- a/Sources/Commands/PackageCommands/APIDiff.swift
+++ b/Sources/Commands/PackageCommands/APIDiff.swift
@@ -32,7 +32,7 @@ struct DeprecatedAPIDiff: ParsableCommand {
     }
 }
 
-struct APIDiff: SwiftCommand {
+struct APIDiff: AsyncSwiftCommand {
     static let configuration = CommandConfiguration(
         commandName: "diagnose-api-breaking-changes",
         abstract: "Diagnose API-breaking changes to Swift modules in a package",
@@ -77,7 +77,7 @@ struct APIDiff: SwiftCommand {
     @Flag(help: "Regenerate the API baseline, even if an existing one is available.")
     var regenerateBaseline: Bool = false
 
-    func run(_ swiftCommandState: SwiftCommandState) throws {
+    func run(_ swiftCommandState: SwiftCommandState) async throws {
         let apiDigesterPath = try swiftCommandState.getTargetToolchain().getSwiftAPIDigester()
         let apiDigesterTool = SwiftAPIDigester(fileSystem: swiftCommandState.fileSystem, tool: apiDigesterPath)
 
@@ -111,7 +111,7 @@ struct APIDiff: SwiftCommand {
             observabilityScope: swiftCommandState.observabilityScope
         )
 
-        let baselineDir = try baselineDumper.emitAPIBaseline(
+        let baselineDir = try await baselineDumper.emitAPIBaseline(
             for: modulesToDiff,
             at: overrideBaselineDir,
             force: regenerateBaseline,

--- a/Sources/Commands/PackageCommands/ArchiveSource.swift
+++ b/Sources/Commands/PackageCommands/ArchiveSource.swift
@@ -38,7 +38,7 @@ extension SwiftPackageCommand {
             if let output {
                 archivePath = output
             } else {
-                let graph = try swiftCommandState.loadPackageGraph()
+                let graph = try await swiftCommandState.loadPackageGraph()
                 let packageName = graph.rootPackages[graph.rootPackages.startIndex].manifest.displayName // TODO: use identity instead?
                 archivePath = packageDirectory.appending("\(packageName).zip")
             }

--- a/Sources/Commands/PackageCommands/CompletionCommand.swift
+++ b/Sources/Commands/PackageCommands/CompletionCommand.swift
@@ -16,7 +16,7 @@ import CoreCommands
 import var TSCBasic.stdoutStream
 
 extension SwiftPackageCommand {
-    struct CompletionCommand: SwiftCommand {
+    struct CompletionCommand: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
             commandName: "completion-tool",
             abstract: "Completion command (for shell completions)"
@@ -52,7 +52,7 @@ extension SwiftPackageCommand {
         @Argument(help: "generate-bash-script | generate-zsh-script |\ngenerate-fish-script | list-dependencies | list-executables")
         var mode: Mode
 
-        func run(_ swiftCommandState: SwiftCommandState) throws {
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
             switch mode {
             case .generateBashScript:
                 let script = SwiftCommand.completionScript(for: .bash)
@@ -64,7 +64,7 @@ extension SwiftPackageCommand {
                 let script = SwiftCommand.completionScript(for: .fish)
                 print(script)
             case .listDependencies:
-                let graph = try swiftCommandState.loadPackageGraph()
+                let graph = try await swiftCommandState.loadPackageGraph()
                 // command's result output goes on stdout
                 // ie "swift package list-dependencies" should output to stdout
                 ShowDependencies.dumpDependenciesOf(
@@ -74,14 +74,14 @@ extension SwiftPackageCommand {
                     on: TSCBasic.stdoutStream
                 )
             case .listExecutables:
-                let graph = try swiftCommandState.loadPackageGraph()
+                let graph = try await swiftCommandState.loadPackageGraph()
                 let package = graph.rootPackages[graph.rootPackages.startIndex].underlying
                 let executables = package.modules.filter { $0.type == .executable }
                 for executable in executables {
                     print(executable.name)
                 }
             case .listSnippets:
-                let graph = try swiftCommandState.loadPackageGraph()
+                let graph = try await swiftCommandState.loadPackageGraph()
                 let package = graph.rootPackages[graph.rootPackages.startIndex].underlying
                 let executables = package.modules.filter { $0.type == .snippet }
                 for executable in executables {

--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -131,7 +131,7 @@ struct DumpPackage: AsyncSwiftCommand {
     }
 }
 
-struct DumpPIF: SwiftCommand {
+struct DumpPIF: AsyncSwiftCommand {
     // hides this command from CLI `--help` output
     static let configuration = CommandConfiguration(shouldDisplay: false) 
 
@@ -141,8 +141,8 @@ struct DumpPIF: SwiftCommand {
     @Flag(help: "Preserve the internal structure of PIF")
     var preserveStructure: Bool = false
 
-    func run(_ swiftCommandState: SwiftCommandState) throws {
-        let graph = try swiftCommandState.loadPackageGraph()
+    func run(_ swiftCommandState: SwiftCommandState) async throws {
+        let graph = try await swiftCommandState.loadPackageGraph()
         let pif = try PIFBuilder.generatePIF(
             buildParameters: swiftCommandState.productsBuildParameters,
             packageGraph: graph,

--- a/Sources/Commands/PackageCommands/EditCommands.swift
+++ b/Sources/Commands/PackageCommands/EditCommands.swift
@@ -16,7 +16,7 @@ import CoreCommands
 import SourceControl
 
 extension SwiftPackageCommand {
-    struct Edit: SwiftCommand {
+    struct Edit: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Put a package in editable mode")
 
@@ -35,12 +35,12 @@ extension SwiftPackageCommand {
         @Argument(help: "The name of the package to edit")
         var packageName: String
 
-        func run(_ swiftCommandState: SwiftCommandState) throws {
-            try swiftCommandState.resolve()
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
+            try await swiftCommandState.resolve()
             let workspace = try swiftCommandState.getActiveWorkspace()
 
             // Put the dependency in edit mode.
-            workspace.edit(
+            await workspace.edit(
                 packageName: packageName,
                 path: path,
                 revision: revision,
@@ -50,7 +50,7 @@ extension SwiftPackageCommand {
         }
     }
 
-    struct Unedit: SwiftCommand {
+    struct Unedit: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Remove a package from editable mode")
 
@@ -64,11 +64,11 @@ extension SwiftPackageCommand {
         @Argument(help: "The name of the package to unedit")
         var packageName: String
 
-        func run(_ swiftCommandState: SwiftCommandState) throws {
-            try swiftCommandState.resolve()
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
+            try await swiftCommandState.resolve()
             let workspace = try swiftCommandState.getActiveWorkspace()
 
-            try workspace.unedit(
+            try await workspace.unedit(
                 packageName: packageName,
                 forceRemove: shouldForceRemove,
                 root: swiftCommandState.getWorkspaceRoot(),

--- a/Sources/Commands/PackageCommands/Install.swift
+++ b/Sources/Commands/PackageCommands/Install.swift
@@ -18,7 +18,7 @@ import PackageModel
 import TSCBasic
 
 extension SwiftPackageCommand {
-    struct Install: SwiftCommand {
+    struct Install: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
             commandName: "experimental-install",
             abstract: "Offers the ability to install executable products of the current package."
@@ -30,7 +30,7 @@ extension SwiftPackageCommand {
         @Option(help: "The name of the executable product to install")
         var product: String?
 
-        func run(_ commandState: SwiftCommandState) throws {
+        func run(_ commandState: SwiftCommandState) async throws {
             let swiftpmBinDir = try commandState.fileSystem.getOrCreateSwiftPMInstalledBinariesDirectory()
 
             let env = Environment.current
@@ -49,7 +49,7 @@ extension SwiftPackageCommand {
             let workspace = try commandState.getActiveWorkspace()
             let packageRoot = try commandState.getPackageRoot()
 
-            let packageGraph = try workspace.loadPackageGraph(
+            let packageGraph = try await workspace.loadPackageGraph(
                 rootPath: packageRoot,
                 observabilityScope: commandState.observabilityScope
             )

--- a/Sources/Commands/PackageCommands/Learn.swift
+++ b/Sources/Commands/PackageCommands/Learn.swift
@@ -17,7 +17,7 @@ import PackageGraph
 import PackageModel
 
 extension SwiftPackageCommand {
-    struct Learn: SwiftCommand {
+    struct Learn: AsyncSwiftCommand {
 
         @OptionGroup()
         var globalOptions: GlobalOptions
@@ -90,8 +90,8 @@ extension SwiftPackageCommand {
             return snippetGroups.filter { !$0.snippets.isEmpty }
         }
 
-        func run(_ swiftCommandState: SwiftCommandState) throws {
-            let graph = try swiftCommandState.loadPackageGraph()
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
+            let graph = try await swiftCommandState.loadPackageGraph()
             let package = graph.rootPackages[graph.rootPackages.startIndex]
             print(package.products.map { $0.description })
 

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -145,7 +145,7 @@ struct PluginCommand: AsyncSwiftCommand {
 
         // List the available plugins, if asked to.
         if self.listCommands {
-            let packageGraph = try swiftCommandState.loadPackageGraph()
+            let packageGraph = try await swiftCommandState.loadPackageGraph()
             let allPlugins = PluginCommand.availableCommandPlugins(
                 in: packageGraph,
                 limitedTo: self.pluginOptions.packageIdentity
@@ -181,7 +181,7 @@ struct PluginCommand: AsyncSwiftCommand {
         swiftCommandState: SwiftCommandState
     ) async throws {
         // Load the workspace and resolve the package graph.
-        let packageGraph = try swiftCommandState.loadPackageGraph()
+        let packageGraph = try await swiftCommandState.loadPackageGraph()
 
         swiftCommandState.observabilityScope.emit(info: "Finding plugin for command ‘\(command)’")
         let matchingPlugins = PluginCommand.findPlugins(matching: command, in: packageGraph, limitedTo: options.packageIdentity)

--- a/Sources/Commands/PackageCommands/Resolve.swift
+++ b/Sources/Commands/PackageCommands/Resolve.swift
@@ -29,7 +29,7 @@ extension SwiftPackageCommand {
         var packageName: String?
     }
 
-    struct Resolve: SwiftCommand {
+    struct Resolve: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Resolve package dependencies")
 
@@ -39,11 +39,11 @@ extension SwiftPackageCommand {
         @OptionGroup()
         var resolveOptions: ResolveOptions
 
-        func run(_ swiftCommandState: SwiftCommandState) throws {
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
             // If a package is provided, use that to resolve the dependencies.
             if let packageName = resolveOptions.packageName {
                 let workspace = try swiftCommandState.getActiveWorkspace()
-                try workspace.resolve(
+                try await workspace.resolve(
                     packageName: packageName,
                     root: swiftCommandState.getWorkspaceRoot(),
                     version: resolveOptions.version,
@@ -56,12 +56,12 @@ extension SwiftPackageCommand {
                 }
             } else {
                 // Otherwise, run a normal resolve.
-                try swiftCommandState.resolve()
+                try await swiftCommandState.resolve()
             }
         }
     }
 
-    struct Fetch: SwiftCommand {
+    struct Fetch: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(shouldDisplay: false)
 
         @OptionGroup(visibility: .hidden)
@@ -70,11 +70,11 @@ extension SwiftPackageCommand {
         @OptionGroup()
         var resolveOptions: ResolveOptions
 
-        func run(_ swiftCommandState: SwiftCommandState) throws {
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
             swiftCommandState.observabilityScope.emit(warning: "'fetch' command is deprecated; use 'resolve' instead")
 
             let resolveCommand = Resolve(globalOptions: _globalOptions, resolveOptions: _resolveOptions)
-            try resolveCommand.run(swiftCommandState)
+            try await resolveCommand.run(swiftCommandState)
         }
     }
 }

--- a/Sources/Commands/PackageCommands/ShowDependencies.swift
+++ b/Sources/Commands/PackageCommands/ShowDependencies.swift
@@ -21,7 +21,7 @@ import protocol TSCBasic.OutputByteStream
 import var TSCBasic.stdoutStream
 
 extension SwiftPackageCommand {
-    struct ShowDependencies: SwiftCommand {
+    struct ShowDependencies: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Print the resolved dependency graph")
 
@@ -35,8 +35,8 @@ extension SwiftPackageCommand {
                 help: "The absolute or relative path to output the resolved dependency graph.")
         var outputPath: AbsolutePath?
 
-        func run(_ swiftCommandState: SwiftCommandState) throws {
-            let graph = try swiftCommandState.loadPackageGraph()
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
+            let graph = try await swiftCommandState.loadPackageGraph()
             // command's result output goes on stdout
             // ie "swift package show-dependencies" should output to stdout
             let stream: OutputByteStream = try outputPath.map { try LocalFileOutputByteStream($0) } ?? TSCBasic.stdoutStream

--- a/Sources/Commands/PackageCommands/Update.swift
+++ b/Sources/Commands/PackageCommands/Update.swift
@@ -18,7 +18,7 @@ import PackageGraph
 import Workspace
 
 extension SwiftPackageCommand {
-    struct Update: SwiftCommand {
+    struct Update: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Update package dependencies")
         
@@ -32,10 +32,10 @@ extension SwiftPackageCommand {
         @Argument(help: "The packages to update")
         var packages: [String] = []
         
-        func run(_ swiftCommandState: SwiftCommandState) throws {
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
             let workspace = try swiftCommandState.getActiveWorkspace()
             
-            let changes = try workspace.updateDependencies(
+            let changes = try await workspace.updateDependencies(
                 root: swiftCommandState.getWorkspaceRoot(),
                 packages: packages,
                 dryRun: dryRun,

--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -124,10 +124,12 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
         switch options.mode {
         case .repl:
             // Load a custom package graph which has a special product for REPL.
-            let graphLoader = {
-                try swiftCommandState.loadPackageGraph(
-                    explicitProduct: self.options.executable
-                )
+            let asyncUnsafeGraphLoader = {
+                try unsafe_await {
+                    try await swiftCommandState.loadPackageGraph(
+                        explicitProduct: self.options.executable
+                    )
+                }
             }
 
             // Construct the build operation.
@@ -136,7 +138,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                 explicitBuildSystem: .native,
                 traitConfiguration: .init(traitOptions: self.options.traits),
                 cacheBuildManifest: false,
-                packageGraphLoader: graphLoader
+                packageGraphLoader: asyncUnsafeGraphLoader
             )
 
             // Perform build.

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -74,7 +74,7 @@ struct APIDigesterBaselineDumper {
         force: Bool,
         logLevel: Basics.Diagnostic.Severity,
         swiftCommandState: SwiftCommandState
-    ) throws -> AbsolutePath {
+    ) async throws -> AbsolutePath {
         var modulesToDiff = modulesToDiff
         let apiDiffDir = productsBuildParameters.apiDiff
         let baselineDir = (baselineDir ?? apiDiffDir).appending(component: baselineRevision.identifier)
@@ -118,7 +118,7 @@ struct APIDigesterBaselineDumper {
             cancellator: swiftCommandState.cancellator
         )
 
-        let graph = try workspace.loadPackageGraph(
+        let graph = try await workspace.loadPackageGraph(
             rootPath: baselinePackageRoot,
             observabilityScope: self.observabilityScope
         )

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 import Build
 import SPMBuildCore
 import XCBuildSupport
@@ -41,11 +42,13 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
             toolsBuildParameters: try toolsBuildParameters ?? self.swiftCommandState.toolsBuildParameters,
             cacheBuildManifest: cacheBuildManifest && self.swiftCommandState.canUseCachedBuildManifest(),
             packageGraphLoader: packageGraphLoader ?? {
-                try self.swiftCommandState.loadPackageGraph(
-                    explicitProduct: explicitProduct,
-                    traitConfiguration: traitConfiguration,
-                    testEntryPointPath: testEntryPointPath
-                )
+                try unsafe_await {
+                    try await self.swiftCommandState.loadPackageGraph(
+                        explicitProduct: explicitProduct,
+                        traitConfiguration: traitConfiguration,
+                        testEntryPointPath: testEntryPointPath
+                    )
+                }
             },
             pluginConfiguration: .init(
                 scriptRunner: self.swiftCommandState.getPluginScriptRunner(),
@@ -80,9 +83,11 @@ private struct XcodeBuildSystemFactory: BuildSystemFactory {
         return try XcodeBuildSystem(
             buildParameters: productsBuildParameters ?? self.swiftCommandState.productsBuildParameters,
             packageGraphLoader: packageGraphLoader ?? {
-                try self.swiftCommandState.loadPackageGraph(
-                    explicitProduct: explicitProduct
-                )
+                try unsafe_await {
+                    try await self.swiftCommandState.loadPackageGraph(
+                        explicitProduct: explicitProduct
+                    )
+                }
             },
             outputStream: outputStream ?? self.swiftCommandState.outputStream,
             logLevel: logLevel ?? self.swiftCommandState.logLevel,

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -16,7 +16,6 @@ import var Basics.localFileSystem
 import struct Basics.AbsolutePath
 import enum Basics.TestingLibrary
 import struct Basics.Triple
-import func Basics.temp_await
 
 import struct Foundation.URL
 

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -590,11 +590,11 @@ public final class SwiftCommandState {
     }
 
     /// Resolve the dependencies.
-    public func resolve() throws {
+    public func resolve() async throws {
         let workspace = try getActiveWorkspace()
         let root = try getWorkspaceRoot()
 
-        try workspace.resolve(
+        try await workspace.resolve(
             root: root,
             forceResolution: false,
             forceResolvedVersions: options.resolver.forceResolvedVersions,
@@ -617,8 +617,8 @@ public final class SwiftCommandState {
     public func loadPackageGraph(
         explicitProduct: String? = nil,
         testEntryPointPath: AbsolutePath? = nil
-    ) throws -> ModulesGraph {
-        try self.loadPackageGraph(
+    ) async throws -> ModulesGraph {
+        try await self.loadPackageGraph(
             explicitProduct: explicitProduct,
             traitConfiguration: nil,
             testEntryPointPath: testEntryPointPath
@@ -635,12 +635,12 @@ public final class SwiftCommandState {
         explicitProduct: String? = nil,
         traitConfiguration: TraitConfiguration? = nil,
         testEntryPointPath: AbsolutePath? = nil
-    ) throws -> ModulesGraph {
+    ) async throws -> ModulesGraph {
         do {
             let workspace = try getActiveWorkspace()
 
             // Fetch and load the package graph.
-            let graph = try workspace.loadPackageGraph(
+            let graph = try await workspace.loadPackageGraph(
                 rootInput: getWorkspaceRoot(),
                 explicitProduct: explicitProduct,
                 traitConfiguration: traitConfiguration,

--- a/Sources/PackageCollections/Storage/PackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/PackageCollectionsStorage.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import PackageModel
 import Basics
 
@@ -90,23 +91,23 @@ public protocol PackageCollectionsStorage {
 
 public extension PackageCollectionsStorage {
     func put(collection: PackageCollectionsModel.Collection) async throws -> PackageCollectionsModel.Collection {
-        try await safe_async {
-            self.put(collection: collection, callback: $0)
+        try await withCheckedThrowingContinuation {
+            self.put(collection: collection, callback: $0.resume(with:))
         }
     }
     func remove(identifier: PackageCollectionsModel.CollectionIdentifier) async throws {
-        try await safe_async {
-            self.remove(identifier: identifier, callback: $0)
+        try await withCheckedThrowingContinuation {
+            self.remove(identifier: identifier, callback: $0.resume(with:))
         }
     }
     func get(identifier: PackageCollectionsModel.CollectionIdentifier) async throws -> PackageCollectionsModel.Collection {
-        try await safe_async {
-            self.get(identifier: identifier, callback: $0)
+        try await withCheckedThrowingContinuation {
+            self.get(identifier: identifier, callback: $0.resume(with:))
         }
     }
     func list(identifiers: [PackageCollectionsModel.CollectionIdentifier]? = nil) async throws -> [PackageCollectionsModel.Collection] {
-        try await safe_async {
-            self.list(identifiers: identifiers, callback: $0)
+        try await withCheckedThrowingContinuation {
+            self.list(identifiers: identifiers, callback: $0.resume(with:))
         }
     }
 
@@ -114,16 +115,16 @@ public extension PackageCollectionsStorage {
         identifiers: [PackageCollectionsModel.CollectionIdentifier]? = nil,
         query: String
     ) async throws -> PackageCollectionsModel.PackageSearchResult {
-        try await safe_async {
-            self.searchPackages(identifiers: identifiers, query: query, callback: $0)
+        try await withCheckedThrowingContinuation {
+            self.searchPackages(identifiers: identifiers, query: query, callback: $0.resume(with:))
         }
     }
     func findPackage(
         identifier: PackageIdentity,
         collectionIdentifiers: [PackageCollectionsModel.CollectionIdentifier]? = nil
     ) async throws -> (packages: [PackageCollectionsModel.Package], collections: [PackageCollectionsModel.CollectionIdentifier]) {
-        try await safe_async {
-            self.findPackage(identifier: identifier, collectionIdentifiers: collectionIdentifiers, callback: $0)
+        try await withCheckedThrowingContinuation {
+            self.findPackage(identifier: identifier, collectionIdentifiers: collectionIdentifiers, callback: $0.resume(with:))
         }
     }
 
@@ -132,8 +133,8 @@ public extension PackageCollectionsStorage {
         query: String,
         type: PackageCollectionsModel.TargetSearchType
     ) async throws -> PackageCollectionsModel.TargetSearchResult {
-        try await safe_async {
-            self.searchTargets(identifiers: identifiers, query: query, type: type, callback: $0)
+        try await withCheckedThrowingContinuation {
+            self.searchTargets(identifiers: identifiers, query: query, type: type, callback: $0.resume(with:))
         }
     }
 }

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Dispatch
 import struct Foundation.Data
 import class Foundation.JSONDecoder
@@ -837,7 +838,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         }
     }
     internal func populateTargetTrie() async throws {
-        try await safe_async { self.populateTargetTrie(callback: $0) }
+        try await withCheckedThrowingContinuation { self.populateTargetTrie(callback: $0.resume(with:)) }
     }
 
     internal func populateTargetTrie(callback: @escaping (Result<Void, Error>) -> Void = { _ in }) {

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Dispatch
 import PackageModel
 
@@ -188,13 +189,13 @@ public extension PackageContainerProvider {
         observabilityScope: ObservabilityScope,
         on queue: DispatchQueue
     ) async throws -> PackageContainer {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.getContainer(
                 for: package,
                 updateStrategy: updateStrategy,
                 observabilityScope: observabilityScope,
                 on: queue,
-                completion: $0)
+                completion: $0.resume(with:))
         }
     }
 }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -340,7 +340,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         delegateQueue: DispatchQueue,
         callbackQueue: DispatchQueue
     ) async throws -> Manifest {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.load(
                 manifestPath: manifestPath,
                 manifestToolsVersion: manifestToolsVersion,
@@ -354,7 +354,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 observabilityScope: observabilityScope,
                 delegateQueue: delegateQueue, 
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }

--- a/Sources/PackageRegistry/ChecksumTOFU.swift
+++ b/Sources/PackageRegistry/ChecksumTOFU.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import Dispatch
 
 import Basics
@@ -45,7 +46,7 @@ struct PackageVersionChecksumTOFU {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.validateSourceArchive(
                 registry: registry,
                 package: package,
@@ -54,7 +55,7 @@ struct PackageVersionChecksumTOFU {
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }
@@ -168,7 +169,7 @@ struct PackageVersionChecksumTOFU {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.validateManifest(
                 registry: registry,
                 package: package,
@@ -178,10 +179,11 @@ struct PackageVersionChecksumTOFU {
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue, 
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }
+
     @available(*, noasync, message: "Use the async alternative")
     func validateManifest(
         registry: Registry,

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Dispatch
 import Foundation
 import PackageFingerprint
@@ -154,13 +155,13 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> PackageMetadata {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.getPackageMetadata(
                 package: package,
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }
@@ -287,7 +288,7 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> PackageVersionMetadata {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.getPackageVersionMetadata(
                 package: package,
                 version: version,
@@ -295,7 +296,7 @@ public final class RegistryClient: Cancellable {
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }
@@ -509,14 +510,14 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> [String: (toolsVersion: ToolsVersion, content: String?)]{
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.getAvailableManifests(
                 package: package,
                 version: version,
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }
@@ -757,7 +758,7 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> String {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.getManifestContent(
                 package: package,
                 version: version,
@@ -765,7 +766,7 @@ public final class RegistryClient: Cancellable {
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }
@@ -989,7 +990,7 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.downloadSourceArchive(
                 package: package,
                 version: version,
@@ -999,7 +1000,7 @@ public final class RegistryClient: Cancellable {
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }
@@ -1302,13 +1303,13 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> Set<PackageIdentity> {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.lookupIdentities(
                 scmURL: scmURL,
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }
@@ -1425,13 +1426,13 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.login(
                 loginURL: loginURL,
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }
@@ -1488,7 +1489,7 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> PublishResult  {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.publish(
                 registryURL: registryURL,
                 packageIdentity: packageIdentity,
@@ -1502,7 +1503,7 @@ public final class RegistryClient: Cancellable {
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }
@@ -1682,13 +1683,13 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> AvailabilityStatus {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.checkAvailability(
                 registry: registry,
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Dispatch
 import Foundation
 import PackageLoading
@@ -51,14 +52,14 @@ public class RegistryDownloadsManager: Cancellable {
         delegateQueue: DispatchQueue,
         callbackQueue: DispatchQueue
     ) async throws -> AbsolutePath {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.lookup(
                 package: package,
                 version: version,
                 observabilityScope: observabilityScope,
                 delegateQueue: delegateQueue,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -64,7 +64,7 @@ struct SignatureValidation {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> SigningEntity? {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.validate(
                 registry: registry,
                 package: package,
@@ -75,7 +75,7 @@ struct SignatureValidation {
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope, 
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }
@@ -324,7 +324,7 @@ struct SignatureValidation {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> SigningEntity? {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.validate(
                 registry: registry,
                 package: package,
@@ -336,7 +336,7 @@ struct SignatureValidation {
                 fileSystem:fileSystem,
                 observabilityScope: observabilityScope, 
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }

--- a/Sources/PackageRegistry/SigningEntityTOFU.swift
+++ b/Sources/PackageRegistry/SigningEntityTOFU.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import Dispatch
 
 import Basics
@@ -38,7 +39,7 @@ struct PackageSigningEntityTOFU {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.validate(
                 registry: registry,
                 package: package,
@@ -46,7 +47,7 @@ struct PackageSigningEntityTOFU {
                 signingEntity: signingEntity,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }

--- a/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
@@ -13,6 +13,7 @@
 import struct Foundation.URL
 
 import Basics
+import _Concurrency
 import Dispatch
 import PackageModel
 
@@ -93,12 +94,12 @@ public extension PackageSigningEntityStorage {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> PackageSigners {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.get(
                 package: package,
                 observabilityScope: observabilityScope, 
                 callbackQueue: callbackQueue,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
     }
@@ -111,7 +112,7 @@ public extension PackageSigningEntityStorage {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.put(
                 package: package,
                 version: version,
@@ -119,7 +120,7 @@ public extension PackageSigningEntityStorage {
                 origin: origin,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
     }
@@ -132,7 +133,7 @@ public extension PackageSigningEntityStorage {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.add(
                 package: package,
                 version: version,
@@ -140,7 +141,7 @@ public extension PackageSigningEntityStorage {
                 origin: origin,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
     }
@@ -153,7 +154,7 @@ public extension PackageSigningEntityStorage {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.changeSigningEntityFromVersion(
                 package: package,
                 version: version,
@@ -161,7 +162,7 @@ public extension PackageSigningEntityStorage {
                 origin: origin,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
     }
@@ -174,7 +175,7 @@ public extension PackageSigningEntityStorage {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.changeSigningEntityForAllVersions(
                 package: package,
                 version: version,
@@ -182,7 +183,7 @@ public extension PackageSigningEntityStorage {
                 origin: origin,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
     }

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -12,6 +12,7 @@
 
 @_spi(SwiftPMInternal)
 import Basics
+import _Concurrency
 
 import Foundation
 import PackageModel
@@ -62,7 +63,7 @@ extension PluginModule {
         callbackQueue: DispatchQueue,
         delegate: PluginInvocationDelegate
     ) async throws -> Bool {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.invoke(
                 action: action,
                 buildEnvironment: buildEnvironment,
@@ -81,7 +82,7 @@ extension PluginModule {
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
                 delegate: delegate,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }
@@ -390,7 +391,7 @@ extension PluginModule {
         modulesGraph: ModulesGraph,
         observabilityScope: ObservabilityScope
     ) async throws -> BuildToolPluginInvocationResult {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.invoke(
                 module: module,
                 action: action,
@@ -408,7 +409,7 @@ extension PluginModule {
                 fileSystem: fileSystem,
                 modulesGraph: modulesGraph,
                 observabilityScope: observabilityScope,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }

--- a/Sources/SPMBuildCore/Plugins/PluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginScriptRunner.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Foundation
 import PackageModel
 import PackageLoading
@@ -71,7 +72,7 @@ public extension PluginScriptRunner {
         callbackQueue: DispatchQueue,
         delegate: PluginScriptCompilerDelegate
     ) async throws -> PluginCompilationResult {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.compilePluginScript(
                 sourceFiles: sourceFiles,
                 pluginName: pluginName,
@@ -79,7 +80,7 @@ public extension PluginScriptRunner {
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
                 delegate: delegate,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Dispatch
 import Foundation
 import PackageModel
@@ -98,7 +99,7 @@ public class RepositoryManager: Cancellable {
         delegateQueue: DispatchQueue,
         callbackQueue: DispatchQueue
     ) async throws -> RepositoryHandle {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.lookup(
                 package: package,
                 repository: repository,
@@ -106,7 +107,7 @@ public class RepositoryManager: Cancellable {
                 observabilityScope: observabilityScope,
                 delegateQueue: delegateQueue,
                 callbackQueue: callbackQueue,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }

--- a/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Dispatch
 import class Foundation.NSLock
 import PackageFingerprint
@@ -156,7 +157,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         return try? self.knownVersions()[version]
     }
 
-    func checkIntegrity(version: Version, revision: Revision) throws {
+    func checkIntegrity(version: Version, revision: Revision) async throws {
         guard let fingerprintStorage else {
             return
         }
@@ -167,7 +168,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
 
         let fingerprint: Fingerprint
         do {
-            fingerprint = try temp_await {
+            fingerprint = try await withCheckedThrowingContinuation {
                 fingerprintStorage.get(
                     package: self.package,
                     version: version,
@@ -175,7 +176,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
                     contentType: .sourceCode,
                     observabilityScope: self.observabilityScope,
                     callbackQueue: .sharedConcurrent,
-                    callback: $0
+                    callback: $0.resume(with:)
                 )
             }
         } catch PackageFingerprintStorageError.notFound {
@@ -186,14 +187,14 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
             )
             // Write to storage if fingerprint not yet recorded
             do {
-                try temp_await {
+                try await withCheckedThrowingContinuation {
                     fingerprintStorage.put(
                         package: self.package,
                         version: version,
                         fingerprint: fingerprint,
                         observabilityScope: self.observabilityScope,
                         callbackQueue: .sharedConcurrent,
-                        callback: $0
+                        callback: $0.resume(with:)
                     )
                 }
             } catch PackageFingerprintStorageError.conflict(_, let existing) {

--- a/Sources/Workspace/Workspace+Editing.swift
+++ b/Sources/Workspace/Workspace+Editing.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import struct Basics.AbsolutePath
 import class Basics.InMemoryFileSystem
 import class Basics.ObservabilityScope
 import struct Basics.RelativePath
-import func Basics.temp_await
 import struct PackageGraph.PackageGraphRootInput
 import struct SourceControl.Revision
 
@@ -26,7 +26,7 @@ extension Workspace {
         revision: Revision? = nil,
         checkoutBranch: String? = nil,
         observabilityScope: ObservabilityScope
-    ) throws {
+    ) async throws {
         // Look up the dependency and check if we can edit it.
         guard let dependency = self.state.dependencies[.plain(packageName)] else {
             observabilityScope.emit(.dependencyNotFound(packageName: packageName))
@@ -64,14 +64,14 @@ extension Workspace {
         // a valid manifest with name same as the package we are trying to edit.
         if fileSystem.exists(destination) {
             // FIXME: this should not block
-            let manifest = try temp_await {
+            let manifest = try await withCheckedThrowingContinuation { continuation in
                 self.loadManifest(
                     packageIdentity: dependency.packageRef.identity,
                     packageKind: .fileSystem(destination),
                     packagePath: destination,
                     packageLocation: dependency.packageRef.locationString,
                     observabilityScope: observabilityScope,
-                    completion: $0
+                    completion: continuation.resume(with:)
                 )
             }
 
@@ -101,17 +101,14 @@ extension Workspace {
             // Get handle to the repository.
             // TODO: replace with async/await when available
             let repository = try dependency.packageRef.makeRepositorySpecifier()
-            let handle = try temp_await {
-                repositoryManager.lookup(
-                    package: dependency.packageRef.identity,
-                    repository: repository,
-                    updateStrategy: .never,
-                    observabilityScope: observabilityScope,
-                    delegateQueue: .sharedConcurrent,
-                    callbackQueue: .sharedConcurrent,
-                    completion: $0
-                )
-            }
+            let handle = try await repositoryManager.lookup(
+                package: dependency.packageRef.identity,
+                repository: repository,
+                updateStrategy: .never,
+                observabilityScope: observabilityScope,
+                delegateQueue: .sharedConcurrent,
+                callbackQueue: .sharedConcurrent
+            )
             let repo = try handle.open()
 
             // Do preliminary checks on branch and revision, if provided.
@@ -170,7 +167,7 @@ extension Workspace {
         forceRemove: Bool,
         root: PackageGraphRootInput? = nil,
         observabilityScope: ObservabilityScope
-    ) throws {
+    ) async throws {
         // Compute if we need to force remove.
         var forceRemove = forceRemove
 
@@ -216,7 +213,7 @@ extension Workspace {
             // Restore the original checkout.
             //
             // The retrieve method will automatically update the managed dependency state.
-            _ = try self.checkoutRepository(
+            _ = try await self.checkoutRepository(
                 package: dependency.packageRef,
                 at: checkoutState,
                 observabilityScope: observabilityScope
@@ -230,7 +227,7 @@ extension Workspace {
         // Resolve the dependencies if workspace root is provided. We do this to
         // ensure the unedited version of this dependency is resolved properly.
         if let root {
-            try self._resolve(
+            try await self._resolve(
                 root: root,
                 explicitProduct: .none,
                 resolvedFileStrategy: .update(forceResolution: false),

--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -10,12 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
+
 import struct Basics.AbsolutePath
 import struct Basics.Diagnostic
 import struct Basics.InternalError
 import class Basics.ObservabilityScope
 import struct Basics.SwiftVersion
-import func Basics.temp_await
 import func Basics.depthFirstSearch
 import class Basics.ThreadSafeKeyValueStore
 import class Dispatch.DispatchGroup
@@ -420,7 +421,7 @@ extension Workspace {
         root: PackageGraphRoot,
         automaticallyAddManagedDependencies: Bool = false,
         observabilityScope: ObservabilityScope
-    ) throws -> DependencyManifests {
+    ) async throws -> DependencyManifests {
         let prepopulateManagedDependencies: ([PackageReference]) throws -> Void = { refs in
             // pre-populate managed dependencies if we are asked to do so (this happens when resolving to a resolved
             // file)
@@ -460,7 +461,9 @@ extension Workspace {
         }
 
         // Validates that all the managed dependencies are still present in the file system.
-        self.fixManagedDependencies(observabilityScope: observabilityScope)
+        await self.fixManagedDependencies(
+            observabilityScope: observabilityScope
+        )
         guard !observabilityScope.errorsReported else {
             // return partial results
             return DependencyManifests(
@@ -474,11 +477,10 @@ extension Workspace {
         // Load root dependencies manifests (in parallel)
         let rootDependencies = root.dependencies.map(\.packageRef)
         try prepopulateManagedDependencies(rootDependencies)
-        let rootDependenciesManifests = try temp_await { self.loadManagedManifests(
+        let rootDependenciesManifests = await self.loadManagedManifests(
             for: rootDependencies,
-            observabilityScope: observabilityScope,
-            completion: $0
-        ) }
+            observabilityScope: observabilityScope
+        )
 
         let topLevelManifests = root.manifests.merging(rootDependenciesManifests, uniquingKeysWith: { lhs, _ in
             lhs // prefer roots!
@@ -486,26 +488,24 @@ extension Workspace {
 
         // optimization: preload first level dependencies manifest (in parallel)
         let firstLevelDependencies = topLevelManifests.values.map { $0.dependencies.map(\.packageRef) }.flatMap { $0 }
-        let firstLevelManifests = try temp_await { self.loadManagedManifests(
+        let firstLevelManifests = await self.loadManagedManifests(
             for: firstLevelDependencies,
-            observabilityScope: observabilityScope,
-            completion: $0
-        ) } // FIXME: this should not block
+            observabilityScope: observabilityScope
+        )
 
         // Continue to load the rest of the manifest for this graph
         // Creates a map of loaded manifests. We do this to avoid reloading the shared nodes.
         var loadedManifests = firstLevelManifests
-        let successorManifests: (KeyedPair<Manifest, Key>) throws -> [KeyedPair<Manifest, Key>] = { pair in
+        let successorManifests: (KeyedPair<Manifest, Key>) async throws -> [KeyedPair<Manifest, Key>] = { pair in
             // optimization: preload manifest we know about in parallel
             let dependenciesRequired = pair.item.dependenciesRequired(for: pair.key.productFilter)
             let dependenciesToLoad = dependenciesRequired.map(\.packageRef)
                 .filter { !loadedManifests.keys.contains($0.identity) }
             try prepopulateManagedDependencies(dependenciesToLoad)
-            let dependenciesManifests = try temp_await { self.loadManagedManifests(
+            let dependenciesManifests = await self.loadManagedManifests(
                 for: dependenciesToLoad,
-                observabilityScope: observabilityScope,
-                completion: $0
-            ) }
+                observabilityScope: observabilityScope
+            )
             dependenciesManifests.forEach { loadedManifests[$0.key] = $0.value }
             return dependenciesRequired.compactMap { dependency in
                 loadedManifests[dependency.identity].flatMap {
@@ -533,7 +533,7 @@ extension Workspace {
             }
 
             var deduplication = [PackageIdentity: Int]()
-            try depthFirstSearch(
+            try await depthFirstSearch(
                 manifestGraphRoots,
                 successors: successorManifests
             ) { pair in
@@ -562,23 +562,19 @@ extension Workspace {
             }
         }
 
-        let dependencies = try dependencyManifests.map { identity, manifest, productFilter -> (
-            Manifest,
-            ManagedDependency,
-            ProductFilter,
-            FileSystem
-        ) in
+        var dependencies: [(Manifest, ManagedDependency, ProductFilter, FileSystem)] = []
+        for (identity, manifest, productFilter) in dependencyManifests {
             guard let dependency = self.state.dependencies[identity] else {
                 throw InternalError("dependency not found for \(identity) at \(manifest.packageLocation)")
             }
 
             let packageRef = PackageReference(identity: identity, kind: manifest.packageKind)
-            let fileSystem = try self.getFileSystem(
+            let fileSystem = try await self.getFileSystem(
                 package: packageRef,
                 state: dependency.state,
                 observabilityScope: observabilityScope
             )
-            return (manifest, dependency, productFilter, fileSystem ?? self.fileSystem)
+            dependencies.append((manifest, dependency, productFilter, fileSystem ?? self.fileSystem))
         }
 
         return DependencyManifests(
@@ -590,41 +586,41 @@ extension Workspace {
     }
 
     /// Loads the given manifests, if it is present in the managed dependencies.
+    ///
+
     private func loadManagedManifests(
         for packages: [PackageReference],
-        observabilityScope: ObservabilityScope,
-        completion: @escaping (Result<[PackageIdentity: Manifest], Error>) -> Void
-    ) {
-        let sync = DispatchGroup()
-        let manifests = ThreadSafeKeyValueStore<PackageIdentity, Manifest>()
-        Set(packages).forEach { package in
-            sync.enter()
-            self.loadManagedManifest(for: package, observabilityScope: observabilityScope) { manifest in
-                defer { sync.leave() }
-                if let manifest {
-                    manifests[package.identity] = manifest
+        observabilityScope: ObservabilityScope
+    ) async -> [PackageIdentity: Manifest] {
+        await withTaskGroup(of: (PackageIdentity, Manifest?).self) { group in
+            for package in Set(packages) {
+                group.addTask {
+                    await (
+                        package.identity,
+                        self.loadManagedManifest(for: package, observabilityScope: observabilityScope)
+                    )
                 }
             }
-        }
-
-        sync.notify(queue: .sharedConcurrent) {
-            completion(.success(manifests.get()))
+            return await group.compactMap {
+                $0 as? (PackageIdentity, Manifest)
+            }.reduce(into: [PackageIdentity:Manifest]()) { partialResult, loadedManifest in
+                partialResult[loadedManifest.0] = loadedManifest.1
+            }
         }
     }
 
     /// Loads the given manifest, if it is present in the managed dependencies.
     private func loadManagedManifest(
         for package: PackageReference,
-        observabilityScope: ObservabilityScope,
-        completion: @escaping (Manifest?) -> Void
-    ) {
+        observabilityScope: ObservabilityScope
+    ) async -> Manifest? {
         // Check if this dependency is available.
         // we also compare the location as this function may attempt to load
         // dependencies that have the same identity but from a different location
         // which is an error case we diagnose an report about in the GraphLoading part which
         // is prepared to handle the case where not all manifest are available
         guard let managedDependency = self.state.dependencies[comparingLocation: package] else {
-            return completion(.none)
+            return nil
         }
 
         // Get the path of the package.
@@ -655,7 +651,7 @@ extension Workspace {
 
         let fileSystem: FileSystem?
         do {
-            fileSystem = try self.getFileSystem(
+            fileSystem = try await self.getFileSystem(
                 package: package,
                 state: managedDependency.state,
                 observabilityScope: observabilityScope
@@ -670,17 +666,18 @@ extension Workspace {
         }
 
         // Load and return the manifest.
-        self.loadManifest(
-            packageIdentity: managedDependency.packageRef.identity,
-            packageKind: packageKind,
-            packagePath: packagePath,
-            packageLocation: managedDependency.packageRef.locationString,
-            packageVersion: packageVersion,
-            fileSystem: fileSystem,
-            observabilityScope: observabilityScope
-        ) { result in
-            // error is added to diagnostics in the function above
-            completion(try? result.get())
+        return await withCheckedContinuation { continuation in
+            self.loadManifest(
+                packageIdentity: managedDependency.packageRef.identity,
+                packageKind: packageKind,
+                packagePath: packagePath,
+                packageLocation: managedDependency.packageRef.locationString,
+                packageVersion: packageVersion,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope
+            ) { result in
+                continuation.resume(returning: try? result.get())
+            }
         }
     }
 
@@ -776,7 +773,9 @@ extension Workspace {
     /// If some checkout dependency is removed form the file system, clone it again.
     /// If some edited dependency is removed from the file system, mark it as unedited and
     /// fallback on the original checkout.
-    private func fixManagedDependencies(observabilityScope: ObservabilityScope) {
+    private func fixManagedDependencies(
+        observabilityScope: ObservabilityScope
+    ) async {
         // Reset managed dependencies if the state file was removed during the lifetime of the Workspace object.
         if !self.state.dependencies.isEmpty && !self.state.stateFileExists() {
             try? self.state.reset()
@@ -785,7 +784,7 @@ extension Workspace {
         // Make a copy of dependencies as we might mutate them in the for loop.
         let allDependencies = Array(self.state.dependencies)
         for dependency in allDependencies {
-            observabilityScope.makeChildScope(
+            await observabilityScope.makeChildScope(
                 description: "copying managed dependencies",
                 metadata: dependency.packageRef.diagnosticsMetadata
             ).trap {
@@ -798,7 +797,7 @@ extension Workspace {
                 switch dependency.state {
                 case .sourceControlCheckout(let checkoutState):
                     // If some checkout dependency has been removed, retrieve it again.
-                    _ = try self.checkoutRepository(
+                    _ = try await self.checkoutRepository(
                         package: dependency.packageRef,
                         at: checkoutState,
                         observabilityScope: observabilityScope
@@ -808,7 +807,7 @@ extension Workspace {
 
                 case .registryDownload(let version):
                     // If some downloaded dependency has been removed, retrieve it again.
-                    _ = try self.downloadRegistryArchive(
+                    _ = try await self.downloadRegistryArchive(
                         package: dependency.packageRef,
                         at: version,
                         observabilityScope: observabilityScope
@@ -817,15 +816,12 @@ extension Workspace {
                         .emit(.registryDependencyMissing(packageName: dependency.packageRef.identity.description))
 
                 case .custom(let version, let path):
-                    let container = try temp_await {
-                        self.packageContainerProvider.getContainer(
-                            for: dependency.packageRef,
-                            updateStrategy: .never,
-                            observabilityScope: observabilityScope,
-                            on: .sharedConcurrent,
-                            completion: $0
-                        )
-                    }
+                    let container = try await self.packageContainerProvider.getContainer(
+                        for: dependency.packageRef,
+                        updateStrategy: .never,
+                        observabilityScope: observabilityScope,
+                        on: .sharedConcurrent
+                    )
                     if let customContainer = container as? CustomPackageContainer {
                         let newPath = try customContainer.retrieve(at: version, observabilityScope: observabilityScope)
                         observabilityScope
@@ -845,7 +841,11 @@ extension Workspace {
                     // Note: We don't resolve the dependencies when unediting
                     // here because we expect this method to be called as part
                     // of some other resolve operation (i.e. resolve, update, etc).
-                    try self.unedit(dependency: dependency, forceRemove: true, observabilityScope: observabilityScope)
+                    try await self.unedit(
+                        dependency: dependency,
+                        forceRemove: true,
+                        observabilityScope: observabilityScope
+                    )
 
                     observabilityScope
                         .emit(.editedDependencyMissing(packageName: dependency.packageRef.identity.description))
@@ -862,7 +862,7 @@ extension Workspace {
         package: PackageReference,
         state: Workspace.ManagedDependency.State,
         observabilityScope: ObservabilityScope
-    ) throws -> FileSystem? {
+    ) async throws -> FileSystem? {
         // Only custom containers may provide a file system.
         guard self.customPackageContainerProvider != nil else {
             return nil
@@ -873,13 +873,13 @@ extension Workspace {
         case .fileSystem:
             return nil
         case .custom:
-            let container = try temp_await {
+            let container = try await withCheckedThrowingContinuation { continuation in
                 self.packageContainerProvider.getContainer(
                     for: package,
                     updateStrategy: .never,
                     observabilityScope: observabilityScope,
                     on: .sharedConcurrent,
-                    completion: $0
+                    completion: continuation.resume(with:)
                 )
             }
             guard let customContainer = container as? CustomPackageContainer else {

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -10,13 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
+
 import struct Basics.AbsolutePath
 import protocol Basics.FileSystem
 import struct Basics.InternalError
 import class Basics.ObservabilityScope
 import struct Basics.SourceControlURL
 import class Basics.ThreadSafeKeyValueStore
-import func Basics.temp_await
 import class PackageGraph.PinsStore
 import protocol PackageLoading.ManifestLoaderProtocol
 import protocol PackageModel.DependencyMapper
@@ -391,18 +392,15 @@ extension Workspace {
         package: PackageReference,
         at version: Version,
         observabilityScope: ObservabilityScope
-    ) throws -> AbsolutePath {
+    ) async throws -> AbsolutePath {
         // FIXME: this should not block
-        let downloadPath = try temp_await {
-            self.registryDownloadsManager.lookup(
-                package: package.identity,
-                version: version,
-                observabilityScope: observabilityScope,
-                delegateQueue: .sharedConcurrent,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+        let downloadPath = try await self.registryDownloadsManager.lookup(
+            package: package.identity,
+            version: version,
+            observabilityScope: observabilityScope,
+            delegateQueue: .sharedConcurrent,
+            callbackQueue: .sharedConcurrent
+        )
 
         // Record the new state.
         observabilityScope.emit(
@@ -425,10 +423,10 @@ extension Workspace {
         package: PackageReference,
         at pinState: PinsStore.PinState,
         observabilityScope: ObservabilityScope
-    ) throws -> AbsolutePath {
+    ) async throws -> AbsolutePath {
         switch pinState {
         case .version(let version, _):
-            return try self.downloadRegistryArchive(
+            return try await self.downloadRegistryArchive(
                 package: package,
                 at: version,
                 observabilityScope: observabilityScope

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -606,9 +606,9 @@ extension Workspace {
         revision: Revision? = nil,
         checkoutBranch: String? = nil,
         observabilityScope: ObservabilityScope
-    ) {
+    ) async {
         do {
-            try self._edit(
+            try await self._edit(
                 packageName: packageName,
                 path: path,
                 revision: revision,
@@ -636,7 +636,7 @@ extension Workspace {
         forceRemove: Bool,
         root: PackageGraphRootInput,
         observabilityScope: ObservabilityScope
-    ) throws {
+    ) async throws {
         guard let dependency = self.state.dependencies[.plain(packageName)] else {
             observabilityScope.emit(.dependencyNotFound(packageName: packageName))
             return
@@ -647,7 +647,7 @@ extension Workspace {
             metadata: dependency.packageRef.diagnosticsMetadata
         )
 
-        try self.unedit(
+        try await self.unedit(
             dependency: dependency,
             forceRemove: forceRemove,
             root: root,
@@ -667,8 +667,8 @@ extension Workspace {
         forceResolution: Bool = false,
         forceResolvedVersions: Bool = false,
         observabilityScope: ObservabilityScope
-    ) throws {
-        try self._resolve(
+    ) async throws {
+        try await self._resolve(
             root: root,
             explicitProduct: explicitProduct,
             resolvedFileStrategy: forceResolvedVersions ? .lockFile : forceResolution ? .update(forceResolution: true) :
@@ -697,7 +697,7 @@ extension Workspace {
         branch: String? = nil,
         revision: String? = nil,
         observabilityScope: ObservabilityScope
-    ) throws {
+    ) async throws {
         // Look up the dependency and check if we can pin it.
         guard let dependency = self.state.dependencies[.plain(packageName)] else {
             throw StringError("dependency '\(packageName)' was not found")
@@ -740,7 +740,7 @@ extension Workspace {
         )
 
         // Run the resolution.
-        try self.resolveAndUpdateResolvedFile(
+        try await self.resolveAndUpdateResolvedFile(
             root: root,
             forceResolution: false,
             constraints: [constraint],
@@ -755,8 +755,8 @@ extension Workspace {
     public func resolveBasedOnResolvedVersionsFile(
         root: PackageGraphRootInput,
         observabilityScope: ObservabilityScope
-    ) throws {
-        try self._resolveBasedOnResolvedVersionsFile(
+    ) async throws {
+        try await self._resolveBasedOnResolvedVersionsFile(
             root: root,
             explicitProduct: .none,
             observabilityScope: observabilityScope
@@ -864,8 +864,8 @@ extension Workspace {
         packages: [String] = [],
         dryRun: Bool = false,
         observabilityScope: ObservabilityScope
-    ) throws -> [(PackageReference, Workspace.PackageStateChange)]? {
-        try self._updateDependencies(
+    ) async throws -> [(PackageReference, Workspace.PackageStateChange)]? {
+        try await self._updateDependencies(
             root: root,
             packages: packages,
             dryRun: dryRun,
@@ -873,6 +873,29 @@ extension Workspace {
         )
     }
 
+    @discardableResult
+    package func loadPackageGraph(
+        rootInput root: PackageGraphRootInput,
+        explicitProduct: String? = nil,
+        forceResolvedVersions: Bool = false,
+        customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
+        testEntryPointPath: AbsolutePath? = nil,
+        expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
+        observabilityScope: ObservabilityScope
+    ) async throws -> ModulesGraph {
+        try await self.loadPackageGraph(
+            rootInput: root,
+            explicitProduct: explicitProduct,
+            traitConfiguration: nil,
+            forceResolvedVersions: forceResolvedVersions,
+            customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
+            testEntryPointPath: testEntryPointPath,
+            expectedSigningEntities: expectedSigningEntities,
+            observabilityScope: observabilityScope
+        )
+    }
+
+    @available(*, deprecated, message: "Use the async alternative")
     @discardableResult
     public func loadPackageGraph(
         rootInput root: PackageGraphRootInput,
@@ -883,16 +906,18 @@ extension Workspace {
         expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
         observabilityScope: ObservabilityScope
     ) throws -> ModulesGraph {
-        try self.loadPackageGraph(
-            rootInput: root,
-            explicitProduct: explicitProduct,
-            traitConfiguration: nil,
-            forceResolvedVersions: forceResolvedVersions,
-            customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
-            testEntryPointPath: testEntryPointPath,
-            expectedSigningEntities: expectedSigningEntities,
-            observabilityScope: observabilityScope
-        )
+        try unsafe_await {
+            try await self.loadPackageGraph(
+                rootInput: root,
+                explicitProduct:explicitProduct,
+                traitConfiguration: nil,
+                forceResolvedVersions: forceResolvedVersions,
+                customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
+                testEntryPointPath: testEntryPointPath,
+                expectedSigningEntities: expectedSigningEntities,
+                observabilityScope: observabilityScope
+            )
+        }
     }
 
     @discardableResult
@@ -905,7 +930,7 @@ extension Workspace {
         testEntryPointPath: AbsolutePath? = nil,
         expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
         observabilityScope: ObservabilityScope
-    ) throws -> ModulesGraph {
+    ) async throws -> ModulesGraph {
         let start = DispatchTime.now()
         self.delegate?.willLoadGraph()
         defer {
@@ -919,7 +944,7 @@ extension Workspace {
         try self.state.reload()
 
         // Perform dependency resolution, if required.
-        let manifests = try self._resolve(
+        let manifests = try await self._resolve(
             root: root,
             explicitProduct: explicitProduct,
             resolvedFileStrategy: forceResolvedVersions ? .lockFile : .bestEffort,
@@ -966,8 +991,8 @@ extension Workspace {
         rootPath: AbsolutePath,
         explicitProduct: String? = nil,
         observabilityScope: ObservabilityScope
-    ) throws -> ModulesGraph {
-        try self.loadPackageGraph(
+    ) async throws -> ModulesGraph {
+        try await self.loadPackageGraph(
             rootPath: rootPath,
             explicitProduct: explicitProduct,
             traitConfiguration: nil,
@@ -981,8 +1006,8 @@ extension Workspace {
         explicitProduct: String? = nil,
         traitConfiguration: TraitConfiguration? = nil,
         observabilityScope: ObservabilityScope
-    ) throws -> ModulesGraph {
-        try self.loadPackageGraph(
+    ) async throws -> ModulesGraph {
+        try await self.loadPackageGraph(
             rootInput: PackageGraphRootInput(packages: [rootPath]),
             explicitProduct: explicitProduct,
             traitConfiguration: traitConfiguration,
@@ -1185,8 +1210,8 @@ extension Workspace {
         packageGraph: ModulesGraph,
         observabilityScope: ObservabilityScope
     ) async throws -> Package {
-        try await safe_async {
-            self.loadPackage(with: identity, packageGraph: packageGraph, observabilityScope: observabilityScope, completion: $0)
+        try await withCheckedThrowingContinuation {
+            self.loadPackage(with: identity, packageGraph: packageGraph, observabilityScope: observabilityScope, completion: $0.resume(with:))
         }
     }
 
@@ -1230,26 +1255,6 @@ extension Workspace {
             }
             completion(result)
         }
-    }
-
-    public func acceptIdentityChange(
-        package: PackageIdentity,
-        version: Version,
-        signingEntity: SigningEntity,
-        origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        completion: @escaping (Result<Void, Error>) -> Void
-    ) {
-        self.registryClient.changeSigningEntityFromVersion(
-            package: package,
-            version: version,
-            signingEntity: signingEntity,
-            origin: origin,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue,
-            completion: completion
-        )
     }
 }
 

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -45,6 +45,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
     /// The delegate used by the build system.
     public weak var delegate: SPMBuildCore.BuildSystemDelegate?
 
+    @available(*, noasync, message: "This must only be called from a dispatch queue")
     public var builtTestProducts: [BuiltTestProduct] {
         do {
             let graph = try getPackageGraph()
@@ -145,6 +146,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         return []
     }
 
+    @available(*, noasync, message: "This must only be called from a dispatch queue")
     public func build(subset: BuildSubset) throws {
         guard !buildParameters.shouldSkipBuilding else {
             return
@@ -309,6 +311,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         return delegate
     }
 
+    @available(*, noasync, message: "This must only be called from a dispatch queue")
     private func getPIFBuilder() throws -> PIFBuilder {
         try memoize(to: &pifBuilder) {
             let graph = try getPackageGraph()
@@ -325,6 +328,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
     /// Returns the package graph using the graph loader closure.
     ///
     /// First access will cache the graph.
+    @available(*, noasync, message: "This must only be called from a dispatch queue")
     public func getPackageGraph() throws -> ModulesGraph {
         try memoize(to: &packageGraph) {
             try packageGraphLoader()

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -374,11 +374,11 @@ public final class MockWorkspace {
         revision: Revision? = nil,
         checkoutBranch: String? = nil,
         _ result: ([Basics.Diagnostic]) -> Void
-    ) {
+    ) async {
         let observability = ObservabilitySystem.makeForTesting()
-        observability.topScope.trap {
+        await observability.topScope.trap {
             let ws = try self.getOrCreateWorkspace()
-            ws.edit(
+            await ws.edit(
                 packageName: packageName,
                 path: path,
                 revision: revision,
@@ -394,22 +394,27 @@ public final class MockWorkspace {
         roots: [String],
         forceRemove: Bool = false,
         _ result: ([Basics.Diagnostic]) -> Void
-    ) {
+    ) async {
         let observability = ObservabilitySystem.makeForTesting()
-        observability.topScope.trap {
+        await observability.topScope.trap {
             let rootInput = PackageGraphRootInput(packages: try rootPaths(for: roots))
             let ws = try self.getOrCreateWorkspace()
-            try ws.unedit(packageName: packageName, forceRemove: forceRemove, root: rootInput, observabilityScope: observability.topScope)
+            try await ws.unedit(
+                packageName: packageName,
+                forceRemove: forceRemove,
+                root: rootInput,
+                observabilityScope: observability.topScope
+            )
         }
         result(observability.diagnostics)
     }
 
-    public func checkResolve(pkg: String, roots: [String], version: TSCUtility.Version, _ result: ([Basics.Diagnostic]) -> Void) {
+    public func checkResolve(pkg: String, roots: [String], version: TSCUtility.Version, _ result: ([Basics.Diagnostic]) -> Void) async {
         let observability = ObservabilitySystem.makeForTesting()
-        observability.topScope.trap {
+        await observability.topScope.trap {
             let rootInput = PackageGraphRootInput(packages: try rootPaths(for: roots))
             let workspace = try self.getOrCreateWorkspace()
-            try workspace.resolve(packageName: pkg, root: rootInput, version: version, branch: nil, revision: nil, observabilityScope: observability.topScope)
+            try await workspace.resolve(packageName: pkg, root: rootInput, version: version, branch: nil, revision: nil, observabilityScope: observability.topScope)
         }
         result(observability.diagnostics)
     }
@@ -437,17 +442,17 @@ public final class MockWorkspace {
         deps: [MockDependency] = [],
         packages: [String] = [],
         _ result: ([Basics.Diagnostic]) -> Void
-    ) throws {
+    ) async throws {
         let dependencies = try deps.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
 
         let observability = ObservabilitySystem.makeForTesting()
-        observability.topScope.trap {
+        await observability.topScope.trap {
             let rootInput = PackageGraphRootInput(
                 packages: try rootPaths(for: roots),
                 dependencies: dependencies
             )
             let workspace = try self.getOrCreateWorkspace()
-            try workspace.updateDependencies(root: rootInput, packages: packages, observabilityScope: observability.topScope)
+            try await workspace.updateDependencies(root: rootInput, packages: packages, observabilityScope: observability.topScope)
         }
         result(observability.diagnostics)
     }
@@ -456,7 +461,7 @@ public final class MockWorkspace {
         roots: [String] = [],
         deps: [MockDependency] = [],
         _ result: ([(PackageReference, Workspace.PackageStateChange)]?, [Basics.Diagnostic]) -> Void
-    ) throws {
+    ) async throws {
         let dependencies = try deps.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
         let rootInput = PackageGraphRootInput(
             packages: try rootPaths(for: roots),
@@ -464,9 +469,9 @@ public final class MockWorkspace {
         )
 
         let observability = ObservabilitySystem.makeForTesting()
-        let changes = observability.topScope.trap { () -> [(PackageReference, Workspace.PackageStateChange)]? in
+        let changes = await observability.topScope.trap { () -> [(PackageReference, Workspace.PackageStateChange)]? in
             let workspace = try self.getOrCreateWorkspace()
-            return try workspace.updateDependencies(root: rootInput, dryRun: true, observabilityScope: observability.topScope)
+            return try await workspace.updateDependencies(root: rootInput, dryRun: true, observabilityScope: observability.topScope)
         } ?? nil
         result(changes, observability.diagnostics)
     }
@@ -475,9 +480,9 @@ public final class MockWorkspace {
         roots: [String] = [],
         deps: [MockDependency],
         _ result: (ModulesGraph, [Basics.Diagnostic]) -> Void
-    ) throws {
+    ) async throws {
         let dependencies = try deps.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
-        try self.checkPackageGraph(roots: roots, dependencies: dependencies, result)
+        try await self.checkPackageGraph(roots: roots, dependencies: dependencies, result)
     }
 
     public func checkPackageGraph(
@@ -486,14 +491,14 @@ public final class MockWorkspace {
         forceResolvedVersions: Bool = false,
         expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
         _ result: (ModulesGraph, [Basics.Diagnostic]) throws -> Void
-    ) throws {
+    ) async throws {
         let observability = ObservabilitySystem.makeForTesting()
         let rootInput = PackageGraphRootInput(
             packages: try rootPaths(for: roots), dependencies: dependencies
         )
         let workspace = try self.getOrCreateWorkspace()
         do {
-            let graph = try workspace.loadPackageGraph(
+            let graph = try await workspace.loadPackageGraph(
                 rootInput: rootInput,
                 forceResolvedVersions: forceResolvedVersions,
                 expectedSigningEntities: expectedSigningEntities,
@@ -513,9 +518,9 @@ public final class MockWorkspace {
         roots: [String] = [],
         deps: [MockDependency],
         _ result: ([Basics.Diagnostic]) -> Void
-    ) throws {
+    ) async throws {
         let dependencies = try deps.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
-        self.checkPackageGraphFailure(roots: roots, dependencies: dependencies, result)
+        await self.checkPackageGraphFailure(roots: roots, dependencies: dependencies, result)
     }
 
     public func checkPackageGraphFailure(
@@ -523,15 +528,15 @@ public final class MockWorkspace {
         dependencies: [PackageDependency] = [],
         forceResolvedVersions: Bool = false,
         _ result: ([Basics.Diagnostic]) -> Void
-    ) {
+    ) async {
         let observability = ObservabilitySystem.makeForTesting()
-        observability.topScope.trap {
+        await observability.topScope.trap {
             let rootInput = PackageGraphRootInput(
                 packages: try rootPaths(for: roots),
                 dependencies: dependencies
             )
             let workspace = try self.getOrCreateWorkspace()
-            try workspace.loadPackageGraph(
+            try await workspace.loadPackageGraph(
                 rootInput: rootInput,
                 forceResolvedVersions: forceResolvedVersions,
                 observabilityScope: observability.topScope
@@ -557,7 +562,10 @@ public final class MockWorkspace {
         )
         let root = PackageGraphRoot(input: rootInput, manifests: rootManifests, observabilityScope: observability.topScope)
 
-        let dependencyManifests = try workspace.loadDependencyManifests(root: root, observabilityScope: observability.topScope)
+        let dependencyManifests = try await workspace.loadDependencyManifests(
+            root: root,
+            observabilityScope: observability.topScope
+        )
 
         let result = try workspace.precomputeResolution(
             root: root,
@@ -772,7 +780,7 @@ public final class MockWorkspace {
         )
         let rootManifests = try await safe_async { workspace.loadRootManifests(packages: rootInput.packages, observabilityScope: observability.topScope, completion: $0) }
         let graphRoot = PackageGraphRoot(input: rootInput, manifests: rootManifests, observabilityScope: observability.topScope)
-        let manifests = try workspace.loadDependencyManifests(root: graphRoot, observabilityScope: observability.topScope)
+        let manifests = try await workspace.loadDependencyManifests(root: graphRoot, observabilityScope: observability.topScope)
         result(manifests, observability.diagnostics)
     }
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -3399,7 +3399,10 @@ final class PackageCommandTests: CommandsTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let _ = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let _ = try await workspace.loadPackageGraph(
+                rootInput: rootInput,
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 
 @_spi(SwiftPMInternal)
 @testable import PackageGraph
@@ -445,7 +446,10 @@ final class PluginTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try await workspace.loadPackageGraph(
+                rootInput: rootInput,
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssert(packageGraph.packages.count == 2, "\(packageGraph.packages)")
             XCTAssert(packageGraph.rootPackages.count == 1, "\(packageGraph.rootPackages)")
@@ -533,7 +537,7 @@ final class PluginTests: XCTestCase {
                     )
 
                     let toolSearchDirectories = [try UserToolchain.default.swiftCompilerPath.parentDirectory]
-                    let success = try await safe_async { plugin.invoke(
+                    let success = try await withCheckedThrowingContinuation { plugin.invoke(
                         action: .performCommand(package: package, arguments: arguments),
                         buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                         scriptRunner: scriptRunner,
@@ -551,7 +555,7 @@ final class PluginTests: XCTestCase {
                         observabilityScope: observability.topScope,
                         callbackQueue: delegateQueue,
                         delegate: delegate,
-                        completion: $0)
+                        completion: $0.resume(with:))
                     }
                     if expectFailure {
                         XCTAssertFalse(success, "expected command to fail, but it succeeded", file: file, line: line)
@@ -629,7 +633,10 @@ final class PluginTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try await workspace.loadPackageGraph(
+                rootInput: rootInput,
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
 
             // Make sure that the use of plugins doesn't bleed into the use of plugins by tools.
@@ -723,7 +730,10 @@ final class PluginTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try await workspace.loadPackageGraph(
+                rootInput: rootInput,
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssert(packageGraph.packages.count == 1, "\(packageGraph.packages)")
             XCTAssert(packageGraph.rootPackages.count == 1, "\(packageGraph.rootPackages)")
@@ -1036,7 +1046,10 @@ final class PluginTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try await workspace.loadPackageGraph(
+                rootInput: rootInput,
+                observabilityScope: observability.topScope
+            )
             XCTAssert(packageGraph.packages.count == 4, "\(packageGraph.packages)")
             XCTAssert(packageGraph.rootPackages.count == 1, "\(packageGraph.rootPackages)")
 

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 @testable import PackageCollectionsSigning
 import _InternalTestSupport
 import SwiftASN1

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTests.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Foundation
 import PackageCollectionsModel
 @testable import PackageCollectionsSigning

--- a/Tests/PackageCollectionsSigningTests/SignatureTests.swift
+++ b/Tests/PackageCollectionsSigningTests/SignatureTests.swift
@@ -12,6 +12,7 @@
 
 import _CryptoExtras
 import Basics
+import _Concurrency
 import Crypto
 import Foundation
 @testable import PackageCollectionsSigning

--- a/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
+++ b/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import struct Foundation.URL
 @testable import PackageFingerprint
 import PackageModel
@@ -405,13 +406,13 @@ extension PackageFingerprintStorage {
         package: PackageIdentity,
         version: Version
     ) async throws -> [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]] {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.get(
                 package: package,
                 version: version,
                 observabilityScope: ObservabilitySystem.NOOP,
                 callbackQueue: .sharedConcurrent,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
     }
@@ -422,7 +423,7 @@ extension PackageFingerprintStorage {
         kind: Fingerprint.Kind,
         contentType: Fingerprint.ContentType
     ) async throws -> Fingerprint {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.get(
                 package: package,
                 version: version,
@@ -430,7 +431,7 @@ extension PackageFingerprintStorage {
                 contentType: contentType,
                 observabilityScope: ObservabilitySystem.NOOP,
                 callbackQueue: .sharedConcurrent,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
     }
@@ -440,14 +441,14 @@ extension PackageFingerprintStorage {
         version: Version,
         fingerprint: Fingerprint
     ) async throws {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.put(
                 package: package,
                 version: version,
                 fingerprint: fingerprint,
                 observabilityScope: ObservabilitySystem.NOOP,
                 callbackQueue: .sharedConcurrent,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
     }
@@ -456,13 +457,13 @@ extension PackageFingerprintStorage {
         package: PackageReference,
         version: Version
     ) async throws -> [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]] {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.get(
                 package: package,
                 version: version,
                 observabilityScope: ObservabilitySystem.NOOP,
                 callbackQueue: .sharedConcurrent,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
     }
@@ -473,7 +474,7 @@ extension PackageFingerprintStorage {
         kind: Fingerprint.Kind,
         contentType: Fingerprint.ContentType
     ) async throws -> Fingerprint {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.get(
                 package: package,
                 version: version,
@@ -481,7 +482,7 @@ extension PackageFingerprintStorage {
                 contentType: contentType,
                 observabilityScope: ObservabilitySystem.NOOP,
                 callbackQueue: .sharedConcurrent,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
     }
@@ -491,14 +492,14 @@ extension PackageFingerprintStorage {
         version: Version,
         fingerprint: Fingerprint
     ) async throws {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.put(
                 package: package,
                 version: version,
                 fingerprint: fingerprint,
                 observabilityScope: ObservabilitySystem.NOOP,
                 callbackQueue: .sharedConcurrent,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
     }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import OrderedCollections
 @testable import PackageGraph
 import PackageLoading
@@ -343,7 +344,7 @@ final class PubgrubTests: XCTestCase {
         let state1 = PubGrubDependencyResolver.State(root: rootNode)
 
         // No decision can be made if no unsatisfied terms are available.
-        let decisionNil = try await safe_async { solver1.makeDecision(state: state1, completion: $0) }
+        let decisionNil = try await withCheckedThrowingContinuation { solver1.makeDecision(state: state1, completion: $0.resume(with:)) }
         XCTAssertNil(decisionNil)
 
         let a = MockContainer(package: aRef, dependenciesByVersion: [
@@ -360,7 +361,7 @@ final class PubgrubTests: XCTestCase {
 
         XCTAssertEqual(state2.incompatibilities.count, 0)
 
-        let decision = try await safe_async {solver2.makeDecision(state: state2, completion: $0) }
+        let decision = try await withCheckedThrowingContinuation {solver2.makeDecision(state: state2, completion: $0.resume(with:)) }
         XCTAssertEqual(decision, .product("a", package: "a"))
 
         XCTAssertEqual(state2.incompatibilities.count, 3)

--- a/Tests/PackageRegistryTests/PackageVersionChecksumTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageVersionChecksumTOFUTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Foundation
 import PackageFingerprint
 import PackageModel
@@ -101,7 +102,7 @@ final class PackageVersionChecksumTOFUTests: XCTestCase {
         )
 
         // Checksum should have been saved to storage
-        let fingerprint = try await safe_async {
+        let fingerprint = try await withCheckedThrowingContinuation {
             fingerprintStorage.get(
                 package: identity,
                 version: version,
@@ -109,7 +110,7 @@ final class PackageVersionChecksumTOFUTests: XCTestCase {
                 contentType: .sourceCode,
                 observabilityScope: ObservabilitySystem.NOOP,
                 callbackQueue: .sharedConcurrent,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
         XCTAssertEqual(SourceControlURL(registryURL), fingerprint.origin.url)
@@ -688,7 +689,7 @@ final class PackageVersionChecksumTOFUTests: XCTestCase {
 
         // Checksums should have been saved to storage
         do {
-            let fingerprint = try await safe_async {
+            let fingerprint = try await withCheckedThrowingContinuation {
                 fingerprintStorage.get(
                     package: identity,
                     version: version,
@@ -696,14 +697,14 @@ final class PackageVersionChecksumTOFUTests: XCTestCase {
                     contentType: .manifest(.none),
                     observabilityScope: ObservabilitySystem.NOOP,
                     callbackQueue: .sharedConcurrent,
-                    callback: $0
+                    callback: $0.resume(with:)
                 )
             }
             XCTAssertEqual(SourceControlURL(registryURL), fingerprint.origin.url)
             XCTAssertEqual("Package.swift checksum", fingerprint.value)
         }
         do {
-            let fingerprint = try await safe_async {
+            let fingerprint = try await withCheckedThrowingContinuation {
                 fingerprintStorage.get(
                     package: identity,
                     version: version,
@@ -711,7 +712,7 @@ final class PackageVersionChecksumTOFUTests: XCTestCase {
                     contentType: .manifest(.v5_6),
                     observabilityScope: ObservabilitySystem.NOOP,
                     callbackQueue: .sharedConcurrent,
-                    callback: $0
+                    callback: $0.resume(with:)
                 )
             }
             XCTAssertEqual(SourceControlURL(registryURL), fingerprint.origin.url)

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Foundation
 import PackageFingerprint
 import PackageLoading
@@ -2536,7 +2537,7 @@ final class RegistryClientTests: XCTestCase {
         XCTAssertEqual(contents.sorted(), [RegistryReleaseMetadataStorage.fileName, "Package.swift"].sorted())
 
         // Expected checksum is not found in storage so the metadata API will be called
-        let fingerprint = try await safe_async {
+        let fingerprint = try await withCheckedThrowingContinuation {
             fingerprintStorage.get(
                 package: identity,
                 version: version,
@@ -2545,7 +2546,7 @@ final class RegistryClientTests: XCTestCase {
                 observabilityScope: ObservabilitySystem
                     .NOOP,
                 callbackQueue: .sharedConcurrent,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
         XCTAssertEqual(SourceControlURL(registryURL), fingerprint.origin.url)

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -317,7 +317,10 @@ final class PluginInvocationTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try await workspace.loadPackageGraph(
+                rootInput: rootInput,
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssert(packageGraph.packages.count == 1, "\(packageGraph.packages)")
             
@@ -694,7 +697,10 @@ final class PluginInvocationTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            XCTAssertThrowsError(try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)) { error in
+            await XCTAssertAsyncThrowsError(try await workspace.loadPackageGraph(
+                rootInput: rootInput,
+                observabilityScope: observability.topScope
+            )) { error in
                 var diagnosed = false
                 if let realError = error as? PackageGraphError,
                    realError.description == "plugin 'MyPlugin' cannot depend on 'FooLib' of type 'library' from package 'foopackage'; this dependency is unsupported" {
@@ -770,7 +776,10 @@ final class PluginInvocationTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            XCTAssertThrowsError(try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)) { error in
+            await XCTAssertAsyncThrowsError(try await workspace.loadPackageGraph(
+                rootInput: rootInput,
+                observabilityScope: observability.topScope
+            )) { error in
                 var diagnosed = false
                 if let realError = error as? PackageGraphError,
                    realError.description == "plugin 'MyPlugin' cannot depend on 'MyLibrary' of type 'library'; this dependency is unsupported" {
@@ -877,7 +886,10 @@ final class PluginInvocationTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try await workspace.loadPackageGraph(
+                rootInput: rootInput,
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssert(packageGraph.packages.count == 1, "\(packageGraph.packages)")
 
@@ -1068,7 +1080,10 @@ final class PluginInvocationTests: XCTestCase {
             )
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
-            let graph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let graph = try await workspace.loadPackageGraph(
+                rootInput: rootInput,
+                observabilityScope: observability.topScope
+            )
             let dict = try await workspace.loadPluginImports(packageGraph: graph)
 
             var count = 0
@@ -1212,7 +1227,10 @@ final class PluginInvocationTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try await workspace.loadPackageGraph(
+                rootInput: rootInput,
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
 
             // Find the build tool plugin.

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Basics
+import _Concurrency
 import PackageModel
 import _InternalTestSupport
 @testable import SourceControl
@@ -697,7 +698,7 @@ extension RepositoryManager {
         updateStrategy: RepositoryUpdateStrategy = .always,
         observabilityScope: ObservabilityScope
     ) async throws -> RepositoryHandle {
-        return try await safe_async {
+        return try await withCheckedThrowingContinuation {
             self.lookup(
                 package: .init(url: SourceControlURL(repository.url)),
                 repository: repository,
@@ -705,7 +706,7 @@ extension RepositoryManager {
                 observabilityScope: observabilityScope,
                 delegateQueue: .sharedConcurrent,
                 callbackQueue: .sharedConcurrent,
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Foundation
 import PackageGraph
 import PackageLoading
@@ -727,13 +728,13 @@ extension PackageContainerProvider {
         for package: PackageReference,
         updateStrategy: ContainerUpdateStrategy = .always
     ) async throws -> PackageContainer {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.getContainer(
                 for: package,
                 updateStrategy: updateStrategy,
                 observabilityScope: ObservabilitySystem.NOOP,
                 on: .global(),
-                completion: $0
+                completion: $0.resume(with:)
             )
         }
     }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -79,7 +79,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(path: "./Quix", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Quix"])),
             .sourceControl(path: "./Baz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo", "Quix")
@@ -143,7 +143,7 @@ final class WorkspaceTests: XCTestCase {
         // Remove state file and check we can get the state back automatically.
         try fs.removeFileTree(stateFile)
 
-        try workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { _, _ in }
+        try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { _, _ in }
         XCTAssertTrue(fs.exists(stateFile), "workspace state file should exist")
 
         // Remove state file and check we get back to a clean state.
@@ -305,7 +305,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Bar", "Foo")
                 result.check(packages: "Bar", "Baz", "Foo")
@@ -371,7 +371,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Foo", "Bar", "Overridden/bazzz"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo", "Bar", "Overridden/bazzz"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Bar", "Foo", "Baz")
                 result.check(packages: "Bar", "Baz", "Foo")
@@ -410,7 +410,7 @@ final class WorkspaceTests: XCTestCase {
             packages: []
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Foo", "Nested/Foo"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Foo", "Nested/Foo"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(diagnostic: .equal("found multiple top-level packages named 'Foo'"), severity: .error)
             }
@@ -472,7 +472,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(
+        try await workspace.checkPackageGraph(
             roots: ["foo-package", "bar-package"],
             dependencies: [
                 .localSourceControl(
@@ -535,7 +535,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Foo", "Baz"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo", "Baz"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Baz", "Foo")
                 result.check(packages: "Baz", "Foo")
@@ -596,7 +596,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load only Foo right now so Baz is loaded from remote.
-        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo")
@@ -616,7 +616,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Now load with Baz as a root package.
         workspace.delegate.clear()
-        try workspace.checkPackageGraph(roots: ["Foo", "Baz"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo", "Baz"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Baz", "Foo")
                 result.check(packages: "Baz", "Foo")
@@ -687,7 +687,7 @@ final class WorkspaceTests: XCTestCase {
             ),
         ]
 
-        try workspace.checkPackageGraph(dependencies: dependencies) { graph, diagnostics in
+        try await workspace.checkPackageGraph(dependencies: dependencies) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(packages: "Bar", "Foo")
                 result.check(modules: "Bar", "Foo")
@@ -754,7 +754,7 @@ final class WorkspaceTests: XCTestCase {
             let deps: [MockDependency] = [
                 .sourceControl(path: "./A", requirement: .exact("1.0.0"), products: .specific(["A"])),
             ]
-            try workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
+            try await workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
                     result.check(packages: "A", "AA")
                     result.check(modules: "A", "AA")
@@ -777,7 +777,7 @@ final class WorkspaceTests: XCTestCase {
             let deps: [MockDependency] = [
                 .sourceControl(path: "./A", requirement: .exact("1.0.1"), products: .specific(["A"])),
             ]
-            try workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
+            try await workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
                     result.checkTarget("A") { result in result.check(dependencies: "AA") }
                 }
@@ -855,7 +855,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(path: "./A", requirement: .exact("1.0.0"), products: .specific(["A"])),
             .sourceControl(path: "./B", requirement: .exact("1.0.0"), products: .specific(["B"])),
         ]
-        try workspace.checkPackageGraph(deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(deps: deps) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(diagnostic: .contains("Dependencies could not be resolved"), severity: .error)
             }
@@ -1440,7 +1440,7 @@ final class WorkspaceTests: XCTestCase {
             packages: []
         )
 
-        try workspace.checkPackageGraph(roots: ["A", "B", "C"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["A", "B", "C"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(packages: "A", "B", "C")
                 result.check(modules: "A", "B", "C")
@@ -1511,7 +1511,7 @@ final class WorkspaceTests: XCTestCase {
         let deps: [MockDependency] = [
             .sourceControl(path: "./Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
@@ -1524,10 +1524,10 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Run update.
-        try workspace.checkUpdate(roots: ["Root"]) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Root"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -1544,7 +1544,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Run update again.
         // Ensure that up-to-date delegate is called when there is nothing to update.
-        try workspace.checkUpdate(roots: ["Root"]) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Root"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         XCTAssertMatch(workspace.delegate.events, [.equal("Everything is already up-to-date")])
@@ -1600,7 +1600,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(path: "./Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
 
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -1612,7 +1612,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Run update.
-        try workspace.checkUpdateDryRun(roots: ["Root"]) { changes, diagnostics in
+        try await workspace.checkUpdateDryRun(roots: ["Root"]) { changes, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             let stateChange = Workspace.PackageStateChange
@@ -1633,7 +1633,7 @@ final class WorkspaceTests: XCTestCase {
             }
             XCTAssertEqual(expectedChange, change)
         }
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -1710,7 +1710,7 @@ final class WorkspaceTests: XCTestCase {
         let deps: [MockDependency] = [
             .sourceControl(path: "./Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -1722,7 +1722,7 @@ final class WorkspaceTests: XCTestCase {
         //
         // Try to update just Bar. This shouldn't do anything because Bar can't be updated due
         // to Foo's requirements.
-        try workspace.checkUpdate(roots: ["Root"], packages: ["Bar"]) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Root"], packages: ["Bar"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -1731,7 +1731,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Try to update just Foo. This should update Foo but not Bar.
-        try workspace.checkUpdate(roots: ["Root"], packages: ["Foo"]) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Root"], packages: ["Foo"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -1740,7 +1740,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Run full update.
-        try workspace.checkUpdate(roots: ["Root"]) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Root"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -1785,7 +1785,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load package graph.
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -1893,7 +1893,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Load the graph with both roots.
-        try workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(packages: "Bar", "Foo", "Root1", "Root2")
             }
@@ -1962,7 +1962,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root1"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root1"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -2027,7 +2027,7 @@ final class WorkspaceTests: XCTestCase {
         let deps: [MockDependency] = [
             .sourceControl(path: "./Bar", requirement: .revision(barRevision), products: .specific(["Bar"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
@@ -2074,7 +2074,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load initial version.
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -2084,23 +2084,23 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.2.3")))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.2.3")))
         }
 
         // Resolve to an older version.
-        workspace.checkResolve(pkg: "Foo", roots: ["Root"], version: "1.0.0") { diagnostics in
+        await workspace.checkResolve(pkg: "Foo", roots: ["Root"], version: "1.0.0") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
 
         // Check failure.
-        workspace.checkResolve(pkg: "Foo", roots: ["Root"], version: "1.3.0") { diagnostics in
+        await workspace.checkResolve(pkg: "Foo", roots: ["Root"], version: "1.3.0") { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(diagnostic: .contains("'foo' 1.3.0"), severity: .error)
             }
@@ -2108,7 +2108,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
     }
@@ -2138,7 +2138,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load the graph.
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -2148,7 +2148,7 @@ final class WorkspaceTests: XCTestCase {
 
         try fs.removeFileTree(workspace.getOrCreateWorkspace().location.repositoriesCheckoutsDirectory)
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -2193,7 +2193,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(diagnostic: .contains("'foo' 1.0.0..<2.0.0"), severity: .error)
             }
@@ -2240,11 +2240,11 @@ final class WorkspaceTests: XCTestCase {
         try fs.writeFileContents(roots[1], bytes: "// swift-tools-version:4.1.0")
         try fs.writeFileContents(roots[2], bytes: "// swift-tools-version:3.1")
 
-        try workspace.checkPackageGraph(roots: ["Foo"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
-        workspace.checkPackageGraphFailure(roots: ["Bar"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Bar"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 let diagnostic = result.check(
                     diagnostic: .equal(
@@ -2255,7 +2255,7 @@ final class WorkspaceTests: XCTestCase {
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, .plain("bar"))
             }
         }
-        workspace.checkPackageGraphFailure(roots: ["Foo", "Bar"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Foo", "Bar"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 let diagnostic = result.check(
                     diagnostic: .equal(
@@ -2266,7 +2266,7 @@ final class WorkspaceTests: XCTestCase {
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, .plain("bar"))
             }
         }
-        workspace.checkPackageGraphFailure(roots: ["Baz"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Baz"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 let diagnostic = result.check(
                     diagnostic: .equal(
@@ -2324,7 +2324,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load the graph.
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
@@ -2334,7 +2334,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Edit foo.
         let fooPath = try workspace.getOrCreateWorkspace().location.editsDirectory.appending("Foo")
-        workspace.checkEdit(packageName: "Foo") { diagnostics in
+        await workspace.checkEdit(packageName: "Foo") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -2349,7 +2349,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Try re-editing foo.
-        workspace.checkEdit(packageName: "Foo") { diagnostics in
+        await workspace.checkEdit(packageName: "Foo") { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(diagnostic: .equal("dependency 'foo' already in edit mode"), severity: .error)
             }
@@ -2359,7 +2359,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Try editing bar at bad revision.
-        workspace.checkEdit(packageName: "Bar", revision: Revision(identifier: "dev")) { diagnostics in
+        await workspace.checkEdit(packageName: "Bar", revision: Revision(identifier: "dev")) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(diagnostic: .equal("revision 'dev' does not exist"), severity: .error)
             }
@@ -2367,7 +2367,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Edit bar at a custom path and branch (ToT).
         let barPath = AbsolutePath("/tmp/ws/custom/bar")
-        workspace.checkEdit(packageName: "Bar", path: barPath, checkoutBranch: "dev") { diagnostics in
+        await workspace.checkEdit(packageName: "Bar", path: barPath, checkoutBranch: "dev") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -2377,11 +2377,11 @@ final class WorkspaceTests: XCTestCase {
         XCTAssert(barRepo.revisions.contains("dev"))
 
         // Test unediting.
-        workspace.checkUnedit(packageName: "Foo", roots: ["Root"]) { diagnostics in
+        await workspace.checkUnedit(packageName: "Foo", roots: ["Root"]) { diagnostics in
             XCTAssertFalse(fs.exists(fooPath))
             XCTAssertNoDiagnostics(diagnostics)
         }
-        workspace.checkUnedit(packageName: "Bar", roots: ["Root"]) { diagnostics in
+        await workspace.checkUnedit(packageName: "Bar", roots: ["Root"]) { diagnostics in
             XCTAssert(fs.exists(barPath))
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -2421,11 +2421,11 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load the graph.
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, _ in }
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, _ in }
 
         // Edit foo.
         let fooPath = try workspace.getOrCreateWorkspace().location.editsDirectory.appending("Foo")
-        workspace.checkEdit(packageName: "Foo") { diagnostics in
+        await workspace.checkEdit(packageName: "Foo") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -2435,7 +2435,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Remove the edited package.
         try fs.removeFileTree(fooPath)
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .equal(
@@ -2478,13 +2478,13 @@ final class WorkspaceTests: XCTestCase {
         let ws = try workspace.getOrCreateWorkspace()
 
         // Load the graph and edit foo.
-        try workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(packages: "Foo")
             }
             XCTAssertNoDiagnostics(diagnostics)
         }
-        workspace.checkEdit(packageName: "Foo") { diagnostics in
+        await workspace.checkEdit(packageName: "Foo") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -2492,14 +2492,14 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Remove foo.
-        try workspace.checkUpdate { diagnostics in
+        try await workspace.checkUpdate { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         XCTAssertMatch(
             workspace.delegate.events,
             [.equal("removing repo: \(sandbox.appending(components: "pkgs", "Foo"))")]
         )
-        try workspace.checkPackageGraph(deps: []) { _, diagnostics in
+        try await workspace.checkPackageGraph(deps: []) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -2516,7 +2516,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Unedit foo.
-        workspace.checkUnedit(packageName: "Foo", roots: []) { diagnostics in
+        await workspace.checkUnedit(packageName: "Foo", roots: []) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -2572,7 +2572,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(path: "./Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
         // Load the graph.
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
@@ -2585,14 +2585,14 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Edit bar.
-        workspace.checkEdit(packageName: "Bar") { diagnostics in
+        await workspace.checkEdit(packageName: "Bar") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .edited(nil))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
@@ -2606,40 +2606,40 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Now, resolve foo at a different version.
-        workspace.checkResolve(pkg: "Foo", roots: ["Root"], version: "1.2.0") { diagnostics in
+        await workspace.checkResolve(pkg: "Foo", roots: ["Root"], version: "1.2.0") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.2.0")))
             result.check(dependency: "bar", at: .edited(nil))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.2.0")))
             result.check(notPresent: "bar")
         }
 
         // Try package update.
-        try workspace.checkUpdate(roots: ["Root"]) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Root"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
             result.check(dependency: "bar", at: .edited(nil))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
             result.check(notPresent: "bar")
         }
 
         // Unedit should get the Package.resolved entry back.
-        workspace.checkUnedit(packageName: "bar", roots: ["Root"]) { diagnostics in
+        await workspace.checkUnedit(packageName: "bar", roots: ["Root"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
@@ -2702,7 +2702,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load the graph.
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -2716,7 +2716,7 @@ final class WorkspaceTests: XCTestCase {
         let deps: [MockDependency] = [
             .fileSystem(path: "./Foo", products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Bar", "Root")
@@ -2766,7 +2766,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Initial resolution.
-        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Bar", "Foo")
@@ -2808,7 +2808,7 @@ final class WorkspaceTests: XCTestCase {
             XCTFail("unexpected dependency type")
         }
 
-        try workspace.checkPackageGraph(roots: ["Foo"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -2860,20 +2860,20 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load the graph.
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
             XCTAssertNoDiagnostics(diagnostics)
         }
-        workspace.checkEdit(packageName: "Foo") { diagnostics in
+        await workspace.checkEdit(packageName: "Foo") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .edited(nil))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
 
@@ -2889,7 +2889,7 @@ final class WorkspaceTests: XCTestCase {
         let deps: [MockDependency] = [
             .sourceControl(path: "./Bar", requirement: .exact("1.1.0"), products: .specific(["Bar"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(diagnostic: .contains("'bar' 1.1.0"), severity: .error)
             }
@@ -2944,7 +2944,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"], deps: []) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: []) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(packages: "Bar", "Foo", "Root")
@@ -2970,7 +2970,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // reload graph after "external" change
-        try workspace.checkPackageGraph(roots: ["Root"], deps: []) { graph, _ in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: []) { graph, _ in
             PackageGraphTester(graph) { result in
                 result.check(packages: "Bar", "Foo", "Root")
             }
@@ -3024,13 +3024,13 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Run update and remove all events.
-        try workspace.checkUpdate(roots: ["Root"]) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Root"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.delegate.clear()
 
         // Check we don't have updating Foo event.
-        try workspace.checkUpdate(roots: ["Root"]) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Root"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertMatch(workspace.delegate.events, ["Everything is already up-to-date"])
         }
@@ -3084,7 +3084,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Bar", "Baz", "Foo")
@@ -3102,12 +3102,12 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Test that its not possible to edit or resolve this package.
-        workspace.checkEdit(packageName: "Bar") { diagnostics in
+        await workspace.checkEdit(packageName: "Bar") { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(diagnostic: .contains("local dependency 'bar' can't be edited"), severity: .error)
             }
         }
-        workspace.checkResolve(pkg: "Bar", roots: ["Foo"], version: "1.0.0") { diagnostics in
+        await workspace.checkResolve(pkg: "Bar", roots: ["Foo"], version: "1.0.0") { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(diagnostic: .contains("local dependency 'bar' can't be resolved"), severity: .error)
             }
@@ -3161,7 +3161,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Foo")
@@ -3209,7 +3209,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Bar", "Foo")
@@ -3224,7 +3224,7 @@ final class WorkspaceTests: XCTestCase {
         let deps: [MockDependency] = [
             .fileSystem(path: "./Bar", products: .specific(["Bar"])),
         ]
-        try workspace.checkUpdate(roots: ["Foo"], deps: deps) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Foo"], deps: deps) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -3232,7 +3232,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Go back to the versioned state.
-        try workspace.checkUpdate(roots: ["Foo"]) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Foo"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -3263,7 +3263,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Foo")
@@ -3317,7 +3317,7 @@ final class WorkspaceTests: XCTestCase {
         var deps: [MockDependency] = [
             .sourceControl(path: "./Foo", requirement: .branch("develop"), products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -3331,7 +3331,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .sourceControl(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -3341,7 +3341,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .sourceControl(path: "./Foo", requirement: .branch("develop"), products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -3386,7 +3386,7 @@ final class WorkspaceTests: XCTestCase {
         var deps: [MockDependency] = [
             .fileSystem(path: "./Foo", products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -3400,7 +3400,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .sourceControl(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -3410,7 +3410,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .fileSystem(path: "./Foo", products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -3466,7 +3466,7 @@ final class WorkspaceTests: XCTestCase {
         var deps: [MockDependency] = [
             .fileSystem(path: "./Foo", products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -3480,7 +3480,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .fileSystem(path: "./Foo2", products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -3535,7 +3535,7 @@ final class WorkspaceTests: XCTestCase {
         var deps: [MockDependency] = [
             .fileSystem(path: "./Foo", products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -3553,7 +3553,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .fileSystem(path: "./Nested/Foo", products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -3613,7 +3613,7 @@ final class WorkspaceTests: XCTestCase {
         var deps: [MockDependency] = [
             .sourceControl(url: "https://scm.com/org/foo", requirement: .exact("1.0.0")),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
@@ -3631,7 +3631,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .sourceControl(url: "https://scm.com/other/foo", requirement: .exact("1.1.0")),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -3677,23 +3677,23 @@ final class WorkspaceTests: XCTestCase {
         let deps: [MockDependency] = [
             .sourceControl(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
 
-        try workspace.checkPackageGraph(roots: ["Root"], deps: []) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: []) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(notPresent: "foo")
         }
     }
@@ -3750,13 +3750,13 @@ final class WorkspaceTests: XCTestCase {
                 ]
             )
 
-            try workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { _, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
             }
             workspace.checkManagedDependencies { result in
                 result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             }
-            workspace.checkResolved { result in
+            await workspace.checkResolved { result in
                 result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             }
 
@@ -3853,7 +3853,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(url: "https://localhost/org/foo", requirement: .exact("1.0.0")),
             .sourceControl(url: "https://localhost/org/bar", requirement: .exact("1.0.0")),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -3868,7 +3868,7 @@ final class WorkspaceTests: XCTestCase {
                 "https://localhost/org/bar"
             )
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             XCTAssertEqual(result.store.pins[.plain("foo")]?.packageRef.locationString, "https://localhost/org/foo")
@@ -3886,7 +3886,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.closeWorkspace(resetResolvedFile: false)
         XCTAssertTrue(fs.exists(sandbox.appending("Package.resolved")))
         // run update
-        try workspace.checkUpdate(roots: ["Root"], deps: deps) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Root"], deps: deps) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -3903,7 +3903,7 @@ final class WorkspaceTests: XCTestCase {
                 "https://localhost/org/bar.git"
             )
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             // URLs should be stable since URLs are canonically the same and we kept the resolved file between the two iterations
@@ -3921,7 +3921,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.closeWorkspace(resetResolvedFile: false)
         XCTAssertTrue(fs.exists(sandbox.appending("Package.resolved")))
         // run update
-        try workspace.checkUpdate(roots: ["Root"], deps: deps) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Root"], deps: deps) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -3938,7 +3938,7 @@ final class WorkspaceTests: XCTestCase {
                 "https://localhost/org/bar.git"
             )
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.1.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.1.0")))
             // URLs should reflect the actual dependencies since the new version forces rewrite of the resolved file
@@ -3960,7 +3960,7 @@ final class WorkspaceTests: XCTestCase {
         try fs.removeFileTree(sandbox.appending("Package.resolved"))
         XCTAssertFalse(fs.exists(sandbox.appending("Package.resolved")))
         // run update
-        try workspace.checkUpdate(roots: ["Root"], deps: deps) { diagnostics in
+        try await workspace.checkUpdate(roots: ["Root"], deps: deps) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -3977,7 +3977,7 @@ final class WorkspaceTests: XCTestCase {
                 "https://localhost/org/bar.git"
             )
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             // URLs should reflect the actual dependencies since we deleted the resolved file
@@ -4059,7 +4059,7 @@ final class WorkspaceTests: XCTestCase {
         // initial resolution without resolved file
 
         do {
-            try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
@@ -4075,7 +4075,7 @@ final class WorkspaceTests: XCTestCase {
                 }
             }
 
-            workspace.checkResolved { result in
+            await workspace.checkResolved { result in
                 result.check(dependency: "foo", at: .checkout(.version("1.3.1")))
                 result.check(dependency: "bar", at: .checkout(.version("1.1.1")))
             }
@@ -4089,7 +4089,7 @@ final class WorkspaceTests: XCTestCase {
             // reset but keep resolved file
             try workspace.closeWorkspace(resetResolvedFile: false)
             // run resolution again, now it should rely on the resolved file
-            try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
@@ -4115,7 +4115,7 @@ final class WorkspaceTests: XCTestCase {
             try fs.writeFileContents(rootManifestPath, string: manifestContent.appending("\n"))
 
             // run resolution again, but change requirements
-            try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
@@ -4140,7 +4140,7 @@ final class WorkspaceTests: XCTestCase {
             // restore original manifest
             try fs.writeFileContents(rootManifestPath, string: manifestContent)
             // run resolution again, now it should rely on the resolved file
-            try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
@@ -4165,7 +4165,7 @@ final class WorkspaceTests: XCTestCase {
                 .remoteSourceControl(url: "https://localhost/org/baz", requirement: .upToNextMinor(from: "1.0.0"))
             ]
             // run resolution again, but change requirements
-            try workspace.checkPackageGraph(roots: ["Root"], dependencies: changedDeps) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["Root"], dependencies: changedDeps) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Baz", "Foo", "Root")
@@ -4188,7 +4188,7 @@ final class WorkspaceTests: XCTestCase {
             // reset but keep resolved file
             try workspace.closeWorkspace(resetResolvedFile: false)
             // run resolution again, but change requirements back to original
-            try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
@@ -4211,7 +4211,7 @@ final class WorkspaceTests: XCTestCase {
             // reset but keep resolved file
             try workspace.closeWorkspace(resetResolvedFile: false)
             // run resolution again, now it should rely on the resolved file
-            try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
@@ -4232,7 +4232,7 @@ final class WorkspaceTests: XCTestCase {
             // reset including removing resolved file
             try workspace.closeWorkspace(resetResolvedFile: true)
             // run resolution again
-            try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
@@ -4335,7 +4335,7 @@ final class WorkspaceTests: XCTestCase {
             mirrors: mirrors
         )
 
-        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "BazMirror", "Foo", "Dep")
@@ -4439,7 +4439,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Baz"])),
         ]
 
-        try workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "Foo", "Dep")
@@ -4527,7 +4527,7 @@ final class WorkspaceTests: XCTestCase {
             mirrors: mirrors
         )
 
-        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "BazMirror", "Foo", "Dep")
@@ -4633,7 +4633,7 @@ final class WorkspaceTests: XCTestCase {
             ),
         ]
 
-        try workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "Foo", "Dep")
@@ -4704,7 +4704,7 @@ final class WorkspaceTests: XCTestCase {
             mirrors: mirrors
         )
 
-        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "Baz", "Foo")
@@ -4774,7 +4774,7 @@ final class WorkspaceTests: XCTestCase {
             mirrors: mirrors
         )
 
-        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "Baz", "Foo")
@@ -4890,7 +4890,7 @@ final class WorkspaceTests: XCTestCase {
         var deps: [MockDependency] = [
             .sourceControl(url: "https://scm.com/org/bar", requirement: .exact("1.0.0")),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
@@ -4905,7 +4905,7 @@ final class WorkspaceTests: XCTestCase {
                 "https://scm.com/org/foo"
             )
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             XCTAssertEqual(result.store.pins[.plain("foo")]?.packageRef.locationString, "https://scm.com/org/foo")
@@ -4917,7 +4917,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .sourceControl(url: "https://scm.com/org/bar", requirement: .exact("1.1.0")),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
@@ -4932,7 +4932,7 @@ final class WorkspaceTests: XCTestCase {
                 "https://scm.com/other/foo"
             )
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.1.0")))
             XCTAssertEqual(result.store.pins[.plain("foo")]?.packageRef.locationString, "https://scm.com/other/foo")
@@ -4987,14 +4987,14 @@ final class WorkspaceTests: XCTestCase {
         let deps: [MockDependency] = [
             .sourceControl(path: "./Bar", requirement: .revision("develop"), products: .specific(["Bar"])),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
             result.check(dependency: "bar", at: .checkout(.branch("develop")))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
             result.check(dependency: "bar", at: .checkout(.branch("develop")))
         }
@@ -5018,7 +5018,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check force resolve. This should produce an error because the resolved file is out-of-date.
-        workspace.checkPackageGraphFailure(roots: ["Root"], forceResolvedVersions: true) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"], forceResolvedVersions: true) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "an out-of-date resolved file was detected at \(sandbox.appending(components: "Package.resolved")), which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies. Running resolver because requirements have changed.",
@@ -5030,33 +5030,33 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.branch("develop")))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.branch("develop")))
         }
 
         // A normal resolution.
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
 
         // This force resolution should succeed.
-        try workspace.checkPackageGraph(roots: ["Root"], forceResolvedVersions: true) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], forceResolvedVersions: true) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
@@ -5105,10 +5105,10 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root", "Bar"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root", "Bar"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
-        try workspace.checkPackageGraph(roots: ["Root", "Bar"], forceResolvedVersions: true) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root", "Bar"], forceResolvedVersions: true) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -5157,7 +5157,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"], forceResolvedVersions: true) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"], forceResolvedVersions: true) { diagnostics in
             // rdar://82544922 (`WorkspaceResolveReason` is non-deterministic)
             testDiagnostics(diagnostics) { result in
                 result.check(
@@ -5203,7 +5203,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"], forceResolvedVersions: true) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], forceResolvedVersions: true) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -5242,7 +5242,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"], dependencies: [.fileSystem(path: workspace.packagesDir.appending(component: "Foo"))], forceResolvedVersions: true) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"], dependencies: [.fileSystem(path: workspace.packagesDir.appending(component: "Foo"))], forceResolvedVersions: true) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -5287,7 +5287,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertFalse(observability.hasWarningDiagnostics, observability.diagnostics.description)
             XCTAssertFalse(observability.hasErrorDiagnostics, observability.diagnostics.description)
 
-            let graph = try workspace.loadPackageGraph(
+            let graph = try await workspace.loadPackageGraph(
                 rootPath: packagePath,
                 observabilityScope: observability.topScope
             )
@@ -5356,7 +5356,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .equal(
@@ -5406,7 +5406,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(path: "./bazzz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
         ]
 
-        try workspace.checkPackageGraphFailure(roots: ["Overridden/bazzz-master"], deps: deps) { diagnostics in
+        try await await workspace.checkPackageGraphFailure(roots: ["Overridden/bazzz-master"], deps: deps) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .equal(
@@ -5483,7 +5483,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Bar", "Baz", "Foo")
@@ -5574,7 +5574,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // We should only see errors about use of unsafe flag in the version-based dependency.
-        try workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 let diagnostic1 = result.checkUnordered(
                     diagnostic: .equal("the target 'Baz' in product 'Baz' contains unsafe build flags"),
@@ -5629,7 +5629,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Test"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Test"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -5695,7 +5695,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load the graph.
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -5706,7 +5706,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Edit foo.
         let fooPath = try workspace.getOrCreateWorkspace().location.editsDirectory.appending("Foo")
-        workspace.checkEdit(packageName: "Foo") { diagnostics in
+        await workspace.checkEdit(packageName: "Foo") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -5724,7 +5724,7 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertMatch(workspace.delegate.events, [.equal("will resolve dependencies")])
         workspace.delegate.clear()
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -5829,7 +5829,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load the graph.
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
@@ -5951,7 +5951,7 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A/A2.artifactbundle")))
         XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/B/B.xcframework")))
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
 
             // Ensure that the artifacts have been properly extracted
@@ -6222,7 +6222,7 @@ final class WorkspaceTests: XCTestCase {
             recursive: true
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
 
             // Ensure that the original archives have been untouched
@@ -6341,7 +6341,7 @@ final class WorkspaceTests: XCTestCase {
             bytes: ByteString([0xA1])
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -6379,7 +6379,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.checkUnordered(
                     diagnostic: .contains(
@@ -6452,7 +6452,7 @@ final class WorkspaceTests: XCTestCase {
         try fs.createDirectory(aArtifactBundlesPath, recursive: true)
         try fs.writeFileContents(aArtifactBundlesPath.appending("A2.zip"), bytes: ByteString([0xA2]))
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -6553,7 +6553,7 @@ final class WorkspaceTests: XCTestCase {
         let a2FrameworkArchivePath = frameworksPath.appending("A2.zip")
         try fs.writeFileContents(a2FrameworkArchivePath, bytes: ByteString([0xA2]))
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, _ in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, _ in
             // Ensure that only the artifact archive with the changed checksum has been extracted
             XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
                 AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A1"),
@@ -6654,7 +6654,7 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root/nested/nested.artifactbundle")))
         XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root/nested2/nested2.xcframework")))
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
             XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
@@ -6718,7 +6718,7 @@ final class WorkspaceTests: XCTestCase {
         try createDummyXCFramework(fileSystem: fs, path: rootPath.appending("XCFrameworks"), name: "A1")
         try createDummyArtifactBundle(fileSystem: fs, path: rootPath.appending("ArtifactBundles"), name: "A2")
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -6764,7 +6764,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.checkUnordered(
                     diagnostic: .contains(
@@ -6906,7 +6906,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b")))
@@ -7200,7 +7200,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "downloaded archive of binary target 'A3' from 'https://a.com/a3.zip' does not contain a binary artifact.",
@@ -7366,7 +7366,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
             XCTAssertEqual(workspace.checksumAlgorithm.hashes.map(\.hexadecimalRepresentation).sorted(), [
@@ -7391,7 +7391,7 @@ final class WorkspaceTests: XCTestCase {
 
         // do it again
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
 
@@ -7459,7 +7459,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .contains(
@@ -7553,7 +7553,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.checkUnordered(
                     diagnostic: .contains(
@@ -7671,7 +7671,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.checkUnordered(
                     diagnostic: .contains(
@@ -7752,7 +7752,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.checkUnordered(
                     diagnostic: .contains(
@@ -7826,7 +7826,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -7957,7 +7957,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .contains("artifact of binary target 'A' has changed checksum"),
@@ -8057,7 +8057,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -8134,7 +8134,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(acceptHeaders, [
                 "application/octet-stream",
@@ -8216,20 +8216,20 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // should not come from cache
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(downloads, 1)
         }
 
         // state is there, should not come from local cache
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(downloads, 1)
         }
 
         // resetting state, should not come from global cache
         try workspace.resetState()
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(downloads, 2)
         }
@@ -8309,20 +8309,20 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // should not come from cache
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(downloads, 1)
         }
 
         // state is there, should not come from local cache
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(downloads, 1)
         }
 
         // resetting state, should come from global cache
         try workspace.resetState()
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(downloads, 1)
         }
@@ -8330,14 +8330,14 @@ final class WorkspaceTests: XCTestCase {
         // delete global cache, should download again
         try workspace.resetState()
         try fs.removeFileTree(fs.swiftPMCacheDirectory)
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(downloads, 2)
         }
 
         // resetting state, should come from global cache again
         try workspace.resetState()
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(downloads, 2)
         }
@@ -8486,7 +8486,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
             XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
@@ -8615,7 +8615,7 @@ final class WorkspaceTests: XCTestCase {
             atomically: true
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -8729,7 +8729,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["App"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["App"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -8862,7 +8862,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
             XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
@@ -9003,7 +9003,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
                 "https://a.com/a1.xcframework.zip",
@@ -9262,7 +9262,7 @@ final class WorkspaceTests: XCTestCase {
             checksumAlgorithm: checksumAlgorithm
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b")))
@@ -9368,7 +9368,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .contains(
@@ -9438,7 +9438,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .contains(
@@ -9490,7 +9490,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .contains("artifact of binary target 'A' has changed checksum"),
@@ -9599,7 +9599,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .contains(
@@ -9675,7 +9675,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .contains(
@@ -9749,7 +9749,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .contains(
@@ -9820,7 +9820,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '\(sandbox.appending(components: "pkgs", "bar", "utility"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo", "utility"))' which has the same identity 'utility'",
@@ -9881,7 +9881,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '\(sandbox.appending(components: "pkgs", "bar", "utility"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo", "utility"))' which has the same identity 'utility'",
@@ -9950,7 +9950,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '\(sandbox.appending(components: "pkgs", "bar"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo"))' which has the same explicit name 'FooPackage'",
@@ -10010,7 +10010,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -10065,7 +10065,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -10120,7 +10120,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -10175,7 +10175,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "dependency 'FooProduct' in target 'RootTarget' requires explicit declaration; reference the package in the target dependency with '.product(name: \"FooProduct\", package: \"foo\")'",
@@ -10239,7 +10239,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -10298,7 +10298,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '\(sandbox.appending(components: "pkgs", "bar"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo"))' which has the same explicit name 'foo'",
@@ -10362,7 +10362,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '\(sandbox.appending(components: "pkgs", "bar"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo"))' which has the same explicit name 'foo'",
@@ -10451,7 +10451,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'bar' dependency on '\(sandbox.appending(components: "pkgs", "other", "utility"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo", "utility"))' which has the same identity 'utility'",
@@ -10530,7 +10530,7 @@ final class WorkspaceTests: XCTestCase {
 
         // 9/2021 this is currently emitting a warning only to support backwards compatibility
         // we will escalate this to an error in a few versions to tighten up the validation
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'bar' dependency on '\(sandbox.appending(components: "pkgs", "other-foo", "utility"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo", "utility"))' which has the same identity 'utility'. this will be escalated to an error in future versions of SwiftPM.",
@@ -10616,7 +10616,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -10691,7 +10691,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -10766,7 +10766,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -10844,7 +10844,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -10924,7 +10924,7 @@ final class WorkspaceTests: XCTestCase {
 
         // 9/2021 this is currently emitting a warning only to support backwards compatibility
         // we will escalate this to an error in a few versions to tighten up the validation
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'bar' dependency on 'https://github.com/foo-moved/foo.git' conflicts with dependency on 'https://github.com/foo/foo.git' which has the same identity 'foo'. this will be escalated to an error in future versions of SwiftPM.",
@@ -11042,7 +11042,7 @@ final class WorkspaceTests: XCTestCase {
 
         // 9/2021 this is currently emitting a warning only to support backwards compatibility
         // we will escalate this to an error in a few versions to tighten up the validation
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics, minSeverity: .info) { result in
                 result.checkUnordered(
                     diagnostic: "dependency on 'foo' is represented by similar locations ('https://github.com/org/foo.git' and 'https://github.com/ORG/Foo.git') which are treated as the same canonical location 'github.com/org/foo'.",
@@ -11138,7 +11138,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
@@ -11222,7 +11222,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
@@ -11297,7 +11297,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["foo"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["foo"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
@@ -11436,7 +11436,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(packages: "BarPackage", "BazPackage", "FooPackage", "Root", "QuxPackage")
@@ -11460,7 +11460,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "https://github.com/org/foo.git")
         }
 
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             XCTAssertEqual(result.store.pins["foo"]?.packageRef.locationString, "https://github.com/org/foo.git")
         }
     }
@@ -11573,7 +11573,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(packages: "BarPackage", "BazPackage", "FooPackage", "Root")
@@ -11597,7 +11597,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
         }
 
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             XCTAssertEqual(result.store.pins["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
         }
     }
@@ -11714,7 +11714,7 @@ final class WorkspaceTests: XCTestCase {
 
          // resolve to set previous state
 
-         try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
              XCTAssertNoDiagnostics(diagnostics)
              PackageGraphTester(graph) { result in
                  result.check(packages: "BarPackage", "FooPackage", "Root")
@@ -11727,13 +11727,13 @@ final class WorkspaceTests: XCTestCase {
              XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
          }
 
-         workspace.checkResolved { result in
+         await workspace.checkResolved { result in
              XCTAssertEqual(result.store.pins["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
          }
 
          // update to a different url via transitive dependencies
 
-         try workspace.checkPackageGraph(roots: ["Root2"]) { graph, diagnostics in
+         try await workspace.checkPackageGraph(roots: ["Root2"]) { graph, diagnostics in
              XCTAssertNoDiagnostics(diagnostics)
              PackageGraphTester(graph) { result in
                  result.check(packages: "BarPackage", "BazPackage", "FooPackage", "Root2")
@@ -11753,7 +11753,7 @@ final class WorkspaceTests: XCTestCase {
              XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
          }
 
-         workspace.checkResolved { result in
+         await workspace.checkResolved { result in
              XCTAssertEqual(result.store.pins["foo"]?.packageRef.locationString, "https://github.com/org/foo")
          }
      }
@@ -11825,7 +11825,7 @@ final class WorkspaceTests: XCTestCase {
 
         // check usage of canonical URL
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(packages: "FooPackage", "Root")
@@ -11838,13 +11838,13 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "https://github.com/org/foo.git")
         }
 
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             XCTAssertEqual(result.store.pins["foo"]?.packageRef.locationString, "https://github.com/org/foo.git")
         }
 
         // update URL to one with different scheme
 
-        try workspace.checkPackageGraph(roots: ["Root2"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root2"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(packages: "FooPackage", "Root2")
@@ -11858,7 +11858,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
         }
 
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             XCTAssertEqual(result.store.pins["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
         }
     }
@@ -11971,7 +11971,7 @@ final class WorkspaceTests: XCTestCase {
 
         // check usage of canonical URL
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(packages: "BarPackage", "FooPackage", "Root")
@@ -11991,13 +11991,13 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "https://github.com/org/foo.git")
         }
 
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             XCTAssertEqual(result.store.pins["foo"]?.packageRef.locationString, "https://github.com/org/foo.git")
         }
 
         // update URL to one with different scheme
 
-        try workspace.checkPackageGraph(roots: ["Root2"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root2"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(packages: "BarPackage", "FooPackage", "Root2")
@@ -12017,7 +12017,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
         }
 
-        workspace.checkResolved { result in
+        await workspace.checkResolved { result in
             XCTAssertEqual(result.store.pins["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
         }
     }
@@ -12128,7 +12128,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { _, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .regex("cyclic dependency declaration found: Root[1|2]Target -> *"),
@@ -12193,7 +12193,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
@@ -12210,7 +12210,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testBinaryArtifactsInvalidPath() async throws {
-        try testWithTemporaryDirectory { path in
+        try await testWithTemporaryDirectory { path in
             let fs = localFileSystem
             let observability = ObservabilitySystem.makeForTesting()
 
@@ -12238,7 +12238,7 @@ final class WorkspaceTests: XCTestCase {
                 delegate: MockWorkspaceDelegate()
             )
 
-            try workspace.resolve(root: .init(packages: [foo]), observabilityScope: observability.topScope)
+            try await workspace.resolve(root: .init(packages: [foo]), observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: "invalid local path '/best.xcframework' for binary target 'best', path expected to be relative to package root.",
@@ -12320,7 +12320,7 @@ final class WorkspaceTests: XCTestCase {
                 customManifestLoader: TestLoader(error: .none),
                 delegate: delegate
             )
-            try workspace.loadPackageGraph(rootPath: .root, observabilityScope: observability.topScope)
+            try await workspace.loadPackageGraph(rootPath: .root, observabilityScope: observability.topScope)
 
             XCTAssertNotNil(delegate.manifest)
             XCTAssertNoDiagnostics(observability.diagnostics)
@@ -12338,7 +12338,7 @@ final class WorkspaceTests: XCTestCase {
                 customManifestLoader: TestLoader(error: StringError("boom")),
                 delegate: delegate
             )
-            try workspace.loadPackageGraph(rootPath: .root, observabilityScope: observability.topScope)
+            try await workspace.loadPackageGraph(rootPath: .root, observabilityScope: observability.topScope)
 
             XCTAssertNil(delegate.manifest)
             testDiagnostics(delegate.manifestLoadingDiagnostics ?? []) { result in
@@ -12409,7 +12409,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(roots: "MyPackage")
@@ -12542,7 +12542,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(roots: "MyPackage")
@@ -12659,7 +12659,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(roots: "MyPackage")
@@ -12792,7 +12792,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(roots: "MyPackage")
@@ -12917,7 +12917,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
@@ -12940,7 +12940,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
@@ -12963,7 +12963,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
@@ -13036,7 +13036,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
 
-            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, _ in
+
+            await XCTAssertAsyncThrowsError(try await workspace.checkPackageGraph(roots: ["root"]) { _, _ in
             }) { error in
                 XCTAssertEqual((error as? PackageGraphError)?.description, "multiple packages (\'foo\' (from \'https://git/org/foo\'), \'org.foo\') declare products with a conflicting name: \'FooProduct’; product names need to be unique across the package graph")
             }
@@ -13048,7 +13049,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: "'root' dependency on 'org.foo' conflicts with dependency on 'https://git/org/foo' which has the same identity 'org.foo'",
@@ -13065,7 +13066,7 @@ final class WorkspaceTests: XCTestCase {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
             // TODO: this error message should be improved
-            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: "'root' dependency on 'org.foo' conflicts with dependency on 'org.foo' which has the same identity 'org.foo'",
@@ -13148,7 +13149,7 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -13157,7 +13158,7 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
-            })
+            }
         }
 
         // reset
@@ -13166,7 +13167,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -13197,7 +13198,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
 
                 PackageGraphTester(graph) { result in
@@ -13221,7 +13222,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
@@ -13311,7 +13312,7 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -13320,7 +13321,7 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
-            })
+            }
         }
 
         // reset
@@ -13329,7 +13330,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -13359,7 +13360,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
@@ -13449,7 +13450,7 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -13458,7 +13459,7 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
-            })
+            }
         }
 
         // reset
@@ -13467,7 +13468,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic:
@@ -13487,7 +13488,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic:
@@ -13574,7 +13575,7 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -13583,7 +13584,7 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
-            })
+            }
         }
 
         // reset
@@ -13592,7 +13593,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -13630,7 +13631,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
@@ -13720,7 +13721,7 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -13729,7 +13730,7 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
-            })
+            }
         }
 
         // reset
@@ -13738,7 +13739,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic:
@@ -13758,7 +13759,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic:
@@ -13861,7 +13862,7 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -13870,7 +13871,7 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
-            })
+            }
         }
 
         // reset
@@ -13879,7 +13880,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -13922,7 +13923,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
@@ -14031,7 +14032,7 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -14040,7 +14041,7 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
-            })
+            }
         }
 
         // reset
@@ -14049,7 +14050,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: """
@@ -14069,7 +14070,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: """
@@ -14156,7 +14157,7 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -14165,7 +14166,7 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
-            })
+            }
         }
 
         // reset
@@ -14174,7 +14175,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -14204,7 +14205,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -14305,7 +14306,7 @@ final class WorkspaceTests: XCTestCase {
         let deps: [MockDependency] = [
             .sourceControl(url: bazURL, requirement: .exact("1.0.0")),
         ]
-        try workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo")
@@ -14368,7 +14369,7 @@ final class WorkspaceTests: XCTestCase {
             registryClient: registryClient
         )
 
-        workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(diagnostic: .equal("no registry configured for 'org' scope"), severity: .error)
             }
@@ -14425,7 +14426,7 @@ final class WorkspaceTests: XCTestCase {
 
             try workspace.closeWorkspace()
             workspace.registryClient = registryClient
-            workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
+            await workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .equal("failed fetching org.foo releases list from http://localhost: boom"),
@@ -14447,7 +14448,7 @@ final class WorkspaceTests: XCTestCase {
 
             try workspace.closeWorkspace()
             workspace.registryClient = registryClient
-            workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
+            await workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .equal(
@@ -14510,7 +14511,7 @@ final class WorkspaceTests: XCTestCase {
 
             try workspace.closeWorkspace()
             workspace.registryClient = registryClient
-            workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
+            await workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .equal(
@@ -14534,7 +14535,7 @@ final class WorkspaceTests: XCTestCase {
 
             try workspace.closeWorkspace()
             workspace.registryClient = registryClient
-            workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
+            await workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .equal(
@@ -14597,7 +14598,7 @@ final class WorkspaceTests: XCTestCase {
 
             try workspace.closeWorkspace()
             workspace.registryClient = registryClient
-            workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
+            await workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .equal("failed retrieving org.foo version 1.0.0 manifest from http://localhost: boom"),
@@ -14619,7 +14620,7 @@ final class WorkspaceTests: XCTestCase {
 
             try workspace.closeWorkspace()
             workspace.registryClient = registryClient
-            workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
+            await workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .equal(
@@ -14682,7 +14683,7 @@ final class WorkspaceTests: XCTestCase {
 
             try workspace.closeWorkspace()
             workspace.registryClient = registryClient
-            workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
+            await workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .equal(
@@ -14706,7 +14707,7 @@ final class WorkspaceTests: XCTestCase {
 
             try workspace.closeWorkspace()
             workspace.registryClient = registryClient
-            workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
+            await workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .equal(
@@ -14769,7 +14770,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.closeWorkspace()
         workspace.registryClient = registryClient
-        workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
+        await workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .regex(
@@ -14844,7 +14845,7 @@ final class WorkspaceTests: XCTestCase {
                 ]
             )
 
-        try workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 guard let foo = result.find(package: "org.foo") else {
@@ -14916,7 +14917,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
+        try await workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 XCTAssertNotNil(result.find(package: "org.foo"), "missing package")
@@ -15022,7 +15023,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try await createBasicRegistryWorkspace(metadata: ["org.bar": actualMetadata])
 
-        try workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
+        try await workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
             PackageIdentity.plain("org.bar"): try XCTUnwrap(actualMetadata.signature?.signedBy),
             ]) { _, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
@@ -15046,7 +15047,7 @@ final class WorkspaceTests: XCTestCase {
         let workspace = try await createBasicRegistryWorkspace(metadata: ["org.bar": actualMetadata])
 
         do {
-            try workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
+            try await workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
                 PackageIdentity.plain("org.bar"): expectedSigningEntity,
             ]) { _, _ in }
             XCTFail("should not succeed")
@@ -15069,7 +15070,7 @@ final class WorkspaceTests: XCTestCase {
         let workspace = try await createBasicRegistryWorkspace(metadata: [:])
 
         do {
-            try workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
+            try await workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
                 PackageIdentity.plain("org.bar"): expectedSigningEntity,
             ]) { _, _ in }
             XCTFail("should not succeed")
@@ -15091,7 +15092,7 @@ final class WorkspaceTests: XCTestCase {
         let workspace = try await createBasicRegistryWorkspace(metadata: [:])
 
         do {
-            try workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
+            try await workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
                 PackageIdentity.plain("foo.bar"): expectedSigningEntity,
             ]) { _, _ in }
             XCTFail("should not succeed")
@@ -15115,7 +15116,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try await createBasicRegistryWorkspace(metadata: ["ecorp.bar": actualMetadata], mirrors: mirrors)
 
-        try workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
+        try await workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
             PackageIdentity.plain("org.bar"): try XCTUnwrap(actualMetadata.signature?.signedBy),
             ]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
@@ -15146,7 +15147,7 @@ final class WorkspaceTests: XCTestCase {
         let workspace = try await createBasicRegistryWorkspace(metadata: ["ecorp.bar": actualMetadata], mirrors: mirrors)
 
         do {
-            try workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
+            try await workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
                 PackageIdentity.plain("org.bar"): expectedSigningEntity,
             ]) { _, _ in }
             XCTFail("should not succeed")
@@ -15172,7 +15173,7 @@ final class WorkspaceTests: XCTestCase {
         let workspace = try await createBasicRegistryWorkspace(metadata: [:], mirrors: mirrors)
 
         do {
-            try workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
+            try await workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
                 PackageIdentity.plain("org.bar"): expectedSigningEntity,
             ]) { _, _ in }
             XCTFail("should not succeed")
@@ -15197,7 +15198,7 @@ final class WorkspaceTests: XCTestCase {
         let workspace = try await createBasicRegistryWorkspace(metadata: [:], mirrors: mirrors)
 
         do {
-            try workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
+            try await workspace.checkPackageGraph(roots: ["MyPackage"], expectedSigningEntities: [
                 PackageIdentity.plain("org.bar"): expectedSigningEntity,
             ]) { _, _ in }
             XCTFail("should not succeed")


### PR DESCRIPTION
Remove usages of `temp_await`.

### Motivation:

`temp_await` is unsafe and it would be better to use true `async` methods.

### Modifications:

Replace 16 uses of `temp_await` with actual async methods.

### Result:

Safer more modern Swift code.