### PR TITLE
Add (partial) support for building on Windows using SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -191,7 +191,8 @@ let package = Package(
             name: "Basics",
             dependencies: [
                 "_AsyncFileSystem",
-                "SPMSQLite3",
+                .target(name: "SPMSQLite3", condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .visionOS, .macCatalyst, .linux])),
+                .product(name: "CSQLite", package: "swift-toolchain-sqlite", condition: .when(platforms: [.windows])),
                 .product(name: "DequeModule", package: "swift-collections"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
@@ -646,6 +647,7 @@ let package = Package(
                 "processInputs/exit4",
                 "processInputs/simple-stdout-stderr",
                 "processInputs/deadlock-if-blocking-io",
+                "processInputs/echo",
                 "processInputs/in-to-out",
             ]
         ),
@@ -854,7 +856,8 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: relatedDependenciesBranch),
         .package(url: "https://github.com/apple/swift-system.git", "1.1.1" ..< "1.4.0"),
         .package(url: "https://github.com/apple/swift-collections.git", "1.0.1" ..< "1.2.0"),
-        .package(url: "https://github.com/apple/swift-certificates.git", "1.0.1" ..< "1.4.0"),
+        .package(url: "https://github.com/apple/swift-certificates.git", "1.0.1" ..< "1.6.0"),
+        .package(url: "https://github.com/swiftlang/swift-toolchain-sqlite.git", from: "0.1.0"),
     ]
 } else {
     package.dependencies += [
@@ -866,5 +869,6 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-system"),
         .package(path: "../swift-collections"),
         .package(path: "../swift-certificates"),
+        .package(path: "../swift-toolchain-sqlite"),
     ]
 }

--- a/Sources/Basics/SQLite.swift
+++ b/Sources/Basics/SQLite.swift
@@ -12,10 +12,18 @@
 
 import Foundation
 
+#if SWIFT_PACKAGE && os(Windows)
+#if USE_IMPL_ONLY_IMPORTS
+@_implementationOnly import CSQLite
+#else
+import CSQLite
+#endif
+#else
 #if USE_IMPL_ONLY_IMPORTS
 @_implementationOnly import SPMSQLite3
 #else
 import SPMSQLite3
+#endif
 #endif
 
 /// A minimal SQLite wrapper.

--- a/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
@@ -45,8 +45,8 @@ final class EnvironmentKeyTests: XCTestCase {
 
         #if os(Windows)
         // Test case insensitivity on windows
-        let key2 = EnvironmentKey("teSt")
-        XCTAssertEqual(key0, key2)
+        let key3 = EnvironmentKey("teSt")
+        XCTAssertEqual(key0, key3)
         #endif
     }
 


### PR DESCRIPTION
This adds a dependency on the new swift-toolchain-sqlite package, which allows swift-package-manager to build using swift build on Windows (including tests) without any additional flags or preinstalled dependencies.

It's "partial" because there is still one final blocker, which is that linking fails because we exceed the 65k exported symbol limit due to limitations in the build system, which can be addressed separately.