### PR TITLE
Remove `temp_await` from `Build`/`BuildPlan`/`*Command`/`Workspace`

### DIFF
--- a/Sources/Basics/Graph/GraphAlgorithms.swift
+++ b/Sources/Basics/Graph/GraphAlgorithms.swift
@@ -59,8 +59,8 @@ public func depthFirstSearch<T: Hashable>(
 public func depthFirstSearch<T: Hashable>(
     _ nodes: [T],
     successors: (T) async throws -> [T],
-    onUnique: (T) -> Void,
-    onDuplicate: (T, T) -> Void
+    onUnique: (T) async throws -> Void,
+    onDuplicate: (T, T) async -> Void
 ) async rethrows {
     var stack = OrderedSet<T>()
     var visited = Set<T>()
@@ -74,9 +74,9 @@ public func depthFirstSearch<T: Hashable>(
 
             let visitResult = visited.insert(curr)
             if visitResult.inserted {
-                onUnique(curr)
+                try await onUnique(curr)
             } else {
-                onDuplicate(visitResult.memberAfterInsert, curr)
+                await onDuplicate(visitResult.memberAfterInsert, curr)
                 continue
             }
 

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -12,6 +12,7 @@
 
 @_spi(SwiftPMInternal)
 import Basics
+import _Concurrency
 import LLBuildManifest
 import PackageGraph
 import PackageLoading
@@ -186,7 +187,9 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     }
 
     public var builtTestProducts: [BuiltTestProduct] {
-        (try? getBuildDescription())?.builtTestProducts ?? []
+        get async {
+            (try? await getBuildDescription())?.builtTestProducts ?? []
+        }
     }
 
     /// File rules to determine resource handling behavior.
@@ -277,8 +280,8 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     ///
     /// This will try skip build planning if build manifest caching is enabled
     /// and the package structure hasn't changed.
-    public func getBuildDescription(subset: BuildSubset? = nil) throws -> BuildDescription {
-        return try self.buildDescription.memoize {
+    public func getBuildDescription(subset: BuildSubset? = nil) async throws -> BuildDescription {
+        return try await self.buildDescription.memoize {
             if self.cacheBuildManifest {
                 do {
                     // if buildPackageStructure returns a valid description we use that, otherwise we perform full planning
@@ -307,12 +310,12 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 }
             }
             // We need to perform actual planning if we reach here.
-            return try self.plan(subset: subset).description
+            return try await self.plan(subset: subset).description
         }
     }
 
-    public func getBuildManifest() throws -> LLBuildManifest {
-        return try self.plan().manifest
+    public func getBuildManifest() async throws -> LLBuildManifest {
+        try await self.plan().manifest
     }
 
     /// Cancel the active build operation.
@@ -397,7 +400,9 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         // Get the build description (either a cached one or newly created).
 
         // Get the build description
-        let buildDescription = try getBuildDescription(subset: subset)
+        let buildDescription = try unsafe_await {
+            try await self.getBuildDescription(subset: subset)
+        }
 
         // Verify dependency imports on the described targets
         try verifyTargetImports(in: buildDescription)
@@ -412,7 +417,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         // If any plugins are part of the build set, compile them now to surface
         // any errors up-front. Returns true if we should proceed with the build
         // or false if not. It will already have thrown any appropriate error.
-        guard try self.compilePlugins(in: subset) else {
+        guard try unsafe_await({ try await self.compilePlugins(in: subset) }) else {
             return
         }
 
@@ -476,10 +481,10 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     /// true if the build should proceed. Throws an error in case of failure. A
     /// reason why the build might not proceed even on success is if only plugins
     /// should be compiled.
-    func compilePlugins(in subset: BuildSubset) throws -> Bool {
+    func compilePlugins(in subset: BuildSubset) async throws -> Bool {
         // Figure out what, if any, plugin descriptions to compile, and whether
         // to continue building after that based on the subset.
-        let allPlugins = try getBuildDescription().pluginDescriptions
+        let allPlugins = try await getBuildDescription().pluginDescriptions
         let pluginsToCompile: [PluginBuildDescription]
         let continueBuilding: Bool
         switch subset {
@@ -497,7 +502,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         // Compile any plugins we ended up with. If any of them fails, it will
         // throw.
         for plugin in pluginsToCompile {
-            try compilePlugin(plugin)
+            try await compilePlugin(plugin)
         }
 
         // If we get this far they all succeeded. Return whether to continue the
@@ -507,7 +512,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
     // Compiles a single plugin, emitting its output and throwing an error if it
     // fails.
-    func compilePlugin(_ plugin: PluginBuildDescription) throws {
+    func compilePlugin(_ plugin: PluginBuildDescription) async throws {
         guard let pluginConfiguration else {
             throw InternalError("unknown plugin script runner")
         }
@@ -554,7 +559,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             preparationStepName: "Compiling plugin \(plugin.moduleName)",
             progressTracker: self.current?.tracker
         )
-        let result = try temp_await {
+        let result = try await withCheckedThrowingContinuation {
             pluginConfiguration.scriptRunner.compilePluginScript(
                 sourceFiles: plugin.sources.paths,
                 pluginName: plugin.moduleName,
@@ -562,7 +567,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 observabilityScope: self.observabilityScope,
                 callbackQueue: DispatchQueue.sharedConcurrent,
                 delegate: delegate,
-                completion: $0)
+                completion: $0.resume(with:))
         }
 
         // Throw an error on failure; we will already have emitted the compiler's output in this case.
@@ -641,7 +646,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     }
 
     /// Create the build plan and return the build description.
-    private func plan(subset: BuildSubset? = nil) throws -> (description: BuildDescription, manifest: LLBuildManifest) {
+    private func plan(subset: BuildSubset? = nil) async throws -> (description: BuildDescription, manifest: LLBuildManifest) {
         // Load the package graph.
         let graph = try getPackageGraph()
 
@@ -655,7 +660,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 satisfying: self.config.buildEnvironment(for: .host)
             )
 
-            pluginTools = try buildPluginTools(
+            pluginTools = try await buildPluginTools(
                 graph: graph,
                 pluginsPerModule: pluginsPerModule,
                 hostTriple: try pluginConfiguration.scriptRunner.hostTriple
@@ -665,7 +670,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         }
 
         // Create the build plan based on the modules graph and any information from plugins.
-        let plan = try BuildPlan(
+        let plan = try await BuildPlan(
             destinationBuildParameters: self.config.destinationBuildParameters,
             toolsBuildParameters: self.config.buildParameters(for: .host),
             graph: graph,
@@ -834,9 +839,9 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         return nil
     }
 
-    public func packageStructureChanged() -> Bool {
+    public func packageStructureChanged() async -> Bool {
         do {
-            _ = try self.plan()
+            _ = try await self.plan()
         }
         catch Diagnostics.fatalError {
             return false
@@ -875,7 +880,7 @@ extension BuildOperation {
         graph: ModulesGraph,
         pluginsPerModule: [ResolvedModule.ID: [ResolvedModule]],
         hostTriple: Basics.Triple
-    ) throws -> [ResolvedModule.ID: [String: PluginTool]] {
+    ) async throws -> [ResolvedModule.ID: [String: PluginTool]] {
         var accessibleToolsPerPlugin: [ResolvedModule.ID: [String: PluginTool]] = [:]
 
         var config = self.config
@@ -893,7 +898,7 @@ extension BuildOperation {
             component: "plugin-tools-description.json"
         )
 
-        let buildPlan = try BuildPlan(
+        let buildPlan = try await BuildPlan(
             destinationBuildParameters: config.destinationBuildParameters,
             toolsBuildParameters: config.toolsBuildParameters,
             graph: graph,

--- a/Sources/Build/LLBuildCommands.swift
+++ b/Sources/Build/LLBuildCommands.swift
@@ -425,7 +425,9 @@ final class PackageStructureCommand: CustomLLBuildCommand {
         _: SPMLLBuild.Command,
         _: SPMLLBuild.BuildSystemCommandInterface
     ) -> Bool {
-        self.context.packageStructureDelegate.packageStructureChanged()
+        unsafe_await {
+            await self.context.packageStructureDelegate.packageStructureChanged()
+        }
     }
 }
 

--- a/Sources/Build/LLBuildProgressTracker.swift
+++ b/Sources/Build/LLBuildProgressTracker.swift
@@ -131,7 +131,7 @@ public final class BuildExecutionContext {
 }
 
 public protocol PackageStructureDelegate {
-    func packageStructureChanged() -> Bool
+    func packageStructureChanged() async -> Bool
 }
 
 /// Convenient llbuild build system delegate implementation

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -142,7 +142,7 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
             ) as? BuildOperation else {
                 throw StringError("asked for native build system but did not get it")
             }
-            let buildManifest = try buildOperation.getBuildManifest()
+            let buildManifest = try await buildOperation.getBuildManifest()
             var serializer = DOTManifestSerializer(manifest: buildManifest)
             // print to stdout
             let outputStream = stdoutStream

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1495,7 +1495,7 @@ private func buildTestsIfNeeded(
     try buildSystem.build(subset: subset)
 
     // Find the test product.
-    let testProducts = buildSystem.builtTestProducts
+    let testProducts = await buildSystem.builtTestProducts
     guard !testProducts.isEmpty else {
         if let testProduct {
             throw TestError.productIsNotTest(productName: testProduct)

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -252,7 +252,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         // Iterate over the tests and run those that match the filter.
         var testTargetResults: [PluginInvocationTestResult.TestTarget] = []
         var numFailedTests = 0
-        for testProduct in buildSystem.builtTestProducts {
+        for testProduct in await buildSystem.builtTestProducts {
             // Get the test suites in the bundle. Each is just a container for test cases.
             let testSuites = try TestingSupport.getTestSuites(
                 fromTestAt: testProduct.bundlePath,
@@ -344,7 +344,7 @@ final class PluginDelegate: PluginInvocationDelegate {
             // Use `llvm-cov` to export the merged `.profdata` file contents in JSON form.
             var llvmCovCommand = [try toolchain.getLLVMCov().pathString]
             llvmCovCommand += ["export", "-instr-profile=\(mergedCovFile.pathString)"]
-            for product in buildSystem.builtTestProducts {
+            for product in await buildSystem.builtTestProducts {
                 llvmCovCommand.append("-object")
                 llvmCovCommand.append(product.binaryPath.pathString)
             }

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -40,7 +40,7 @@ public protocol BuildSystem: Cancellable {
     var delegate: BuildSystemDelegate? { get }
 
     /// The test products that this build system will build.
-    var builtTestProducts: [BuiltTestProduct] { get }
+    var builtTestProducts: [BuiltTestProduct] { get async }
 
     /// Returns the package graph used by the build system.
     func getPackageGraph() throws -> ModulesGraph

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -878,7 +878,7 @@ extension Workspace {
     }
 
     @discardableResult
-    package func loadPackageGraph(
+    public func loadPackageGraph(
         rootInput root: PackageGraphRootInput,
         explicitProduct: String? = nil,
         forceResolvedVersions: Bool = false,
@@ -897,31 +897,6 @@ extension Workspace {
             expectedSigningEntities: expectedSigningEntities,
             observabilityScope: observabilityScope
         )
-    }
-
-    @available(*, deprecated, message: "Use the async alternative")
-    @discardableResult
-    public func loadPackageGraph(
-        rootInput root: PackageGraphRootInput,
-        explicitProduct: String? = nil,
-        forceResolvedVersions: Bool = false,
-        customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
-        testEntryPointPath: AbsolutePath? = nil,
-        expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
-        observabilityScope: ObservabilityScope
-    ) throws -> ModulesGraph {
-        try unsafe_await {
-            try await self.loadPackageGraph(
-                rootInput: root,
-                explicitProduct:explicitProduct,
-                traitConfiguration: nil,
-                forceResolvedVersions: forceResolvedVersions,
-                customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
-                testEntryPointPath: testEntryPointPath,
-                expectedSigningEntities: expectedSigningEntities,
-                observabilityScope: observabilityScope
-            )
-        }
     }
 
     @discardableResult

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -161,8 +161,8 @@ public func mockBuildPlan(
     targetSanitizers: EnabledSanitizers = .init(),
     fileSystem fs: any FileSystem,
     observabilityScope: ObservabilityScope
-) throws -> Build.BuildPlan {
-    try mockBuildPlan(
+) async throws -> Build.BuildPlan {
+    try await mockBuildPlan(
         buildPath: buildPath,
         config: environment.configuration ?? .debug,
         platform: environment.platform,
@@ -194,7 +194,7 @@ public func mockBuildPlan(
     targetSanitizers: EnabledSanitizers = .init(),
     fileSystem fs: any FileSystem,
     observabilityScope: ObservabilityScope
-) throws -> Build.BuildPlan {
+) async throws -> Build.BuildPlan {
     let inferredTriple: Basics.Triple
     if let platform {
         precondition(triple == nil)
@@ -248,7 +248,7 @@ public func mockBuildPlan(
     hostParameters.driverParameters = driverParameters
     hostParameters.linkingParameters = linkingParameters
 
-    return try BuildPlan(
+    return try await BuildPlan(
         destinationBuildParameters: destinationParameters,
         toolsBuildParameters: hostParameters,
         graph: graph,

--- a/Tests/BuildTests/BuildOperationTests.swift
+++ b/Tests/BuildTests/BuildOperationTests.swift
@@ -49,7 +49,7 @@ private func mockBuildOperation(
 }
 
 final class BuildOperationTests: XCTestCase {
-    func testDetectProductTripleChange() throws {
+    func testDetectProductTripleChange() async throws {
         let observability = ObservabilitySystem.makeForTesting()
         let fs = InMemoryFileSystem(
             emptyFiles: "/Pkg/Sources/ATarget/foo.swift"
@@ -67,7 +67,7 @@ final class BuildOperationTests: XCTestCase {
             ],
             observabilityScope: observability.topScope
         )
-        try withTemporaryDirectory { tmpDir in
+        try await withTemporaryDirectory { tmpDir in
             let scratchDirectory = tmpDir.appending(".build")
             let fs = localFileSystem
             let triples = try [Triple("x86_64-unknown-linux-gnu"), Triple("wasm32-unknown-wasi")]
@@ -90,7 +90,7 @@ final class BuildOperationTests: XCTestCase {
                     fs: fs, observabilityScope: observability.topScope
                 )
                 // Generate initial llbuild manifest
-                let _ = try buildOp.getBuildDescription()
+                let _ = try await buildOp.getBuildDescription()
                 // Record the initial llbuild manifest as expected one
                 llbuildManifestByTriple[triple.tripleString] = try fs.readFileContents(targetBuildParameters.llbuildManifest)
             }
@@ -123,7 +123,7 @@ final class BuildOperationTests: XCTestCase {
                         fs: fs, observabilityScope: observability.topScope
                     )
                     // Generate llbuild manifest
-                    let _ = try buildOp.getBuildDescription()
+                    let _ = try await buildOp.getBuildDescription()
 
                     // Ensure that llbuild manifest is updated to the expected one
                     let actualManifest: String = try fs.readFileContents(targetBuildParameters.llbuildManifest)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -52,7 +52,7 @@ final class BuildPlanTests: XCTestCase {
         "-j3"
     }
 
-    func testDuplicateProductNamesWithNonDefaultLibsThrowError() throws {
+    func testDuplicateProductNamesWithNonDefaultLibsThrowError() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles: "/thisPkg/Sources/exe/main.swift",
             "/fooPkg/Sources/FooLogging/file.swift",
@@ -111,7 +111,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testDuplicateProductNamesWithADylib() throws {
+    func testDuplicateProductNamesWithADylib() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -169,7 +169,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -183,7 +183,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" })
     }
 
-    func testDuplicateProductNamesUpstream1() throws {
+    func testDuplicateProductNamesUpstream1() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -294,7 +294,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -311,7 +311,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "YUtils" })
     }
 
-    func testDuplicateProductNamesUpstream2() throws {
+    func testDuplicateProductNamesUpstream2() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -389,7 +389,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -404,7 +404,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BazLogging" })
     }
 
-    func testDuplicateProductNamesChained() throws {
+    func testDuplicateProductNamesChained() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -466,7 +466,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -480,7 +480,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" })
     }
 
-    func testDuplicateProductNamesThrowError() throws {
+    func testDuplicateProductNamesThrowError() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -541,7 +541,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testDuplicateProductNamesAllowed() throws {
+    func testDuplicateProductNamesAllowed() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -599,7 +599,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -720,7 +720,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testBasicSwiftPackage() throws {
+    func testBasicSwiftPackage() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -744,7 +744,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -851,10 +851,10 @@ final class BuildPlanTests: XCTestCase {
         #endif
     }
 
-    func testExplicitSwiftPackageBuild() throws {
+    func testExplicitSwiftPackageBuild() async throws {
         // <rdar://82053045> Fix and re-enable SwiftPM test `testExplicitSwiftPackageBuild`
         try XCTSkipIf(true)
-        try withTemporaryDirectory { path in
+        try await withTemporaryDirectory { path in
             // Create a test package with three targets:
             // A -> B -> C
             let fs = localFileSystem
@@ -912,7 +912,7 @@ final class BuildPlanTests: XCTestCase {
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
             do {
-                let plan = try mockBuildPlan(
+                let plan = try await mockBuildPlan(
                     config: .release,
                     triple: UserToolchain.default.targetTriple,
                     toolchain: UserToolchain.default,
@@ -950,7 +950,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testSwiftConditionalDependency() throws {
+    func testSwiftConditionalDependency() async throws {
         let Pkg: AbsolutePath = "/Pkg"
 
         let fs: FileSystem = InMemoryFileSystem(
@@ -1022,7 +1022,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         do {
-            let plan = try mockBuildPlan(
+            let plan = try await mockBuildPlan(
                 environment: BuildEnvironment(
                     platform: .linux,
                     configuration: .release
@@ -1064,7 +1064,7 @@ final class BuildPlanTests: XCTestCase {
         }
 
         do {
-            let plan = try mockBuildPlan(
+            let plan = try await mockBuildPlan(
                 environment: BuildEnvironment(
                     platform: .macOS,
                     configuration: .debug
@@ -1099,7 +1099,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testBasicExtPackages() throws {
+    func testBasicExtPackages() async throws {
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/A/Sources/ATarget/foo.swift",
@@ -1139,7 +1139,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             fileSystem: fileSystem,
             observabilityScope: observability.topScope
@@ -1158,7 +1158,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(Set(result.targetMap.keys.map(\.moduleName)), expectedTargets)
     }
 
-    func testBasicReleasePackage() throws {
+    func testBasicReleasePackage() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift"
@@ -1180,7 +1180,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             config: .release,
             graph: graph,
             fileSystem: fs,
@@ -1249,7 +1249,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
     }
 
-    func testBasicReleasePackageNoDeadStrip() throws {
+    func testBasicReleasePackageNoDeadStrip() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift"
@@ -1271,7 +1271,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             config: .release,
             graph: graph,
             linkingParameters: .init(
@@ -1340,7 +1340,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
     }
 
-    func testBasicClangPackage() throws {
+    func testBasicClangPackage() async throws {
         let Pkg: AbsolutePath = "/Pkg"
         let ExtPkg: AbsolutePath = "/ExtPkg"
 
@@ -1387,7 +1387,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -1515,7 +1515,7 @@ final class BuildPlanTests: XCTestCase {
         ])
     }
 
-    func testClangConditionalDependency() throws {
+    func testClangConditionalDependency() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.c",
@@ -1568,7 +1568,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         do {
-            let result = try BuildPlanResult(plan: mockBuildPlan(
+            let result = try await BuildPlanResult(plan: mockBuildPlan(
                 environment: BuildEnvironment(
                     platform: .linux,
                     configuration: .release
@@ -1587,7 +1587,7 @@ final class BuildPlanTests: XCTestCase {
         }
 
         do {
-            let result = try BuildPlanResult(plan: mockBuildPlan(
+            let result = try await BuildPlanResult(plan: mockBuildPlan(
                 environment: BuildEnvironment(
                     platform: .macOS,
                     configuration: .debug
@@ -1605,7 +1605,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testCLanguageStandard() throws {
+    func testCLanguageStandard() async throws {
         let Pkg: AbsolutePath = "/Pkg"
 
         let fs: FileSystem = InMemoryFileSystem(
@@ -1643,7 +1643,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -1746,7 +1746,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testSwiftCMixed() throws {
+    func testSwiftCMixed() async throws {
         let Pkg: AbsolutePath = "/Pkg"
 
         let fs = InMemoryFileSystem(
@@ -1773,7 +1773,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -1875,7 +1875,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
     }
 
-    func testSwiftCAsmMixed() throws {
+    func testSwiftCAsmMixed() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -1902,7 +1902,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -1917,7 +1917,7 @@ final class BuildPlanTests: XCTestCase {
         ])
     }
 
-    func testSwiftSettings_interoperabilityMode_cxx() throws {
+    func testSwiftSettings_interoperabilityMode_cxx() async throws {
         let Pkg: AbsolutePath = "/Pkg"
 
         let fs: FileSystem = InMemoryFileSystem(
@@ -1951,7 +1951,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -1999,7 +1999,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func test_symbolGraphExtract_arguments() throws {
+    func test_symbolGraphExtract_arguments() async throws {
         // ModuleGraph:
         // .
         // ├── A (Swift)
@@ -2043,7 +2043,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -2108,7 +2108,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testREPLArguments() throws {
+    func testREPLArguments() async throws {
         let Dep = AbsolutePath("/Dep")
         let fs = InMemoryFileSystem(
             emptyFiles:
@@ -2155,7 +2155,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -2181,7 +2181,7 @@ final class BuildPlanTests: XCTestCase {
         ])
     }
 
-    func testTestModule() throws {
+    func testTestModule() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/Foo/foo.swift",
@@ -2206,7 +2206,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -2312,7 +2312,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
     }
 
-    func testConcurrencyInOS() throws {
+    func testConcurrencyInOS() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift"
@@ -2337,7 +2337,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             config: .release,
             graph: graph,
             fileSystem: fs,
@@ -2383,7 +2383,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
     }
 
-    func testParseAsLibraryFlagForExe() throws {
+    func testParseAsLibraryFlagForExe() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             // executable has a single source file not named `main.swift`, without @main.
@@ -2594,7 +2594,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -2669,7 +2669,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(atMainSnippet, ["-parse-as-library"])
     }
 
-    func testCModule() throws {
+    func testCModule() async throws {
         let Clibgit = AbsolutePath("/Clibgit")
 
         let fs = InMemoryFileSystem(
@@ -2704,7 +2704,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -2774,7 +2774,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
     }
 
-    func testCppModule() throws {
+    func testCppModule() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -2799,7 +2799,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        var result = try BuildPlanResult(plan: mockBuildPlan(
+        var result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -2815,7 +2815,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
 
         // Verify that `-lstdc++` is passed instead of `-lc++` when cross-compiling to Linux.
-        result = try BuildPlanResult(plan: mockBuildPlan(
+        result = try await BuildPlanResult(plan: mockBuildPlan(
             triple: .arm64Linux,
             graph: graph,
             fileSystem: fs,
@@ -2828,7 +2828,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(linkArgs, ["-lstdc++"])
     }
 
-    func testDynamicProducts() throws {
+    func testDynamicProducts() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Foo/Sources/Foo/main.swift",
@@ -2864,7 +2864,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: g,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -2972,7 +2972,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
     }
 
-    func testExecAsDependency() throws {
+    func testExecAsDependency() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -2999,7 +2999,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -3092,7 +3092,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), linkArguments)
     }
 
-    func testClangTargets() throws {
+    func testClangTargets() async throws {
         let Pkg: AbsolutePath = "/Pkg"
 
         let fs = InMemoryFileSystem(
@@ -3122,7 +3122,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -3269,7 +3269,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
     }
 
-    func testNonReachableProductsAndTargets() throws {
+    func testNonReachableProductsAndTargets() async throws {
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/A/Sources/ATarget/main.swift",
@@ -3342,7 +3342,7 @@ final class BuildPlanTests: XCTestCase {
         graphResult.check(modules: "ATarget", "BTarget1", "BTarget2", "CTarget")
         #endif
 
-        let planResult = try BuildPlanResult(plan: mockBuildPlan(
+        let planResult = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             fileSystem: fileSystem,
             observabilityScope: observability.topScope
@@ -3357,7 +3357,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
     }
 
-    func testReachableBuildProductsAndTargets() throws {
+    func testReachableBuildProductsAndTargets() async throws {
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/A/Sources/ATarget/main.swift",
@@ -3438,7 +3438,7 @@ final class BuildPlanTests: XCTestCase {
             try graphResult.check(reachableBuildProducts: "aexec", "BLibrary1", "BLibrary2", in: linuxDebug)
             try graphResult.check(reachableBuildTargets: "ATarget", "BTarget1", "BTarget2", in: linuxDebug)
 
-            let planResult = try BuildPlanResult(plan: mockBuildPlan(
+            let planResult = try await BuildPlanResult(plan: mockBuildPlan(
                 environment: linuxDebug,
                 graph: graph,
                 fileSystem: fileSystem,
@@ -3453,7 +3453,7 @@ final class BuildPlanTests: XCTestCase {
             try graphResult.check(reachableBuildProducts: "aexec", "BLibrary2", in: macosDebug)
             try graphResult.check(reachableBuildTargets: "ATarget", "BTarget2", "BTarget3", in: macosDebug)
 
-            let planResult = try BuildPlanResult(plan: mockBuildPlan(
+            let planResult = try await BuildPlanResult(plan: mockBuildPlan(
                 environment: macosDebug,
                 graph: graph,
                 fileSystem: fileSystem,
@@ -3468,7 +3468,7 @@ final class BuildPlanTests: XCTestCase {
             try graphResult.check(reachableBuildProducts: "aexec", "CLibrary", in: androidRelease)
             try graphResult.check(reachableBuildTargets: "ATarget", "CTarget", in: androidRelease)
 
-            let planResult = try BuildPlanResult(plan: mockBuildPlan(
+            let planResult = try await BuildPlanResult(plan: mockBuildPlan(
                 environment: androidRelease,
                 graph: graph,
                 fileSystem: fileSystem,
@@ -3479,7 +3479,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testSystemPackageBuildPlan() throws {
+    func testSystemPackageBuildPlan() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/module.modulemap"
@@ -3498,16 +3498,23 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        XCTAssertThrows(BuildPlan.Error.noBuildableTarget) {
-            _ = try mockBuildPlan(
+        do {
+            _ = try await mockBuildPlan(
                 graph: graph,
                 fileSystem: fs,
                 observabilityScope: observability.topScope
             )
+            XCTFail()
+        } catch {
+            if let buildError = error as? Build.BuildPlan.Error {
+                XCTAssert(buildError == .noBuildableTarget)
+            } else {
+                XCTFail()
+            }
         }
     }
 
-    func testPkgConfigHintDiagnostic() throws {
+    func testPkgConfigHintDiagnostic() async throws {
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/A/Sources/ATarget/foo.swift",
@@ -3539,7 +3546,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        _ = try mockBuildPlan(
+        _ = try await mockBuildPlan(
             graph: graph,
             fileSystem: fileSystem,
             observabilityScope: observability.topScope
@@ -3553,7 +3560,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
     }
 
-    func testPkgConfigGenericDiagnostic() throws {
+    func testPkgConfigGenericDiagnostic() async throws {
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/A/Sources/ATarget/foo.swift",
@@ -3580,7 +3587,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        _ = try mockBuildPlan(
+        _ = try await mockBuildPlan(
             graph: graph,
             fileSystem: fileSystem,
             observabilityScope: observability.topScope
@@ -3594,7 +3601,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(diagnostic.metadata?.pcFile, "BTarget.pc")
     }
 
-    func testWindowsTarget() throws {
+    func testWindowsTarget() async throws {
         let Pkg: AbsolutePath = "/Pkg"
         let fs = InMemoryFileSystem(
             emptyFiles:
@@ -3620,7 +3627,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             triple: .windows,
             graph: graph,
             fileSystem: fs,
@@ -3679,7 +3686,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(executablePathExtension, "exe")
     }
 
-    func testEntrypointRenaming() throws {
+    func testEntrypointRenaming() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift"
@@ -3701,8 +3708,8 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        func createResult(for triple: Basics.Triple) throws -> BuildPlanResult {
-            try BuildPlanResult(plan: mockBuildPlan(
+        func createResult(for triple: Basics.Triple) async throws -> BuildPlanResult {
+            try await BuildPlanResult(plan: mockBuildPlan(
                 triple: triple,
                 graph: graph,
                 driverParameters: .init(
@@ -3714,7 +3721,7 @@ final class BuildPlanTests: XCTestCase {
         }
         let supportingTriples: [Basics.Triple] = [.x86_64Linux, .x86_64MacOS]
         for triple in supportingTriples {
-            let result = try createResult(for: triple)
+            let result = try await createResult(for: triple)
             let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
             XCTAssertMatch(exe, ["-Xfrontend", "-entry-point-function-name", "-Xfrontend", "exe_main"])
             let linkExe = try result.buildProduct(for: "exe").linkArguments()
@@ -3723,13 +3730,13 @@ final class BuildPlanTests: XCTestCase {
 
         let unsupportingTriples: [Basics.Triple] = [.wasi, .windows]
         for triple in unsupportingTriples {
-            let result = try createResult(for: triple)
+            let result = try await createResult(for: triple)
             let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
             XCTAssertNoMatch(exe, ["-entry-point-function-name"])
         }
     }
 
-    func testIndexStore() throws {
+    func testIndexStore() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -3754,8 +3761,8 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        func check(for mode: BuildParameters.IndexStoreMode, config: BuildConfiguration) throws {
-            let result = try BuildPlanResult(plan: mockBuildPlan(
+        func check(for mode: BuildParameters.IndexStoreMode, config: BuildConfiguration) async throws {
+            let result = try await BuildPlanResult(plan: mockBuildPlan(
                 config: config,
                 toolchain: try UserToolchain.default,
                 graph: graph,
@@ -3776,12 +3783,12 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(exe, [.anySequence, "-index-store-path", path, .anySequence])
         }
 
-        try check(for: .auto, config: .debug)
-        try check(for: .on, config: .debug)
-        try check(for: .on, config: .release)
+        try await check(for: .auto, config: .debug)
+        try await check(for: .on, config: .debug)
+        try await check(for: .on, config: .release)
     }
 
-    func testPlatforms() throws {
+    func testPlatforms() async throws {
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/A/Sources/ATarget/foo.swift",
@@ -3825,7 +3832,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             fileSystem: fileSystem,
             observabilityScope: observability.topScope
@@ -3852,7 +3859,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
     }
 
-    func testPlatformsCustomTriple() throws {
+    func testPlatformsCustomTriple() async throws {
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/A/Sources/ATarget/foo.swift",
@@ -3898,7 +3905,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             triple: .init("arm64-apple-ios"),
             graph: graph,
             fileSystem: fileSystem,
@@ -3924,7 +3931,7 @@ final class BuildPlanTests: XCTestCase {
         ])
     }
 
-    func testPlatformsValidationComparesSpecifiedDarwinTriple() throws {
+    func testPlatformsValidationComparesSpecifiedDarwinTriple() async throws {
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/A/Sources/ATarget/foo.swift",
@@ -3974,23 +3981,27 @@ final class BuildPlanTests: XCTestCase {
         // however our build triple *only specifies* `iOS`.
         // Therefore, we expect no error, as the iOS version
         // constraints above are valid.
-        XCTAssertNoThrow(
-            _ = try mockBuildPlan(
-                triple: .arm64iOS,
-                graph: graph,
-                fileSystem: fileSystem,
-                observabilityScope: observability.topScope
-            )
+
+        _ = try await mockBuildPlan(
+            triple: .arm64iOS,
+            graph: graph,
+            fileSystem: fileSystem,
+            observabilityScope: observability.topScope
         )
 
+
         // For completeness, the invalid target should still throw an error.
-        XCTAssertThrows(Diagnostics.fatalError) {
-            _ = try mockBuildPlan(
+        do {
+            _ = try await mockBuildPlan(
                 triple: .x86_64MacOS,
                 graph: graph,
                 fileSystem: fileSystem,
                 observabilityScope: observability.topScope
             )
+            XCTFail()
+        } catch Diagnostics.fatalError {
+        } catch {
+            XCTFail()
         }
 
         testDiagnostics(observability.diagnostics) { result in
@@ -4003,7 +4014,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testPlatformsValidationWhenADependencyRequiresHigherOSVersionThanPackage() throws {
+    func testPlatformsValidationWhenADependencyRequiresHigherOSVersionThanPackage() async throws {
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/A/Sources/ATarget/foo.swift",
@@ -4047,13 +4058,17 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        XCTAssertThrows(Diagnostics.fatalError) {
-            _ = try mockBuildPlan(
+        do {
+            _ = try await mockBuildPlan(
                 triple: .x86_64MacOS,
                 graph: graph,
                 fileSystem: fileSystem,
                 observabilityScope: observability.topScope
             )
+            XCTFail()
+        } catch Diagnostics.fatalError {
+        } catch {
+            XCTFail()
         }
 
         testDiagnostics(observability.diagnostics) { result in
@@ -4066,7 +4081,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testBuildSettings() throws {
+    func testBuildSettings() async throws {
         let A = AbsolutePath("/A")
 
         let fs = InMemoryFileSystem(
@@ -4213,8 +4228,8 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        func createResult(for dest: Basics.Triple) throws -> BuildPlanResult {
-            try BuildPlanResult(plan: mockBuildPlan(
+        func createResult(for dest: Basics.Triple) async throws -> BuildPlanResult {
+            try await BuildPlanResult(plan: mockBuildPlan(
                 triple: dest,
                 graph: graph,
                 fileSystem: fs,
@@ -4223,7 +4238,7 @@ final class BuildPlanTests: XCTestCase {
         }
 
         do {
-            let result = try createResult(for: .x86_64Linux)
+            let result = try await createResult(for: .x86_64Linux)
 
             let dep = try result.moduleBuildDescription(for: "t1").swift().compileArguments()
             XCTAssertMatch(dep, [.anySequence, "-DDEP", .anySequence])
@@ -4281,7 +4296,7 @@ final class BuildPlanTests: XCTestCase {
 
         // omit frame pointers explicitly set to true
         do {
-            let result = try BuildPlanResult(plan: mockBuildPlan(
+            let result = try await BuildPlanResult(plan: mockBuildPlan(
                 triple: .x86_64Linux,
                 graph: graph,
                 omitFramePointers: true,
@@ -4336,7 +4351,7 @@ final class BuildPlanTests: XCTestCase {
 
         // omit frame pointers explicitly set to false
         do {
-            let result = try BuildPlanResult(plan: mockBuildPlan(
+            let result = try await BuildPlanResult(plan: mockBuildPlan(
                 triple: .x86_64Linux,
                 graph: graph,
                 omitFramePointers: false,
@@ -4390,7 +4405,7 @@ final class BuildPlanTests: XCTestCase {
         }
 
         do {
-            let result = try createResult(for: .x86_64MacOS)
+            let result = try await createResult(for: .x86_64MacOS)
 
             let cbar = try result.moduleBuildDescription(for: "cbar").clang().basicArguments(isCXX: false)
             XCTAssertMatch(
@@ -4460,7 +4475,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testExtraBuildFlags() throws {
+    func testExtraBuildFlags() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/A/Sources/exe/main.swift",
@@ -4486,7 +4501,7 @@ final class BuildPlanTests: XCTestCase {
 
         var flags = BuildFlags()
         flags.linkerFlags = ["-L", "/path/to/foo", "-L/path/to/foo", "-rpath=foo", "-rpath", "foo"]
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             commonFlags: flags,
             fileSystem: fs,
@@ -4507,7 +4522,7 @@ final class BuildPlanTests: XCTestCase {
         )
     }
 
-    func testUserToolchainCompileFlags() throws {
+    func testUserToolchainCompileFlags() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -4558,7 +4573,7 @@ final class BuildPlanTests: XCTestCase {
             swiftCompilerFlags: ["-swift-command-line-flag"]
         )
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             toolchain: mockToolchain,
             graph: graph,
             commonFlags: commonFlags,
@@ -4606,7 +4621,7 @@ final class BuildPlanTests: XCTestCase {
             .anySequence,
         ])
 
-        let staticResult = try BuildPlanResult(plan: mockBuildPlan(
+        let staticResult = try await BuildPlanResult(plan: mockBuildPlan(
             triple: .x86_64Linux,
             toolchain: mockToolchain,
             graph: graph,
@@ -4635,7 +4650,7 @@ final class BuildPlanTests: XCTestCase {
         ])
     }
 
-    func testUserToolchainWithToolsetCompileFlags() throws {
+    func testUserToolchainWithToolsetCompileFlags() async throws {
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -4690,7 +4705,7 @@ final class BuildPlanTests: XCTestCase {
             )
         )
         let toolchain = try UserToolchain(swiftSDK: swiftSDK, environment: .mockEnvironment, fileSystem: fileSystem)
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             triple: targetTriple,
             toolchain: toolchain,
             graph: graph,
@@ -4803,7 +4818,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertCount(1, exeLinkArguments, cliFlag(tool: .linker))
     }
 
-    func testUserToolchainWithSDKSearchPaths() throws {
+    func testUserToolchainWithSDKSearchPaths() async throws {
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -4844,7 +4859,7 @@ final class BuildPlanTests: XCTestCase {
             ])
         )
         let toolchain = try UserToolchain(swiftSDK: swiftSDK, environment: .mockEnvironment, fileSystem: fileSystem)
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             toolchain: toolchain,
             graph: graph,
             fileSystem: fileSystem,
@@ -4869,7 +4884,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(exeLinkArguments, exeLinkArgumentsPattern)
     }
 
-    func testExecBuildTimeDependency() throws {
+    func testExecBuildTimeDependency() async throws {
         let PkgA = AbsolutePath("/PkgA")
 
         let fs: FileSystem = InMemoryFileSystem(
@@ -4914,7 +4929,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -4952,7 +4967,7 @@ final class BuildPlanTests: XCTestCase {
         """))
         }
 
-    func testObjCHeader1() throws {
+    func testObjCHeader1() async throws {
         let PkgA = AbsolutePath("/PkgA")
 
         // This has a Swift and ObjC target in the same package.
@@ -4979,7 +4994,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -5039,7 +5054,7 @@ final class BuildPlanTests: XCTestCase {
         """))
     }
 
-    func testObjCHeader2() throws {
+    func testObjCHeader2() async throws {
         let PkgA = AbsolutePath("/PkgA")
 
         // This has a Swift and ObjC target in different packages with automatic product type.
@@ -5078,7 +5093,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -5148,7 +5163,7 @@ final class BuildPlanTests: XCTestCase {
         """))
     }
 
-    func testObjCHeader3() throws {
+    func testObjCHeader3() async throws {
         let PkgA = AbsolutePath("/PkgA")
 
         // This has a Swift and ObjC target in different packages with dynamic product type.
@@ -5187,7 +5202,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -5265,7 +5280,7 @@ final class BuildPlanTests: XCTestCase {
         """))
     }
 
-    func testModulewrap() throws {
+    func testModulewrap() async throws {
         let fs: FileSystem = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -5289,7 +5304,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             triple: .x86_64Linux,
             graph: graph,
             fileSystem: fs,
@@ -5349,7 +5364,7 @@ final class BuildPlanTests: XCTestCase {
         """))
     }
 
-    func testArchiving() throws {
+    func testArchiving() async throws {
         let fs: FileSystem = InMemoryFileSystem(
             emptyFiles:
             "/Package/Sources/rary/rary.swift"
@@ -5374,7 +5389,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -5487,7 +5502,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testSwiftBundleAccessor() throws {
+    func testSwiftBundleAccessor() async throws {
         // This has a Swift and ObjC target in the same package.
         let fs = InMemoryFileSystem(
             emptyFiles:
@@ -5525,7 +5540,7 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -5554,7 +5569,7 @@ final class BuildPlanTests: XCTestCase {
         ])
     }
 
-    func testSwiftWASIBundleAccessor() throws {
+    func testSwiftWASIBundleAccessor() async throws {
         // This has a Swift and ObjC target in the same package.
         let fs = InMemoryFileSystem(
             emptyFiles:
@@ -5592,7 +5607,7 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             triple: .wasi,
             graph: graph,
             fileSystem: fs,
@@ -5622,7 +5637,7 @@ final class BuildPlanTests: XCTestCase {
         ])
     }
 
-    func testClangBundleAccessor() throws {
+    func testClangBundleAccessor() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/Foo/include/Foo.h",
@@ -5659,7 +5674,7 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -5698,7 +5713,7 @@ final class BuildPlanTests: XCTestCase {
         )
     }
 
-    func testShouldLinkStaticSwiftStdlib() throws {
+    func testShouldLinkStaticSwiftStdlib() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -5724,7 +5739,7 @@ final class BuildPlanTests: XCTestCase {
 
         let supportingTriples: [Basics.Triple] = [.x86_64Linux, .arm64Linux, .wasi]
         for triple in supportingTriples {
-            let result = try BuildPlanResult(plan: mockBuildPlan(
+            let result = try await BuildPlanResult(plan: mockBuildPlan(
                 triple: triple,
                 graph: graph,
                 linkingParameters: .init(
@@ -5743,7 +5758,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testXCFrameworkBinaryTargets(platform: String, arch: String, targetTriple: Basics.Triple) throws {
+    func testXCFrameworkBinaryTargets(platform: String, arch: String, targetTriple: Basics.Triple) async throws {
         let Pkg: AbsolutePath = "/Pkg"
 
         let fs = InMemoryFileSystem(
@@ -5852,7 +5867,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             triple: targetTriple,
             graph: graph,
             fileSystem: fs,
@@ -5913,20 +5928,20 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(dynamicLibraryPathExtension, "dylib")
     }
 
-    func testXCFrameworkBinaryTargets() throws {
-        try self.testXCFrameworkBinaryTargets(platform: "macos", arch: "x86_64", targetTriple: .x86_64MacOS)
+    func testXCFrameworkBinaryTargets() async throws {
+        try await self.testXCFrameworkBinaryTargets(platform: "macos", arch: "x86_64", targetTriple: .x86_64MacOS)
 
         let arm64Triple = try Basics.Triple("arm64-apple-macosx")
-        try self.testXCFrameworkBinaryTargets(platform: "macos", arch: "arm64", targetTriple: arm64Triple)
+        try await self.testXCFrameworkBinaryTargets(platform: "macos", arch: "arm64", targetTriple: arm64Triple)
 
         let arm64eTriple = try Basics.Triple("arm64e-apple-macosx")
-        try self.testXCFrameworkBinaryTargets(platform: "macos", arch: "arm64e", targetTriple: arm64eTriple)
+        try await self.testXCFrameworkBinaryTargets(platform: "macos", arch: "arm64e", targetTriple: arm64eTriple)
     }
 
     func testArtifactsArchiveBinaryTargets(
         artifactTriples: [Basics.Triple],
         targetTriple: Basics.Triple
-    ) throws -> Bool {
+    ) async throws -> Bool {
         let fs = InMemoryFileSystem(emptyFiles: "/Pkg/Sources/exe/main.swift")
 
         let artifactName = "my-tool"
@@ -5981,7 +5996,7 @@ final class BuildPlanTests: XCTestCase {
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             triple: targetTriple,
             graph: graph,
             fileSystem: fs,
@@ -5996,47 +6011,50 @@ final class BuildPlanTests: XCTestCase {
         return availableTools.contains(where: { $0.key == artifactName })
     }
 
-    func testArtifactsArchiveBinaryTargets() throws {
-        XCTAssertTrue(try self.testArtifactsArchiveBinaryTargets(
+    func testArtifactsArchiveBinaryTargets() async throws {
+        let result = try await self.testArtifactsArchiveBinaryTargets(
             artifactTriples: [.x86_64MacOS],
             targetTriple: .x86_64MacOS
-        ))
+        )
+        XCTAssertTrue(result)
 
         do {
             let triples = try ["arm64-apple-macosx", "x86_64-apple-macosx", "x86_64-unknown-linux-gnu"]
                 .map(Basics.Triple.init)
-            XCTAssertTrue(try self.testArtifactsArchiveBinaryTargets(
+            let result2 = try await self.testArtifactsArchiveBinaryTargets(
                 artifactTriples: triples,
                 targetTriple: triples.first!
-            ))
+            )
+            XCTAssertTrue(result2)
         }
 
         do {
             let triples = try ["x86_64-unknown-linux-gnu"].map(Basics.Triple.init)
-            XCTAssertFalse(try self.testArtifactsArchiveBinaryTargets(
+            let result3 = try await self.testArtifactsArchiveBinaryTargets(
                 artifactTriples: triples,
                 targetTriple: .x86_64MacOS
-            ))
+            )
+            XCTAssertFalse(result3)
         }
     }
 
-    func testAddressSanitizer() throws {
-        try self.sanitizerTest(.address, expectedName: "address")
+    func testAddressSanitizer() async throws {
+        try await self.sanitizerTest(.address, expectedName: "address")
     }
 
-    func testThreadSanitizer() throws {
-        try self.sanitizerTest(.thread, expectedName: "thread")
+    func testThreadSanitizer() async throws {
+        try await self.sanitizerTest(.thread, expectedName: "thread")
     }
 
-    func testUndefinedSanitizer() throws {
-        try self.sanitizerTest(.undefined, expectedName: "undefined")
+    func testUndefinedSanitizer() async throws {
+        try await self.sanitizerTest(.undefined, expectedName: "undefined")
     }
 
-    func testScudoSanitizer() throws {
-        try self.sanitizerTest(.scudo, expectedName: "scudo")
+    func testScudoSanitizer() async throws {
+        try await self.sanitizerTest(.scudo, expectedName: "scudo")
     }
 
-    func testSnippets() throws {
+    func testSnippets() async throws {
         let fs: FileSystem = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/Lib/Lib.swift",
@@ -6064,7 +6082,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let plan = try mockBuildPlan(
+        let plan = try await mockBuildPlan(
             buildPath: buildPath,
             graph: graph,
             fileSystem: fs,
@@ -6091,7 +6109,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(yamlContents, .contains(inputs.underlying))
     }
 
-    private func sanitizerTest(_ sanitizer: PackageModel.Sanitizer, expectedName: String) throws {
+    private func sanitizerTest(_ sanitizer: PackageModel.Sanitizer, expectedName: String) async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -6118,7 +6136,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -6146,7 +6164,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(try result.buildProduct(for: "exe").linkArguments(), ["-sanitize=\(expectedName)"])
     }
 
-    func testBuildParameterLTOMode() throws {
+    func testBuildParameterLTOMode() async throws {
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -6172,7 +6190,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let toolchain = try UserToolchain.default
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             toolchain: toolchain,
             graph: graph,
             linkingParameters: .init(
@@ -6207,7 +6225,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testPackageDependencySetsUserModuleVersion() throws {
+    func testPackageDependencySetsUserModuleVersion() async throws {
         let fs = InMemoryFileSystem(emptyFiles: "/Pkg/Sources/exe/main.swift", "/ExtPkg/Sources/ExtLib/best.swift")
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -6244,7 +6262,7 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             environment: BuildEnvironment(
                 platform: .linux,
                 configuration: .release
@@ -6270,7 +6288,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testBasicSwiftPackageWithoutLocalRpath() throws {
+    func testBasicSwiftPackageWithoutLocalRpath() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -6294,7 +6312,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldDisableLocalRpath: true
@@ -6354,7 +6372,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     // testing of deriving dynamic libraries for explicitly linking rdar://108561857
-    func testDerivingDylibs() throws {
+    func testDerivingDylibs() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -6410,7 +6428,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -6433,7 +6451,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(dylibs, ["BarLogging", "FooLogging"])
     }
 
-    func testDefaultVersions() throws {
+    func testDefaultVersions() async throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/foo/foo.swift"
         )
@@ -6464,7 +6482,7 @@ final class BuildPlanTests: XCTestCase {
               observabilityScope: observability.topScope
             )
 
-            let result = try BuildPlanResult(plan: mockBuildPlan(
+            let result = try await BuildPlanResult(plan: mockBuildPlan(
               graph: graph,
               fileSystem: fs,
               observabilityScope: observability.topScope

--- a/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
+++ b/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
@@ -40,7 +40,7 @@ import func _InternalTestSupport.XCTAssertNoDiagnostics
 import XCTest
 
 final class CrossCompilationBuildPlanTests: XCTestCase {
-    func testEmbeddedWasmTarget() throws {
+    func testEmbeddedWasmTarget() async throws {
         var (graph, fs, observabilityScope) = try trivialPackageGraph()
 
         let triple = try Triple("wasm32-unknown-none-wasm")
@@ -49,7 +49,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
             shouldLinkStaticSwiftStdlib: true
         )
 
-        var result = try BuildPlanResult(plan: mockBuildPlan(
+        var result = try await BuildPlanResult(plan: mockBuildPlan(
             triple: triple,
             graph: graph,
             linkingParameters: linkingParameters,
@@ -78,7 +78,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
 
         (graph, fs, observabilityScope) = try embeddedCxxInteropPackageGraph()
 
-        result = try BuildPlanResult(plan: mockBuildPlan(
+        result = try await BuildPlanResult(plan: mockBuildPlan(
             triple: triple,
             graph: graph,
             linkingParameters: linkingParameters,
@@ -106,10 +106,10 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         )
     }
 
-    func testWasmTargetRelease() throws {
+    func testWasmTargetRelease() async throws {
         let (graph, fs, observabilityScope) = try trivialPackageGraph()
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             config: .release,
             triple: .wasi,
             graph: graph,
@@ -138,12 +138,12 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         )
     }
 
-    func testWASITarget() throws {
+    func testWASITarget() async throws {
         let pkgPath = AbsolutePath("/Pkg")
 
         let (graph, fs, observabilityScope) = try trivialPackageGraph()
 
-        let result = try BuildPlanResult(plan: mockBuildPlan(
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
             triple: .wasi,
             graph: graph,
             linkingParameters: .init(
@@ -224,12 +224,12 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         XCTAssertEqual(testPathExtension, "wasm")
     }
 
-    func testMacros() throws {
+    func testMacros() async throws {
         let (graph, fs, scope) = try macrosPackageGraph()
 
         let destinationTriple = Triple.arm64Linux
         let toolsTriple = Triple.x86_64MacOS
-        let plan = try BuildPlan(
+        let plan = try await BuildPlan(
             destinationBuildParameters: mockBuildParameters(
                 destination: .target,
                 shouldLinkStaticSwiftStdlib: true,
@@ -276,12 +276,12 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         )
     }
 
-    func testMacrosTests() throws {
+    func testMacrosTests() async throws {
         let (graph, fs, scope) = try macrosTestsPackageGraph()
 
         let destinationTriple = Triple.arm64Linux
         let toolsTriple = Triple.x86_64MacOS
-        let plan = try BuildPlan(
+        let plan = try await BuildPlan(
             destinationBuildParameters: mockBuildParameters(
                 destination: .target,
                 shouldLinkStaticSwiftStdlib: true,
@@ -330,13 +330,13 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         )
     }
 
-    func testToolsExplicitLibraries() throws {
+    func testToolsExplicitLibraries() async throws {
         let destinationTriple = Triple.arm64Linux
         let toolsTriple = Triple.x86_64MacOS
 
         for (linkage, productFileName) in [(ProductType.LibraryType.static, "libSwiftSyntax-tool.a"), (.dynamic, "libSwiftSyntax-tool.dylib")] {
             let (graph, fs, scope) = try toolsExplicitLibrariesGraph(linkage: linkage)
-            let plan = try BuildPlan(
+            let plan = try await BuildPlan(
                 destinationBuildParameters: mockBuildParameters(
                     destination: .target,
                     shouldLinkStaticSwiftStdlib: true,

--- a/Tests/BuildTests/LLBuildManifestBuilderTests.swift
+++ b/Tests/BuildTests/LLBuildManifestBuilderTests.swift
@@ -26,7 +26,7 @@ import _InternalTestSupport
 import XCTest
 
 final class LLBuildManifestBuilderTests: XCTestCase {
-    func testCreateProductCommand() throws {
+    func testCreateProductCommand() async throws {
         let pkg = AbsolutePath("/pkg")
         let fs = InMemoryFileSystem(
             emptyFiles:
@@ -50,7 +50,7 @@ final class LLBuildManifestBuilderTests: XCTestCase {
 
         // macOS, release build
 
-        var plan = try mockBuildPlan(
+        var plan = try await mockBuildPlan(
             environment: BuildEnvironment(
                 platform: .macOS,
                 configuration: .release
@@ -83,7 +83,7 @@ final class LLBuildManifestBuilderTests: XCTestCase {
 
         // macOS, debug build
 
-        plan = try mockBuildPlan(
+        plan = try await mockBuildPlan(
             environment: BuildEnvironment(
                 platform: .macOS,
                 configuration: .debug
@@ -135,7 +135,7 @@ final class LLBuildManifestBuilderTests: XCTestCase {
 
         // Linux, release build
 
-        plan = try mockBuildPlan(
+        plan = try await mockBuildPlan(
             environment: BuildEnvironment(
                 platform: .linux,
                 configuration: .release
@@ -164,7 +164,7 @@ final class LLBuildManifestBuilderTests: XCTestCase {
 
         // Linux, debug build
 
-        plan = try mockBuildPlan(
+        plan = try await mockBuildPlan(
             environment: BuildEnvironment(
                 platform: .linux,
                 configuration: .debug
@@ -193,12 +193,12 @@ final class LLBuildManifestBuilderTests: XCTestCase {
     }
     
     /// Verifies that two modules with the same name but different triples don't share same build manifest keys.
-    func testToolsBuildTriple() throws {
+    func testToolsBuildTriple() async throws {
         let (graph, fs, scope) = try macrosPackageGraph()
         let productsTriple = Triple.x86_64MacOS
         let toolsTriple = Triple.arm64Linux
 
-        let plan = try BuildPlan(
+        let plan = try await BuildPlan(
             destinationBuildParameters: mockBuildParameters(
                 destination: .target,
                 shouldLinkStaticSwiftStdlib: true,

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -25,7 +25,7 @@ import Workspace
 import XCTest
 
 final class ModuleAliasingBuildTests: XCTestCase {
-    func testModuleAliasingEmptyAlias() throws {
+    func testModuleAliasingEmptyAlias() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -75,7 +75,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         }
     }
 
-    func testModuleAliasingInvalidIdentifierAlias() throws {
+    func testModuleAliasingInvalidIdentifierAlias() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -128,7 +128,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         }
     }
 
-    func testModuleAliasingDuplicateProductNames() throws {
+    func testModuleAliasingDuplicateProductNames() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -187,7 +187,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -207,7 +207,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
     }
 
-    func testModuleAliasingDuplicateDylibProductNames() throws {
+    func testModuleAliasingDuplicateDylibProductNames() async throws {
         let fooPkg: AbsolutePath = "/fooPkg"
         let barPkg: AbsolutePath = "/barPkg"
         let fs = InMemoryFileSystem(
@@ -269,7 +269,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         }
     }
 
-    func testModuleAliasingDuplicateDylibStaticLibProductNames() throws {
+    func testModuleAliasingDuplicateDylibStaticLibProductNames() async throws {
         let fooPkg: AbsolutePath = "/fooPkg"
         let barPkg: AbsolutePath = "/barPkg"
         let fs = InMemoryFileSystem(
@@ -331,7 +331,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         }
     }
 
-    func testModuleAliasingDuplicateDylibAutomaticProductNames() throws {
+    func testModuleAliasingDuplicateDylibAutomaticProductNames() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -391,7 +391,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -418,7 +418,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         #endif
     }
 
-    func testModuleAliasingDuplicateStaticLibAutomaticProductNames() throws {
+    func testModuleAliasingDuplicateStaticLibAutomaticProductNames() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -477,7 +477,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -504,7 +504,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         #endif
     }
 
-    func testModuleAliasingDuplicateProductNamesUpstream() throws {
+    func testModuleAliasingDuplicateProductNamesUpstream() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -605,7 +605,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -637,7 +637,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         #endif
     }
 
-    func testModuleAliasingDirectDeps() throws {
+    func testModuleAliasingDirectDeps() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -703,7 +703,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -766,7 +766,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         #endif
     }
 
-    func testModuleAliasingDuplicateTargetNameInUpstream() throws {
+    func testModuleAliasingDuplicateTargetNameInUpstream() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -823,7 +823,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -876,7 +876,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         #endif
     }
 
-    func testModuleAliasingMultipleAliasesInProduct() throws {
+    func testModuleAliasingMultipleAliasesInProduct() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -940,7 +940,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         }
     }
 
-    func testModuleAliasingSameNameTargetsWithAliasesInMultiProducts() throws {
+    func testModuleAliasingSameNameTargetsWithAliasesInMultiProducts() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -999,7 +999,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -1022,7 +1022,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingInvalidSourcesUpstream() throws {
+    func testModuleAliasingInvalidSourcesUpstream() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -1077,7 +1077,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         }
     }
 
-    func testModuleAliasingInvalidSourcesNestedUpstream() throws {
+    func testModuleAliasingInvalidSourcesNestedUpstream() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -1148,7 +1148,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         }
     }
 
-    func testModuleAliasingInvalidSourcesInNonAliasedModulesUpstream() throws {
+    func testModuleAliasingInvalidSourcesInNonAliasedModulesUpstream() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -1200,7 +1200,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
     }
 
-    func testModuleAliasingInvalidSourcesInNonAliasedModulesNestedUpstream() throws {
+    func testModuleAliasingInvalidSourcesInNonAliasedModulesNestedUpstream() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -1268,7 +1268,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
     }
 
-    func testModuleAliasingDuplicateTargetNameInNestedUpstream() throws {
+    func testModuleAliasingDuplicateTargetNameInNestedUpstream() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -1330,7 +1330,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -1356,7 +1356,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
     }
 
-    func testModuleAliasingOverrideMultipleAliases() throws {
+    func testModuleAliasingOverrideMultipleAliases() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -1437,7 +1437,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -1473,7 +1473,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "BarLogging" })
     }
 
-    func testModuleAliasingAliasSkipUpstreamTargets() throws {
+    func testModuleAliasingAliasSkipUpstreamTargets() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -1640,7 +1640,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -1688,7 +1688,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingAllConflictingAliasesFromMultiProducts() throws {
+    func testModuleAliasingAllConflictingAliasesFromMultiProducts() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/aPkg/Sources/A/main.swift",
@@ -1817,7 +1817,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -1892,7 +1892,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
     }
 
-    func testModuleAliasingSomeConflictingAliasesInMultiProducts() throws {
+    func testModuleAliasingSomeConflictingAliasesInMultiProducts() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/aPkg/Sources/A/main.swift",
@@ -2032,7 +2032,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -2104,7 +2104,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
     }
 
-    func testModuleAliasingMergeAliasesOfSameTargets() throws {
+    func testModuleAliasingMergeAliasesOfSameTargets() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/aPkg/Sources/A/main.swift",
@@ -2251,7 +2251,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -2321,7 +2321,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
     }
 
-    func testModuleAliasingOverrideSameNameTargetAndDepWithAliases() throws {
+    func testModuleAliasingOverrideSameNameTargetAndDepWithAliases() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -2430,7 +2430,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -2474,7 +2474,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "GameUtils" })
     }
 
-    func testModuleAliasingAddOverrideAliasesUpstream() throws {
+    func testModuleAliasingAddOverrideAliasesUpstream() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -2576,7 +2576,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -2612,7 +2612,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingOverrideUpstreamTargetsWithAliases() throws {
+    func testModuleAliasingOverrideUpstreamTargetsWithAliases() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -2721,7 +2721,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -2761,7 +2761,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingOverrideUpstreamTargetsWithAliasesMultipleAliasesInProduct() throws {
+    func testModuleAliasingOverrideUpstreamTargetsWithAliasesMultipleAliasesInProduct() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -2873,7 +2873,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -2913,7 +2913,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingOverrideUpstreamTargetsWithAliasesDownstream() throws {
+    func testModuleAliasingOverrideUpstreamTargetsWithAliasesDownstream() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -3027,7 +3027,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -3071,7 +3071,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingSameTargetFromUpstreamWithoutAlias() throws {
+    func testModuleAliasingSameTargetFromUpstreamWithoutAlias() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -3142,7 +3142,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -3172,7 +3172,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
     }
 
-    func testModuleAliasingDuplicateTargetNamesFromMultiplePkgs() throws {
+    func testModuleAliasingDuplicateTargetNamesFromMultiplePkgs() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/thisPkg/Sources/exe/main.swift",
@@ -3255,7 +3255,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -3289,7 +3289,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
     }
 
-    func testModuleAliasingTargetAndProductTargetWithSameName() throws {
+    func testModuleAliasingTargetAndProductTargetWithSameName() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -3335,7 +3335,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -3357,7 +3357,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingProductTargetsWithSameName1() throws {
+    func testModuleAliasingProductTargetsWithSameName1() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -3483,7 +3483,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -3517,7 +3517,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingUpstreamProductTargetsWithSameName2() throws {
+    func testModuleAliasingUpstreamProductTargetsWithSameName2() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -3659,7 +3659,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -3691,7 +3691,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingUpstreamProductTargetsWithSameName3() throws {
+    func testModuleAliasingUpstreamProductTargetsWithSameName3() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -3794,7 +3794,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -3821,7 +3821,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingUpstreamProductTargetsWithSameName4() throws {
+    func testModuleAliasingUpstreamProductTargetsWithSameName4() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -3924,7 +3924,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -3951,7 +3951,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingChainedAliases1() throws {
+    func testModuleAliasingChainedAliases1() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -4067,7 +4067,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -4110,7 +4110,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingChainedAliases2() throws {
+    func testModuleAliasingChainedAliases2() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -4241,7 +4241,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -4278,7 +4278,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingChainedAliases3() throws {
+    func testModuleAliasingChainedAliases3() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -4413,7 +4413,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -4457,7 +4457,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingChainedAliases5() throws {
+    func testModuleAliasingChainedAliases5() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/appPkg/Sources/App/main.swift",
@@ -4582,7 +4582,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -4619,7 +4619,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
     }
 
-    func testProductAliasingDoesNotBreakPackagesWithOlderToolsVersions() throws {
+    func testProductAliasingDoesNotBreakPackagesWithOlderToolsVersions() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Lunch/Sources/MyTarget/file.swift",
@@ -4679,7 +4679,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = try BuildPlanResult(plan: try mockBuildPlan(
+        let result = try await BuildPlanResult(plan: try mockBuildPlan(
             graph: graph,
             linkingParameters: .init(
                 shouldLinkStaticSwiftStdlib: true
@@ -4690,7 +4690,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkTargetsCount(3)
     }
 
-    func testProductAliasingWarnsIfPackageWithOlderToolsVersionIsPossibleCauseOfConflict() throws {
+    func testProductAliasingWarnsIfPackageWithOlderToolsVersionIsPossibleCauseOfConflict() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Lunch/Sources/MyTarget/file.swift",

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -23,10 +23,10 @@ import class PackageModel.Manifest
 import struct PackageModel.TargetDescription
 
 class PrepareForIndexTests: XCTestCase {
-    func testPrepare() throws {
+    func testPrepare() async throws {
         let (graph, fs, scope) = try macrosPackageGraph()
 
-        let plan = try BuildPlan(
+        let plan = try await BuildPlan(
             destinationBuildParameters: mockBuildParameters(destination: .target, prepareForIndexing: .on),
             toolsBuildParameters: mockBuildParameters(destination: .host, prepareForIndexing: .off),
             graph: graph,
@@ -68,10 +68,10 @@ class PrepareForIndexTests: XCTestCase {
         )
     }
 
-    func testCModuleTarget() throws {
+    func testCModuleTarget() async throws {
         let (graph, fs, scope) = try trivialPackageGraph()
 
-        let plan = try BuildPlan(
+        let plan = try await BuildPlan(
             destinationBuildParameters: mockBuildParameters(destination: .target, prepareForIndexing: .on),
             toolsBuildParameters: mockBuildParameters(destination: .host, prepareForIndexing: .off),
             graph: graph,
@@ -88,7 +88,7 @@ class PrepareForIndexTests: XCTestCase {
     }
 
     // enable-testing requires the non-exportable-decls, make sure they aren't skipped.
-    func testEnableTesting() throws {
+    func testEnableTesting() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/lib/lib.swift",
@@ -115,7 +115,7 @@ class PrepareForIndexTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         // Under debug, enable-testing is turned on by default. Make sure the flag is not added.
-        let debugPlan = try BuildPlan(
+        let debugPlan = try await BuildPlan(
             destinationBuildParameters: mockBuildParameters(destination: .target, config: .debug, prepareForIndexing: .on),
             toolsBuildParameters: mockBuildParameters(destination: .host, prepareForIndexing: .off),
             graph: graph,
@@ -136,7 +136,7 @@ class PrepareForIndexTests: XCTestCase {
         }))
 
         // Under release, enable-testing is turned off by default so we should see our flag
-        let releasePlan = try BuildPlan(
+        let releasePlan = try await BuildPlan(
             destinationBuildParameters: mockBuildParameters(destination: .target, config: .release, prepareForIndexing: .on),
             toolsBuildParameters: mockBuildParameters(destination: .host, prepareForIndexing: .off),
             graph: graph,
@@ -157,10 +157,10 @@ class PrepareForIndexTests: XCTestCase {
         }).count, 1)
     }
 
-    func testPrepareNoLazy() throws {
+    func testPrepareNoLazy() async throws {
         let (graph, fs, scope) = try macrosPackageGraph()
 
-        let plan = try BuildPlan(
+        let plan = try await BuildPlan(
             destinationBuildParameters: mockBuildParameters(destination: .target, prepareForIndexing: .noLazy),
             toolsBuildParameters: mockBuildParameters(destination: .host, prepareForIndexing: .off),
             graph: graph,

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -27,7 +27,7 @@ import protocol TSCBasic.OutputByteStream
 import var TSCBasic.stderrStream
 
 final class SwiftCommandStateTests: CommandsTestCase {
-    func testVerbosityLogLevel() throws {
+    func testVerbosityLogLevel() async throws {
         try fixture(name: "Miscellaneous/Simple") { fixturePath in
             do {
                 let outputStream = BufferedOutputByteStream()
@@ -164,7 +164,7 @@ final class SwiftCommandStateTests: CommandsTestCase {
         }
     }
 
-    func testAuthorizationProviders() throws {
+    func testAuthorizationProviders() async throws {
         try fixture(name: "DependencyResolution/External/XCFramework") { fixturePath in
             let fs = localFileSystem
 
@@ -199,7 +199,7 @@ final class SwiftCommandStateTests: CommandsTestCase {
         }
     }
 
-    func testRegistryAuthorizationProviders() throws {
+    func testRegistryAuthorizationProviders() async throws {
         try fixture(name: "DependencyResolution/External/XCFramework") { fixturePath in
             let fs = localFileSystem
 
@@ -239,7 +239,7 @@ final class SwiftCommandStateTests: CommandsTestCase {
         }
     }
 
-    func testDebugFormatFlags() throws {
+    func testDebugFormatFlags() async throws {
         let fs = InMemoryFileSystem(emptyFiles: [
             "/Pkg/Sources/exe/main.swift",
         ])
@@ -257,7 +257,7 @@ final class SwiftCommandStateTests: CommandsTestCase {
         /* -debug-info-format dwarf */
         let explicitDwarfOptions = try GlobalOptions.parse(["--triple", "x86_64-unknown-windows-msvc", "-debug-info-format", "dwarf"])
         let explicitDwarf = try SwiftCommandState.makeMockState(options: explicitDwarfOptions)
-        plan = try BuildPlan(
+        plan = try await BuildPlan(
             destinationBuildParameters: explicitDwarf.productsBuildParameters,
             toolsBuildParameters: explicitDwarf.toolsBuildParameters,
             graph: graph,
@@ -272,7 +272,7 @@ final class SwiftCommandStateTests: CommandsTestCase {
         let explicitCodeViewOptions = try GlobalOptions.parse(["--triple", "x86_64-unknown-windows-msvc", "-debug-info-format", "codeview"])
         let explicitCodeView = try SwiftCommandState.makeMockState(options: explicitCodeViewOptions)
 
-        plan = try BuildPlan(
+        plan = try await BuildPlan(
             destinationBuildParameters: explicitCodeView.productsBuildParameters,
             toolsBuildParameters: explicitCodeView.productsBuildParameters,
             graph: graph,
@@ -295,7 +295,7 @@ final class SwiftCommandStateTests: CommandsTestCase {
         /* <<null>> */
         let implicitDwarfOptions = try GlobalOptions.parse(["--triple", "x86_64-unknown-windows-msvc"])
         let implicitDwarf = try SwiftCommandState.makeMockState(options: implicitDwarfOptions)
-        plan = try BuildPlan(
+        plan = try await BuildPlan(
             destinationBuildParameters: implicitDwarf.productsBuildParameters,
             toolsBuildParameters: implicitDwarf.toolsBuildParameters,
             graph: graph,
@@ -308,7 +308,7 @@ final class SwiftCommandStateTests: CommandsTestCase {
         /* -debug-info-format none */
         let explicitNoDebugInfoOptions = try GlobalOptions.parse(["--triple", "x86_64-unknown-windows-msvc", "-debug-info-format", "none"])
         let explicitNoDebugInfo = try SwiftCommandState.makeMockState(options: explicitNoDebugInfoOptions)
-        plan = try BuildPlan(
+        plan = try await BuildPlan(
             destinationBuildParameters: explicitNoDebugInfo.productsBuildParameters,
             toolsBuildParameters: explicitNoDebugInfo.toolsBuildParameters,
             graph: graph,
@@ -319,7 +319,7 @@ final class SwiftCommandStateTests: CommandsTestCase {
                            [.anySequence, "-gnone", .anySequence])
     }
 
-    func testToolchainArgument() throws {
+    func testToolchainArgument() async throws {
         let customTargetToolchain = AbsolutePath("/path/to/toolchain")
         let hostSwiftcPath = AbsolutePath("/usr/bin/swiftc")
         let hostArPath = AbsolutePath("/usr/bin/ar")
@@ -371,7 +371,7 @@ final class SwiftCommandStateTests: CommandsTestCase {
             try swiftCommandState.getTargetToolchain().swiftSDK.toolset.knownTools[.swiftCompiler]?.path,
             nil
         )
-        let plan = try BuildPlan(
+        let plan = try await BuildPlan(
             destinationBuildParameters: swiftCommandState.productsBuildParameters,
             toolsBuildParameters: swiftCommandState.toolsBuildParameters,
             graph: graph,

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -32,7 +32,7 @@ import struct Build.PluginConfiguration
 import struct TSCUtility.SerializedDiagnostics
 
 final class PluginInvocationTests: XCTestCase {
-    func testBasics() throws {
+    func testBasics() async throws {
         // Construct a canned file system and package graph with a single package and a library that uses a build tool plugin that invokes a tool.
         let fileSystem = InMemoryFileSystem(emptyFiles:
             "/Foo/Plugins/FooPlugin/source.swift",
@@ -216,7 +216,7 @@ final class PluginInvocationTests: XCTestCase {
             environment: BuildEnvironment(platform: .macOS, configuration: .debug)
         )
 
-        let results = try invokeBuildToolPlugins(
+        let results = try await invokeBuildToolPlugins(
             graph: graph,
             buildParameters: buildParameters,
             fileSystem: fileSystem,
@@ -914,7 +914,7 @@ final class PluginInvocationTests: XCTestCase {
                     environment: BuildEnvironment(platform: .macOS, configuration: .debug)
                 )
 
-                let result = try invokeBuildToolPlugins(
+                let result = try await invokeBuildToolPlugins(
                     graph: packageGraph,
                     buildParameters: buildParameters,
                     fileSystem: localFileSystem,
@@ -1268,7 +1268,7 @@ final class PluginInvocationTests: XCTestCase {
                 environment: BuildEnvironment(platform: .macOS, configuration: .debug)
             )
 
-            return try invokeBuildToolPlugins(
+            return try await invokeBuildToolPlugins(
                 graph: packageGraph,
                 buildParameters: buildParameters,
                 fileSystem: localFileSystem,
@@ -1331,7 +1331,7 @@ final class PluginInvocationTests: XCTestCase {
         outputDir: AbsolutePath,
         pluginScriptRunner: PluginScriptRunner,
         observabilityScope: ObservabilityScope
-    ) throws -> [ResolvedModule.ID: (target: ResolvedModule, results: [BuildToolPluginInvocationResult])] {
+    ) async throws -> [ResolvedModule.ID: (target: ResolvedModule, results: [BuildToolPluginInvocationResult])] {
         let pluginsPerModule = graph.pluginsPerModule(
             satisfying: buildParameters.buildEnvironment
         )
@@ -1354,7 +1354,7 @@ final class PluginInvocationTests: XCTestCase {
         for (moduleID, _) in pluginsPerModule {
             let module = graph.allModules[moduleID]!
 
-            let results = try BuildPlan.invokeBuildToolPlugins(
+            let results = try await BuildPlan.invokeBuildToolPlugins(
                 for: module,
                 configuration: pluginConfiguration,
                 buildParameters: buildParameters,

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -22,7 +22,7 @@ import _InternalTestSupport
 import XCTest
 
 final class SourceKitLSPAPITests: XCTestCase {
-    func testBasicSwiftPackage() throws {
+    func testBasicSwiftPackage() async throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/exe/main.swift",
             "/Pkg/Sources/lib/lib.swift",
@@ -46,7 +46,7 @@ final class SourceKitLSPAPITests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try BuildPlan(
+        let plan = try await BuildPlan(
             destinationBuildParameters: mockBuildParameters(
                 destination: .target,
                 shouldLinkStaticSwiftStdlib: true


### PR DESCRIPTION
Remove `temp_await` from build related code

### Motivation:

`temp_await` is unsafe and it would be better to use true async methods

### Modifications:

Remove `temp_await` from BuildPlan
Remove `temp_await` from BuildOperation

### Result:

Safer more modern Swift code
