### PR TITLE
Remove `temp_await` from PubGrub code

### DIFF
--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Dispatch
 import class Foundation.NSLock
 import OrderedCollections
@@ -140,7 +141,7 @@ public struct PubGrubDependencyResolver {
     }
 
     /// Execute the resolution algorithm to find a valid assignment of versions.
-    public func solve(constraints: [Constraint]) -> Result<[DependencyResolverBinding], Error> {
+    public func solve(constraints: [Constraint]) async -> Result<[DependencyResolverBinding], Error> {
         // the graph resolution root
         let root: DependencyResolutionNode
         if constraints.count == 1, let constraint = constraints.first, constraint.package.kind.isRoot {
@@ -156,7 +157,8 @@ public struct PubGrubDependencyResolver {
 
         do {
             // strips state
-            return .success(try self.solve(root: root, constraints: constraints).bindings)
+            let bindings = try await self.solve(root: root, constraints: constraints).bindings
+            return .success(bindings)
         } catch {
             // If version solving failing, build the user-facing diagnostic.
             if let pubGrubError = error as? PubgrubError, let rootCause = pubGrubError.rootCause, let incompatibilities = pubGrubError.incompatibilities {
@@ -180,9 +182,9 @@ public struct PubGrubDependencyResolver {
     /// Find a set of dependencies that fit the given constraints. If dependency
     /// resolution is unable to provide a result, an error is thrown.
     /// - Warning: It is expected that the root package reference has been set  before this is called.
-    internal func solve(root: DependencyResolutionNode, constraints: [Constraint]) throws -> (bindings: [DependencyResolverBinding], state: State) {
+    internal func solve(root: DependencyResolutionNode, constraints: [Constraint]) async throws -> (bindings: [DependencyResolverBinding], state: State) {
         // first process inputs
-        let inputs = try self.processInputs(root: root, with: constraints)
+        let inputs = try await self.processInputs(root: root, with: constraints)
 
         // Prefetch the containers if prefetching is enabled.
         if self.prefetchBasedOnResolvedFile {
@@ -208,7 +210,7 @@ public struct PubGrubDependencyResolver {
             state.addIncompatibility(incompatibility, at: .topLevel)
         }
 
-        try self.run(state: state)
+        try await self.run(state: state)
 
         let decisions = state.solution.assignments.filter(\.isDecision)
         var flattenedAssignments: [PackageReference: (binding: BoundVersion, products: ProductFilter)] = [:]
@@ -226,9 +228,12 @@ public struct PubGrubDependencyResolver {
             }
 
             let products = assignment.term.node.productFilter
-
-            // TODO: replace with async/await when available
-            let container = try temp_await { provider.getContainer(for: assignment.term.node.package, completion: $0) }
+            let container = try await withCheckedThrowingContinuation {
+                self.provider.getContainer(
+                    for: assignment.term.node.package,
+                    completion: $0.resume(with:)
+                )
+            }
             let updatePackage = try container.underlying.loadPackageReference(at: boundVersion)
 
             if var existing = flattenedAssignments[updatePackage] {
@@ -249,8 +254,9 @@ public struct PubGrubDependencyResolver {
 
         // Add overridden packages to the result.
         for (package, override) in state.overriddenPackages {
-            // TODO: replace with async/await when available
-            let container = try temp_await { provider.getContainer(for: package, completion: $0) }
+            let container = try await withCheckedThrowingContinuation {
+                self.provider.getContainer(for: package, completion: $0.resume(with:))
+            }
             let updatePackage = try container.underlying.loadPackageReference(at: override.version)
             finalAssignments.append(.init(
                     package: updatePackage,
@@ -267,7 +273,7 @@ public struct PubGrubDependencyResolver {
     private func processInputs(
         root: DependencyResolutionNode,
         with constraints: [Constraint]
-    ) throws -> (
+    ) async throws -> (
         overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)],
         rootIncompatibilities: [Incompatibility]
     ) {
@@ -310,8 +316,12 @@ public struct PubGrubDependencyResolver {
                 // We collect all version-based dependencies in a separate structure so they can
                 // be process at the end. This allows us to override them when there is a non-version
                 // based (unversioned/branch-based) constraint present in the graph.
-                // TODO: replace with async/await when available
-                let container = try temp_await { provider.getContainer(for: node.package, completion: $0) }
+                let container = try await withCheckedThrowingContinuation {
+                    self.provider.getContainer(
+                        for: node.package,
+                        completion: $0.resume(with:)
+                    )
+                }
                 for dependency in try container.underlying.getUnversionedDependencies(productFilter: node.productFilter) {
                     if let versionedBasedConstraints = VersionBasedConstraint.constraints(dependency) {
                         for constraint in versionedBasedConstraints {
@@ -358,8 +368,9 @@ public struct PubGrubDependencyResolver {
 
             // Process dependencies of this package, similar to the first phase but branch-based dependencies
             // are not allowed to contain local/unversioned packages.
-            // TODO: replace with async/await when avail
-            let container = try temp_await { provider.getContainer(for: package, completion: $0) }
+            let container = try await withCheckedThrowingContinuation {
+                self.provider.getContainer(for: package, completion: $0.resume(with:))
+            }
 
             // If there is a pin for this revision-based dependency, get
             // the dependencies at the pinned revision instead of using
@@ -442,7 +453,7 @@ public struct PubGrubDependencyResolver {
     /// decisions if nothing else is left to be done.
     /// After this method returns `solution` is either populated with a list of
     /// final version assignments or an error is thrown.
-    private func run(state: State) throws {
+    private func run(state: State) async throws {
         var next: DependencyResolutionNode? = state.root
 
         while let nxt = next {
@@ -453,8 +464,9 @@ public struct PubGrubDependencyResolver {
 
             // If decision making determines that no more decisions are to be
             // made, it returns nil to signal that version solving is done.
-            // TODO: replace with async/await when available
-            next = try temp_await { self.makeDecision(state: state, completion: $0) }
+            next = try await withCheckedThrowingContinuation {
+                self.makeDecision(state: state, completion: $0.resume(with:))
+            }
         }
     }
 

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -121,7 +121,7 @@ extension Workspace {
         let resolver = try self.createResolver(pins: pins, observabilityScope: observabilityScope)
         self.activeResolver = resolver
 
-        let updateResults = self.resolveDependencies(
+        let updateResults = await self.resolveDependencies(
             resolver: resolver,
             constraints: updateConstraints,
             observabilityScope: observabilityScope
@@ -455,7 +455,7 @@ extension Workspace {
             observabilityScope: observabilityScope
         )
 
-        let precomputationResult = try self.precomputeResolution(
+        let precomputationResult = try await self.precomputeResolution(
             root: graphRoot,
             dependencyManifests: currentManifests,
             pinsStore: pinsStore,
@@ -533,7 +533,7 @@ extension Workspace {
         } else if !constraints.isEmpty || forceResolution {
             delegate?.willResolveDependencies(reason: .forced)
         } else {
-            let result = try self.precomputeResolution(
+            let result = try await self.precomputeResolution(
                 root: graphRoot,
                 dependencyManifests: currentManifests,
                 pinsStore: pinsStore,
@@ -574,7 +574,7 @@ extension Workspace {
         let resolver = try self.createResolver(pins: pinsStore.pins, observabilityScope: observabilityScope)
         self.activeResolver = resolver
 
-        let result = self.resolveDependencies(
+        let result = await self.resolveDependencies(
             resolver: resolver,
             constraints: computedConstraints,
             observabilityScope: observabilityScope
@@ -806,7 +806,7 @@ extension Workspace {
         pinsStore: PinsStore,
         constraints: [PackageContainerConstraint],
         observabilityScope: ObservabilityScope
-    ) throws -> ResolutionPrecomputationResult {
+    ) async throws -> ResolutionPrecomputationResult {
         let computedConstraints =
             try root.constraints() +
             // Include constraints from the manifests in the graph root.
@@ -823,7 +823,7 @@ extension Workspace {
             pins: pinsStore.pins,
             observabilityScope: observabilityScope
         )
-        let result = resolver.solve(constraints: computedConstraints)
+        let result = await resolver.solve(constraints: computedConstraints)
 
         guard !observabilityScope.errorsReported else {
             return .required(reason: .errorsPreviouslyReported)
@@ -1120,9 +1120,9 @@ extension Workspace {
         resolver: PubGrubDependencyResolver,
         constraints: [PackageContainerConstraint],
         observabilityScope: ObservabilityScope
-    ) -> [DependencyResolverBinding] {
+    ) async -> [DependencyResolverBinding] {
         os_signpost(.begin, name: SignpostName.pubgrub)
-        let result = resolver.solve(constraints: constraints)
+        let result = await resolver.solve(constraints: constraints)
         os_signpost(.end, name: SignpostName.pubgrub)
 
         // Take an action based on the result.

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import PackageGraph
 import PackageLoading
 import PackageModel
@@ -567,7 +568,7 @@ public final class MockWorkspace {
             observabilityScope: observability.topScope
         )
 
-        let result = try workspace.precomputeResolution(
+        let result = try await workspace.precomputeResolution(
             root: root,
             dependencyManifests: dependencyManifests,
             pinsStore: pinsStore,

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import PackageGraph
 import PackageLoading
 import PackageModel
@@ -31,57 +32,59 @@ private let v1: Version = "1.0.0"
 private let v1Range: VersionSetSpecifier = .range("1.0.0" ..< "2.0.0")
 
 class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
-    func testKituraPubGrub_X100() throws {
+    func testKituraPubGrub_X100() async throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        try runPackageTestPubGrub(name: "kitura.json", N: 100)
+        try await runPackageTestPubGrub(name: "kitura.json", N: 100)
     }
 
-    func testZewoPubGrub_X100() throws {
+    func testZewoPubGrub_X100() async throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        try runPackageTestPubGrub(name: "ZewoHTTPServer.json", N: 100)
+        try await runPackageTestPubGrub(name: "ZewoHTTPServer.json", N: 100)
     }
 
-    func testPerfectPubGrub_X100() throws {
+    func testPerfectPubGrub_X100() async throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        try runPackageTestPubGrub(name: "PerfectHTTPServer.json", N: 100)
+        try await runPackageTestPubGrub(name: "PerfectHTTPServer.json", N: 100)
     }
 
-    func testSourceKittenPubGrub_X100() throws {
+    func testSourceKittenPubGrub_X100() async throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        try runPackageTestPubGrub(name: "SourceKitten.json", N: 100)
+        try await runPackageTestPubGrub(name: "SourceKitten.json", N: 100)
     }
 
-    func runPackageTestPubGrub(name: String, N: Int = 1) throws {
+    func runPackageTestPubGrub(name: String, N: Int = 1) async throws {
         let graph = try mockGraph(for: name)
         let provider = MockPackageContainerProvider(containers: graph.containers)
 
-        measure {
-            for _ in 0 ..< N {
-                let resolver = PubGrubDependencyResolver(provider: provider, observabilityScope: ObservabilitySystem.NOOP)
-                switch resolver.solve(constraints: graph.constraints) {
-                case .success(let result):
-                    let result: [(container: PackageReference, version: Version)] = result.compactMap {
-                        guard case .version(let version) = $0.boundVersion else {
-                            XCTFail("Unexpected result")
-                            return nil
-                        }
-                        return ($0.package, version)
+        self.startMeasuring()
+
+        for _ in 0 ..< N {
+            let resolver = PubGrubDependencyResolver(provider: provider, observabilityScope: ObservabilitySystem.NOOP)
+            switch await resolver.solve(constraints: graph.constraints) {
+            case .success(let result):
+                let result: [(container: PackageReference, version: Version)] = result.compactMap {
+                    guard case .version(let version) = $0.boundVersion else {
+                        XCTFail("Unexpected result")
+                        return nil
                     }
-                    graph.checkResult(result)
-                case .failure:
-                    XCTFail("Unexpected result")
-                    return
+                    return ($0.package, version)
                 }
+                graph.checkResult(result)
+            case .failure:
+                XCTFail("Unexpected result")
+                return
             }
         }
+
+        self.stopMeasuring()
     }
 
     func mockGraph(for name: String) throws -> MockDependencyGraph {


### PR DESCRIPTION
Remove temp_await from pubgrub

### Motivation:

temp_await is unsafe and it would be better to use true async methods

### Modifications:

Remove 5 usages of temp_await from pub_grub

### Result:

Safer more modern Swift code
