### PR TITLE
[PackageModel] UserToolchain: Add Testing framework from commandline …

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -416,7 +416,11 @@ public final class UserToolchain: Toolchain {
             validating: "../../Library/Developer/Frameworks",
             relativeTo: resolveSymlinks(derivedSwiftCompiler).parentDirectory
         ), fileSystem.exists(frameworksPath.appending("Testing.framework")) {
-            return ["-F", frameworksPath.pathString]
+            return [
+                "-F", frameworksPath.pathString,
+                "-Xlinker", "-rpath",
+                "-Xlinker", frameworksPath.pathString
+            ]
         }
 
         guard let toolchainLibDir = try? toolchainLibDir(


### PR DESCRIPTION
…tools to `RPATH`

### Motivation:

The framework is not autolinked and requires `-Xlinker -rpath` flag together with `-F` while building.

### Modifications:

- Added `-Xlinker -rpath -Xlinker <frameworks>` argument for Testing.framework location in `deriveMacOSSpecificSwiftTestingFlags`.

### Result:

Fixes missing symbols while trying to run swift-testing tests without Xcode selected. 
