### PR TITLE
Remove usage of `temp_await` in PackageContainer

### DIFF
--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -44,25 +44,25 @@ public protocol PackageContainer {
     var shouldInvalidatePinnedVersions: Bool { get }
 
     /// Returns true if the tools version is compatible at the given version.
-    func isToolsVersionCompatible(at version: Version) -> Bool
+    func isToolsVersionCompatible(at version: Version) async -> Bool
 
     /// Returns the tools version for the given version
-    func toolsVersion(for version: Version) throws -> ToolsVersion
+    func toolsVersion(for version: Version) async throws -> ToolsVersion
 
     /// Get the list of versions which are available for the package.
     ///
     /// The list will be returned in sorted order, with the latest version *first*.
     /// All versions will not be requested at once. Resolver will request the next one only
     /// if the previous one did not satisfy all constraints.
-    func toolsVersionsAppropriateVersionsDescending() throws -> [Version]
+    func toolsVersionsAppropriateVersionsDescending() async throws -> [Version]
 
     /// Get the list of versions in the repository sorted in the ascending order, that is the earliest
     /// version appears first.
-    func versionsAscending() throws -> [Version]
+    func versionsAscending() async throws -> [Version]
 
     /// Get the list of versions in the repository sorted in the descending order, that is the latest
     /// version appears first.
-    func versionsDescending() throws -> [Version]
+    func versionsDescending() async throws -> [Version]
 
     // FIXME: We should perhaps define some particularly useful error codes
     // here, so the resolver can handle errors more meaningfully.
@@ -75,7 +75,7 @@ public protocol PackageContainer {
     /// - Precondition: `versions.contains(version)`
     /// - Throws: If the version could not be resolved; this will abort
     ///   dependency resolution completely.
-    func getDependencies(at version: Version, productFilter: ProductFilter) throws -> [PackageContainerConstraint]
+    func getDependencies(at version: Version, productFilter: ProductFilter) async throws -> [PackageContainerConstraint]
 
     /// Fetch the declared dependencies for a particular revision.
     ///
@@ -84,28 +84,28 @@ public protocol PackageContainer {
     ///
     /// - Throws: If the revision could not be resolved; this will abort
     ///   dependency resolution completely.
-    func getDependencies(at revision: String, productFilter: ProductFilter) throws -> [PackageContainerConstraint]
+    func getDependencies(at revision: String, productFilter: ProductFilter) async throws -> [PackageContainerConstraint]
 
     /// Fetch the dependencies of an unversioned package container.
     ///
     /// NOTE: This method should not be called on a versioned container.
-    func getUnversionedDependencies(productFilter: ProductFilter) throws -> [PackageContainerConstraint]
+    func getUnversionedDependencies(productFilter: ProductFilter) async throws -> [PackageContainerConstraint]
 
     /// Get the updated identifier at a bound version.
     ///
     /// This can be used by the containers to fill in the missing information that is obtained
     /// after the container is available. The updated identifier is returned in result of the
     /// dependency resolution.
-    func loadPackageReference(at boundVersion: BoundVersion) throws -> PackageReference
+    func loadPackageReference(at boundVersion: BoundVersion) async throws -> PackageReference
 }
 
 extension PackageContainer {
-    public func reversedVersions() throws -> [Version] {
-        try self.versionsDescending()
+    public func reversedVersions() async throws -> [Version] {
+        try await self.versionsDescending()
     }
 
-    public func versionsDescending() throws -> [Version] {
-        try self.versionsAscending().reversed()
+    public func versionsDescending() async throws -> [Version] {
+        try await self.versionsAscending().reversed()
     }
 
     public var shouldInvalidatePinnedVersions: Bool {

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import OrderedCollections
 import PackageModel
 
@@ -45,11 +46,11 @@ final class PubGrubPackageContainer {
     }
 
     /// Returns the numbers of versions that are satisfied by the given version requirement.
-    func versionCount(_ requirement: VersionSetSpecifier) throws -> Int {
+    func versionCount(_ requirement: VersionSetSpecifier) async throws -> Int {
         if let pinnedVersion, requirement.contains(pinnedVersion) {
             return 1
         }
-        return try self.underlying.versionsDescending().filter(requirement.contains).count
+        return try await self.underlying.versionsDescending().filter(requirement.contains).count
     }
 
     /// Computes the bounds of the given range against the versions available in the package.
@@ -57,11 +58,11 @@ final class PubGrubPackageContainer {
     /// `includesLowerBound` is `false` if range's lower bound is less than or equal to the lowest available version.
     /// Similarly, `includesUpperBound` is `false` if range's upper bound is greater than or equal to the highest
     /// available version.
-    func computeBounds(for range: Range<Version>) throws -> (includesLowerBound: Bool, includesUpperBound: Bool) {
+    func computeBounds(for range: Range<Version>) async throws -> (includesLowerBound: Bool, includesUpperBound: Bool) {
         var includeLowerBound = true
         var includeUpperBound = true
 
-        let versions = try self.underlying.versionsDescending()
+        let versions = try await self.underlying.versionsDescending()
 
         if let last = versions.last, range.lowerBound < last {
             includeLowerBound = false
@@ -75,7 +76,7 @@ final class PubGrubPackageContainer {
     }
 
     /// Returns the best available version for a given term.
-    func getBestAvailableVersion(for term: Term) throws -> Version? {
+    func getBestAvailableVersion(for term: Term) async throws -> Version? {
         assert(term.isPositive, "Expected term to be positive")
         var versionSet = term.requirement
 
@@ -86,7 +87,7 @@ final class PubGrubPackageContainer {
                     versionSet = .exact(pinnedVersion)
                 } else {
                     // Make sure the pinned version is still available
-                    let version = try self.underlying.versionsDescending().first { pinnedVersion == $0 }
+                    let version = try await self.underlying.versionsDescending().first { pinnedVersion == $0 }
                     if version != nil {
                         return version
                     }
@@ -95,13 +96,14 @@ final class PubGrubPackageContainer {
         }
 
         // Return the highest version that is allowed by the input requirement.
-        return try self.underlying.versionsDescending().first { versionSet.contains($0) }
+        return try await self.underlying.versionsDescending().first { versionSet.contains($0) }
     }
 
     /// Compute the bounds of incompatible tools version starting from the given version.
-    private func computeIncompatibleToolsVersionBounds(fromVersion: Version) throws -> VersionSetSpecifier {
-        assert(!self.underlying.isToolsVersionCompatible(at: fromVersion))
-        let versions: [Version] = try self.underlying.versionsAscending()
+    private func computeIncompatibleToolsVersionBounds(fromVersion: Version) async throws -> VersionSetSpecifier {
+        // TODO: do we really want to compute this for an assert?
+        // assert(!self.underlying.isToolsVersionCompatible(at: fromVersion))
+        let versions: [Version] = try await self.underlying.versionsAscending()
 
         // This is guaranteed to be present.
         let idx = versions.firstIndex(of: fromVersion)!
@@ -110,7 +112,7 @@ final class PubGrubPackageContainer {
         var upperBound = fromVersion
 
         for version in versions.dropFirst(idx + 1) {
-            let isToolsVersionCompatible = self.underlying.isToolsVersionCompatible(at: version)
+            let isToolsVersionCompatible = await self.underlying.isToolsVersionCompatible(at: version)
             if isToolsVersionCompatible {
                 break
             }
@@ -118,7 +120,7 @@ final class PubGrubPackageContainer {
         }
 
         for version in versions.dropLast(versions.count - idx).reversed() {
-            let isToolsVersionCompatible = self.underlying.isToolsVersionCompatible(at: version)
+            let isToolsVersionCompatible = await self.underlying.isToolsVersionCompatible(at: version)
             if isToolsVersionCompatible {
                 break
             }
@@ -153,11 +155,11 @@ final class PubGrubPackageContainer {
         node: DependencyResolutionNode,
         overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)],
         root: DependencyResolutionNode
-    ) throws -> [Incompatibility] {
+    ) async throws -> [Incompatibility] {
         // FIXME: It would be nice to compute bounds for this as well.
-        if !self.underlying.isToolsVersionCompatible(at: version) {
-            let requirement = try self.computeIncompatibleToolsVersionBounds(fromVersion: version)
-            let toolsVersion = try self.underlying.toolsVersion(for: version)
+        if await !self.underlying.isToolsVersionCompatible(at: version) {
+            let requirement = try await self.computeIncompatibleToolsVersionBounds(fromVersion: version)
+            let toolsVersion = try await self.underlying.toolsVersion(for: version)
             return try [Incompatibility(
                 Term(node, requirement),
                 root: root,
@@ -165,7 +167,7 @@ final class PubGrubPackageContainer {
             )]
         }
 
-        var unprocessedDependencies = try self.underlying.getDependencies(
+        var unprocessedDependencies = try await self.underlying.getDependencies(
             at: version,
             productFilter: node.productFilter
         )

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -31,7 +31,7 @@ struct SignatureValidation {
 
     private let skipSignatureValidation: Bool
     private let signingEntityTOFU: PackageSigningEntityTOFU
-    private let versionMetadataProvider: (PackageIdentity.RegistryIdentity, Version) throws -> RegistryClient
+    private let versionMetadataProvider: (PackageIdentity.RegistryIdentity, Version) async throws -> RegistryClient
         .PackageVersionMetadata
     private let delegate: Delegate
 
@@ -39,7 +39,7 @@ struct SignatureValidation {
         skipSignatureValidation: Bool,
         signingEntityStorage: PackageSigningEntityStorage?,
         signingEntityCheckingMode: SigningEntityCheckingMode,
-        versionMetadataProvider: @escaping (PackageIdentity.RegistryIdentity, Version) throws -> RegistryClient
+        versionMetadataProvider: @escaping (PackageIdentity.RegistryIdentity, Version) async throws -> RegistryClient
             .PackageVersionMetadata,
         delegate: Delegate
     ) {
@@ -140,93 +140,95 @@ struct SignatureValidation {
         callbackQueue: DispatchQueue,
         completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
     ) {
-        do {
-            let versionMetadata = try self.versionMetadataProvider(package, version)
+        Task {
+            do {
+                let versionMetadata = try await self.versionMetadataProvider(package, version)
 
-            guard let sourceArchiveResource = versionMetadata.sourceArchive else {
-                throw RegistryError.missingSourceArchive
-            }
-            guard let signatureBase64Encoded = sourceArchiveResource.signing?.signatureBase64Encoded else {
-                throw RegistryError.sourceArchiveNotSigned(
+                guard let sourceArchiveResource = versionMetadata.sourceArchive else {
+                    throw RegistryError.missingSourceArchive
+                }
+                guard let signatureBase64Encoded = sourceArchiveResource.signing?.signatureBase64Encoded else {
+                    throw RegistryError.sourceArchiveNotSigned(
+                        registry: registry,
+                        package: package.underlying,
+                        version: version
+                    )
+                }
+
+                guard let signatureData = Data(base64Encoded: signatureBase64Encoded) else {
+                    throw RegistryError.failedLoadingSignature
+                }
+                guard let signatureFormatString = sourceArchiveResource.signing?.signatureFormat else {
+                    throw RegistryError.missingSignatureFormat
+                }
+                guard let signatureFormat = SignatureFormat(rawValue: signatureFormatString) else {
+                    throw RegistryError.unknownSignatureFormat(signatureFormatString)
+                }
+
+                self.validateSourceArchiveSignature(
+                    registry: registry,
+                    package: package,
+                    version: version,
+                    signature: Array(signatureData),
+                    signatureFormat: signatureFormat,
+                    content: Array(content),
+                    configuration: configuration,
+                    fileSystem: fileSystem,
+                    observabilityScope: observabilityScope,
+                    completion: completion
+                )
+            } catch RegistryError.sourceArchiveNotSigned {
+                observabilityScope.emit(
+                    info: "\(package) \(version) from \(registry) is unsigned",
+                    metadata: .registryPackageMetadata(identity: package)
+                )
+                guard let onUnsigned = configuration.onUnsigned else {
+                    return completion(.failure(RegistryError.missingConfiguration(details: "security.signing.onUnsigned")))
+                }
+
+                let sourceArchiveNotSignedError = RegistryError.sourceArchiveNotSigned(
                     registry: registry,
                     package: package.underlying,
                     version: version
                 )
-            }
 
-            guard let signatureData = Data(base64Encoded: signatureBase64Encoded) else {
-                throw RegistryError.failedLoadingSignature
-            }
-            guard let signatureFormatString = sourceArchiveResource.signing?.signatureFormat else {
-                throw RegistryError.missingSignatureFormat
-            }
-            guard let signatureFormat = SignatureFormat(rawValue: signatureFormatString) else {
-                throw RegistryError.unknownSignatureFormat(signatureFormatString)
-            }
-
-            self.validateSourceArchiveSignature(
-                registry: registry,
-                package: package,
-                version: version,
-                signature: Array(signatureData),
-                signatureFormat: signatureFormat,
-                content: Array(content),
-                configuration: configuration,
-                fileSystem: fileSystem,
-                observabilityScope: observabilityScope,
-                completion: completion
-            )
-        } catch RegistryError.sourceArchiveNotSigned {
-            observabilityScope.emit(
-                info: "\(package) \(version) from \(registry) is unsigned",
-                metadata: .registryPackageMetadata(identity: package)
-            )
-            guard let onUnsigned = configuration.onUnsigned else {
-                return completion(.failure(RegistryError.missingConfiguration(details: "security.signing.onUnsigned")))
-            }
-
-            let sourceArchiveNotSignedError = RegistryError.sourceArchiveNotSigned(
-                registry: registry,
-                package: package.underlying,
-                version: version
-            )
-
-            switch onUnsigned {
-            case .prompt:
-                self.delegate
-                    .onUnsigned(registry: registry, package: package.underlying, version: version) { `continue` in
-                        if `continue` {
-                            completion(.success(.none))
-                        } else {
-                            completion(.failure(sourceArchiveNotSignedError))
+                switch onUnsigned {
+                case .prompt:
+                    self.delegate
+                        .onUnsigned(registry: registry, package: package.underlying, version: version) { `continue` in
+                            if `continue` {
+                                completion(.success(.none))
+                            } else {
+                                completion(.failure(sourceArchiveNotSignedError))
+                            }
                         }
-                    }
-            case .error:
-                completion(.failure(sourceArchiveNotSignedError))
-            case .warn:
-                observabilityScope.emit(
-                    warning: "\(sourceArchiveNotSignedError)",
-                    metadata: .registryPackageMetadata(identity: package)
-                )
-                completion(.success(.none))
-            case .silentAllow:
-                // Continue without logging
-                completion(.success(.none))
+                case .error:
+                    completion(.failure(sourceArchiveNotSignedError))
+                case .warn:
+                    observabilityScope.emit(
+                        warning: "\(sourceArchiveNotSignedError)",
+                        metadata: .registryPackageMetadata(identity: package)
+                    )
+                    completion(.success(.none))
+                case .silentAllow:
+                    // Continue without logging
+                    completion(.success(.none))
+                }
+            } catch RegistryError.failedRetrievingReleaseInfo(_, _, _, let error) {
+                completion(.failure(RegistryError.failedRetrievingSourceArchiveSignature(
+                    registry: registry,
+                    package: package.underlying,
+                    version: version,
+                    error: error
+                )))
+            } catch {
+                completion(.failure(RegistryError.failedRetrievingSourceArchiveSignature(
+                    registry: registry,
+                    package: package.underlying,
+                    version: version,
+                    error: error
+                )))
             }
-        } catch RegistryError.failedRetrievingReleaseInfo(_, _, _, let error) {
-            completion(.failure(RegistryError.failedRetrievingSourceArchiveSignature(
-                registry: registry,
-                package: package.underlying,
-                version: version,
-                error: error
-            )))
-        } catch {
-            completion(.failure(RegistryError.failedRetrievingSourceArchiveSignature(
-                registry: registry,
-                package: package.underlying,
-                version: version,
-                error: error
-            )))
         }
     }
 
@@ -405,94 +407,96 @@ struct SignatureValidation {
         completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
     ) {
         let manifestName = toolsVersion.map { "Package@swift-\($0).swift" } ?? Manifest.filename
+        Task {
+            do {
+                let versionMetadata = try await self.versionMetadataProvider(package, version)
 
-        do {
-            let versionMetadata = try self.versionMetadataProvider(package, version)
-
-            guard let sourceArchiveResource = versionMetadata.sourceArchive else {
-                observabilityScope
-                    .emit(
-                        debug: "cannot determine if \(manifestName) should be signed because source archive for \(package) \(version) is not found in \(registry)",
-                        metadata: .registryPackageMetadata(identity: package)
+                guard let sourceArchiveResource = versionMetadata.sourceArchive else {
+                    observabilityScope
+                        .emit(
+                            debug: "cannot determine if \(manifestName) should be signed because source archive for \(package) \(version) is not found in \(registry)",
+                            metadata: .registryPackageMetadata(identity: package)
+                        )
+                    return completion(.success(.none))
+                }
+                guard sourceArchiveResource.signing?.signatureBase64Encoded != nil else {
+                    throw RegistryError.sourceArchiveNotSigned(
+                        registry: registry,
+                        package: package.underlying,
+                        version: version
                     )
-                return completion(.success(.none))
-            }
-            guard sourceArchiveResource.signing?.signatureBase64Encoded != nil else {
-                throw RegistryError.sourceArchiveNotSigned(
+                }
+
+                // source archive is signed, so the manifest must also be signed
+                guard let manifestSignature = try ManifestSignatureParser.parse(utf8String: manifestContent) else {
+                    return completion(.failure(RegistryError.manifestNotSigned(
+                        registry: registry,
+                        package: package.underlying,
+                        version: version,
+                        toolsVersion: toolsVersion
+                    )))
+                }
+
+                guard let signatureFormat = SignatureFormat(rawValue: manifestSignature.signatureFormat) else {
+                    return completion(.failure(RegistryError.unknownSignatureFormat(manifestSignature.signatureFormat)))
+                }
+
+                self.validateManifestSignature(
+                    registry: registry,
+                    package: package,
+                    version: version,
+                    manifestName: manifestName,
+                    signature: manifestSignature.signature,
+                    signatureFormat: signatureFormat,
+                    content: manifestSignature.contents,
+                    configuration: configuration,
+                    fileSystem: fileSystem,
+                    observabilityScope: observabilityScope,
+                    completion: completion
+                )
+            } catch RegistryError.sourceArchiveNotSigned {
+                observabilityScope.emit(
+                    debug: "\(manifestName) is not signed because source archive for \(package) \(version) from \(registry) is not signed",
+                    metadata: .registryPackageMetadata(identity: package)
+                )
+                guard let onUnsigned = configuration.onUnsigned else {
+                    return completion(.failure(RegistryError.missingConfiguration(details: "security.signing.onUnsigned")))
+                }
+
+                let sourceArchiveNotSignedError = RegistryError.sourceArchiveNotSigned(
                     registry: registry,
                     package: package.underlying,
                     version: version
                 )
-            }
 
-            // source archive is signed, so the manifest must also be signed
-            guard let manifestSignature = try ManifestSignatureParser.parse(utf8String: manifestContent) else {
-                return completion(.failure(RegistryError.manifestNotSigned(
-                    registry: registry,
-                    package: package.underlying,
-                    version: version,
-                    toolsVersion: toolsVersion
-                )))
-            }
-
-            guard let signatureFormat = SignatureFormat(rawValue: manifestSignature.signatureFormat) else {
-                return completion(.failure(RegistryError.unknownSignatureFormat(manifestSignature.signatureFormat)))
-            }
-
-            self.validateManifestSignature(
-                registry: registry,
-                package: package,
-                version: version,
-                manifestName: manifestName,
-                signature: manifestSignature.signature,
-                signatureFormat: signatureFormat,
-                content: manifestSignature.contents,
-                configuration: configuration,
-                fileSystem: fileSystem,
-                observabilityScope: observabilityScope,
-                completion: completion
-            )
-        } catch RegistryError.sourceArchiveNotSigned {
-            observabilityScope.emit(
-                debug: "\(manifestName) is not signed because source archive for \(package) \(version) from \(registry) is not signed",
-                metadata: .registryPackageMetadata(identity: package)
-            )
-            guard let onUnsigned = configuration.onUnsigned else {
-                return completion(.failure(RegistryError.missingConfiguration(details: "security.signing.onUnsigned")))
-            }
-
-            let sourceArchiveNotSignedError = RegistryError.sourceArchiveNotSigned(
-                registry: registry,
-                package: package.underlying,
-                version: version
-            )
-
-            // Prompt if configured, otherwise just continue (this differs
-            // from source archive to minimize duplicate loggings).
-            switch onUnsigned {
-            case .prompt:
-                self.delegate
-                    .onUnsigned(registry: registry, package: package.underlying, version: version) { `continue` in
-                        if `continue` {
-                            completion(.success(.none))
-                        } else {
-                            completion(.failure(sourceArchiveNotSignedError))
+                // Prompt if configured, otherwise just continue (this differs
+                // from source archive to minimize duplicate loggings).
+                switch onUnsigned {
+                case .prompt:
+                    self.delegate
+                        .onUnsigned(registry: registry, package: package.underlying, version: version) { `continue` in
+                            if `continue` {
+                                completion(.success(.none))
+                            } else {
+                                completion(.failure(sourceArchiveNotSignedError))
+                            }
                         }
-                    }
-            default:
+                default:
+                    completion(.success(.none))
+                }
+            } catch ManifestSignatureParser.Error.malformedManifestSignature {
+                completion(.failure(RegistryError.invalidSignature(reason: "manifest signature is malformed")))
+            } catch {
+                observabilityScope
+                    .emit(
+                        debug: "cannot determine if \(manifestName) should be signed because retrieval of source archive signature for \(package) \(version) from \(registry) failed",
+                        metadata: .registryPackageMetadata(identity: package),
+                        underlyingError: error
+                    )
                 completion(.success(.none))
             }
-        } catch ManifestSignatureParser.Error.malformedManifestSignature {
-            completion(.failure(RegistryError.invalidSignature(reason: "manifest signature is malformed")))
-        } catch {
-            observabilityScope
-                .emit(
-                    debug: "cannot determine if \(manifestName) should be signed because retrieval of source archive signature for \(package) \(version) from \(registry) failed",
-                    metadata: .registryPackageMetadata(identity: package),
-                    underlyingError: error
-                )
-            completion(.success(.none))
         }
+
     }
 
     private func validateManifestSignature(
@@ -576,6 +580,22 @@ struct SignatureValidation {
         signature: [UInt8],
         signatureFormat: SignatureFormat,
         configuration: RegistryConfiguration.Security.Signing,
+        fileSystem: FileSystem
+    ) async throws ->  SigningEntity? {
+        try await withCheckedThrowingContinuation {
+            SignatureValidation.extractSigningEntity(
+                signature: signature,
+                signatureFormat: signatureFormat,
+                configuration: configuration,
+                fileSystem: fileSystem,
+                completion: $0.resume(with:)
+            )
+        }
+    }
+    static func extractSigningEntity(
+        signature: [UInt8],
+        signatureFormat: SignatureFormat,
+        configuration: RegistryConfiguration.Security.Signing,
         fileSystem: FileSystem,
         completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
     ) {
@@ -587,9 +607,9 @@ struct SignatureValidation {
                     format: signatureFormat,
                     verifierConfiguration: verifierConfiguration
                 )
-                return completion(.success(signingEntity))
+                completion(.success(signingEntity))
             } catch {
-                return completion(.failure(error))
+                completion(.failure(error))
             }
         }
     }

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -122,8 +122,8 @@ private struct LocalPackageContainer: PackageContainer {
         return currentToolsVersion
     }
 
-    func toolsVersionsAppropriateVersionsDescending() throws -> [Version] {
-        return try self.versionsDescending()
+    func toolsVersionsAppropriateVersionsDescending() async throws -> [Version] {
+        return try await self.versionsDescending()
     }
 
     func getDependencies(at version: Version, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -721,7 +721,7 @@ extension Workspace {
                 // way to get it back out of the resolver which is very
                 // annoying. Maybe we should make an SPI on the provider for this?
                 guard let tag = container.getTag(for: version) else {
-                    throw try InternalError(
+                    throw try await InternalError(
                         "unable to get tag for \(package) \(version); available versions \(container.versionsDescending())"
                     )
                 }

--- a/Sources/_InternalTestSupport/MockPackageContainer.swift
+++ b/Sources/_InternalTestSupport/MockPackageContainer.swift
@@ -38,8 +38,8 @@ public class MockPackageContainer: CustomPackageContainer {
     public var requestedVersions: Set<Version> = []
 
     public let _versions: [Version]
-    public func toolsVersionsAppropriateVersionsDescending() throws -> [Version] {
-        return try self.versionsDescending()
+    public func toolsVersionsAppropriateVersionsDescending() async throws -> [Version] {
+        return try await self.versionsDescending()
     }
 
     public func versionsAscending() throws -> [Version] {

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -1653,16 +1653,17 @@ final class PubGrubTests: XCTestCase {
         let other = PackageReference.localSourceControl(identity: .init(path: otherLocation), path: otherLocation)
         let dependencyA = PackageReference.localSourceControl(identity: .init(path: dependencyALocation), path: dependencyALocation)
         let dependencyB = PackageReference.localSourceControl(identity: .init(path: dependencyBLocation), path: dependencyBLocation)
-        XCTAssertEqual(
-            try container.incompatibilites(
-                at: Version(1, 0, 0),
-                node: .product(
-                    "FilterA",
-                    package: other
-                ),
-                overriddenPackages: [:],
-                root: .root(package: root)
+        let result = try await container.incompatibilites(
+            at: Version(1, 0, 0),
+            node: .product(
+                "FilterA",
+                package: other
             ),
+            overriddenPackages: [:],
+            root: .root(package: root)
+        )
+        XCTAssertEqual(
+            result,
             [
                 Incompatibility(
                     terms: [
@@ -1692,16 +1693,17 @@ final class PubGrubTests: XCTestCase {
                 )
             ]
         )
-        XCTAssertEqual(
-            try container.incompatibilites(
-                at: Version(1, 0, 0),
-                node: .product(
-                    "FilterB",
-                    package: other
-                ),
-                overriddenPackages: [:],
-                root: .root(package: root)
+        let result2 = try await container.incompatibilites(
+            at: Version(1, 0, 0),
+            node: .product(
+                "FilterB",
+                package: other
             ),
+            overriddenPackages: [:],
+            root: .root(package: root)
+        )
+        XCTAssertEqual(
+            result2,
             [
                 Incompatibility(
                     terms: [

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -3843,18 +3843,15 @@ extension RegistryClient {
     func getPackageVersionMetadata(
         package: PackageIdentity.RegistryIdentity,
         version: Version
-    ) throws -> PackageVersionMetadata {
-        // TODO: Finish removing this temp_await
-        // It can't currently be removed because it is passed to
-        // PackageVersionChecksumTOFU which expects a non async method
-        return try temp_await { completion in
+    ) async throws -> PackageVersionMetadata {
+        return try await withCheckedThrowingContinuation {
             self.getPackageVersionMetadata(
                 package: package.underlying,
                 version: version,
                 fileSystem: InMemoryFileSystem(),
                 observabilityScope: ObservabilitySystem.NOOP,
                 callbackQueue: .sharedConcurrent,
-                completion: completion
+                completion: $0.resume(with:)
             )
         }
     }

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Foundation
 import PackageGraph
 import PackageLoading
@@ -99,7 +100,7 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v4)
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending()
+            let versions = try await container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, ["1.0.1"])
         }
 
@@ -107,7 +108,7 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v4_2)
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending()
+            let versions = try await container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, ["1.0.2", "1.0.1"])
         }
 
@@ -115,7 +116,7 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v5_4)
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending()
+            let versions = try await container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, ["1.0.3", "1.0.2", "1.0.1"])
         }
     }
@@ -167,8 +168,9 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v5_2) // the version of the alternate
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref)
-            XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_3)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending()
+            let version = try await container.toolsVersion(for: packageVersion)
+            XCTAssertEqual(version, .v5_3)
+            let versions = try await container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, [])
         }
 
@@ -176,8 +178,9 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v5_3) // the version of the alternate
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref)
-            XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_3)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending()
+            let version = try await container.toolsVersion(for: packageVersion)
+            XCTAssertEqual(version, .v5_3)
+            let versions = try await container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, [packageVersion])
         }
 
@@ -185,8 +188,9 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v5_4) // the version of the alternate
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref)
-            XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_4)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending()
+            let version = try await container.toolsVersion(for: packageVersion)
+            XCTAssertEqual(version, .v5_4)
+            let versions = try await container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, [packageVersion])
         }
 
@@ -194,8 +198,9 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v5_5) // the version of the alternate
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref)
-            XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_5)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending()
+            let version = try await container.toolsVersion(for: packageVersion)
+            XCTAssertEqual(version, .v5_5)
+            let versions = try await container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, [packageVersion])
         }
 
@@ -203,8 +208,9 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v5_6) // the version of the alternate
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref)
-            XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_5)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending()
+            let version = try await container.toolsVersion(for: packageVersion)
+            XCTAssertEqual(version, .v5_5)
+            let versions = try await container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, [packageVersion])
         }
     }
@@ -293,7 +299,7 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v5_3) // the version of the alternate
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref) as! RegistryPackageContainer
-            let manifest = try container.loadManifest(version: packageVersion)
+            let manifest = try await container.loadManifest(version: packageVersion)
             XCTAssertEqual(manifest.toolsVersion, .v5_3)
         }
 
@@ -301,7 +307,7 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(v5_3_3) // the version of the alternate
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref) as! RegistryPackageContainer
-            let manifest = try container.loadManifest(version: packageVersion)
+            let manifest = try await container.loadManifest(version: packageVersion)
             XCTAssertEqual(manifest.toolsVersion, v5_3_3)
         }
 
@@ -309,7 +315,7 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v5_4) // the version of the alternate
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref) as! RegistryPackageContainer
-            let manifest = try container.loadManifest(version: packageVersion)
+            let manifest = try await container.loadManifest(version: packageVersion)
             XCTAssertEqual(manifest.toolsVersion, .v5_4)
         }
 
@@ -317,7 +323,7 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v5_5) // the version of the alternate
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref) as! RegistryPackageContainer
-            let manifest = try container.loadManifest(version: packageVersion)
+            let manifest = try await container.loadManifest(version: packageVersion)
             XCTAssertEqual(manifest.toolsVersion, .v5_5)
         }
 
@@ -325,7 +331,7 @@ final class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v5_6) // the version of the alternate
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try await provider.getContainer(for: ref) as! RegistryPackageContainer
-            let manifest = try container.loadManifest(version: packageVersion)
+            let manifest = try await container.loadManifest(version: packageVersion)
             XCTAssertEqual(manifest.toolsVersion, .v5_5)
         }
     }

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -165,7 +165,7 @@ final class SourceControlPackageContainerTests: XCTestCase {
 
         let ref = PackageReference.localSourceControl(identity: PackageIdentity(path: repoPath), path: repoPath)
         let container = try await provider.getContainer(for: ref)
-        let v = try container.toolsVersionsAppropriateVersionsDescending()
+        let v = try await container.toolsVersionsAppropriateVersionsDescending()
         XCTAssertEqual(v, ["2.0.3", "1.0.3", "1.0.2", "1.0.1", "1.0.0"])
     }
 
