### PR TITLE
Move plugins to `async`/`await`

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -561,7 +561,6 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             pluginName: plugin.moduleName,
             toolsVersion: plugin.toolsVersion,
             observabilityScope: self.observabilityScope,
-            callbackQueue: DispatchQueue.sharedConcurrent,
             delegate: delegate
         )
 

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -377,8 +377,8 @@ struct PluginCommand: AsyncSwiftCommand {
             fileSystem: swiftCommandState.fileSystem,
             modulesGraph: packageGraph,
             observabilityScope: swiftCommandState.observabilityScope,
-            callbackQueue: delegateQueue,
-            delegate: pluginDelegate
+            delegate: pluginDelegate,
+            delegateQueue: delegateQueue
         )
 
         // TODO: We should also emit a final line of output regarding the result.

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -537,7 +537,7 @@ final class PluginTests: XCTestCase {
                     )
 
                     let toolSearchDirectories = [try UserToolchain.default.swiftCompilerPath.parentDirectory]
-                    let success = try await withCheckedThrowingContinuation { plugin.invoke(
+                    let success = try await plugin.invoke(
                         action: .performCommand(package: package, arguments: arguments),
                         buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                         scriptRunner: scriptRunner,
@@ -553,10 +553,9 @@ final class PluginTests: XCTestCase {
                         fileSystem: localFileSystem,
                         modulesGraph: packageGraph,
                         observabilityScope: observability.topScope,
-                        callbackQueue: delegateQueue,
                         delegate: delegate,
-                        completion: $0.resume(with:))
-                    }
+                        delegateQueue: delegateQueue
+                    )
                     if expectFailure {
                         XCTAssertFalse(success, "expected command to fail, but it succeeded", file: file, line: line)
                     }
@@ -831,8 +830,8 @@ final class PluginTests: XCTestCase {
                             fileSystem: localFileSystem,
                             modulesGraph: packageGraph,
                             observabilityScope: observability.topScope,
-                            callbackQueue: delegateQueue,
-                            delegate: delegate
+                            delegate: delegate,
+                            delegateQueue: delegateQueue
                         )
                     } onCancel: {
                         do {


### PR DESCRIPTION
Move plugins to async/await

### Motivation:

Continue the migration from callbacks to async/await
Make progress to Swift 6 compatibility

### Modifications:

Move plugin related APIs to async/await

### Result:

Simpler more readable Swift code