### PR TITLE
[PackageModel] SwiftTesting: Fix directory existence check to use tes…

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -433,7 +433,7 @@ public final class UserToolchain: Toolchain {
             components: ["swift", "host", "plugins", "testing"]
         )
 
-        guard fileSystem.exists(toolchainLibDir), fileSystem.exists(testingPluginsDir) else {
+        guard fileSystem.exists(testingLibDir), fileSystem.exists(testingPluginsDir) else {
             return []
         }
 


### PR DESCRIPTION
…ting directory

The original check was using "lib" directory which would always be there, it should be using "testing" directory instead which might not actually be there always.