@@ -225,7 +225,7 @@ final class SourceControlPackageContainerTests: XCTestCase {
             let provider = try createProvider(ToolsVersion(version: "4.0.0"))
             let ref = PackageReference.localSourceControl(identity: PackageIdentity(path: repoPath), path: repoPath)
             let container = try await provider.getContainer(for: ref)
-            let v = try container.toolsVersionsAppropriateVersionsDescending()
+            let v = try await container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(v, ["1.0.1"])
         }
 
@@ -234,7 +234,7 @@ final class SourceControlPackageContainerTests: XCTestCase {
             let ref = PackageReference.localSourceControl(identity: PackageIdentity(path: repoPath), path: repoPath)
             let container = try await provider.getContainer(for: ref) as! SourceControlPackageContainer
             XCTAssertTrue(container.validToolsVersionsCache.isEmpty)
-            let v = try container.toolsVersionsAppropriateVersionsDescending()
+            let v = try await container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(container.validToolsVersionsCache["1.0.0"], false)
             XCTAssertEqual(container.validToolsVersionsCache["1.0.1"], true)
             XCTAssertEqual(container.validToolsVersionsCache["1.0.2"], true)
@@ -246,7 +246,7 @@ final class SourceControlPackageContainerTests: XCTestCase {
             let provider = try createProvider(ToolsVersion(version: "3.0.0"))
             let ref = PackageReference.localSourceControl(identity: PackageIdentity(path: repoPath), path: repoPath)
             let container = try await provider.getContainer(for: ref)
-            let v = try container.toolsVersionsAppropriateVersionsDescending()
+            let v = try await container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(v, [])
         }
 
@@ -257,7 +257,7 @@ final class SourceControlPackageContainerTests: XCTestCase {
             let container = try await provider.getContainer(for: ref) as! SourceControlPackageContainer
             let revision = try container.getRevision(forTag: "1.0.0")
             do {
-                _ = try container.getDependencies(at: revision.identifier, productFilter: .nothing)
+                _ = try await container.getDependencies(at: revision.identifier, productFilter: .nothing)
             } catch let error as SourceControlPackageContainer.GetDependenciesError {
                 let error = error.underlyingError as! UnsupportedToolsVersion
                 XCTAssertMatch(error.description, .and(.prefix("package '\(PackageIdentity(path: repoPath))' @"), .suffix("is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version")))
@@ -308,7 +308,7 @@ final class SourceControlPackageContainerTests: XCTestCase {
 
         let ref = PackageReference.localSourceControl(identity: PackageIdentity(path: repoPath), path: repoPath)
         let container = try await provider.getContainer(for: ref)
-        let v = try container.toolsVersionsAppropriateVersionsDescending()
+        let v = try await container.toolsVersionsAppropriateVersionsDescending()
         XCTAssertEqual(v, ["1.0.4-alpha", "1.0.2-dev.2", "1.0.2-dev", "1.0.1", "1.0.0", "1.0.0-beta.1", "1.0.0-alpha.1"])
     }
 
@@ -359,7 +359,7 @@ final class SourceControlPackageContainerTests: XCTestCase {
         )
         let ref = PackageReference.localSourceControl(identity: PackageIdentity(path: repoPath), path: repoPath)
         let container = try await provider.getContainer(for: ref)
-        let v = try container.toolsVersionsAppropriateVersionsDescending()
+        let v = try await container.toolsVersionsAppropriateVersionsDescending()
         XCTAssertEqual(v, ["2.0.1", "1.3.0", "1.2.0", "1.1.0", "1.0.4", "1.0.2", "1.0.1", "1.0.0"])
     }
 
@@ -548,7 +548,7 @@ final class SourceControlPackageContainerTests: XCTestCase {
             let container = try await containerProvider.getContainer(for: packageRef) as! SourceControlPackageContainer
 
             // Simulate accessing a fictitious dependency on the `master` branch, and check that we get back the expected error.
-            do { _ = try container.getDependencies(at: "master", productFilter: .everything) }
+            do { _ = try await container.getDependencies(at: "master", productFilter: .everything) }
             catch let error as SourceControlPackageContainer.GetDependenciesError {
                 // We expect to get an error message that mentions main.
                 XCTAssertMatch(error.description, .and(.prefix("could not find a branch named ‘master’"), .suffix("(did you mean ‘main’?)")))
@@ -557,7 +557,7 @@ final class SourceControlPackageContainerTests: XCTestCase {
             }
 
             // Simulate accessing a fictitious dependency on some random commit that doesn't exist, and check that we get back the expected error.
-            do { _ = try container.getDependencies(at: "535f4cb5b4a0872fa691473e82d7b27b9894df00", productFilter: .everything) }
+            do { _ = try await container.getDependencies(at: "535f4cb5b4a0872fa691473e82d7b27b9894df00", productFilter: .everything) }
             catch let error as SourceControlPackageContainer.GetDependenciesError {
                 // We expect to get an error message about the specific commit.
                 XCTAssertMatch(error.description, .prefix("could not find the commit 535f4cb5b4a0872fa691473e82d7b27b9894df00"))
@@ -713,8 +713,8 @@ final class SourceControlPackageContainerTests: XCTestCase {
             let packageReference = PackageReference.localSourceControl(identity: PackageIdentity(path: packageDirectory), path: packageDirectory)
             let container = try await containerProvider.getContainer(for: packageReference)
 
-            let forNothing = try container.getDependencies(at: version, productFilter: .specific([]))
-            let forProduct = try container.getDependencies(at: version, productFilter: .specific(["Product"]))
+            let forNothing = try await container.getDependencies(at: version, productFilter: .specific([]))
+            let forProduct = try await container.getDependencies(at: version, productFilter: .specific(["Product"]))
             #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             // If the cache overlaps (incorrectly), these will be the same.
             XCTAssertNotEqual(forNothing, forProduct)


### PR DESCRIPTION
Remove usage of `temp_await` in PackageContainer

### Motivation:

`temp_await` is unsafe and it would be better to use true async methods

### Modifications:

Remove `temp_await` from PackageContainer

### Result:

Safer more modern Swift code