### PR TITLE
Restore XML output for Swift Testing when `--disable-xctest` is passed.

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -469,15 +469,17 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
             additionalArguments += commandLineArguments
 
-            if var xunitPath = options.xUnitOutput, options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
-                // We are running Swift Testing, XCTest is also running in this session, and an xUnit path
-                // was specified. Make sure we don't stomp on XCTest's XML output by having Swift Testing
-                // write to a different path.
-                var xunitFileName = "\(xunitPath.basenameWithoutExt)-swift-testing"
-                if let ext = xunitPath.extension {
-                    xunitFileName = "\(xunitFileName).\(ext)"
+            if var xunitPath = options.xUnitOutput {
+                if options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
+                    // We are running Swift Testing, XCTest is also running in this session, and an xUnit path
+                    // was specified. Make sure we don't stomp on XCTest's XML output by having Swift Testing
+                    // write to a different path.
+                    var xunitFileName = "\(xunitPath.basenameWithoutExt)-swift-testing"
+                    if let ext = xunitPath.extension {
+                        xunitFileName = "\(xunitFileName).\(ext)"
+                    }
+                    xunitPath = xunitPath.parentDirectory.appending(xunitFileName)
                 }
-                xunitPath = xunitPath.parentDirectory.appending(xunitFileName)
                 additionalArguments += ["--xunit-output", xunitPath.pathString]
             }
         }


### PR DESCRIPTION
A previous PR, #7796, avoided Swift Testing stomping on XML output from XCTest when both libraries were running tests. However, there's a bug in the implementation where if you pass `--disable-xctest`, we don't end up telling Swift Testing to write any XML at all. This PR fixes that.

Tested with:

```sh
swift build
$(pwd)/.build/debug/swift-test --package-path /Volumes/Dev/Source/swift-testing --disable-xctest --xunit-output /dev/stdout
```

To confirm that XML output was produced for Swift Testing's test target (as an exemplar package that uses Swift Testing.)