### PR TITLE
[Build/Commands] Switch `SymbolGraphExtract` to use build plan

### DIFF
--- a/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
@@ -212,6 +212,11 @@ public final class ClangModuleBuildDescription {
     /// this module.
     package func symbolGraphExtractArguments() throws -> [String] {
         var args = [String]()
+
+        args += ["-module-name", self.target.c99name]
+        args += try self.buildParameters.tripleArgs(for: self.target)
+        args += ["-module-cache-path", try self.buildParameters.moduleCache.pathString]
+
         if self.clangTarget.isCXX {
             args += ["-cxx-interoperability-mode=default"]
         }

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -639,6 +639,11 @@ public final class SwiftModuleBuildDescription {
     /// this module.
     package func symbolGraphExtractArguments() throws -> [String] {
         var args = [String]()
+
+        args += ["-module-name", self.target.c99name]
+        args += try self.buildParameters.tripleArgs(for: self.target)
+        args += ["-module-cache-path", try self.buildParameters.moduleCache.pathString]
+
         args += try self.cxxInteroperabilityModeArguments(
             propagateFromCurrentModuleOtherSwiftFlags: true)
 

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -216,6 +216,10 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         AnySequence(self.productMap.values.map { $0 as SPMBuildCore.ProductBuildDescription })
     }
 
+    public var buildModules: AnySequence<SPMBuildCore.ModuleBuildDescription> {
+        AnySequence(self.targetMap.values.map { $0 as SPMBuildCore.ModuleBuildDescription })
+    }
+
     /// The results of invoking any build tool plugins used by targets in this build.
     public let buildToolPluginInvocationResults: [ResolvedModule.ID: [BuildToolPluginInvocationResult]]
 
@@ -672,15 +676,6 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         try self.externalLibrariesCache.memoize(key: binaryTarget) {
             try binaryTarget.parseXCFrameworks(for: triple, fileSystem: self.fileSystem)
         }
-    }
-
-    /// Determines the arguments needed to run `swift-symbolgraph-extract` for
-    /// a particular module.
-    public func symbolGraphExtractArguments(for module: ResolvedModule) throws -> [String] {
-        guard let description = self.targetMap[module.id] else {
-            throw InternalError("Expected description for module \(module)")
-        }
-        return try description.symbolGraphExtractArguments()
     }
 
     /// Returns the files and directories that affect the build process of this build plan.

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -80,6 +80,23 @@ extension ProductBuildDescription {
     }
 }
 
+public protocol ModuleBuildDescription {
+    /// The package the module belongs to.
+    var package: ResolvedPackage { get }
+
+    /// The underlying module this description is for.
+    var module: ResolvedModule { get }
+
+    /// The build parameters.
+    var buildParameters: BuildParameters { get }
+
+    /// FIXME: This shouldn't be necessary and ideally
+    /// there should be a way to ask build system to
+    /// introduce these arguments while building for symbol
+    /// graph extraction.
+    func symbolGraphExtractArguments() throws -> [String]
+}
+
 public protocol BuildPlan {
     /// Parameters used when building end products for the destination platform.
     var destinationBuildParameters: BuildParameters { get }
@@ -89,12 +106,10 @@ public protocol BuildPlan {
 
     var buildProducts: AnySequence<ProductBuildDescription> { get }
 
+    var buildModules: AnySequence<ModuleBuildDescription> { get }
+
     func createAPIToolCommonArgs(includeLibrarySearchPaths: Bool) throws -> [String]
     func createREPLArguments() throws -> [String]
-
-    /// Determines the arguments needed to run `swift-symbolgraph-extract` for
-    /// a particular module.
-    func symbolGraphExtractArguments(for module: ResolvedModule) throws -> [String]
 }
 
 public protocol BuildSystemFactory {

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -285,7 +285,7 @@ enum BuildError: Swift.Error {
 
 public struct BuildPlanResult {
     public let plan: Build.BuildPlan
-    public let targetMap: [ResolvedModule.ID: ModuleBuildDescription]
+    public let targetMap: [ResolvedModule.ID: Build.ModuleBuildDescription]
     public let productMap: [ResolvedProduct.ID: Build.ProductBuildDescription]
 
     public init(plan: Build.BuildPlan) throws {
@@ -316,7 +316,7 @@ public struct BuildPlanResult {
         XCTAssertEqual(self.plan.productMap.count, count, file: file, line: line)
     }
 
-    public func moduleBuildDescription(for name: String) throws -> ModuleBuildDescription {
+    public func moduleBuildDescription(for name: String) throws -> Build.ModuleBuildDescription {
         let matchingIDs = targetMap.keys.filter({ $0.moduleName == name })
         guard matchingIDs.count == 1, let target = targetMap[matchingIDs[0]] else {
             if matchingIDs.isEmpty {
@@ -342,7 +342,7 @@ public struct BuildPlanResult {
     }
 }
 
-extension ModuleBuildDescription {
+extension Build.ModuleBuildDescription {
     public func swift() throws -> SwiftModuleBuildDescription {
         switch self {
         case .swift(let description):


### PR DESCRIPTION
Yet another step on the path to remove `buildTriple` from `Resolved{Product, Module}`.

### Motivation:

Instead of trying to lookup modules in the module graph and then going the build plan for their descriptions, symbol-graph-extract should refer to the build plan directly.

### Modifications:

- Adds a new protocol `ModuleBuildDescription` to SPMBuildCore
- Conforms `Build.ModuleBuildDescription` to `SPMCore.ModuleBuildDescription`
- Adds a new field to BuildPlan and its protocol to expose build modules
- Uses buildModules to implement symbol graph extraction as a replacement for module graph + build plan lookups.

### Result:

One less place that replies on `buildTriple` which brings us closer to its eventual removal.
