### PR TITLE
Remove `temp_await` from Snippets

### DIFF
--- a/Sources/Commands/PackageCommands/APIDiff.swift
+++ b/Sources/Commands/PackageCommands/APIDiff.swift
@@ -86,7 +86,7 @@ struct APIDiff: AsyncSwiftCommand {
         let baselineRevision = try repository.resolveRevision(identifier: treeish)
 
         // We turn build manifest caching off because we need the build plan.
-        let buildSystem = try swiftCommandState.createBuildSystem(
+        let buildSystem = try await swiftCommandState.createBuildSystem(
             explicitBuildSystem: .native,
             traitConfiguration: .init(traitOptions: self.traits),
             cacheBuildManifest: false

--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -17,7 +17,7 @@ import Foundation
 import PackageModel
 import XCBuildSupport
 
-struct DumpSymbolGraph: SwiftCommand {
+struct DumpSymbolGraph: AsyncSwiftCommand {
     static let configuration = CommandConfiguration(
         abstract: "Dump Symbol Graph")
     static let defaultMinimumAccessLevel = SymbolGraphExtract.AccessLevel.public
@@ -43,11 +43,11 @@ struct DumpSymbolGraph: SwiftCommand {
     @Flag(help: "Emit extension block symbols for extensions to external types or directly associate members and conformances with the extended nominal.")
     var extensionBlockSymbolBehavior: ExtensionBlockSymbolBehavior = .omitExtensionBlockSymbols
 
-    func run(_ swiftCommandState: SwiftCommandState) throws {
+    func run(_ swiftCommandState: SwiftCommandState) async throws {
         // Build the current package.
         //
         // We turn build manifest caching off because we need the build plan.
-        let buildSystem = try swiftCommandState.createBuildSystem(
+        let buildSystem = try await swiftCommandState.createBuildSystem(
             explicitBuildSystem: .native,
             // We are enabling all traits for dumping the symbol graph.
             traitConfiguration: .init(enableAllTraits: true),

--- a/Sources/Commands/PackageCommands/Install.swift
+++ b/Sources/Commands/PackageCommands/Install.swift
@@ -85,7 +85,7 @@ extension SwiftPackageCommand {
                 commandState.preferredBuildConfiguration = .release
             }
 
-            try commandState.createBuildSystem(explicitProduct: productToInstall.name, traitConfiguration: .init())
+            try await commandState.createBuildSystem(explicitProduct: productToInstall.name, traitConfiguration: .init())
                 .build(subset: .product(productToInstall.name))
 
             let binPath = try commandState.productsBuildParameters.buildPath.appending(component: productToInstall.name)

--- a/Sources/Commands/PackageCommands/Learn.swift
+++ b/Sources/Commands/PackageCommands/Learn.swift
@@ -49,7 +49,7 @@ extension SwiftPackageCommand {
                 .filter { fileSystem.isDirectory($0) }
         }
 
-        func loadSnippetsAndSnippetGroups(fileSystem: FileSystem, from package: ResolvedPackage) throws -> [SnippetGroup] {
+        func loadSnippetsAndSnippetGroups(fileSystem: FileSystem, from package: ResolvedPackage) async throws -> [SnippetGroup] {
             let snippetsDirectory = package.path.appending("Snippets")
             guard fileSystem.isDirectory(snippetsDirectory) else {
                 return []
@@ -95,11 +95,11 @@ extension SwiftPackageCommand {
             let package = graph.rootPackages[graph.rootPackages.startIndex]
             print(package.products.map { $0.description })
 
-            let snippetGroups = try loadSnippetsAndSnippetGroups(fileSystem: swiftCommandState.fileSystem, from: package)
+            let snippetGroups = try await loadSnippetsAndSnippetGroups(fileSystem: swiftCommandState.fileSystem, from: package)
 
             var cardStack = CardStack(package: package, snippetGroups: snippetGroups, swiftCommandState: swiftCommandState)
 
-            cardStack.run()
+            await cardStack.run()
         }
     }
 }

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -324,7 +324,7 @@ struct PluginCommand: AsyncSwiftCommand {
 
         let buildParameters = try swiftCommandState.toolsBuildParameters
         // Build or bring up-to-date any executable host-side tools on which this plugin depends. Add them and any binary dependencies to the tool-names-to-path map.
-        let buildSystem = try swiftCommandState.createBuildSystem(
+        let buildSystem = try await swiftCommandState.createBuildSystem(
             explicitBuildSystem: .native,
             traitConfiguration: .init(),
             cacheBuildManifest: false,

--- a/Sources/Commands/Snippets/Card.swift
+++ b/Sources/Commands/Snippets/Card.swift
@@ -18,7 +18,7 @@ protocol Card {
 
     /// Accept a line of input from the user's terminal and provide
     /// an optional ``CardEvent`` which can alter the card stack.
-    func acceptLineInput<S: StringProtocol>(_ line: S) -> CardEvent?
+    func acceptLineInput<S: StringProtocol>(_ line: S) async -> CardEvent?
 
     /// The input prompt to present to the user when accepting a line of input.
     var inputPrompt: String? { get }

--- a/Sources/Commands/Snippets/CardStack.swift
+++ b/Sources/Commands/Snippets/CardStack.swift
@@ -67,7 +67,7 @@ struct CardStack {
         return readLine(strippingNewline: true)
     }
 
-    mutating func run() {
+    mutating func run() async {
         var inputFinished = false
         while !inputFinished {
             guard let top = cards.last else {
@@ -91,7 +91,7 @@ struct CardStack {
                                             .reversed()
                                             .drop { $0.isWhitespace }
                                             .reversed())
-                let response = top.acceptLineInput(trimmedLine)
+                let response = await top.acceptLineInput(trimmedLine)
                 switch response {
                 case .none:
                     continue askForLine

--- a/Sources/Commands/Snippets/Cards/SnippetCard.swift
+++ b/Sources/Commands/Snippets/Cards/SnippetCard.swift
@@ -67,7 +67,7 @@ struct SnippetCard: Card {
         return "\nRun this snippet? [R: run, or press Enter to return]"
     }
 
-    func acceptLineInput<S>(_ line: S) -> CardEvent? where S : StringProtocol {
+    func acceptLineInput<S>(_ line: S) async -> CardEvent? where S : StringProtocol {
         let trimmed = line.drop { $0.isWhitespace }.prefix { !$0.isWhitespace }.lowercased()
         guard !trimmed.isEmpty else {
             return .pop()
@@ -76,7 +76,7 @@ struct SnippetCard: Card {
         switch trimmed {
         case "r", "run":
             do {
-                try runExample()
+                try await runExample()
             } catch {
                 return .pop(SnippetCard.Error.cantRunSnippet(reason: error.localizedDescription))
             }
@@ -91,9 +91,9 @@ struct SnippetCard: Card {
         return .pop()
     }
 
-    func runExample() throws {
+    func runExample() async throws {
         print("Building '\(snippet.path)'\n")
-        let buildSystem = try swiftCommandState.createBuildSystem(explicitProduct: snippet.name, traitConfiguration: .init())
+        let buildSystem = try await swiftCommandState.createBuildSystem(explicitProduct: snippet.name, traitConfiguration: .init())
         try buildSystem.build(subset: .product(snippet.name))
         let executablePath = try swiftCommandState.productsBuildParameters.buildPath.appending(component: snippet.name)
         if let exampleTarget = try buildSystem.getPackageGraph().module(for: snippet.name, destination: .destination) {

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -136,7 +136,7 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
 
         if options.printManifestGraphviz {
             // FIXME: Doesn't seem ideal that we need an explicit build operation, but this concretely uses the `LLBuildManifest`.
-            guard let buildOperation = try swiftCommandState.createBuildSystem(
+            guard let buildOperation = try await swiftCommandState.createBuildSystem(
                 explicitBuildSystem: .native,
                 traitConfiguration: .init(traitOptions: self.options.traits)
             ) as? BuildOperation else {
@@ -163,7 +163,7 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
             toolsBuildParameters.testingParameters.enableCodeCoverage = true
         }
 
-        try build(swiftCommandState, subset: subset, productsBuildParameters: productsBuildParameters, toolsBuildParameters: toolsBuildParameters)
+        try await build(swiftCommandState, subset: subset, productsBuildParameters: productsBuildParameters, toolsBuildParameters: toolsBuildParameters)
     }
 
     private func build(
@@ -171,8 +171,8 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
         subset: BuildSubset,
         productsBuildParameters: BuildParameters,
         toolsBuildParameters: BuildParameters
-    ) throws {
-        let buildSystem = try swiftCommandState.createBuildSystem(
+    ) async throws {
+        let buildSystem = try await swiftCommandState.createBuildSystem(
             explicitProduct: options.product,
             traitConfiguration: .init(traitOptions: self.options.traits),
             shouldLinkStaticSwiftStdlib: options.shouldLinkStaticSwiftStdlib,

--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -134,7 +134,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
 
             // Construct the build operation.
             // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with the REPL. rdar://86112934
-            let buildSystem = try swiftCommandState.createBuildSystem(
+            let buildSystem = try await swiftCommandState.createBuildSystem(
                 explicitBuildSystem: .native,
                 traitConfiguration: .init(traitOptions: self.options.traits),
                 cacheBuildManifest: false,
@@ -156,7 +156,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
 
         case .debugger:
             do {
-                let buildSystem = try swiftCommandState.createBuildSystem(
+                let buildSystem = try await swiftCommandState.createBuildSystem(
                     explicitProduct: options.executable,
                     traitConfiguration: .init(traitOptions: self.options.traits)
                 )
@@ -201,7 +201,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
             }
 
             do {
-                let buildSystem = try swiftCommandState.createBuildSystem(
+                let buildSystem = try await swiftCommandState.createBuildSystem(
                     explicitProduct: options.executable,
                     traitConfiguration: .init(traitOptions: self.options.traits)
                 )

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -428,7 +428,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             try await command.run(swiftCommandState)
         } else {
             let (productsBuildParameters, _) = try swiftCommandState.buildParametersForTest(options: self.options)
-            let testProducts = try buildTestsIfNeeded(swiftCommandState: swiftCommandState)
+            let testProducts = try await buildTestsIfNeeded(swiftCommandState: swiftCommandState)
 
             // Clean out the code coverage directory that may contain stale
             // profraw files from a previous run of the code coverage tool.
@@ -625,9 +625,9 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     /// - Returns: The paths to the build test products.
     private func buildTestsIfNeeded(
         swiftCommandState: SwiftCommandState
-    ) throws -> [BuiltTestProduct] {
+    ) async throws -> [BuiltTestProduct] {
         let (productsBuildParameters, toolsBuildParameters) = try swiftCommandState.buildParametersForTest(options: self.options)
-        return try Commands.buildTestsIfNeeded(
+        return try await Commands.buildTestsIfNeeded(
             swiftCommandState: swiftCommandState,
             productsBuildParameters: productsBuildParameters,
             toolsBuildParameters: toolsBuildParameters,
@@ -725,12 +725,12 @@ extension SwiftTestCommand {
         @Flag(name: [.customLong("list-tests"), .customShort("l")], help: .hidden)
         var _deprecated_passthrough: Bool = false
 
-        func run(_ swiftCommandState: SwiftCommandState) throws {
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
             let (productsBuildParameters, toolsBuildParameters) = try swiftCommandState.buildParametersForTest(
                 enableCodeCoverage: false,
                 shouldSkipBuilding: sharedOptions.shouldSkipBuilding
             )
-            let testProducts = try buildTestsIfNeeded(
+            let testProducts = try await buildTestsIfNeeded(
                 swiftCommandState: swiftCommandState,
                 productsBuildParameters: productsBuildParameters,
                 toolsBuildParameters: toolsBuildParameters
@@ -797,8 +797,8 @@ extension SwiftTestCommand {
             swiftCommandState: SwiftCommandState,
             productsBuildParameters: BuildParameters,
             toolsBuildParameters: BuildParameters
-        ) throws -> [BuiltTestProduct] {
-            return try Commands.buildTestsIfNeeded(
+        ) async throws -> [BuiltTestProduct] {
+            return try await Commands.buildTestsIfNeeded(
                 swiftCommandState: swiftCommandState,
                 productsBuildParameters: productsBuildParameters,
                 toolsBuildParameters: toolsBuildParameters,
@@ -1479,8 +1479,8 @@ private func buildTestsIfNeeded(
     toolsBuildParameters: BuildParameters,
     testProduct: String?,
     traitConfiguration: TraitConfiguration
-) throws -> [BuiltTestProduct] {
-    let buildSystem = try swiftCommandState.createBuildSystem(
+) async throws -> [BuiltTestProduct] {
+    let buildSystem = try await swiftCommandState.createBuildSystem(
         traitConfiguration: traitConfiguration,
         productsBuildParameters: productsBuildParameters,
         toolsBuildParameters: toolsBuildParameters

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -137,7 +137,7 @@ struct APIDigesterBaselineDumper {
 
         // Build the baseline module.
         // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with the APIDigester. rdar://86112934
-        let buildSystem = try swiftCommandState.createBuildSystem(
+        let buildSystem = try await swiftCommandState.createBuildSystem(
             explicitBuildSystem: .native,
             traitConfiguration: .init(),
             cacheBuildManifest: false,

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -34,8 +34,8 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
         outputStream: OutputByteStream?,
         logLevel: Diagnostic.Severity?,
         observabilityScope: ObservabilityScope?
-    ) throws -> any BuildSystem {
-        let rootPackageInfo = try swiftCommandState.getRootPackageInformation()
+    ) async throws -> any BuildSystem {
+        let rootPackageInfo = try await swiftCommandState.getRootPackageInformation()
         let testEntryPointPath = productsBuildParameters?.testingParameters.testProductStyle.explicitlySpecifiedEntryPointPath
         return try BuildOperation(
             productsBuildParameters: try productsBuildParameters ?? self.swiftCommandState.productsBuildParameters,

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Dispatch
 import class Foundation.NSLock
 import OrderedCollections
@@ -140,7 +141,7 @@ public struct PubGrubDependencyResolver {
     }
 
     /// Execute the resolution algorithm to find a valid assignment of versions.
-    public func solve(constraints: [Constraint]) -> Result<[DependencyResolverBinding], Error> {
+    public func solve(constraints: [Constraint]) async -> Result<[DependencyResolverBinding], Error> {
         // the graph resolution root
         let root: DependencyResolutionNode
         if constraints.count == 1, let constraint = constraints.first, constraint.package.kind.isRoot {
@@ -156,7 +157,8 @@ public struct PubGrubDependencyResolver {
 
         do {
             // strips state
-            return .success(try self.solve(root: root, constraints: constraints).bindings)
+            let bindings = try await self.solve(root: root, constraints: constraints).bindings
+            return .success(bindings)
         } catch {
             // If version solving failing, build the user-facing diagnostic.
             if let pubGrubError = error as? PubgrubError, let rootCause = pubGrubError.rootCause, let incompatibilities = pubGrubError.incompatibilities {
@@ -180,9 +182,9 @@ public struct PubGrubDependencyResolver {
     /// Find a set of dependencies that fit the given constraints. If dependency
     /// resolution is unable to provide a result, an error is thrown.
     /// - Warning: It is expected that the root package reference has been set  before this is called.
-    internal func solve(root: DependencyResolutionNode, constraints: [Constraint]) throws -> (bindings: [DependencyResolverBinding], state: State) {
+    internal func solve(root: DependencyResolutionNode, constraints: [Constraint]) async throws -> (bindings: [DependencyResolverBinding], state: State) {
         // first process inputs
-        let inputs = try self.processInputs(root: root, with: constraints)
+        let inputs = try await self.processInputs(root: root, with: constraints)
 
         // Prefetch the containers if prefetching is enabled.
         if self.prefetchBasedOnResolvedFile {
@@ -208,7 +210,7 @@ public struct PubGrubDependencyResolver {
             state.addIncompatibility(incompatibility, at: .topLevel)
         }
 
-        try self.run(state: state)
+        try await self.run(state: state)
 
         let decisions = state.solution.assignments.filter(\.isDecision)
         var flattenedAssignments: [PackageReference: (binding: BoundVersion, products: ProductFilter)] = [:]
@@ -226,9 +228,12 @@ public struct PubGrubDependencyResolver {
             }
 
             let products = assignment.term.node.productFilter
-
-            // TODO: replace with async/await when available
-            let container = try temp_await { provider.getContainer(for: assignment.term.node.package, completion: $0) }
+            let container = try await withCheckedThrowingContinuation {
+                self.provider.getContainer(
+                    for: assignment.term.node.package,
+                    completion: $0.resume(with:)
+                )
+            }
             let updatePackage = try container.underlying.loadPackageReference(at: boundVersion)
 
             if var existing = flattenedAssignments[updatePackage] {
@@ -249,8 +254,9 @@ public struct PubGrubDependencyResolver {
 
         // Add overridden packages to the result.
         for (package, override) in state.overriddenPackages {
-            // TODO: replace with async/await when available
-            let container = try temp_await { provider.getContainer(for: package, completion: $0) }
+            let container = try await withCheckedThrowingContinuation {
+                self.provider.getContainer(for: package, completion: $0.resume(with:))
+            }
             let updatePackage = try container.underlying.loadPackageReference(at: override.version)
             finalAssignments.append(.init(
                     package: updatePackage,
@@ -267,7 +273,7 @@ public struct PubGrubDependencyResolver {
     private func processInputs(
         root: DependencyResolutionNode,
         with constraints: [Constraint]
-    ) throws -> (
+    ) async throws -> (
         overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)],
         rootIncompatibilities: [Incompatibility]
     ) {
@@ -310,8 +316,12 @@ public struct PubGrubDependencyResolver {
                 // We collect all version-based dependencies in a separate structure so they can
                 // be process at the end. This allows us to override them when there is a non-version
                 // based (unversioned/branch-based) constraint present in the graph.
-                // TODO: replace with async/await when available
-                let container = try temp_await { provider.getContainer(for: node.package, completion: $0) }
+                let container = try await withCheckedThrowingContinuation {
+                    self.provider.getContainer(
+                        for: node.package,
+                        completion: $0.resume(with:)
+                    )
+                }
                 for dependency in try container.underlying.getUnversionedDependencies(productFilter: node.productFilter) {
                     if let versionedBasedConstraints = VersionBasedConstraint.constraints(dependency) {
                         for constraint in versionedBasedConstraints {
@@ -358,8 +368,9 @@ public struct PubGrubDependencyResolver {
 
             // Process dependencies of this package, similar to the first phase but branch-based dependencies
             // are not allowed to contain local/unversioned packages.
-            // TODO: replace with async/await when avail
-            let container = try temp_await { provider.getContainer(for: package, completion: $0) }
+            let container = try await withCheckedThrowingContinuation {
+                self.provider.getContainer(for: package, completion: $0.resume(with:))
+            }
 
             // If there is a pin for this revision-based dependency, get
             // the dependencies at the pinned revision instead of using
@@ -442,7 +453,7 @@ public struct PubGrubDependencyResolver {
     /// decisions if nothing else is left to be done.
     /// After this method returns `solution` is either populated with a list of
     /// final version assignments or an error is thrown.
-    private func run(state: State) throws {
+    private func run(state: State) async throws {
         var next: DependencyResolutionNode? = state.root
 
         while let nxt = next {
@@ -453,8 +464,9 @@ public struct PubGrubDependencyResolver {
 
             // If decision making determines that no more decisions are to be
             // made, it returns nil to signal that version solving is done.
-            // TODO: replace with async/await when available
-            next = try temp_await { self.makeDecision(state: state, completion: $0) }
+            next = try await withCheckedThrowingContinuation {
+                self.makeDecision(state: state, completion: $0.resume(with:))
+            }
         }
     }
 

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -108,7 +108,7 @@ public protocol BuildSystemFactory {
         outputStream: OutputByteStream?,
         logLevel: Diagnostic.Severity?,
         observabilityScope: ObservabilityScope?
-    ) throws -> any BuildSystem
+    ) async throws -> any BuildSystem
 }
 
 public struct BuildSystemProvider {
@@ -135,11 +135,11 @@ public struct BuildSystemProvider {
         outputStream: OutputByteStream? = .none,
         logLevel: Diagnostic.Severity? = .none,
         observabilityScope: ObservabilityScope? = .none
-    ) throws -> any BuildSystem {
+    ) async throws -> any BuildSystem {
         guard let buildSystemFactory = self.providers[kind] else {
             throw Errors.buildSystemProviderNotRegistered(kind: kind)
         }
-        return try buildSystemFactory.makeBuildSystem(
+        return try await buildSystemFactory.makeBuildSystem(
             explicitProduct: explicitProduct,
             traitConfiguration: traitConfiguration,
             cacheBuildManifest: cacheBuildManifest,

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -121,7 +121,7 @@ extension Workspace {
         let resolver = try self.createResolver(pins: pins, observabilityScope: observabilityScope)
         self.activeResolver = resolver
 
-        let updateResults = self.resolveDependencies(
+        let updateResults = await self.resolveDependencies(
             resolver: resolver,
             constraints: updateConstraints,
             observabilityScope: observabilityScope
@@ -455,7 +455,7 @@ extension Workspace {
             observabilityScope: observabilityScope
         )
 
-        let precomputationResult = try self.precomputeResolution(
+        let precomputationResult = try await self.precomputeResolution(
             root: graphRoot,
             dependencyManifests: currentManifests,
             pinsStore: pinsStore,
@@ -533,7 +533,7 @@ extension Workspace {
         } else if !constraints.isEmpty || forceResolution {
             delegate?.willResolveDependencies(reason: .forced)
         } else {
-            let result = try self.precomputeResolution(
+            let result = try await self.precomputeResolution(
                 root: graphRoot,
                 dependencyManifests: currentManifests,
                 pinsStore: pinsStore,
@@ -574,7 +574,7 @@ extension Workspace {
         let resolver = try self.createResolver(pins: pinsStore.pins, observabilityScope: observabilityScope)
         self.activeResolver = resolver
 
-        let result = self.resolveDependencies(
+        let result = await self.resolveDependencies(
             resolver: resolver,
             constraints: computedConstraints,
             observabilityScope: observabilityScope
@@ -806,7 +806,7 @@ extension Workspace {
         pinsStore: PinsStore,
         constraints: [PackageContainerConstraint],
         observabilityScope: ObservabilityScope
-    ) throws -> ResolutionPrecomputationResult {
+    ) async throws -> ResolutionPrecomputationResult {
         let computedConstraints =
             try root.constraints() +
             // Include constraints from the manifests in the graph root.
@@ -823,7 +823,7 @@ extension Workspace {
             pins: pinsStore.pins,
             observabilityScope: observabilityScope
         )
-        let result = resolver.solve(constraints: computedConstraints)
+        let result = await resolver.solve(constraints: computedConstraints)
 
         guard !observabilityScope.errorsReported else {
             return .required(reason: .errorsPreviouslyReported)
@@ -1120,9 +1120,9 @@ extension Workspace {
         resolver: PubGrubDependencyResolver,
         constraints: [PackageContainerConstraint],
         observabilityScope: ObservabilityScope
-    ) -> [DependencyResolverBinding] {
+    ) async -> [DependencyResolverBinding] {
         os_signpost(.begin, name: SignpostName.pubgrub)
-        let result = resolver.solve(constraints: constraints)
+        let result = await resolver.solve(constraints: constraints)
         os_signpost(.end, name: SignpostName.pubgrub)
 
         // Take an action based on the result.

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import PackageGraph
 import PackageLoading
 import PackageModel
@@ -567,7 +568,7 @@ public final class MockWorkspace {
             observabilityScope: observability.topScope
         )
 
-        let result = try workspace.precomputeResolution(
+        let result = try await workspace.precomputeResolution(
             root: root,
             dependencyManifests: dependencyManifests,
             pinsStore: pinsStore,

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import PackageGraph
 import PackageLoading
 import PackageModel
@@ -31,57 +32,59 @@ private let v1: Version = "1.0.0"
 private let v1Range: VersionSetSpecifier = .range("1.0.0" ..< "2.0.0")
 
 class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
-    func testKituraPubGrub_X100() throws {
+    func testKituraPubGrub_X100() async throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        try runPackageTestPubGrub(name: "kitura.json", N: 100)
+        try await runPackageTestPubGrub(name: "kitura.json", N: 100)
     }
 
-    func testZewoPubGrub_X100() throws {
+    func testZewoPubGrub_X100() async throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        try runPackageTestPubGrub(name: "ZewoHTTPServer.json", N: 100)
+        try await runPackageTestPubGrub(name: "ZewoHTTPServer.json", N: 100)
     }
 
-    func testPerfectPubGrub_X100() throws {
+    func testPerfectPubGrub_X100() async throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        try runPackageTestPubGrub(name: "PerfectHTTPServer.json", N: 100)
+        try await runPackageTestPubGrub(name: "PerfectHTTPServer.json", N: 100)
     }
 
-    func testSourceKittenPubGrub_X100() throws {
+    func testSourceKittenPubGrub_X100() async throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        try runPackageTestPubGrub(name: "SourceKitten.json", N: 100)
+        try await runPackageTestPubGrub(name: "SourceKitten.json", N: 100)
     }
 
-    func runPackageTestPubGrub(name: String, N: Int = 1) throws {
+    func runPackageTestPubGrub(name: String, N: Int = 1) async throws {
         let graph = try mockGraph(for: name)
         let provider = MockPackageContainerProvider(containers: graph.containers)
 
-        measure {
-            for _ in 0 ..< N {
-                let resolver = PubGrubDependencyResolver(provider: provider, observabilityScope: ObservabilitySystem.NOOP)
-                switch resolver.solve(constraints: graph.constraints) {
-                case .success(let result):
-                    let result: [(container: PackageReference, version: Version)] = result.compactMap {
-                        guard case .version(let version) = $0.boundVersion else {
-                            XCTFail("Unexpected result")
-                            return nil
-                        }
-                        return ($0.package, version)
+        self.startMeasuring()
+
+        for _ in 0 ..< N {
+            let resolver = PubGrubDependencyResolver(provider: provider, observabilityScope: ObservabilitySystem.NOOP)
+            switch await resolver.solve(constraints: graph.constraints) {
+            case .success(let result):
+                let result: [(container: PackageReference, version: Version)] = result.compactMap {
+                    guard case .version(let version) = $0.boundVersion else {
+                        XCTFail("Unexpected result")
+                        return nil
                     }
-                    graph.checkResult(result)
-                case .failure:
-                    XCTFail("Unexpected result")
-                    return
+                    return ($0.package, version)
                 }
+                graph.checkResult(result)
+            case .failure:
+                XCTFail("Unexpected result")
+                return
             }
         }
+
+        self.stopMeasuring()
     }
 
     func mockGraph(for name: String) throws -> MockDependencyGraph {


### PR DESCRIPTION
Remove temp_await from Snippets

### Motivation:

temp_await is unsafe and it would be better to use true async methods

### Modifications:

Remove usages of temp_await from Snippets

### Result:

Safer more modern Swift code
