### PR TITLE
[SourceKitLSPAPI] Adjust `BuildDescription` APIs use use build plan

### DIFF
--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -35,8 +35,16 @@ struct PluginTargetBuildDescription: BuildTarget {
         self.isPartOfRootPackage = isPartOfRootPackage
     }
 
+    public var root: URL {
+        return target.sources.root.asURL
+    }
+
     var sources: [URL] {
         return target.sources.paths.map { URL(fileURLWithPath: $0.pathString) }
+    }
+
+    var paths: [URL] {
+        return target.sources.paths.map(\.asURL)
     }
 
     var name: String {


### PR DESCRIPTION
These changes represent one my step towards the goal of removing `buildTriple` from `Resolved{Product, Module}`.

### Motivation:

Instead using modules graph and lookup descriptions up, let's provide API to fetch all available modules which has all of the information needed by the sourcekit-lsp at the moment. In the future we could add an additional `getDescription` method if it becomes necessary.

### Modifications:

- Add `paths` and `root` to `BuildTarget` to expose information necessary to construct some sourcekit-lsp internal data structures while reloading packages.

- Remove `BuildDescription.getBuildTarget`
- Replace `allTargetsInTopologicalOrder` with `allModules`.

### Result:

Package reloading that happens in sourcekit-lsp is now based purely on build plan information which facilitates `buildTriple` removal from `Resolved{Product, Module}`.
