### PR TITLE
Replace withCheckedThrowingContinuation with native async/await

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -556,16 +556,14 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             preparationStepName: "Compiling plugin \(plugin.moduleName)",
             progressTracker: self.current?.tracker
         )
-        let result = try await withCheckedThrowingContinuation {
-            pluginConfiguration.scriptRunner.compilePluginScript(
-                sourceFiles: plugin.sources.paths,
-                pluginName: plugin.moduleName,
-                toolsVersion: plugin.toolsVersion,
-                observabilityScope: self.observabilityScope,
-                callbackQueue: DispatchQueue.sharedConcurrent,
-                delegate: delegate,
-                completion: $0.resume(with:))
-        }
+        let result = try await pluginConfiguration.scriptRunner.compilePluginScript(
+            sourceFiles: plugin.sources.paths,
+            pluginName: plugin.moduleName,
+            toolsVersion: plugin.toolsVersion,
+            observabilityScope: self.observabilityScope,
+            callbackQueue: DispatchQueue.sharedConcurrent,
+            delegate: delegate
+        )
 
         // Throw an error on failure; we will already have emitted the compiler's output in this case.
         if !result.succeeded {

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -800,32 +800,30 @@ extension BuildPlan {
                 pluginDerivedResources = []
             }
 
-            let result = try await withCheckedThrowingContinuation {
-                pluginModule.invoke(
-                    module: plugin,
-                    action: .createBuildToolCommands(
-                        package: package,
-                        target: module,
-                        pluginGeneratedSources: pluginDerivedSources.paths,
-                        pluginGeneratedResources: pluginDerivedResources.map(\.path)
-                    ),
-                    buildEnvironment: buildParameters.buildEnvironment,
-                    scriptRunner: configuration.scriptRunner,
-                    workingDirectory: package.path,
-                    outputDirectory: pluginOutputDir,
-                    toolSearchDirectories: [buildParameters.toolchain.swiftCompilerPath.parentDirectory],
-                    accessibleTools: accessibleTools,
-                    writableDirectories: writableDirectories,
-                    readOnlyDirectories: readOnlyDirectories,
-                    allowNetworkConnections: [],
-                    pkgConfigDirectories: pkgConfigDirectories,
-                    sdkRootPath: buildParameters.toolchain.sdkRootPath,
-                    fileSystem: fileSystem,
-                    modulesGraph: modulesGraph,
-                    observabilityScope: observabilityScope,
-                    completion: $0.resume(with:)
-                )
-            }
+            let result = try await pluginModule.invoke(
+                module: plugin,
+                action: .createBuildToolCommands(
+                    package: package,
+                    target: module,
+                    pluginGeneratedSources: pluginDerivedSources.paths,
+                    pluginGeneratedResources: pluginDerivedResources.map(\.path)
+                ),
+                buildEnvironment: buildParameters.buildEnvironment,
+                scriptRunner: configuration.scriptRunner,
+                workingDirectory: package.path,
+                outputDirectory: pluginOutputDir,
+                toolSearchDirectories: [buildParameters.toolchain.swiftCompilerPath.parentDirectory],
+                accessibleTools: accessibleTools,
+                writableDirectories: writableDirectories,
+                readOnlyDirectories: readOnlyDirectories,
+                allowNetworkConnections: [],
+                pkgConfigDirectories: pkgConfigDirectories,
+                sdkRootPath: buildParameters.toolchain.sdkRootPath,
+                fileSystem: fileSystem,
+                modulesGraph: modulesGraph,
+                observabilityScope: observabilityScope
+            )
+
 
             if surfaceDiagnostics {
                 let diagnosticsEmitter = observabilityScope.makeDiagnosticsEmitter {

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -361,7 +361,7 @@ struct PluginCommand: AsyncSwiftCommand {
         let allowNetworkConnectionsCopy = allowNetworkConnections
 
         let buildEnvironment = buildParameters.buildEnvironment
-        let _ = try await withCheckedThrowingContinuation { pluginTarget.invoke(
+        let _ = try await pluginTarget.invoke(
             action: .performCommand(package: package, arguments: arguments),
             buildEnvironment: buildEnvironment,
             scriptRunner: pluginScriptRunner,
@@ -378,9 +378,8 @@ struct PluginCommand: AsyncSwiftCommand {
             modulesGraph: packageGraph,
             observabilityScope: swiftCommandState.observabilityScope,
             callbackQueue: delegateQueue,
-            delegate: pluginDelegate,
-            completion: $0.resume(with:)
-        ) }
+            delegate: pluginDelegate
+        )
 
         // TODO: We should also emit a final line of output regarding the result.
     }

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -673,13 +673,10 @@ extension SwiftTestCommand {
     func printCodeCovPath(_ swiftCommandState: SwiftCommandState) async throws {
         let workspace = try swiftCommandState.getActiveWorkspace()
         let root = try swiftCommandState.getWorkspaceRoot()
-        let rootManifests = try await withCheckedThrowingContinuation {
-            workspace.loadRootManifests(
-                packages: root.packages,
-                observabilityScope: swiftCommandState.observabilityScope,
-                completion: $0.resume(with: )
-            )
-        }
+        let rootManifests = try await workspace.loadRootManifests(
+            packages: root.packages,
+            observabilityScope: swiftCommandState.observabilityScope
+        )
         guard let rootManifest = rootManifests.values.first else {
             throw StringError("invalid manifests at \(root.packages)")
         }

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -486,13 +486,10 @@ public final class SwiftCommandState {
     public func getRootPackageInformation() async throws -> (dependencies: [PackageIdentity: [PackageIdentity]], targets: [PackageIdentity: [String]]) {
         let workspace = try self.getActiveWorkspace()
         let root = try self.getWorkspaceRoot()
-        let rootManifests = try await withCheckedThrowingContinuation {
-            workspace.loadRootManifests(
-                packages: root.packages,
-                observabilityScope: self.observabilityScope,
-                completion: $0.resume(with:)
-            )
-        }
+        let rootManifests = try await workspace.loadRootManifests(
+            packages: root.packages,
+            observabilityScope: self.observabilityScope
+        )
 
         var identities = [PackageIdentity: [PackageIdentity]]()
         var targets = [PackageIdentity: [String]]()

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -779,9 +779,7 @@ public final class MockWorkspace {
         let rootInput = PackageGraphRootInput(
             packages: try rootPaths(for: roots), dependencies: dependencies
         )
-        let rootManifests = try await withCheckedThrowingContinuation {
-            workspace.loadRootManifests(packages: rootInput.packages, observabilityScope: observability.topScope, completion: $0.resume(with:))
-        }
+        let rootManifests = try await workspace.loadRootManifests(packages: rootInput.packages, observabilityScope: observability.topScope)
         let graphRoot = PackageGraphRoot(input: rootInput, manifests: rootManifests, observabilityScope: observability.topScope)
         let manifests = try await workspace.loadDependencyManifests(root: graphRoot, observabilityScope: observability.topScope)
         result(manifests, observability.diagnostics)

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -344,7 +344,7 @@ final class PubGrubTests: XCTestCase {
         let state1 = PubGrubDependencyResolver.State(root: rootNode)
 
         // No decision can be made if no unsatisfied terms are available.
-        let decisionNil = try await withCheckedThrowingContinuation { solver1.makeDecision(state: state1, completion: $0.resume(with:)) }
+        let decisionNil = try await solver1.makeDecision(state: state1)
         XCTAssertNil(decisionNil)
 
         let a = MockContainer(package: aRef, dependenciesByVersion: [
@@ -361,7 +361,7 @@ final class PubGrubTests: XCTestCase {
 
         XCTAssertEqual(state2.incompatibilities.count, 0)
 
-        let decision = try await withCheckedThrowingContinuation {solver2.makeDecision(state: state2, completion: $0.resume(with:)) }
+        let decision = try await solver2.makeDecision(state: state2)
         XCTAssertEqual(decision, .product("a", package: "a"))
 
         XCTAssertEqual(state2.incompatibilities.count, 3)


### PR DESCRIPTION
Replace withCheckedThrowingContinuation with native async/await

### Motivation:

Replace callback and continuation usage with async/await

### Modifications:

Replaced calls to `withCheckedThrowingContinuation` on APIs that have async alternatives 
Replaced 3 completion handler APIs in swift-bootstrap making it fully async/await

### Result:

11 fewer continuation usages
1 fewer unstructured Task
3 fewer completion handler APIs
