### PR TITLE
Refactored PackageFingerprintStorage to not use callbacks or async/await

### DIFF
--- a/Sources/PackageFingerprint/PackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/PackageFingerprintStorage.swift
@@ -20,36 +20,28 @@ public protocol PackageFingerprintStorage {
     func get(
         package: PackageIdentity,
         version: Version,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<[Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]], Error>) -> Void
-    )
+        observabilityScope: ObservabilityScope
+    ) throws -> [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]]
 
     func put(
         package: PackageIdentity,
         version: Version,
         fingerprint: Fingerprint,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    )
+        observabilityScope: ObservabilityScope
+    ) throws
 
     func get(
         package: PackageReference,
         version: Version,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<[Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]], Error>) -> Void
-    )
+        observabilityScope: ObservabilityScope
+    ) throws -> [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]]
 
     func put(
         package: PackageReference,
         version: Version,
         fingerprint: Fingerprint,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    )
+        observabilityScope: ObservabilityScope
+    ) throws
 }
 
 extension PackageFingerprintStorage {
@@ -58,18 +50,17 @@ extension PackageFingerprintStorage {
         version: Version,
         kind: Fingerprint.Kind,
         contentType: Fingerprint.ContentType,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Fingerprint, Error>) -> Void
-    ) {
-        self.get(
+        observabilityScope: ObservabilityScope
+    ) throws -> Fingerprint {
+        let fingerprints = try self.get(
             package: package,
             version: version,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue
-        ) { result in
-            self.get(kind: kind, contentType: contentType, result, callback: callback)
+            observabilityScope: observabilityScope
+        )
+        guard let fingerprint = fingerprints[kind]?[contentType] else {
+            throw PackageFingerprintStorageError.notFound
         }
+        return fingerprint
     }
 
     public func get(
@@ -77,18 +68,17 @@ extension PackageFingerprintStorage {
         version: Version,
         kind: Fingerprint.Kind,
         contentType: Fingerprint.ContentType,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Fingerprint, Error>) -> Void
-    ) {
-        self.get(
+        observabilityScope: ObservabilityScope
+    ) throws -> Fingerprint{
+        let fingerprints = try self.get(
             package: package,
             version: version,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue
-        ) { result in
-            self.get(kind: kind, contentType: contentType, result, callback: callback)
+            observabilityScope: observabilityScope
+        )
+        guard let fingerprint = fingerprints[kind]?[contentType] else {
+            throw PackageFingerprintStorageError.notFound
         }
+        return fingerprint
     }
 
     private func get(

--- a/Sources/PackageRegistry/ChecksumTOFU.swift
+++ b/Sources/PackageRegistry/ChecksumTOFU.swift
@@ -107,82 +107,48 @@ struct PackageVersionChecksumTOFU {
         completion: @escaping (Result<String, Error>) -> Void
     ) {
         // We either use a previously recorded checksum, or fetch it from the registry.
-        self.readFromStorage(
-            package: package,
-            version: version,
-            contentType: .sourceCode,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue
-        ) { result in
-            switch result {
-            case .success(.some(let savedChecksum)):
-                completion(.success(savedChecksum))
-            default:
-                // Try fetching checksum from registry if:
-                //   - No storage available
-                //   - Checksum not found in storage
-                //   - Reading from storage resulted in error
-                Task {
-                    do {
-                        let versionMetadata = try await self.versionMetadataProvider(package, version)
-                        guard let sourceArchiveResource = versionMetadata.sourceArchive else {
-                            throw RegistryError.missingSourceArchive
-                        }
-                        guard let checksum = sourceArchiveResource.checksum else {
-                            throw RegistryError.sourceArchiveMissingChecksum(
-                                registry: registry,
-                                package: package.underlying,
-                                version: version
-                            )
-                        }
-
-                        self.writeToStorage(
-                            registry: registry,
-                            package: package,
-                            version: version,
-                            checksum: checksum,
-                            contentType: .sourceCode,
-                            observabilityScope: observabilityScope,
-                            callbackQueue: callbackQueue
-                        ) { writeResult in
-                            completion(writeResult.tryMap { _ in checksum })
-                        }
-                    } catch {
-                        completion(.failure(RegistryError.failedRetrievingReleaseChecksum(
-                            registry: registry,
-                            package: package.underlying,
-                            version: version,
-                            error: error
-                        )))
-                    }
-                }
-            }
+        if let savedChecksum = try? self.readFromStorage(package: package, version: version, contentType: .sourceCode, observabilityScope: observabilityScope) {
+            return completion(.success(savedChecksum))
         }
-    }
 
-    // MARK: - manifests
-    func validateManifest(
-        registry: Registry,
-        package: PackageIdentity.RegistryIdentity,
-        version: Version,
-        toolsVersion: ToolsVersion?,
-        checksum: String,
-        timeout: DispatchTimeInterval?,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
-    ) async throws {
-        try await withCheckedThrowingContinuation {
-            self.validateManifest(
-                registry: registry,
-                package: package,
-                version: version,
-                toolsVersion: toolsVersion,
-                checksum: checksum,
-                timeout: timeout,
-                observabilityScope: observabilityScope,
-                callbackQueue: callbackQueue, 
-                completion: $0.resume(with:)
-            )
+        // Try fetching checksum from registry if:
+        //   - No storage available
+        //   - Checksum not found in storage
+        //   - Reading from storage resulted in error
+        Task {
+            do {
+                let versionMetadata = try await self.versionMetadataProvider(package, version)
+                guard let sourceArchiveResource = versionMetadata.sourceArchive else {
+                    throw RegistryError.missingSourceArchive
+                }
+                guard let checksum = sourceArchiveResource.checksum else {
+                    throw RegistryError.sourceArchiveMissingChecksum(
+                        registry: registry,
+                        package: package.underlying,
+                        version: version
+                    )
+                }
+                do {
+                    try self.writeToStorage(
+                        registry: registry,
+                        package: package,
+                        version: version,
+                        checksum: checksum,
+                        contentType: .sourceCode,
+                        observabilityScope: observabilityScope
+                    )
+                    completion(.success(checksum))
+                } catch {
+                    completion(.failure(error))
+                }
+            } catch {
+                completion(.failure(RegistryError.failedRetrievingReleaseChecksum(
+                    registry: registry,
+                    package: package.underlying,
+                    version: version,
+                    error: error
+                )))
+            }
         }
     }
 
@@ -194,50 +160,35 @@ struct PackageVersionChecksumTOFU {
         toolsVersion: ToolsVersion?,
         checksum: String,
         timeout: DispatchTimeInterval?,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        completion: @escaping (Result<Void, Error>) -> Void
-    ) {
+        observabilityScope: ObservabilityScope
+    ) throws {
         let contentType = Fingerprint.ContentType.manifest(toolsVersion)
 
-        self.readFromStorage(
+        guard let expectedChecksum = try? self.readFromStorage(
             package: package,
             version: version,
             contentType: .manifest(toolsVersion),
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue
-        ) { result in
-            switch result {
-            case .success(.some(let expectedChecksum)):
-                // Previously recorded checksum
-                do {
-                    if checksum != expectedChecksum {
-                        switch self.fingerprintCheckingMode {
-                        case .strict:
-                            throw RegistryError.invalidChecksum(expected: expectedChecksum, actual: checksum)
-                        case .warn:
-                            observabilityScope
-                                .emit(
-                                    warning: "the checksum \(checksum) for \(contentType) of \(package) \(version) does not match previously recorded value \(expectedChecksum)"
-                                )
-                        }
-                    }
-                    completion(.success(()))
-                } catch {
-                    completion(.failure(error))
-                }
-            default:
-                self.writeToStorage(
-                    registry: registry,
-                    package: package,
-                    version: version,
-                    checksum: checksum,
-                    contentType: .manifest(toolsVersion),
-                    observabilityScope: observabilityScope,
-                    callbackQueue: callbackQueue
-                ) { writeResult in
-                    completion(writeResult.tryMap { _ in () })
-                }
+            observabilityScope: observabilityScope
+        ) else {
+            return try self.writeToStorage(
+                registry: registry,
+                package: package,
+                version: version,
+                checksum: checksum,
+                contentType: .manifest(toolsVersion),
+                observabilityScope: observabilityScope
+            )
+        }
+        // Previously recorded checksum
+        if checksum != expectedChecksum {
+            switch self.fingerprintCheckingMode {
+            case .strict:
+                throw RegistryError.invalidChecksum(expected: expectedChecksum, actual: checksum)
+            case .warn:
+                observabilityScope
+                    .emit(
+                        warning: "the checksum \(checksum) for \(contentType) of \(package) \(version) does not match previously recorded value \(expectedChecksum)"
+                    )
             }
         }
     }
@@ -248,35 +199,29 @@ struct PackageVersionChecksumTOFU {
         package: PackageIdentity.RegistryIdentity,
         version: Version,
         contentType: Fingerprint.ContentType,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        completion: @escaping (Result<String?, Error>) -> Void
-    ) {
+        observabilityScope: ObservabilityScope
+    ) throws -> String? {
         guard let fingerprintStorage else {
-            return completion(.success(nil))
+            return nil
         }
 
-        fingerprintStorage.get(
-            package: package.underlying,
-            version: version,
-            kind: .registry,
-            contentType: contentType,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue
-        ) { result in
-            switch result {
-            case .success(let fingerprint):
-                completion(.success(fingerprint.value))
-            case .failure(PackageFingerprintStorageError.notFound):
-                completion(.success(nil))
-            case .failure(let error):
-                observabilityScope
-                    .emit(
-                        error: "failed to get registry fingerprint for \(contentType) of \(package) \(version) from storage",
-                        underlyingError: error
-                    )
-                completion(.failure(error))
-            }
+        do {
+            return try fingerprintStorage.get(
+                package: package.underlying,
+                version: version,
+                kind: .registry,
+                contentType: contentType,
+                observabilityScope: observabilityScope
+            ).value
+        } catch PackageFingerprintStorageError.notFound {
+            return nil
+        } catch {
+            observabilityScope
+                .emit(
+                    error: "failed to get registry fingerprint for \(contentType) of \(package) \(version) from storage",
+                    underlyingError: error
+                )
+            throw error
         }
     }
 
@@ -286,38 +231,29 @@ struct PackageVersionChecksumTOFU {
         version: Version,
         checksum: String,
         contentType: Fingerprint.ContentType,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        completion: @escaping (Result<Void, Error>) -> Void
-    ) {
+        observabilityScope: ObservabilityScope
+    ) throws {
         guard let fingerprintStorage else {
-            return completion(.success(()))
+            return
         }
 
         let fingerprint = Fingerprint(origin: .registry(registry.url), value: checksum, contentType: contentType)
-        fingerprintStorage.put(
-            package: package.underlying,
-            version: version,
-            fingerprint: fingerprint,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue
-        ) { result in
-            switch result {
-            case .success:
-                completion(.success(()))
-            case .failure(PackageFingerprintStorageError.conflict(_, let existing)):
-                switch self.fingerprintCheckingMode {
-                case .strict:
-                    completion(.failure(RegistryError.checksumChanged(latest: checksum, previous: existing.value)))
-                case .warn:
-                    observabilityScope
-                        .emit(
-                            warning: "the checksum \(checksum) for \(contentType) of \(package) \(version) from \(registry.url.absoluteString) does not match previously recorded value \(existing.value) from \(String(describing: existing.origin.url?.absoluteString))"
-                        )
-                    completion(.success(()))
-                }
-            case .failure(let error):
-                completion(.failure(error))
+        do {
+            try fingerprintStorage.put(
+                package: package.underlying,
+                version: version,
+                fingerprint: fingerprint,
+                observabilityScope: observabilityScope
+            )
+        } catch PackageFingerprintStorageError.conflict(_, let existing){
+            switch self.fingerprintCheckingMode {
+            case .strict:
+                throw RegistryError.checksumChanged(latest: checksum, previous: existing.value)
+            case .warn:
+                observabilityScope
+                    .emit(
+                        warning: "the checksum \(checksum) for \(contentType) of \(package) \(version) from \(registry.url.absoluteString) does not match previously recorded value \(existing.value) from \(String(describing: existing.origin.url?.absoluteString))"
+                    )
             }
         }
     }

--- a/Sources/PackageSigning/SigningEntity/FilePackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/FilePackageSigningEntityStorage.swift
@@ -34,19 +34,10 @@ public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
 
     public func get(
         package: PackageIdentity,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<PackageSigners, Error>) -> Void
-    ) {
-        let callback = self.makeAsync(callback, on: callbackQueue)
-
-        do {
-            let packageSigners = try self.withLock {
-                try self.loadFromDisk(package: package)
-            }
-            callback(.success(packageSigners))
-        } catch {
-            callback(.failure(error))
+        observabilityScope: ObservabilityScope
+    ) throws -> PackageSigners {
+        try self.withLock {
+            try self.loadFromDisk(package: package)
         }
     }
 
@@ -55,39 +46,29 @@ public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
-        let callback = self.makeAsync(callback, on: callbackQueue)
+        observabilityScope: ObservabilityScope
+    ) throws {
+        try self.withLock {
+            var packageSigners = try self.loadFromDisk(package: package)
 
-        do {
-            try self.withLock {
-                var packageSigners = try self.loadFromDisk(package: package)
-
-                let otherSigningEntities = packageSigners.signingEntities(of: version).filter { $0 != signingEntity }
-                // Error if we try to write a different signing entity for a version
-                guard otherSigningEntities.isEmpty else {
-                    throw PackageSigningEntityStorageError.conflict(
-                        package: package,
-                        version: version,
-                        given: signingEntity,
-                        existing: otherSigningEntities.first! // !-safe because otherSigningEntities is not empty
-                    )
-                }
-
-                try self.add(
-                    packageSigners: &packageSigners,
-                    signingEntity: signingEntity,
-                    origin: origin,
-                    version: version
+            let otherSigningEntities = packageSigners.signingEntities(of: version).filter { $0 != signingEntity }
+            // Error if we try to write a different signing entity for a version
+            guard otherSigningEntities.isEmpty else {
+                throw PackageSigningEntityStorageError.conflict(
+                    package: package,
+                    version: version,
+                    given: signingEntity,
+                    existing: otherSigningEntities.first! // !-safe because otherSigningEntities is not empty
                 )
-
-                try self.saveToDisk(package: package, packageSigners: packageSigners)
             }
-            callback(.success(()))
-        } catch {
-            callback(.failure(error))
+
+            try self.add(
+                packageSigners: &packageSigners,
+                signingEntity: signingEntity,
+                origin: origin,
+                version: version
+            )
+            try self.saveToDisk(package: package, packageSigners: packageSigners)
         }
     }
 
@@ -96,26 +77,17 @@ public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
-        let callback = self.makeAsync(callback, on: callbackQueue)
-
-        do {
-            try self.withLock {
-                var packageSigners = try self.loadFromDisk(package: package)
-                try self.add(
-                    packageSigners: &packageSigners,
-                    signingEntity: signingEntity,
-                    origin: origin,
-                    version: version
-                )
-                try self.saveToDisk(package: package, packageSigners: packageSigners)
-            }
-            callback(.success(()))
-        } catch {
-            callback(.failure(error))
+        observabilityScope: ObservabilityScope
+    ) throws {
+        try self.withLock {
+            var packageSigners = try self.loadFromDisk(package: package)
+            try self.add(
+                packageSigners: &packageSigners,
+                signingEntity: signingEntity,
+                origin: origin,
+                version: version
+            )
+            try self.saveToDisk(package: package, packageSigners: packageSigners)
         }
     }
 
@@ -124,27 +96,18 @@ public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
-        let callback = self.makeAsync(callback, on: callbackQueue)
-
-        do {
-            try self.withLock {
-                var packageSigners = try self.loadFromDisk(package: package)
-                packageSigners.expectedSigner = (signingEntity: signingEntity, fromVersion: version)
-                try self.add(
-                    packageSigners: &packageSigners,
-                    signingEntity: signingEntity,
-                    origin: origin,
-                    version: version
-                )
-                try self.saveToDisk(package: package, packageSigners: packageSigners)
-            }
-            callback(.success(()))
-        } catch {
-            callback(.failure(error))
+        observabilityScope: ObservabilityScope
+    ) throws {
+        try self.withLock {
+            var packageSigners = try self.loadFromDisk(package: package)
+            packageSigners.expectedSigner = (signingEntity: signingEntity, fromVersion: version)
+            try self.add(
+                packageSigners: &packageSigners,
+                signingEntity: signingEntity,
+                origin: origin,
+                version: version
+            )
+            try self.saveToDisk(package: package, packageSigners: packageSigners)
         }
     }
 
@@ -153,29 +116,20 @@ public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
-        let callback = self.makeAsync(callback, on: callbackQueue)
-
-        do {
-            try self.withLock {
-                var packageSigners = try self.loadFromDisk(package: package)
-                packageSigners.expectedSigner = (signingEntity: signingEntity, fromVersion: version)
-                // Delete all other signers
-                packageSigners.signers = packageSigners.signers.filter { $0.key == signingEntity }
-                try self.add(
-                    packageSigners: &packageSigners,
-                    signingEntity: signingEntity,
-                    origin: origin,
-                    version: version
-                )
-                try self.saveToDisk(package: package, packageSigners: packageSigners)
-            }
-            callback(.success(()))
-        } catch {
-            callback(.failure(error))
+        observabilityScope: ObservabilityScope
+    ) throws {
+        try self.withLock {
+            var packageSigners = try self.loadFromDisk(package: package)
+            packageSigners.expectedSigner = (signingEntity: signingEntity, fromVersion: version)
+            // Delete all other signers
+            packageSigners.signers = packageSigners.signers.filter { $0.key == signingEntity }
+            try self.add(
+                packageSigners: &packageSigners,
+                signingEntity: signingEntity,
+                origin: origin,
+                version: version
+            )
+            try self.saveToDisk(package: package, packageSigners: packageSigners)
         }
     }
 

--- a/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
@@ -21,172 +21,56 @@ import struct TSCUtility.Version
 
 public protocol PackageSigningEntityStorage {
     /// For a given package, return the signing entities and the package versions that each of them signed.
-    @available(*, noasync, message: "Use the async alternative")
     func get(
         package: PackageIdentity,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<PackageSigners, Error>) -> Void
-    )
+        observabilityScope: ObservabilityScope
+    ) throws -> PackageSigners
 
     /// Record signer for a given package version.
     ///
     /// This throws `PackageSigningEntityStorageError.conflict` if `signingEntity`
     /// of the package version is different from that in storage.
-    @available(*, noasync, message: "Use the async alternative")
     func put(
         package: PackageIdentity,
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    )
+        observabilityScope: ObservabilityScope
+    ) throws
 
     /// Add signer for a given package version.
     ///
     /// If the package version already has other `SigningEntity`s in storage, this
     /// API **adds** `signingEntity` to the package version's signers rather than
     /// throwing an error.
-    @available(*, noasync, message: "Use the async alternative")
     func add(
         package: PackageIdentity,
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    )
+        observabilityScope: ObservabilityScope
+    ) throws
 
     /// Make `signingEntity` the package's expected signer starting from the given version.
-    @available(*, noasync, message: "Use the async alternative")
     func changeSigningEntityFromVersion(
         package: PackageIdentity,
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    )
+        observabilityScope: ObservabilityScope
+    ) throws
 
     /// Make `signingEntity` the only signer for a given package.
     ///
     /// This API deletes all other existing signers from storage, therefore making
     /// `signingEntity` the package's sole signer.
-    @available(*, noasync, message: "Use the async alternative")
     func changeSigningEntityForAllVersions(
         package: PackageIdentity,
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    )
-}
-
-public extension PackageSigningEntityStorage {
-    func get(
-        package: PackageIdentity,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
-    ) async throws -> PackageSigners {
-        try await withCheckedThrowingContinuation {
-            self.get(
-                package: package,
-                observabilityScope: observabilityScope, 
-                callbackQueue: callbackQueue,
-                callback: $0.resume(with:)
-            )
-        }
-    }
-
-    func put(
-        package: PackageIdentity,
-        version: Version,
-        signingEntity: SigningEntity,
-        origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
-    ) async throws {
-        try await withCheckedThrowingContinuation {
-            self.put(
-                package: package,
-                version: version,
-                signingEntity: signingEntity,
-                origin: origin,
-                observabilityScope: observabilityScope,
-                callbackQueue: callbackQueue,
-                callback: $0.resume(with:)
-            )
-        }
-    }
-
-    func add(
-        package: PackageIdentity,
-        version: Version,
-        signingEntity: SigningEntity,
-        origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
-    ) async throws {
-        try await withCheckedThrowingContinuation {
-            self.add(
-                package: package,
-                version: version,
-                signingEntity: signingEntity,
-                origin: origin,
-                observabilityScope: observabilityScope,
-                callbackQueue: callbackQueue,
-                callback: $0.resume(with:)
-            )
-        }
-    }
-
-    func changeSigningEntityFromVersion(
-        package: PackageIdentity,
-        version: Version,
-        signingEntity: SigningEntity,
-        origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
-    ) async throws {
-        try await withCheckedThrowingContinuation {
-            self.changeSigningEntityFromVersion(
-                package: package,
-                version: version,
-                signingEntity: signingEntity,
-                origin: origin,
-                observabilityScope: observabilityScope,
-                callbackQueue: callbackQueue,
-                callback: $0.resume(with:)
-            )
-        }
-    }
-
-    func changeSigningEntityForAllVersions(
-        package: PackageIdentity,
-        version: Version,
-        signingEntity: SigningEntity,
-        origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
-    ) async throws {
-        try await withCheckedThrowingContinuation {
-            self.changeSigningEntityForAllVersions(
-                package: package,
-                version: version,
-                signingEntity: signingEntity,
-                origin: origin,
-                observabilityScope: observabilityScope,
-                callbackQueue: callbackQueue,
-                callback: $0.resume(with:)
-            )
-        }
-    }
+        observabilityScope: ObservabilityScope
+    ) throws
 }
 
 // MARK: - Models

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -726,7 +726,7 @@ extension Workspace {
                     )
                 }
                 let revision = try container.getRevision(forTag: tag)
-                try await container.checkIntegrity(version: version, revision: revision)
+                try container.checkIntegrity(version: version, revision: revision)
                 return try await self.checkoutRepository(
                     package: package,
                     at: .version(version, revision: revision),

--- a/Sources/_InternalTestSupport/MockPackageFingerprintStorage.swift
+++ b/Sources/_InternalTestSupport/MockPackageFingerprintStorage.swift
@@ -32,73 +32,50 @@ public class MockPackageFingerprintStorage: PackageFingerprintStorage {
     public func get(
         package: PackageIdentity,
         version: Version,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<[Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]], Error>) -> Void
-    ) {
-        if let fingerprints = self.lock.withLock({ self.packageFingerprints[package]?[version] }) {
-            callbackQueue.async {
-                callback(.success(fingerprints))
-            }
-        } else {
-            callbackQueue.async {
-                callback(.failure(PackageFingerprintStorageError.notFound))
-            }
+        observabilityScope: ObservabilityScope
+    ) throws -> [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]] {
+        guard let fingerprints = self.lock.withLock({ self.packageFingerprints[package]?[version] }) else {
+            throw PackageFingerprintStorageError.notFound
         }
+        return fingerprints
     }
 
     public func put(
         package: PackageIdentity,
         version: Version,
         fingerprint: Fingerprint,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
-        do {
-            try self.lock.withLock {
-                var versionFingerprints = self.packageFingerprints.removeValue(forKey: package) ?? [:]
-                var fingerprintsForVersion = versionFingerprints.removeValue(forKey: version) ?? [:]
-                var fingerprintsForKind = fingerprintsForVersion.removeValue(forKey: fingerprint.origin.kind) ?? [:]
+        observabilityScope: ObservabilityScope
+    ) throws {
+        try self.lock.withLock {
+            var versionFingerprints = self.packageFingerprints.removeValue(forKey: package) ?? [:]
+            var fingerprintsForVersion = versionFingerprints.removeValue(forKey: version) ?? [:]
+            var fingerprintsForKind = fingerprintsForVersion.removeValue(forKey: fingerprint.origin.kind) ?? [:]
 
-                if let existing = fingerprintsForKind[fingerprint.contentType] {
-                    // Error if we try to write a different fingerprint
-                    guard fingerprint == existing else {
-                        throw PackageFingerprintStorageError.conflict(given: fingerprint, existing: existing)
-                    }
-                    // Don't need to do anything if fingerprints are the same
-                    return
+            if let existing = fingerprintsForKind[fingerprint.contentType] {
+                // Error if we try to write a different fingerprint
+                guard fingerprint == existing else {
+                    throw PackageFingerprintStorageError.conflict(given: fingerprint, existing: existing)
                 }
-
-                fingerprintsForKind[fingerprint.contentType] = fingerprint
-                fingerprintsForVersion[fingerprint.origin.kind] = fingerprintsForKind
-                versionFingerprints[version] = fingerprintsForVersion
-                self.packageFingerprints[package] = versionFingerprints
+                // Don't need to do anything if fingerprints are the same
+                return
             }
 
-            callbackQueue.async {
-                callback(.success(()))
-            }
-        } catch {
-            callbackQueue.async {
-                callback(.failure(error))
-            }
+            fingerprintsForKind[fingerprint.contentType] = fingerprint
+            fingerprintsForVersion[fingerprint.origin.kind] = fingerprintsForKind
+            versionFingerprints[version] = fingerprintsForVersion
+            self.packageFingerprints[package] = versionFingerprints
         }
     }
 
     public func get(
         package: PackageReference,
         version: Version,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<[Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]], Error>) -> Void
-    ) {
-        self.get(
+        observabilityScope: ObservabilityScope
+    ) throws -> [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]] {
+        try self.get(
             package: package.identity,
             version: version,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue,
-            callback: callback
+            observabilityScope: observabilityScope
         )
     }
 
@@ -106,17 +83,13 @@ public class MockPackageFingerprintStorage: PackageFingerprintStorage {
         package: PackageReference,
         version: Version,
         fingerprint: Fingerprint,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
-        self.put(
+        observabilityScope: ObservabilityScope
+    ) throws {
+        try self.put(
             package: package.identity,
             version: version,
             fingerprint: fingerprint,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue,
-            callback: callback
+            observabilityScope: observabilityScope
         )
     }
 }

--- a/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
+++ b/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
@@ -30,12 +30,12 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
         // Add fingerprints for mona.LinkedList
         let package = PackageIdentity.plain("mona.LinkedList")
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             fingerprint: .init(origin: .registry(registryURL), value: "checksum-1.0.0", contentType: .sourceCode)
         )
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             fingerprint: .init(
@@ -44,7 +44,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
                 contentType: .sourceCode
             )
         )
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.1.0"),
             fingerprint: .init(origin: .registry(registryURL), value: "checksum-1.1.0", contentType: .sourceCode)
@@ -52,7 +52,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
         // Fingerprint for another package
         let otherPackage = PackageIdentity.plain("other.LinkedList")
-        try await storage.put(
+        try storage.put(
             package: otherPackage,
             version: Version("1.0.0"),
             fingerprint: .init(origin: .registry(registryURL), value: "checksum-1.0.0", contentType: .sourceCode)
@@ -67,7 +67,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
         // Fingerprints should be saved
         do {
-            let fingerprints = try await storage.get(package: package, version: Version("1.0.0"))
+            let fingerprints = try storage.get(package: package, version: Version("1.0.0"))
             XCTAssertEqual(fingerprints.count, 2)
 
             let registryFingerprints = fingerprints[.registry]
@@ -82,7 +82,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         }
 
         do {
-            let fingerprints = try await storage.get(package: package, version: Version("1.1.0"))
+            let fingerprints = try storage.get(package: package, version: Version("1.1.0"))
             XCTAssertEqual(fingerprints.count, 1)
 
             let registryFingerprints = fingerprints[.registry]
@@ -92,7 +92,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         }
 
         do {
-            let fingerprints = try await storage.get(package: otherPackage, version: Version("1.0.0"))
+            let fingerprints = try storage.get(package: otherPackage, version: Version("1.0.0"))
             XCTAssertEqual(fingerprints.count, 1)
 
             let registryFingerprints = fingerprints[.registry]
@@ -109,14 +109,14 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         let registryURL = URL("https://example.packages.com")
 
         let package = PackageIdentity.plain("mona.LinkedList")
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             fingerprint: .init(origin: .registry(registryURL), value: "checksum-1.0.0", contentType: .sourceCode)
         )
 
         // No fingerprints found for the content type
-        await XCTAssertAsyncThrowsError(try await storage.get(
+        await XCTAssertAsyncThrowsError(try storage.get(
             package: package,
             version: Version("1.0.0"),
             kind: .registry,
@@ -128,7 +128,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         }
 
         // No fingerprints found for the version
-        await XCTAssertAsyncThrowsError(try await storage.get(package: package, version: Version("1.1.0"))) { error in
+        await XCTAssertAsyncThrowsError(try storage.get(package: package, version: Version("1.1.0"))) { error in
             guard case PackageFingerprintStorageError.notFound = error else {
                 return XCTFail("Expected PackageFingerprintStorageError.notFound, got \(error)")
             }
@@ -136,7 +136,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
         // No fingerprints found for the package
         let otherPackage = PackageIdentity.plain("other.LinkedList")
-        await XCTAssertAsyncThrowsError(try await storage.get(package: otherPackage, version: Version("1.0.0"))) { error in
+        await XCTAssertAsyncThrowsError(try storage.get(package: otherPackage, version: Version("1.0.0"))) { error in
             guard case PackageFingerprintStorageError.notFound = error else {
                 return XCTFail("Expected PackageFingerprintStorageError.notFound, got \(error)")
             }
@@ -151,14 +151,14 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
         let package = PackageIdentity.plain("mona.LinkedList")
         // Write registry checksum for v1.0.0
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             fingerprint: .init(origin: .registry(registryURL), value: "checksum-1.0.0", contentType: .sourceCode)
         )
 
         // Writing for the same version and kind and content type but different checksum should fail
-        await XCTAssertAsyncThrowsError(try await storage.put(
+        await XCTAssertAsyncThrowsError(try storage.put(
             package: package,
             version: Version("1.0.0"),
             fingerprint: .init(
@@ -173,7 +173,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         }
 
         // Writing for the same version and kind and content type same checksum should not fail
-        _ = try await storage.put(
+        _ = try storage.put(
             package: package,
             version: Version("1.0.0"),
             fingerprint: .init(
@@ -194,7 +194,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
             url: sourceControlURL
         )
 
-        try await storage.put(
+        try storage.put(
             package: packageRef,
             version: Version("1.0.0"),
             fingerprint: .init(
@@ -203,7 +203,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
                 contentType: .sourceCode
             )
         )
-        try await storage.put(
+        try storage.put(
             package: packageRef,
             version: Version("1.1.0"),
             fingerprint: .init(
@@ -214,7 +214,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         )
 
         // Fingerprints should be saved
-        let fingerprints = try await storage.get(package: packageRef, version: Version("1.1.0"))
+        let fingerprints = try storage.get(package: packageRef, version: Version("1.1.0"))
         XCTAssertEqual(fingerprints.count, 1)
 
         let scmFingerprints = fingerprints[.sourceControl]
@@ -235,13 +235,13 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         let fooRef = PackageReference.remoteSourceControl(identity: PackageIdentity(url: fooURL), url: fooURL)
         let barRef = PackageReference.remoteSourceControl(identity: PackageIdentity(url: barURL), url: barURL)
 
-        try await storage.put(
+        try storage.put(
             package: fooRef,
             version: Version("1.0.0"),
             fingerprint: .init(origin: .sourceControl(fooURL), value: "abcde-foo", contentType: .sourceCode)
         )
         // This should succeed because they get written to different files
-        try await storage.put(
+        try storage.put(
             package: barRef,
             version: Version("1.0.0"),
             fingerprint: .init(origin: .sourceControl(barURL), value: "abcde-bar", contentType: .sourceCode)
@@ -260,7 +260,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         )
 
         // This should fail because fingerprint for 1.0.0 already exists and it's different
-        await XCTAssertAsyncThrowsError(try await storage.put(
+        await XCTAssertAsyncThrowsError(try storage.put(
             package: fooRef,
             version: Version("1.0.0"),
             fingerprint: .init(
@@ -275,7 +275,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         }
 
         // This should succeed because fingerprint for 2.0.0 doesn't exist yet
-        try await storage.put(
+        try storage.put(
             package: fooRef,
             version: Version("2.0.0"),
             fingerprint: .init(origin: .sourceControl(fooURL), value: "abcde-foo", contentType: .sourceCode)
@@ -313,7 +313,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         try mockFileSystem.writeFileContents(fingerprintsPath, string: v1Fingerprints)
 
         // v1 fingerprints file should be converted to v2 when read
-        let fingerprints = try await storage.get(package: package, version: Version("1.0.3"))
+        let fingerprints = try storage.get(package: package, version: Version("1.0.3"))
         XCTAssertEqual(fingerprints.count, 1)
 
         let scmFingerprints = fingerprints[.sourceControl]
@@ -332,7 +332,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
         // Add fingerprints for 1.0.0 source archive/code
         let package = PackageIdentity.plain("mona.LinkedList")
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             fingerprint: .init(
@@ -341,7 +341,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
                 contentType: .sourceCode
             )
         )
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             fingerprint: .init(
@@ -352,7 +352,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         )
 
         // Add fingerprints for 1.0.0 manifests
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             fingerprint: .init(
@@ -361,7 +361,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
                 contentType: .manifest(.none)
             )
         )
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             fingerprint: .init(
@@ -372,7 +372,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         )
 
         // Add fingerprint for 1.1.0 source archive
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.1.0"),
             fingerprint: .init(
@@ -382,7 +382,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
             )
         )
 
-        let fingerprints = try await storage.get(package: package, version: Version("1.0.0"))
+        let fingerprints = try storage.get(package: package, version: Version("1.0.0"))
         XCTAssertEqual(fingerprints.count, 2)
 
         let registryFingerprints = fingerprints[.registry]
@@ -405,16 +405,12 @@ extension PackageFingerprintStorage {
     fileprivate func get(
         package: PackageIdentity,
         version: Version
-    ) async throws -> [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]] {
-        try await withCheckedThrowingContinuation {
-            self.get(
-                package: package,
-                version: version,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: $0.resume(with:)
-            )
-        }
+    ) throws -> [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]] {
+        try self.get(
+            package: package,
+            version: version,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
     }
 
     fileprivate func get(
@@ -422,50 +418,38 @@ extension PackageFingerprintStorage {
         version: Version,
         kind: Fingerprint.Kind,
         contentType: Fingerprint.ContentType
-    ) async throws -> Fingerprint {
-        try await withCheckedThrowingContinuation {
-            self.get(
-                package: package,
-                version: version,
-                kind: kind,
-                contentType: contentType,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: $0.resume(with:)
-            )
-        }
+    ) throws -> Fingerprint {
+        try self.get(
+            package: package,
+            version: version,
+            kind: kind,
+            contentType: contentType,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
     }
 
     fileprivate func put(
         package: PackageIdentity,
         version: Version,
         fingerprint: Fingerprint
-    ) async throws {
-        try await withCheckedThrowingContinuation {
-            self.put(
-                package: package,
-                version: version,
-                fingerprint: fingerprint,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: $0.resume(with:)
-            )
-        }
+    ) throws {
+        try self.put(
+            package: package,
+            version: version,
+            fingerprint: fingerprint,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
     }
 
     fileprivate func get(
         package: PackageReference,
         version: Version
-    ) async throws -> [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]] {
-        try await withCheckedThrowingContinuation {
-            self.get(
-                package: package,
-                version: version,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: $0.resume(with:)
-            )
-        }
+    ) throws -> [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]] {
+        try self.get(
+            package: package,
+            version: version,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
     }
 
     fileprivate func get(
@@ -473,34 +457,26 @@ extension PackageFingerprintStorage {
         version: Version,
         kind: Fingerprint.Kind,
         contentType: Fingerprint.ContentType
-    ) async throws -> Fingerprint {
-        try await withCheckedThrowingContinuation {
-            self.get(
-                package: package,
-                version: version,
-                kind: kind,
-                contentType: contentType,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: $0.resume(with:)
-            )
-        }
+    ) throws -> Fingerprint {
+        try self.get(
+            package: package,
+            version: version,
+            kind: kind,
+            contentType: contentType,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
     }
 
     fileprivate func put(
         package: PackageReference,
         version: Version,
         fingerprint: Fingerprint
-    ) async throws {
-        try await withCheckedThrowingContinuation {
-            self.put(
-                package: package,
-                version: version,
-                fingerprint: fingerprint,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: $0.resume(with:)
-            )
-        }
+    ) throws {
+        try self.put(
+            package: package,
+            version: version,
+            fingerprint: fingerprint,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
     }
 }

--- a/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
@@ -52,10 +52,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
 
         // `signingEntity` meets requirement to be used for TOFU
         // (i.e., it's .recognized), so it should be saved to storage.
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[signingEntity]?.versions, [version])
@@ -84,10 +83,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         )
 
         // `signingEntity` is nil, so it should not be saved to storage.
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertTrue(packageSigners.isEmpty)
     }
@@ -120,10 +118,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         )
 
         // `signingEntity` is not .recognized, so it should not be saved to storage.
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertTrue(packageSigners.isEmpty)
     }
@@ -218,10 +215,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, [version])
@@ -280,10 +276,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, [version])
@@ -335,10 +330,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, [version])
@@ -383,10 +377,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         )
 
         // Storage should be updated with version 1.1.1 added
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[signingEntity]?.versions, [existingVersion, version])
@@ -453,10 +446,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, [existingVersion])
@@ -516,10 +508,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, [existingVersion])
@@ -565,10 +556,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         )
 
         // Storage should not be updated
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, existingVersions)
@@ -630,10 +620,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, existingVersions)
@@ -688,10 +677,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, existingVersions)
@@ -739,10 +727,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         )
 
         // Storage should not be updated
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, existingVersions)
@@ -788,10 +775,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         )
 
         // Storage should be updated with v2.0.0 added
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[expectedSigningEntity]?.versions, [expectedFromVersion, version])
@@ -852,10 +838,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         )
 
         // Storage should be updated with v2.0.0 added
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 2)
         XCTAssertEqual(packageSigners.signers[expectedSigningEntity]?.versions, [expectedFromVersion])
@@ -933,10 +918,9 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try await signingEntityStorage.get(
+        let packageSigners = try signingEntityStorage.get(
             package: package.underlying,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
         XCTAssertEqual(packageSigners.signers.count, 2)
         XCTAssertEqual(packageSigners.signers[expectedSigningEntity]?.versions, [expectedFromVersion])
@@ -1035,13 +1019,8 @@ extension PackageSigningEntityTOFU {
 }
 
 private class WriteConflictSigningEntityStorage: PackageSigningEntityStorage {
-    public func get(
-        package: PackageIdentity,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<PackageSigners, Error>) -> Void
-    ) {
-        callback(.success(PackageSigners()))
+    func get(package: PackageModel.PackageIdentity, observabilityScope: Basics.ObservabilityScope) throws -> PackageSigning.PackageSigners {
+        return PackageSigners()
     }
 
     public func put(
@@ -1049,22 +1028,20 @@ private class WriteConflictSigningEntityStorage: PackageSigningEntityStorage {
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
+        observabilityScope: ObservabilityScope
+    ) throws {
         let existing = SigningEntity.recognized(
             type: .adp,
             name: "xxx-\(signingEntity.name ?? "")",
             organizationalUnit: "xxx-\(signingEntity.organizationalUnit ?? "")",
             organization: "xxx-\(signingEntity.organization ?? "")"
         )
-        callback(.failure(PackageSigningEntityStorageError.conflict(
+        throw PackageSigningEntityStorageError.conflict(
             package: package,
             version: version,
             given: signingEntity,
             existing: existing
-        )))
+        )
     }
 
     public func add(
@@ -1072,11 +1049,9 @@ private class WriteConflictSigningEntityStorage: PackageSigningEntityStorage {
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
-        callback(.failure(StringError("unexpected call")))
+        observabilityScope: ObservabilityScope
+    ) throws {
+        throw StringError("unexpected call")
     }
 
     public func changeSigningEntityFromVersion(
@@ -1084,11 +1059,9 @@ private class WriteConflictSigningEntityStorage: PackageSigningEntityStorage {
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
-        callback(.failure(StringError("unexpected call")))
+        observabilityScope: ObservabilityScope
+    ) throws {
+        throw StringError("unexpected call")
     }
 
     public func changeSigningEntityForAllVersions(
@@ -1096,11 +1069,9 @@ private class WriteConflictSigningEntityStorage: PackageSigningEntityStorage {
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
-        callback(.failure(StringError("unexpected call")))
+        observabilityScope: ObservabilityScope
+    ) throws {
+        throw StringError("unexpected call")
     }
 }
 

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -2537,18 +2537,14 @@ final class RegistryClientTests: XCTestCase {
         XCTAssertEqual(contents.sorted(), [RegistryReleaseMetadataStorage.fileName, "Package.swift"].sorted())
 
         // Expected checksum is not found in storage so the metadata API will be called
-        let fingerprint = try await withCheckedThrowingContinuation {
-            fingerprintStorage.get(
-                package: identity,
-                version: version,
-                kind: .registry,
-                contentType: .sourceCode,
-                observabilityScope: ObservabilitySystem
-                    .NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: $0.resume(with:)
-            )
-        }
+        let fingerprint = try fingerprintStorage.get(
+            package: identity,
+            version: version,
+            kind: .registry,
+            contentType: .sourceCode,
+            observabilityScope: ObservabilitySystem
+                .NOOP
+        )
         XCTAssertEqual(SourceControlURL(registryURL), fingerprint.origin.url)
         XCTAssertEqual(checksum, fingerprint.value)
     }

--- a/Tests/PackageRegistryTests/SignatureValidationTests.swift
+++ b/Tests/PackageRegistryTests/SignatureValidationTests.swift
@@ -2097,11 +2097,10 @@ private struct AcceptingSignatureValidationDelegate: SignatureValidation.Delegat
 }
 
 extension PackageSigningEntityStorage {
-    fileprivate func get(package: PackageIdentity) async throws -> PackageSigners {
-        try await self.get(
+    fileprivate func get(package: PackageIdentity) throws -> PackageSigners {
+        try self.get(
             package: package,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
     }
 }

--- a/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
+++ b/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
@@ -40,19 +40,19 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
             organizationalUnit: "SwiftPM Test Unit 2",
             organization: "SwiftPM Test"
         )
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             signingEntity: davinci,
             origin: .registry(URL("http://foo.com"))
         )
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.1.0"),
             signingEntity: davinci,
             origin: .registry(URL("http://bar.com"))
         )
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("2.0.0"),
             signingEntity: appleseed,
@@ -60,7 +60,7 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         )
         // Record signing entity for another package
         let otherPackage = PackageIdentity.plain("other.LinkedList")
-        try await storage.put(
+        try storage.put(
             package: otherPackage,
             version: Version("1.0.0"),
             signingEntity: appleseed,
@@ -76,7 +76,7 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
 
         // Signed versions should be saved
         do {
-            let packageSigners = try await storage.get(package: package)
+            let packageSigners = try storage.get(package: package)
             XCTAssertNil(packageSigners.expectedSigner)
             XCTAssertEqual(packageSigners.signers.count, 2)
             XCTAssertEqual(packageSigners.signers[davinci]?.versions, [Version("1.0.0"), Version("1.1.0")])
@@ -89,7 +89,7 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         }
 
         do {
-            let packageSigners = try await storage.get(package: otherPackage)
+            let packageSigners = try storage.get(package: otherPackage)
             XCTAssertNil(packageSigners.expectedSigner)
             XCTAssertEqual(packageSigners.signers.count, 1)
             XCTAssertEqual(packageSigners.signers[appleseed]?.versions, [Version("1.0.0")])
@@ -116,7 +116,7 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
             organization: "SwiftPM Test"
         )
         let version = Version("1.0.0")
-        try await storage.put(
+        try storage.put(
             package: package,
             version: version,
             signingEntity: davinci,
@@ -124,7 +124,7 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         )
 
         // Writing different signing entities for the same version should fail
-        await XCTAssertAsyncThrowsError(try await storage.put(
+        await XCTAssertAsyncThrowsError(try storage.put(
             package: package,
             version: version,
             signingEntity: appleseed,
@@ -149,7 +149,7 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
             organization: "SwiftPM Test"
         )
         let version = Version("1.0.0")
-        try await storage.put(
+        try storage.put(
             package: package,
             version: version,
             signingEntity: appleseed,
@@ -157,14 +157,14 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         )
 
         // Writing same signing entity for version should be ok
-        try await storage.put(
+        try storage.put(
             package: package,
             version: version,
             signingEntity: appleseed,
             origin: .registry(URL("http://bar.com")) // origin is different and should be added
         )
 
-        let packageSigners = try await storage.get(package: package)
+        let packageSigners = try storage.get(package: package)
         XCTAssertNil(packageSigners.expectedSigner)
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[appleseed]?.versions, [Version("1.0.0")])
@@ -183,7 +183,7 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         let appleseed = SigningEntity.unrecognized(name: "J. Appleseed", organizationalUnit: nil, organization: nil)
         let version = Version("1.0.0")
 
-        await XCTAssertAsyncThrowsError(try await storage.put(
+        await XCTAssertAsyncThrowsError(try storage.put(
             package: package,
             version: version,
             signingEntity: appleseed,
@@ -214,7 +214,7 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
             organization: "SwiftPM Test"
         )
         let version = Version("1.0.0")
-        try await storage.put(
+        try storage.put(
             package: package,
             version: version,
             signingEntity: davinci,
@@ -222,14 +222,14 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         )
 
         // Adding different signing entity for the same version should not fail
-        try await storage.add(
+        try storage.add(
             package: package,
             version: version,
             signingEntity: appleseed,
             origin: .registry(URL("http://bar.com"))
         )
 
-        let packageSigners = try await storage.get(package: package)
+        let packageSigners = try storage.get(package: package)
         XCTAssertNil(packageSigners.expectedSigner)
         XCTAssertEqual(packageSigners.signers.count, 2)
         XCTAssertEqual(packageSigners.signers[appleseed]?.versions, [Version("1.0.0")])
@@ -253,14 +253,14 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
             organization: "SwiftPM Test"
         )
         let version = Version("1.0.0")
-        try await storage.put(
+        try storage.put(
             package: package,
             version: version,
             signingEntity: davinci,
             origin: .registry(URL("http://foo.com"))
         )
 
-        await XCTAssertAsyncThrowsError(try await storage.add(
+        await XCTAssertAsyncThrowsError(try storage.add(
             package: package,
             version: version,
             signingEntity: appleseed,
@@ -290,7 +290,7 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
             organizationalUnit: "SwiftPM Test Unit 2",
             organization: "SwiftPM Test"
         )
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             signingEntity: davinci,
@@ -298,14 +298,14 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         )
 
         // Sets package's expectedSigner and add package version signer
-        try await storage.changeSigningEntityFromVersion(
+        try storage.changeSigningEntityFromVersion(
             package: package,
             version: Version("1.5.0"),
             signingEntity: appleseed,
             origin: .registry(URL("http://bar.com"))
         )
 
-        let packageSigners = try await storage.get(package: package)
+        let packageSigners = try storage.get(package: package)
         XCTAssertEqual(packageSigners.expectedSigner?.signingEntity, appleseed)
         XCTAssertEqual(packageSigners.expectedSigner?.fromVersion, Version("1.5.0"))
         XCTAssertEqual(packageSigners.signers.count, 2)
@@ -328,14 +328,14 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
             organizationalUnit: "SwiftPM Test Unit",
             organization: "SwiftPM Test"
         )
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             signingEntity: davinci,
             origin: .registry(URL("http://foo.com"))
         )
 
-        await XCTAssertAsyncThrowsError(try await storage.changeSigningEntityFromVersion(
+        await XCTAssertAsyncThrowsError(try storage.changeSigningEntityFromVersion(
             package: package,
             version: Version("1.5.0"),
             signingEntity: appleseed,
@@ -365,13 +365,13 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
             organizationalUnit: "SwiftPM Test Unit 2",
             organization: "SwiftPM Test"
         )
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             signingEntity: davinci,
             origin: .registry(URL("http://foo.com"))
         )
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("2.0.0"),
             signingEntity: appleseed,
@@ -379,14 +379,14 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         )
 
         // Sets package's expectedSigner and remove all other signers
-        try await storage.changeSigningEntityForAllVersions(
+        try storage.changeSigningEntityForAllVersions(
             package: package,
             version: Version("1.5.0"),
             signingEntity: appleseed,
             origin: .registry(URL("http://bar.com"))
         )
 
-        let packageSigners = try await storage.get(package: package)
+        let packageSigners = try storage.get(package: package)
         XCTAssertEqual(packageSigners.expectedSigner?.signingEntity, appleseed)
         XCTAssertEqual(packageSigners.expectedSigner?.fromVersion, Version("1.5.0"))
         XCTAssertEqual(packageSigners.signers.count, 1)
@@ -407,14 +407,14 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
             organizationalUnit: "SwiftPM Test Unit",
             organization: "SwiftPM Test"
         )
-        try await storage.put(
+        try storage.put(
             package: package,
             version: Version("1.0.0"),
             signingEntity: davinci,
             origin: .registry(URL("http://foo.com"))
         )
 
-        await XCTAssertAsyncThrowsError(try await storage.changeSigningEntityForAllVersions(
+        await XCTAssertAsyncThrowsError(try storage.changeSigningEntityForAllVersions(
             package: package,
             version: Version("1.5.0"),
             signingEntity: appleseed,
@@ -428,11 +428,10 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
 }
 
 extension PackageSigningEntityStorage {
-    fileprivate func get(package: PackageIdentity) async throws -> PackageSigners {
-        try await self.get(
+    fileprivate func get(package: PackageIdentity) throws -> PackageSigners {
+        try self.get(
             package: package,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
     }
 
@@ -441,14 +440,13 @@ extension PackageSigningEntityStorage {
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin
-    ) async throws {
-        try await self.put(
-                package: package,
-                version: version,
-                signingEntity: signingEntity,
-                origin: origin,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent
+    ) throws {
+        try self.put(
+            package: package,
+            version: version,
+            signingEntity: signingEntity,
+            origin: origin,
+            observabilityScope: ObservabilitySystem.NOOP
         )
     }
 
@@ -457,14 +455,13 @@ extension PackageSigningEntityStorage {
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin
-    ) async throws {
-        try await self.add(
+    ) throws {
+        try self.add(
             package: package,
             version: version,
             signingEntity: signingEntity,
             origin: origin,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
     }
 
@@ -473,16 +470,14 @@ extension PackageSigningEntityStorage {
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin
-    ) async throws {
-        try await self.changeSigningEntityFromVersion(
+    ) throws {
+        try self.changeSigningEntityFromVersion(
             package: package,
             version: version,
             signingEntity: signingEntity,
             origin: origin,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
-
     }
 
     fileprivate func changeSigningEntityForAllVersions(
@@ -490,14 +485,13 @@ extension PackageSigningEntityStorage {
         version: Version,
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin
-    ) async throws {
-        try await self.changeSigningEntityForAllVersions(
+    ) throws {
+        try self.changeSigningEntityForAllVersions(
             package: package,
             version: version,
             signingEntity: signingEntity,
             origin: origin,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
     }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -2084,7 +2084,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.2.3")))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.2.3")))
         }
 
@@ -2095,7 +2095,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
 
@@ -2108,7 +2108,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
     }
@@ -2592,7 +2592,7 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .edited(nil))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
@@ -2613,7 +2613,7 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.2.0")))
             result.check(dependency: "bar", at: .edited(nil))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.2.0")))
             result.check(notPresent: "bar")
         }
@@ -2626,7 +2626,7 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
             result.check(dependency: "bar", at: .edited(nil))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
             result.check(notPresent: "bar")
         }
@@ -2639,7 +2639,7 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
@@ -2873,7 +2873,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .edited(nil))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
 
@@ -3683,7 +3683,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
 
@@ -3693,7 +3693,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(notPresent: "foo")
         }
     }
@@ -3756,7 +3756,7 @@ final class WorkspaceTests: XCTestCase {
             workspace.checkManagedDependencies { result in
                 result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             }
-            await workspace.checkResolved { result in
+            workspace.checkResolved { result in
                 result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             }
 
@@ -3868,7 +3868,7 @@ final class WorkspaceTests: XCTestCase {
                 "https://localhost/org/bar"
             )
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             XCTAssertEqual(result.store.resolvedPackages[.plain("foo")]?.packageRef.locationString, "https://localhost/org/foo")
@@ -3903,7 +3903,7 @@ final class WorkspaceTests: XCTestCase {
                 "https://localhost/org/bar.git"
             )
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             // URLs should be stable since URLs are canonically the same and we kept the resolved file between the two iterations
@@ -3938,7 +3938,7 @@ final class WorkspaceTests: XCTestCase {
                 "https://localhost/org/bar.git"
             )
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.1.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.1.0")))
             // URLs should reflect the actual dependencies since the new version forces rewrite of the resolved file
@@ -3977,7 +3977,7 @@ final class WorkspaceTests: XCTestCase {
                 "https://localhost/org/bar.git"
             )
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             // URLs should reflect the actual dependencies since we deleted the resolved file
@@ -4075,7 +4075,7 @@ final class WorkspaceTests: XCTestCase {
                 }
             }
 
-            await workspace.checkResolved { result in
+            workspace.checkResolved { result in
                 result.check(dependency: "foo", at: .checkout(.version("1.3.1")))
                 result.check(dependency: "bar", at: .checkout(.version("1.1.1")))
             }
@@ -4905,7 +4905,7 @@ final class WorkspaceTests: XCTestCase {
                 "https://scm.com/org/foo"
             )
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             XCTAssertEqual(result.store.resolvedPackages[.plain("foo")]?.packageRef.locationString, "https://scm.com/org/foo")
@@ -4932,7 +4932,7 @@ final class WorkspaceTests: XCTestCase {
                 "https://scm.com/other/foo"
             )
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.1.0")))
             XCTAssertEqual(result.store.resolvedPackages[.plain("foo")]?.packageRef.locationString, "https://scm.com/other/foo")
@@ -4994,7 +4994,7 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
             result.check(dependency: "bar", at: .checkout(.branch("develop")))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
             result.check(dependency: "bar", at: .checkout(.branch("develop")))
         }
@@ -5030,7 +5030,7 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.branch("develop")))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.branch("develop")))
         }
@@ -5043,7 +5043,7 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
@@ -5056,7 +5056,7 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
@@ -5406,7 +5406,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(path: "./bazzz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
         ]
 
-        try await await workspace.checkPackageGraphFailure(roots: ["Overridden/bazzz-master"], deps: deps) { diagnostics in
+        try await workspace.checkPackageGraphFailure(roots: ["Overridden/bazzz-master"], deps: deps) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .equal(
@@ -11460,7 +11460,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "https://github.com/org/foo.git")
         }
 
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             XCTAssertEqual(result.store.resolvedPackages["foo"]?.packageRef.locationString, "https://github.com/org/foo.git")
         }
     }
@@ -11597,7 +11597,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
         }
 
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             XCTAssertEqual(result.store.resolvedPackages["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
         }
     }
@@ -11727,7 +11727,7 @@ final class WorkspaceTests: XCTestCase {
              XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
          }
 
-         await workspace.checkResolved { result in
+         workspace.checkResolved { result in
              XCTAssertEqual(result.store.resolvedPackages["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
          }
 
@@ -11753,7 +11753,7 @@ final class WorkspaceTests: XCTestCase {
              XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
          }
 
-         await workspace.checkResolved { result in
+         workspace.checkResolved { result in
              XCTAssertEqual(result.store.resolvedPackages["foo"]?.packageRef.locationString, "https://github.com/org/foo")
          }
      }
@@ -11838,7 +11838,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "https://github.com/org/foo.git")
         }
 
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             XCTAssertEqual(result.store.resolvedPackages["foo"]?.packageRef.locationString, "https://github.com/org/foo.git")
         }
 
@@ -11858,7 +11858,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
         }
 
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             XCTAssertEqual(result.store.resolvedPackages["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
         }
     }
@@ -11991,7 +11991,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "https://github.com/org/foo.git")
         }
 
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             XCTAssertEqual(result.store.resolvedPackages["foo"]?.packageRef.locationString, "https://github.com/org/foo.git")
         }
 
@@ -12017,7 +12017,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.managedDependencies["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
         }
 
-        await workspace.checkResolved { result in
+        workspace.checkResolved { result in
             XCTAssertEqual(result.store.resolvedPackages["foo"]?.packageRef.locationString, "git@github.com:org/foo.git")
         }
     }


### PR DESCRIPTION
Refactored PackageFingerprintStorage to not use callbacks or async/await

### Motivation:

None of the implementations of PackageFingerprintStorage were actually async so completionHandlers were completely unnecessary. It is much simpler to make these traditional throwing methods and allow the caller to handle threading concerns themselves

### Modifications:

Removed callback and queues from PackageFingerprintStorage APIs
Remove async wrappers of PackageFingerprintStorage APIs
Recursively refactored callers of PackageFingerprintStorage that were actually sync to have sync signatures

### Result:

Significantly simpler and more readable code that can more easily be refactored to async when needed