### PR TITLE
Remove all remaining usages of `temp_await` and `safe_async`

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -24,31 +24,6 @@ public enum Concurrency {
     }
 }
 
-// FIXME: mark as deprecated once async/await is available
-@available(*, noasync, message: "replace with async/await when available")
-@inlinable
-public func temp_await<T, ErrorType>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
-    try tsc_await(body)
-}
-
-@available(*, noasync, message: "This method blocks the current thread indefinitely. Calling it from the concurrency pool can cause deadlocks")
-public func unsafe_await<T>(_ body: @Sendable @escaping () async throws -> T) throws -> T {
-    let semaphore = DispatchSemaphore(value: 0)
-    let box = ThreadSafeBox<Result<T, Error>>()
-    Task {
-        let localResult: Result<T, Error>
-        do {
-            localResult = try await .success(body())
-        } catch {
-            localResult = .failure(error)
-        }
-        box.mutate { _ in localResult }
-        semaphore.signal()
-    }
-    semaphore.wait()
-    return try box.get()!.get()
-}
-
 @available(*, noasync, message: "This method blocks the current thread indefinitely. Calling it from the concurrency pool can cause deadlocks")
 public func unsafe_await<T>(_ body: @Sendable @escaping () async -> T) -> T {
     let semaphore = DispatchSemaphore(value: 0)
@@ -63,12 +38,6 @@ public func unsafe_await<T>(_ body: @Sendable @escaping () async -> T) -> T {
     return box.get()!
 }
 
-// FIXME: mark as deprecated once async/await is available
-@available(*, deprecated, message: "replace with async/await when available")
-@inlinable
-public func temp_await<T>(_ body: (@escaping (T) -> Void) -> Void) -> T {
-    tsc_await(body)
-}
 
 extension DispatchQueue {
     // a shared concurrent queue for running concurrent asynchronous operations
@@ -78,35 +47,6 @@ extension DispatchQueue {
     )
 }
 
-/// Bridges between potentially blocking methods that take a result completion closure and async/await
-public func safe_async<T, ErrorType: Error>(
-    _ body: @escaping @Sendable (@escaping @Sendable (Result<T, ErrorType>) -> Void) -> Void
-) async throws -> T {
-    try await withCheckedThrowingContinuation { continuation in
-        // It is possible that body make block indefinitely on a lock, semaphore,
-        // or similar then synchronously call the completion handler. For full safety
-        // it is essential to move the execution off the swift concurrency pool
-        DispatchQueue.sharedConcurrent.async {
-            body {
-                continuation.resume(with: $0)
-            }
-        }
-    }
-}
-
-/// Bridges between potentially blocking methods that take a result completion closure and async/await
-public func safe_async<T>(_ body: @escaping @Sendable (@escaping (Result<T, Never>) -> Void) -> Void) async -> T {
-    await withCheckedContinuation { continuation in
-        // It is possible that body make block indefinitely on a lock, semaphore,
-        // or similar then synchronously call the completion handler. For full safety
-        // it is essential to move the execution off the swift concurrency pool
-        DispatchQueue.sharedConcurrent.async {
-            body {
-                continuation.resume(with: $0)
-            }
-        }
-    }
-}
 
 #if !canImport(Darwin)
 // As of Swift 5.7 and 5.8 swift-corelibs-foundation doesn't have `Sendable` annotations yet.

--- a/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import Dispatch
 import struct Foundation.Data
 import struct Foundation.Date
@@ -313,8 +314,8 @@ extension LegacyHTTPClient {
         options: Request.Options = .init(),
         observabilityScope: ObservabilityScope? = .none
     ) async throws -> Response {
-        try await safe_async {
-            self.head(url, headers: headers, options: options, completion: $0)
+        try await withCheckedThrowingContinuation {
+            self.head(url, headers: headers, options: options, completion: $0.resume(with:))
         }
     }
     @available(*, noasync, message: "Use the async alternative")
@@ -338,8 +339,8 @@ extension LegacyHTTPClient {
         options: Request.Options = .init(),
         observabilityScope: ObservabilityScope? = .none
     ) async throws -> Response {
-        try await safe_async {
-            self.get(url, headers: headers, options: options, completion: $0)
+        try await withCheckedThrowingContinuation {
+            self.get(url, headers: headers, options: options, completion: $0.resume(with:))
         }
     }
     @available(*, noasync, message: "Use the async alternative")

--- a/Sources/Commands/PackageCommands/APIDiff.swift
+++ b/Sources/Commands/PackageCommands/APIDiff.swift
@@ -92,14 +92,14 @@ struct APIDiff: AsyncSwiftCommand {
             cacheBuildManifest: false
         )
 
-        let packageGraph = try buildSystem.getPackageGraph()
+        let packageGraph = try await buildSystem.getPackageGraph()
         let modulesToDiff = try determineModulesToDiff(
             packageGraph: packageGraph,
             observabilityScope: swiftCommandState.observabilityScope
         )
 
         // Build the current package.
-        try buildSystem.build()
+        try await buildSystem.build()
 
         // Dump JSON for the baseline package.
         let baselineDumper = try APIDigesterBaselineDumper(

--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -53,7 +53,7 @@ struct DumpSymbolGraph: AsyncSwiftCommand {
             traitConfiguration: .init(enableAllTraits: true),
             cacheBuildManifest: false
         )
-        try buildSystem.build()
+        try await buildSystem.build()
 
         // Configure the symbol graph extractor.
         let symbolGraphExtractor = try SymbolGraphExtract(
@@ -71,7 +71,7 @@ struct DumpSymbolGraph: AsyncSwiftCommand {
         // Run the tool once for every library and executable target in the root package.
         let buildPlan = try buildSystem.buildPlan
         let symbolGraphDirectory = buildPlan.destinationBuildParameters.dataPath.appending("symbolgraph")
-        let targets = try buildSystem.getPackageGraph().rootPackages.flatMap{ $0.modules }.filter{ $0.type == .library }
+        let targets = try await buildSystem.getPackageGraph().rootPackages.flatMap{ $0.modules }.filter{ $0.type == .library }
         for target in targets {
             print("-- Emitting symbol graph for", target.name)
             let result = try symbolGraphExtractor.extractSymbolGraph(

--- a/Sources/Commands/Snippets/Cards/SnippetCard.swift
+++ b/Sources/Commands/Snippets/Cards/SnippetCard.swift
@@ -94,9 +94,9 @@ struct SnippetCard: Card {
     func runExample() async throws {
         print("Building '\(snippet.path)'\n")
         let buildSystem = try await swiftCommandState.createBuildSystem(explicitProduct: snippet.name, traitConfiguration: .init())
-        try buildSystem.build(subset: .product(snippet.name))
+        try await buildSystem.build(subset: .product(snippet.name))
         let executablePath = try swiftCommandState.productsBuildParameters.buildPath.appending(component: snippet.name)
-        if let exampleTarget = try buildSystem.getPackageGraph().module(for: snippet.name, destination: .destination) {
+        if let exampleTarget = try await buildSystem.getPackageGraph().module(for: snippet.name, destination: .destination) {
             try ProcessEnv.chdir(exampleTarget.sources.paths[0].parentDirectory)
         }
         try exec(path: executablePath.pathString, args: [])

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -183,7 +183,7 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
             outputStream: TSCBasic.stdoutStream
         )
         do {
-            try buildSystem.build(subset: subset)
+            try await buildSystem.build(subset: subset)
         } catch _ as Diagnostics {
             throw ExitCode.failure
         }

--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -125,11 +125,9 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
         case .repl:
             // Load a custom package graph which has a special product for REPL.
             let asyncUnsafeGraphLoader = {
-                try unsafe_await {
-                    try await swiftCommandState.loadPackageGraph(
-                        explicitProduct: self.options.executable
-                    )
-                }
+                try await swiftCommandState.loadPackageGraph(
+                    explicitProduct: self.options.executable
+                )
             }
 
             // Construct the build operation.
@@ -142,7 +140,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
             )
 
             // Perform build.
-            try buildSystem.build()
+            try await buildSystem.build()
 
             // Execute the REPL.
             let arguments = try buildSystem.buildPlan.createREPLArguments()
@@ -160,11 +158,11 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                     explicitProduct: options.executable,
                     traitConfiguration: .init(traitOptions: self.options.traits)
                 )
-                let productName = try findProductName(in: buildSystem.getPackageGraph())
+                let productName = try await findProductName(in: buildSystem.getPackageGraph())
                 if options.shouldBuildTests {
-                    try buildSystem.build(subset: .allIncludingTests)
+                    try await buildSystem.build(subset: .allIncludingTests)
                 } else if options.shouldBuild {
-                    try buildSystem.build(subset: .product(productName))
+                    try await buildSystem.build(subset: .product(productName))
                 }
 
                 let executablePath = try swiftCommandState.productsBuildParameters.buildPath.appending(component: productName)
@@ -205,11 +203,11 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                     explicitProduct: options.executable,
                     traitConfiguration: .init(traitOptions: self.options.traits)
                 )
-                let productName = try findProductName(in: buildSystem.getPackageGraph())
+                let productName = try await findProductName(in: buildSystem.getPackageGraph())
                 if options.shouldBuildTests {
-                    try buildSystem.build(subset: .allIncludingTests)
+                    try await buildSystem.build(subset: .allIncludingTests)
                 } else if options.shouldBuild {
-                    try buildSystem.build(subset: .product(productName))
+                    try await buildSystem.build(subset: .product(productName))
                 }
 
                 let executablePath = try swiftCommandState.productsBuildParameters.buildPath.appending(component: productName)

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -15,6 +15,8 @@ import ArgumentParser
 @_spi(SwiftPMInternal)
 import Basics
 
+import _Concurrency
+
 @_spi(SwiftPMInternal)
 import CoreCommands
 
@@ -671,11 +673,11 @@ extension SwiftTestCommand {
     func printCodeCovPath(_ swiftCommandState: SwiftCommandState) async throws {
         let workspace = try swiftCommandState.getActiveWorkspace()
         let root = try swiftCommandState.getWorkspaceRoot()
-        let rootManifests = try await safe_async {
+        let rootManifests = try await withCheckedThrowingContinuation {
             workspace.loadRootManifests(
                 packages: root.packages,
                 observabilityScope: swiftCommandState.observabilityScope,
-                completion: $0
+                completion: $0.resume(with: )
             )
         }
         guard let rootManifest = rootManifests.values.first else {
@@ -1492,7 +1494,7 @@ private func buildTestsIfNeeded(
         .allIncludingTests
     }
 
-    try buildSystem.build(subset: subset)
+    try await buildSystem.build(subset: subset)
 
     // Find the test product.
     let testProducts = await buildSystem.builtTestProducts

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import Dispatch
 import Foundation
 
@@ -145,31 +146,32 @@ struct APIDigesterBaselineDumper {
             toolsBuildParameters: toolsBuildParameters,
             packageGraphLoader: { graph }
         )
-        try buildSystem.build()
+        try await buildSystem.build()
 
         // Dump the SDK JSON.
         try swiftCommandState.fileSystem.createDirectory(baselineDir, recursive: true)
-        let group = DispatchGroup()
-        let semaphore = DispatchSemaphore(value: Int(productsBuildParameters.workers))
-        let errors = ThreadSafeArrayStore<Swift.Error>()
-        for module in modulesToDiff {
-            semaphore.wait()
-            DispatchQueue.sharedConcurrent.async(group: group) {
-                do {
-                    try apiDigesterTool.emitAPIBaseline(
-                        to: baselinePath(module),
-                        for: module,
-                        buildPlan: buildSystem.buildPlan
-                    )
-                } catch {
-                    errors.append(error)
+
+        let errors = await withTaskGroup(of: Error?.self) { group in
+            for module in modulesToDiff {
+                group.addTask {
+                    do {
+                        try apiDigesterTool.emitAPIBaseline(
+                            to: baselinePath(module),
+                            for: module,
+                            buildPlan: buildSystem.buildPlan
+                        )
+                        return nil
+                    } catch {
+                        return error
+                    }
                 }
-                semaphore.signal()
+            }
+            return await group.compactMap { $0 }.reduce(into: []) {
+                $0.append($1)
             }
         }
-        group.wait()
 
-        for error in errors.get() {
+        for error in errors {
             observabilityScope.emit(error)
         }
         if observabilityScope.errorsReported {

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -172,7 +172,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         )
 
         // Run the build. This doesn't return until the build is complete.
-        let success = buildSystem.buildIgnoringError(subset: buildSubset)
+        let success = await buildSystem.buildIgnoringError(subset: buildSubset)
 
         // Create and return the build result record based on what the delegate collected and what's in the build plan.
         let builtProducts = try buildSystem.buildPlan.buildProducts.filter {
@@ -233,7 +233,7 @@ final class PluginDelegate: PluginInvocationDelegate {
             traitConfiguration: .init(),
             toolsBuildParameters: toolsBuildParameters
         )
-        try buildSystem.build(subset: .allIncludingTests)
+        try await buildSystem.build(subset: .allIncludingTests)
 
         // Clean out the code coverage directory that may contain stale `profraw` files from a previous run of
         // the code coverage tool.
@@ -399,7 +399,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         )
 
         // Find the target in the build operation's package graph; it's an error if we don't find it.
-        let packageGraph = try buildSystem.getPackageGraph()
+        let packageGraph = try await buildSystem.getPackageGraph()
         guard let target = packageGraph.module(for: targetName) else {
             throw StringError("could not find a target named “\(targetName)”")
         }
@@ -416,7 +416,7 @@ final class PluginDelegate: PluginInvocationDelegate {
             }
 
         // Build the target, if needed.
-        try buildSystem.build(subset: .target(target.name, for: buildParameters.destination))
+        try await buildSystem.build(subset: .target(target.name, for: buildParameters.destination))
 
         // Configure the symbol graph extractor.
         var symbolGraphExtractor = try SymbolGraphExtract(
@@ -472,9 +472,9 @@ final class PluginDelegate: PluginInvocationDelegate {
 }
 
 extension BuildSystem {
-    fileprivate func buildIgnoringError(subset: BuildSubset) -> Bool {
+    fileprivate func buildIgnoringError(subset: BuildSubset) async -> Bool {
         do {
-            try self.build(subset: subset)
+            try await self.build(subset: subset)
             return true
         } catch {
             return false

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -30,7 +30,7 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
         cacheBuildManifest: Bool,
         productsBuildParameters: BuildParameters?,
         toolsBuildParameters: BuildParameters?,
-        packageGraphLoader: (() throws -> ModulesGraph)?,
+        packageGraphLoader: (() async throws -> ModulesGraph)?,
         outputStream: OutputByteStream?,
         logLevel: Diagnostic.Severity?,
         observabilityScope: ObservabilityScope?
@@ -42,13 +42,11 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
             toolsBuildParameters: try toolsBuildParameters ?? self.swiftCommandState.toolsBuildParameters,
             cacheBuildManifest: cacheBuildManifest && self.swiftCommandState.canUseCachedBuildManifest(),
             packageGraphLoader: packageGraphLoader ?? {
-                try unsafe_await {
-                    try await self.swiftCommandState.loadPackageGraph(
-                        explicitProduct: explicitProduct,
-                        traitConfiguration: traitConfiguration,
-                        testEntryPointPath: testEntryPointPath
-                    )
-                }
+                try await self.swiftCommandState.loadPackageGraph(
+                    explicitProduct: explicitProduct,
+                    traitConfiguration: traitConfiguration,
+                    testEntryPointPath: testEntryPointPath
+                )
             },
             pluginConfiguration: .init(
                 scriptRunner: self.swiftCommandState.getPluginScriptRunner(),
@@ -75,7 +73,7 @@ private struct XcodeBuildSystemFactory: BuildSystemFactory {
         cacheBuildManifest: Bool,
         productsBuildParameters: BuildParameters?,
         toolsBuildParameters: BuildParameters?,
-        packageGraphLoader: (() throws -> ModulesGraph)?,
+        packageGraphLoader: (() async throws -> ModulesGraph)?,
         outputStream: OutputByteStream?,
         logLevel: Diagnostic.Severity?,
         observabilityScope: ObservabilityScope?
@@ -83,11 +81,9 @@ private struct XcodeBuildSystemFactory: BuildSystemFactory {
         return try XcodeBuildSystem(
             buildParameters: productsBuildParameters ?? self.swiftCommandState.productsBuildParameters,
             packageGraphLoader: packageGraphLoader ?? {
-                try unsafe_await {
-                    try await self.swiftCommandState.loadPackageGraph(
-                        explicitProduct: explicitProduct
-                    )
-                }
+                try await self.swiftCommandState.loadPackageGraph(
+                    explicitProduct: explicitProduct
+                )
             },
             outputStream: outputStream ?? self.swiftCommandState.outputStream,
             logLevel: logLevel ?? self.swiftCommandState.logLevel,

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -727,7 +727,7 @@ public final class SwiftCommandState {
         shouldLinkStaticSwiftStdlib: Bool = false,
         productsBuildParameters: BuildParameters? = .none,
         toolsBuildParameters: BuildParameters? = .none,
-        packageGraphLoader: (() throws -> ModulesGraph)? = .none,
+        packageGraphLoader: (() async throws -> ModulesGraph)? = .none,
         outputStream: OutputByteStream? = .none,
         logLevel: Basics.Diagnostic.Severity? = .none,
         observabilityScope: ObservabilityScope? = .none

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -43,20 +43,20 @@ public protocol BuildSystem: Cancellable {
     var builtTestProducts: [BuiltTestProduct] { get async }
 
     /// Returns the package graph used by the build system.
-    func getPackageGraph() throws -> ModulesGraph
+    func getPackageGraph() async throws -> ModulesGraph
 
     /// Builds a subset of the package graph.
     /// - Parameters:
     ///   - subset: The subset of the package graph to build.
-    func build(subset: BuildSubset) throws
+    func build(subset: BuildSubset) async throws
 
     var buildPlan: BuildPlan { get throws }
 }
 
 extension BuildSystem {
     /// Builds the default subset: all targets excluding tests.
-    public func build() throws {
-        try build(subset: .allExcludingTests)
+    public func build() async throws {
+        try await build(subset: .allExcludingTests)
     }
 }
 
@@ -104,7 +104,7 @@ public protocol BuildSystemFactory {
         cacheBuildManifest: Bool,
         productsBuildParameters: BuildParameters?,
         toolsBuildParameters: BuildParameters?,
-        packageGraphLoader: (() throws -> ModulesGraph)?,
+        packageGraphLoader: (() async throws -> ModulesGraph)?,
         outputStream: OutputByteStream?,
         logLevel: Diagnostic.Severity?,
         observabilityScope: ObservabilityScope?
@@ -131,7 +131,7 @@ public struct BuildSystemProvider {
         cacheBuildManifest: Bool = true,
         productsBuildParameters: BuildParameters? = .none,
         toolsBuildParameters: BuildParameters? = .none,
-        packageGraphLoader: (() throws -> ModulesGraph)? = .none,
+        packageGraphLoader: (() async throws -> ModulesGraph)? = .none,
         outputStream: OutputByteStream? = .none,
         logLevel: Diagnostic.Severity? = .none,
         observabilityScope: ObservabilityScope? = .none

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -635,8 +635,8 @@ public extension ResolvedModule {
         fileSystem: FileSystem,
         environment: BuildEnvironment,
         for hostTriple: Triple,
-        builtToolHandler: (_ name: String, _ path: RelativePath) throws -> AbsolutePath?
-    ) throws -> [String: PluginTool] {
+        builtToolHandler: (_ name: String, _ path: RelativePath) async throws -> AbsolutePath?
+    ) async throws -> [String: PluginTool] {
         precondition(self.underlying is PluginModule)
 
         var tools: [String: PluginTool] = [:]
@@ -649,7 +649,7 @@ public extension ResolvedModule {
         ) {
             switch tool {
             case .builtTool(let name, let path):
-                if let path = try builtToolHandler(name, path) {
+                if let path = try await builtToolHandler(name, path) {
                     tools[name] = PluginTool(path: path)
                 }
             case .vendedTool(let name, let path, let triples):

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -123,7 +123,7 @@ private struct LocalPackageContainer: PackageContainer {
     }
 
     func toolsVersionsAppropriateVersionsDescending() async throws -> [Version] {
-        return try await self.versionsDescending()
+        try await self.versionsDescending()
     }
 
     func getDependencies(at version: Version, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -31,11 +31,11 @@ import enum TSCUtility.Diagnostics
 
 public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
     private let buildParameters: BuildParameters
-    private let packageGraphLoader: () throws -> ModulesGraph
+    private let packageGraphLoader: () async throws -> ModulesGraph
     private let logLevel: Basics.Diagnostic.Severity
     private let xcbuildPath: AbsolutePath
-    private var packageGraph: ModulesGraph?
-    private var pifBuilder: PIFBuilder?
+    private var packageGraph: AsyncThrowingValueMemoizer<ModulesGraph> = .init()
+    private var pifBuilder: AsyncThrowingValueMemoizer<PIFBuilder> = .init()
     private let fileSystem: FileSystem
     private let observabilityScope: ObservabilityScope
 
@@ -45,31 +45,32 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
     /// The delegate used by the build system.
     public weak var delegate: SPMBuildCore.BuildSystemDelegate?
 
-    @available(*, noasync, message: "This must only be called from a dispatch queue")
     public var builtTestProducts: [BuiltTestProduct] {
-        do {
-            let graph = try getPackageGraph()
+        get async {
+            do {
+                let graph = try await getPackageGraph()
 
-            var builtProducts: [BuiltTestProduct] = []
+                var builtProducts: [BuiltTestProduct] = []
 
-            for package in graph.rootPackages {
-                for product in package.products where product.type == .test {
-                    let binaryPath = try buildParameters.binaryPath(for: product)
-                    builtProducts.append(
-                        BuiltTestProduct(
-                            productName: product.name,
-                            binaryPath: binaryPath,
-                            packagePath: package.path,
-                            testEntryPointPath: product.underlying.testEntryPointPath
+                for package in graph.rootPackages {
+                    for product in package.products where product.type == .test {
+                        let binaryPath = try buildParameters.binaryPath(for: product)
+                        builtProducts.append(
+                            BuiltTestProduct(
+                                productName: product.name,
+                                binaryPath: binaryPath,
+                                packagePath: package.path,
+                                testEntryPointPath: product.underlying.testEntryPointPath
+                            )
                         )
-                    )
+                    }
                 }
-            }
 
-            return builtProducts
-        } catch {
-            self.observabilityScope.emit(error)
-            return []
+                return builtProducts
+            } catch {
+                self.observabilityScope.emit(error)
+                return []
+            }
         }
     }
 
@@ -81,7 +82,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
 
     public init(
         buildParameters: BuildParameters,
-        packageGraphLoader: @escaping () throws -> ModulesGraph,
+        packageGraphLoader: @escaping () async throws -> ModulesGraph,
         outputStream: OutputByteStream,
         logLevel: Basics.Diagnostic.Severity,
         fileSystem: FileSystem,
@@ -146,13 +147,12 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         return []
     }
 
-    @available(*, noasync, message: "This must only be called from a dispatch queue")
-    public func build(subset: BuildSubset) throws {
+    public func build(subset: BuildSubset) async throws {
         guard !buildParameters.shouldSkipBuilding else {
             return
         }
 
-        let pifBuilder = try getPIFBuilder()
+        let pifBuilder = try await getPIFBuilder()
         let pif = try pifBuilder.generatePIF()
         try self.fileSystem.writeIfChanged(path: buildParameters.pifManifest, string: pif)
 
@@ -209,7 +209,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
             outputRedirection: redirection
         )
         try process.launch()
-        let result = try process.waitUntilExit()
+        let result = try await process.waitUntilExit()
 
         if let buildParamsFile {
             try? self.fileSystem.removeFileTree(buildParamsFile)
@@ -311,10 +311,9 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         return delegate
     }
 
-    @available(*, noasync, message: "This must only be called from a dispatch queue")
-    private func getPIFBuilder() throws -> PIFBuilder {
-        try memoize(to: &pifBuilder) {
-            let graph = try getPackageGraph()
+    private func getPIFBuilder() async throws -> PIFBuilder {
+        try await pifBuilder.memoize {
+            let graph = try await getPackageGraph()
             let pifBuilder = try PIFBuilder(
                 graph: graph,
                 parameters: .init(buildParameters, supportedSwiftVersions: supportedSwiftVersions()),
@@ -328,10 +327,9 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
     /// Returns the package graph using the graph loader closure.
     ///
     /// First access will cache the graph.
-    @available(*, noasync, message: "This must only be called from a dispatch queue")
-    public func getPackageGraph() throws -> ModulesGraph {
-        try memoize(to: &packageGraph) {
-            try packageGraphLoader()
+    public func getPackageGraph() async throws -> ModulesGraph {
+        try await packageGraph.memoize {
+            try await packageGraphLoader()
         }
     }
 }

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -262,10 +262,10 @@ package func mockPluginTools(
     fileSystem: any FileSystem,
     buildParameters: BuildParameters,
     hostTriple: Basics.Triple
-) throws -> [ResolvedModule.ID: [String: PluginTool]] {
+) async throws -> [ResolvedModule.ID: [String: PluginTool]] {
     var accessibleToolsPerPlugin: [ResolvedModule.ID: [String: PluginTool]] = [:]
     for plugin in plugins where accessibleToolsPerPlugin[plugin.id] == nil {
-        let accessibleTools = try plugin.preparePluginTools(
+        let accessibleTools = try await plugin.preparePluginTools(
             fileSystem: fileSystem,
             environment: buildParameters.buildEnvironment,
             for: hostTriple

--- a/Sources/_InternalTestSupport/MockPackageSigningEntityStorage.swift
+++ b/Sources/_InternalTestSupport/MockPackageSigningEntityStorage.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import Dispatch
 import class Foundation.NSLock
 import PackageModel
@@ -31,12 +32,12 @@ public class MockPackageSigningEntityStorage: PackageSigningEntityStorage {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> PackageSigners {
-        try await safe_async {
+        try await withCheckedThrowingContinuation {
             self.get(
                 package: package,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                callback: $0
+                callback: $0.resume(with:)
             )
         }
     }

--- a/Tests/BasicsTests/AsyncProcessTests.swift
+++ b/Tests/BasicsTests/AsyncProcessTests.swift
@@ -9,6 +9,7 @@
  */
 
 import _InternalTestSupport
+import _Concurrency
 import Basics
 import XCTest
 

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Basics
+import _Concurrency
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/BuildTests/BuildOperationTests.swift
+++ b/Tests/BuildTests/BuildOperationTests.swift
@@ -134,7 +134,7 @@ final class BuildOperationTests: XCTestCase {
         }
     }
 
-    func testHostProductsAndTargetsWithoutExplicitDestination() throws {
+    func testHostProductsAndTargetsWithoutExplicitDestination() async throws {
         let mock  = try macrosTestsPackageGraph()
 
         let op = mockBuildOperation(
@@ -146,15 +146,17 @@ final class BuildOperationTests: XCTestCase {
             observabilityScope: mock.observabilityScope
         )
 
+        let result = try await op.computeLLBuildTargetName(for: .product("MMIOMacros"))
         XCTAssertEqual(
             "MMIOMacros-\(hostTriple)-debug-tool.exe",
-            try op.computeLLBuildTargetName(for: .product("MMIOMacros"))
+            result
         )
 
         for target in ["MMIOMacros", "MMIOPlugin", "MMIOMacrosTests", "MMIOMacro+PluginTests"] {
+            let targetName = try await op.computeLLBuildTargetName(for: .target(target))
             XCTAssertEqual(
                 "\(target)-\(hostTriple)-debug-tool.module",
-                try op.computeLLBuildTargetName(for: .target(target))
+                targetName
             )
         }
 

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import _Concurrency
 import PackageModel
 import PackageLoading
 @testable import PackageRegistry


### PR DESCRIPTION
Remove all remaining usages of `temp_await` and `safe_async`

### Motivation:

`temp_await` can cause deadlocks when called from swift concurrency and `safe_async` can cause thread explosion. Replacing the usage of  these methods 

### Modifications:

Vendor topological sort so that we can have an async/await version
Replace use of safe_async with withCheckedThrowingContinuation
Remove temp_await and safe_async methods
Remove uses of unsafe_await in package graph resolution

### Result:

No `temp_await` 
No `safe_async`
Only one usage of `unsafe_await` which is exclusively called from the C++ llbuild
