### PR TITLE
[Build] NFC: Rename `ModuleBuildDescription` property from `target` t…

### DIFF
--- a/Sources/Build/BuildDescription/ModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ModuleBuildDescription.swift
@@ -66,7 +66,7 @@ public enum ModuleBuildDescription: SPMBuildCore.ModuleBuildDescription {
         }
     }
 
-    var target: ResolvedModule {
+    public var module: ResolvedModule {
         switch self {
         case .swift(let buildDescription):
             return buildDescription.target
@@ -82,10 +82,6 @@ public enum ModuleBuildDescription: SPMBuildCore.ModuleBuildDescription {
         case .clang(let description):
             description.package
         }
-    }
-
-    public var module: ResolvedModule {
-        self.target
     }
 
     /// Paths to the binary libraries the target depends on.

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -192,7 +192,7 @@ extension LLBuildManifestBuilder {
         // Sort the product targets in topological order in order to collect and "bubble up"
         // their respective dependency graphs to the depending targets.
         let nodes = self.plan.targets.compactMap {
-            ResolvedModule.Dependency.module($0.target, conditions: [])
+            ResolvedModule.Dependency.module($0.module, conditions: [])
         }
         let allPackageDependencies = try topologicalSort(nodes, successors: { $0.dependencies })
         // Instantiate the inter-module dependency oracle which will cache commonly-scanned
@@ -319,7 +319,7 @@ extension LLBuildManifestBuilder {
         for targetDescription: ModuleBuildDescription,
         dependencyModuleDetailsMap: inout SwiftDriver.ExternalTargetModuleDetailsMap
     ) throws {
-        for dependency in targetDescription.target.dependencies(satisfying: targetDescription.buildParameters.buildEnvironment) {
+        for dependency in targetDescription.module.dependencies(satisfying: targetDescription.buildParameters.buildEnvironment) {
             switch dependency {
             case .product:
                 // Product dependencies are broken down into the targets that make them up.
@@ -358,7 +358,7 @@ extension LLBuildManifestBuilder {
         guard case .swift(let dependencySwiftTargetDescription) = targetDescription else {
             return
         }
-        dependencyModuleDetailsMap[ModuleDependencyId.swiftPlaceholder(targetDescription.target.c99name)] =
+        dependencyModuleDetailsMap[ModuleDependencyId.swiftPlaceholder(targetDescription.module.c99name)] =
             SwiftDriver.ExternalTargetModuleDetails(
                 path: TSCAbsolutePath(dependencySwiftTargetDescription.moduleOutputPath),
                 isFramework: false

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -239,11 +239,11 @@ extension LLBuildManifestBuilder {
                 let additionalOutputs: [Node]
                 if command.outputFiles.isEmpty {
                     if target.toolsVersion >= .v6_0 {
-                        additionalOutputs = [.virtual("\(target.target.c99name)-\(command.configuration.displayName ?? "\(pluginNumber)")")]
+                        additionalOutputs = [.virtual("\(target.module.c99name)-\(command.configuration.displayName ?? "\(pluginNumber)")")]
                         phonyOutputs += additionalOutputs
                     } else {
                         additionalOutputs = []
-                        observabilityScope.emit(warning: "Build tool command '\(displayName)' (applied to target '\(target.target.name)') does not declare any output files and therefore will not run. You may want to consider updating the given package to tools-version 6.0 (or higher) which would run such a build tool command even without declared outputs.")
+                        observabilityScope.emit(warning: "Build tool command '\(displayName)' (applied to target '\(target.module.name)') does not declare any output files and therefore will not run. You may want to consider updating the given package to tools-version 6.0 (or higher) which would run such a build tool command even without declared outputs.")
                     }
                     pluginNumber += 1
                 } else {
@@ -334,7 +334,7 @@ extension ModuleBuildDescription {
 
 extension ModuleBuildDescription {
     package var llbuildResourcesCmdName: String {
-        "\(self.target.name)-\(self.buildParameters.triple.tripleString)-\(self.buildParameters.buildConfig)\(self.buildParameters.suffix).module-resources"
+        "\(self.module.name)-\(self.buildParameters.triple.tripleString)-\(self.buildParameters.buildConfig)\(self.buildParameters.suffix).module-resources"
     }
 }
 

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -812,19 +812,19 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
     public func provideBuildErrorAdvice(for target: String, command: String, message: String) -> String? {
         // Find the target for which the error was emitted.  If we don't find it, we can't give any advice.
-        guard let _ = self._buildPlan?.targets.first(where: { $0.target.name == target }) else { return nil }
+        guard let _ = self._buildPlan?.targets.first(where: { $0.module.name == target }) else { return nil }
 
         // Check for cases involving modules that cannot be found.
         if let importedModule = try? RegEx(pattern: "no such module '(.+)'").matchGroups(in: message).first?.first {
             // A target is importing a module that can't be found.  We take a look at the build plan and see if can offer any advice.
 
             // Look for a target with the same module name as the one that's being imported.
-            if let importedTarget = self._buildPlan?.targets.first(where: { $0.target.c99name == importedModule }) {
+            if let importedTarget = self._buildPlan?.targets.first(where: { $0.module.c99name == importedModule }) {
                 // For the moment we just check for executables that other targets try to import.
-                if importedTarget.target.type == .executable {
+                if importedTarget.module.type == .executable {
                     return "module '\(importedModule)' is the main module of an executable, and cannot be imported by tests and other targets"
                 }
-                if importedTarget.target.type == .macro {
+                if importedTarget.module.type == .macro {
                     return "module '\(importedModule)' is a macro, and cannot be imported by tests and other targets"
                 }
 

--- a/Sources/Build/LLBuildDescription.swift
+++ b/Sources/Build/LLBuildDescription.swift
@@ -109,11 +109,11 @@ public struct BuildDescription: Codable {
         self.traitConfiguration = traitConfiguration
         self.targetDependencyMap = try plan.targets
             .reduce(into: [TargetName: [TargetName]]()) { partial, targetBuildDescription in
-                let deps = try targetBuildDescription.target.recursiveDependencies(
+                let deps = try targetBuildDescription.module.recursiveDependencies(
                     satisfying: targetBuildDescription.buildParameters.buildEnvironment
                 )
                 .compactMap(\.module).map(\.c99name)
-                partial[targetBuildDescription.target.c99name] = deps
+                partial[targetBuildDescription.module.c99name] = deps
             }
         var targetCommandLines: [TargetName: [CommandLineFlag]] = [:]
         var generatedSourceTargets: [TargetName] = []

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -179,8 +179,8 @@ final class BuildPlanTests: XCTestCase {
         ))
         result.checkProductsCount(2)
         result.checkTargetsCount(3)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "FooLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "BarLogging" })
     }
 
     func testDuplicateProductNamesUpstream1() async throws {
@@ -304,11 +304,11 @@ final class BuildPlanTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(6)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BazLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "YUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "FooLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "BarLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "BazLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "XUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "YUtils" })
     }
 
     func testDuplicateProductNamesUpstream2() async throws {
@@ -399,9 +399,9 @@ final class BuildPlanTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(4)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BazLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Logging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "BarLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "BazLogging" })
     }
 
     func testDuplicateProductNamesChained() async throws {
@@ -476,8 +476,8 @@ final class BuildPlanTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(3)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "FooLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "BarLogging" })
     }
 
     func testDuplicateProductNamesThrowError() async throws {
@@ -609,8 +609,8 @@ final class BuildPlanTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(3)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "FooLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "BarLogging" })
     }
 
     func testPackageNameFlag() async throws {
@@ -6092,8 +6092,8 @@ final class BuildPlanTests: XCTestCase {
         let result = try BuildPlanResult(plan: plan)
         result.checkProductsCount(1)
         result.checkTargetsCount(2)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "ASnippet" && $0.target.type == .snippet })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Lib" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "ASnippet" && $0.module.type == .snippet })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Lib" })
 
         let yaml = buildPath.appending("release.yaml")
         let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
@@ -6438,8 +6438,8 @@ final class BuildPlanTests: XCTestCase {
         ))
         result.checkProductsCount(3)
         result.checkTargetsCount(3)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "FooLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "BarLogging" })
         let buildProduct = try XCTUnwrap(
             result.productMap[.init(
                 productName: "exe",

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -199,11 +199,11 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkTargetsCount(3)
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "Logging" && $0.module.moduleAliases == nil }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" }
+                .contains { $0.module.name == "BarLogging" && $0.module.moduleAliases?["Logging"] == "BarLogging" }
         )
     }
 
@@ -403,11 +403,11 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkTargetsCount(3)
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "Logging" && $0.module.moduleAliases == nil }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" }
+                .contains { $0.module.name == "BarLogging" && $0.module.moduleAliases?["Logging"] == "BarLogging" }
         )
         #if os(macOS)
         let dylib = try result.buildProduct(for: "Logging")
@@ -489,11 +489,11 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkTargetsCount(3)
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "Logging" && $0.module.moduleAliases == nil }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "BazLogging" && $0.target.moduleAliases?["Logging"] == "BazLogging" }
+                .contains { $0.module.name == "BazLogging" && $0.module.moduleAliases?["Logging"] == "BazLogging" }
         )
         #if os(macOS)
         let staticlib = try result.buildProduct(for: "Logging")
@@ -617,17 +617,17 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkTargetsCount(5)
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "ALogging" && $0.target.moduleAliases?["Logging"] == "ALogging" }
+                .contains { $0.module.name == "ALogging" && $0.module.moduleAliases?["Logging"] == "ALogging" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "A" && $0.target.moduleAliases?["Logging"] == "ALogging" }
+                .contains { $0.module.name == "A" && $0.module.moduleAliases?["Logging"] == "ALogging" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "Logging" && $0.module.moduleAliases == nil }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "B" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "B" && $0.module.moduleAliases == nil })
         #if os(macOS)
         let dylib = try result.buildProduct(for: "Logging")
         XCTAssertTrue(
@@ -717,15 +717,15 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+                .contains { $0.module.name == "FooLogging" && $0.module.moduleAliases?["Logging"] == "FooLogging" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" }
+                .contains { $0.module.name == "BarLogging" && $0.module.moduleAliases?["Logging"] == "BarLogging" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "Logging" && $0.module.moduleAliases == nil }
         )
 
         let fooLoggingArgs = try result.moduleBuildDescription(for: "FooLogging").swift().compileArguments()
@@ -837,15 +837,15 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "OtherLogging" && $0.target.moduleAliases?["Logging"] == "OtherLogging" }
+                .contains { $0.module.name == "OtherLogging" && $0.module.moduleAliases?["Logging"] == "OtherLogging" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "OtherLogging" }
+                .contains { $0.module.name == "Utils" && $0.module.moduleAliases?["Logging"] == "OtherLogging" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "Logging" && $0.module.moduleAliases == nil }
         )
 
         let otherLoggingArgs = try result.moduleBuildDescription(for: "OtherLogging").swift().compileArguments()
@@ -1011,15 +1011,15 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkTargetsCount(4)
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "Logging" && $0.module.moduleAliases == nil }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "MetricsLogging" && $0.target.moduleAliases?["Logging"] == "MetricsLogging"
+                    $0.module.name == "MetricsLogging" && $0.module.moduleAliases?["Logging"] == "MetricsLogging"
                 }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingInvalidSourcesUpstream() async throws {
@@ -1344,15 +1344,15 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+                .contains { $0.module.name == "Utils" && $0.module.moduleAliases?["Logging"] == "FooLogging" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+                .contains { $0.module.name == "FooLogging" && $0.module.moduleAliases?["Logging"] == "FooLogging" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "Logging" && $0.module.moduleAliases == nil }
         )
     }
 
@@ -1451,26 +1451,26 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+                .contains { $0.module.name == "FooLogging" && $0.module.moduleAliases?["Logging"] == "FooLogging" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "FooMath" && $0.target.moduleAliases?["Math"] == "FooMath" }
+                .contains { $0.module.name == "FooMath" && $0.module.moduleAliases?["Math"] == "FooMath" }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" && $0.target
+                    $0.module.name == "Utils" && $0.module.moduleAliases?["Logging"] == "FooLogging" && $0.module
                         .moduleAliases?["Math"] == "FooMath"
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "Logging" && $0.module.moduleAliases == nil }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Math" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "exe" && $0.target.moduleAliases == nil })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "BarLogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Math" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "exe" && $0.module.moduleAliases == nil })
+        XCTAssertFalse(result.targetMap.values.contains { $0.module.name == "BarLogging" })
     }
 
     func testModuleAliasingAliasSkipUpstreamTargets() async throws {
@@ -1652,40 +1652,40 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(11)
 
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "D" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "D" && $0.module.moduleAliases == nil })
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "FooA" && $0.target.moduleAliases?["Foo"] == "FooA" }
+                .contains { $0.module.name == "FooA" && $0.module.moduleAliases?["Foo"] == "FooA" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "C" && $0.target.moduleAliases?["Foo"] == "FooA" }
+                .contains { $0.module.name == "C" && $0.module.moduleAliases?["Foo"] == "FooA" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "B" && $0.target.moduleAliases?["Foo"] == "FooA" }
+                .contains { $0.module.name == "B" && $0.module.moduleAliases?["Foo"] == "FooA" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "A" && $0.target.moduleAliases?["Foo"] == "FooA" }
+                .contains { $0.module.name == "A" && $0.module.moduleAliases?["Foo"] == "FooA" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "FooX" && $0.target.moduleAliases?["Foo"] == "FooX" }
+                .contains { $0.module.name == "FooX" && $0.module.moduleAliases?["Foo"] == "FooX" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Z" && $0.target.moduleAliases?["Foo"] == "FooX" }
+                .contains { $0.module.name == "Z" && $0.module.moduleAliases?["Foo"] == "FooX" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Y" && $0.target.moduleAliases?["Foo"] == "FooX" }
+                .contains { $0.module.name == "Y" && $0.module.moduleAliases?["Foo"] == "FooX" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "X" && $0.target.moduleAliases?["Foo"] == "FooX" }
+                .contains { $0.module.name == "X" && $0.module.moduleAliases?["Foo"] == "FooX" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingAllConflictingAliasesFromMultiProducts() async throws {
@@ -1830,19 +1830,19 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkTargetsCount(9)
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+                .contains { $0.module.name == "A" && $0.module.moduleAliases?["Utils"] == "XUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
-                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "B" && $0.module.moduleAliases?["Utils"] == "XUtils" && $0.module
+                        .moduleAliases?["Log"] == "XLog" && $0.module.moduleAliases?.count == 2
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                    $0.module.name == "XUtils" && $0.module.moduleAliases?["Utils"] == "XUtils" && $0.module
                         .moduleAliases?
                         .count == 1
                 }
@@ -1850,28 +1850,28 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "C" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target
-                        .moduleAliases?["Utils"] == "YUtils" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "C" && $0.module.moduleAliases?["Log"] == "XLog" && $0.module
+                        .moduleAliases?["Utils"] == "YUtils" && $0.module.moduleAliases?.count == 2
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "XLog" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target
-                        .moduleAliases?["Utils"] == "YUtils" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "XLog" && $0.module.moduleAliases?["Log"] == "XLog" && $0.module
+                        .moduleAliases?["Utils"] == "YUtils" && $0.module.moduleAliases?.count == 2
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "D" && $0.target.moduleAliases?["Utils"] == "YUtils" && $0.target
-                        .moduleAliases?["Log"] == "ZLog" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "D" && $0.module.moduleAliases?["Utils"] == "YUtils" && $0.module
+                        .moduleAliases?["Log"] == "ZLog" && $0.module.moduleAliases?.count == 2
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" && $0.target
+                    $0.module.name == "YUtils" && $0.module.moduleAliases?["Utils"] == "YUtils" && $0.module
                         .moduleAliases?
                         .count == 1
                 }
@@ -1879,15 +1879,15 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "ZLog" && $0.target.moduleAliases?["Log"] == "ZLog" && $0.target.moduleAliases?
+                    $0.module.name == "ZLog" && $0.module.moduleAliases?["Log"] == "ZLog" && $0.module.moduleAliases?
                         .count == 1
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "G" && $0.target.moduleAliases?["Utils"] == "YUtils" && $0.target
-                        .moduleAliases?["Log"] == "ZLog" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "G" && $0.module.moduleAliases?["Utils"] == "YUtils" && $0.module
+                        .moduleAliases?["Log"] == "ZLog" && $0.module.moduleAliases?.count == 2
                 }
         )
     }
@@ -2047,35 +2047,35 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "A" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?
+                    $0.module.name == "A" && $0.module.moduleAliases?["Log"] == "XLog" && $0.module.moduleAliases?
                         .count == 1
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
-                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "B" && $0.module.moduleAliases?["Utils"] == "XUtils" && $0.module
+                        .moduleAliases?["Log"] == "XLog" && $0.module.moduleAliases?.count == 2
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "C" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target
-                        .moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "C" && $0.module.moduleAliases?["Log"] == "XLog" && $0.module
+                        .moduleAliases?["Utils"] == "XUtils" && $0.module.moduleAliases?.count == 2
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "D" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
-                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "D" && $0.module.moduleAliases?["Utils"] == "XUtils" && $0.module
+                        .moduleAliases?["Log"] == "XLog" && $0.module.moduleAliases?.count == 2
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                    $0.module.name == "XUtils" && $0.module.moduleAliases?["Utils"] == "XUtils" && $0.module
                         .moduleAliases?
                         .count == 1
                 }
@@ -2083,21 +2083,21 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "XLog" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?
+                    $0.module.name == "XLog" && $0.module.moduleAliases?["Log"] == "XLog" && $0.module.moduleAliases?
                         .count == 1
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "G" && $0.target.moduleAliases?["Utils"] == "GUtils" && $0.target.moduleAliases?
+                    $0.module.name == "G" && $0.module.moduleAliases?["Utils"] == "GUtils" && $0.module.moduleAliases?
                         .count == 1
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "GUtils" && $0.target.moduleAliases?["Utils"] == "GUtils" && $0.target
+                    $0.module.name == "GUtils" && $0.module.moduleAliases?["Utils"] == "GUtils" && $0.module
                         .moduleAliases?
                         .count == 1
                 }
@@ -2265,35 +2265,35 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
-                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "A" && $0.module.moduleAliases?["Utils"] == "XUtils" && $0.module
+                        .moduleAliases?["Log"] == "XLog" && $0.module.moduleAliases?.count == 2
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
-                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "B" && $0.module.moduleAliases?["Utils"] == "XUtils" && $0.module
+                        .moduleAliases?["Log"] == "XLog" && $0.module.moduleAliases?.count == 2
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "C" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target
-                        .moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "C" && $0.module.moduleAliases?["Log"] == "XLog" && $0.module
+                        .moduleAliases?["Utils"] == "XUtils" && $0.module.moduleAliases?.count == 2
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "D" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
-                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "D" && $0.module.moduleAliases?["Utils"] == "XUtils" && $0.module
+                        .moduleAliases?["Log"] == "XLog" && $0.module.moduleAliases?.count == 2
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                    $0.module.name == "XUtils" && $0.module.moduleAliases?["Utils"] == "XUtils" && $0.module
                         .moduleAliases?
                         .count == 1
                 }
@@ -2301,22 +2301,22 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "XLog" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?
+                    $0.module.name == "XLog" && $0.module.moduleAliases?["Log"] == "XLog" && $0.module.moduleAliases?
                         .count == 1
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "G" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
-                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "G" && $0.module.moduleAliases?["Utils"] == "XUtils" && $0.module
+                        .moduleAliases?["Log"] == "XLog" && $0.module.moduleAliases?.count == 2
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "H" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
-                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                    $0.module.name == "H" && $0.module.moduleAliases?["Utils"] == "XUtils" && $0.module
+                        .moduleAliases?["Log"] == "XLog" && $0.module.moduleAliases?.count == 2
                 }
         )
     }
@@ -2445,33 +2445,33 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "LibUtils" && $0.target
+                    $0.module.name == "Lib" && $0.module.moduleAliases?["Utils"] == "LibUtils" && $0.module
                         .moduleAliases?["Render"] == "LibRender"
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "LibRender" && $0.target.moduleAliases?["Render"] == "LibRender" }
+                .contains { $0.module.name == "LibRender" && $0.module.moduleAliases?["Render"] == "LibRender" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "LibUtils" && $0.target.moduleAliases?["Utils"] == "LibUtils" }
+                .contains { $0.module.name == "LibUtils" && $0.module.moduleAliases?["Utils"] == "LibUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "Game" && $0.target.moduleAliases?["Utils"] == "LibUtils" && $0.target
+                    $0.module.name == "Game" && $0.module.moduleAliases?["Utils"] == "LibUtils" && $0.module
                         .moduleAliases?["Render"] == nil
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "DrawRender" && $0.target.moduleAliases?["Render"] == "DrawRender" }
+                .contains { $0.module.name == "DrawRender" && $0.module.moduleAliases?["Render"] == "DrawRender" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Render" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "GameUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Render" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Utils" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
+        XCTAssertFalse(result.targetMap.values.contains { $0.module.name == "GameUtils" })
     }
 
     func testModuleAliasingAddOverrideAliasesUpstream() async throws {
@@ -2591,25 +2591,25 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "GameUtils" && $0.target
+                    $0.module.name == "Lib" && $0.module.moduleAliases?["Utils"] == "GameUtils" && $0.module
                         .moduleAliases?["Render"] == "GameRender"
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "GameRender" && $0.target.moduleAliases?["Render"] == "GameRender" }
+                .contains { $0.module.name == "GameRender" && $0.module.moduleAliases?["Render"] == "GameRender" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "GameUtils" && $0.target.moduleAliases?["Utils"] == "GameUtils" }
+                .contains { $0.module.name == "GameUtils" && $0.module.moduleAliases?["Utils"] == "GameUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "DrawRender" && $0.target.moduleAliases?["Render"] == "DrawRender" }
+                .contains { $0.module.name == "DrawRender" && $0.module.moduleAliases?["Render"] == "DrawRender" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Render" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Render" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Utils" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingOverrideUpstreamTargetsWithAliases() async throws {
@@ -2736,29 +2736,29 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "GameUtils" && $0.target
+                    $0.module.name == "Lib" && $0.module.moduleAliases?["Utils"] == "GameUtils" && $0.module
                         .moduleAliases?["Render"] == "GameRender"
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "GameRender" && $0.target.moduleAliases?["Render"] == "GameRender" }
+                .contains { $0.module.name == "GameRender" && $0.module.moduleAliases?["Render"] == "GameRender" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "GameUtils" && $0.target.moduleAliases?["Utils"] == "GameUtils" }
+                .contains { $0.module.name == "GameUtils" && $0.module.moduleAliases?["Utils"] == "GameUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Scene" && $0.target.moduleAliases?["Render"] == "DrawRender" }
+                .contains { $0.module.name == "Scene" && $0.module.moduleAliases?["Render"] == "DrawRender" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "DrawRender" && $0.target.moduleAliases?["Render"] == "DrawRender" }
+                .contains { $0.module.name == "DrawRender" && $0.module.moduleAliases?["Render"] == "DrawRender" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Render" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Render" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Utils" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingOverrideUpstreamTargetsWithAliasesMultipleAliasesInProduct() async throws {
@@ -2888,29 +2888,29 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "LibUtils" && $0.target
+                    $0.module.name == "Lib" && $0.module.moduleAliases?["Utils"] == "LibUtils" && $0.module
                         .moduleAliases?["Render"] == "LibRender"
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "LibRender" && $0.target.moduleAliases?["Render"] == "LibRender" }
+                .contains { $0.module.name == "LibRender" && $0.module.moduleAliases?["Render"] == "LibRender" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "LibUtils" && $0.target.moduleAliases?["Utils"] == "LibUtils" }
+                .contains { $0.module.name == "LibUtils" && $0.module.moduleAliases?["Utils"] == "LibUtils" }
         )
         XCTAssertFalse(
             result.targetMap.values
-                .contains { $0.target.name == "DrawRender" || $0.target.moduleAliases?["Render"] == "DrawRender" }
+                .contains { $0.module.name == "DrawRender" || $0.module.moduleAliases?["Render"] == "DrawRender" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Game" && $0.target.moduleAliases?["Utils"] == "LibUtils" }
+                .contains { $0.module.name == "Game" && $0.module.moduleAliases?["Utils"] == "LibUtils" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Render" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Render" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Utils" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingOverrideUpstreamTargetsWithAliasesDownstream() async throws {
@@ -3042,33 +3042,33 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "LibUtils" && $0.target
+                    $0.module.name == "Lib" && $0.module.moduleAliases?["Utils"] == "LibUtils" && $0.module
                         .moduleAliases?["Render"] == "LibRender"
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "LibRender" && $0.target.moduleAliases?["Render"] == "LibRender" }
+                .contains { $0.module.name == "LibRender" && $0.module.moduleAliases?["Render"] == "LibRender" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "LibUtils" && $0.target.moduleAliases?["Utils"] == "LibUtils" }
+                .contains { $0.module.name == "LibUtils" && $0.module.moduleAliases?["Utils"] == "LibUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Game" && $0.target.moduleAliases?["Utils"] == "LibUtils" }
+                .contains { $0.module.name == "Game" && $0.module.moduleAliases?["Utils"] == "LibUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Scene" && $0.target.moduleAliases?["Render"] == "DrawRender" }
+                .contains { $0.module.name == "Scene" && $0.module.moduleAliases?["Render"] == "DrawRender" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "DrawRender" && $0.target.moduleAliases?["Render"] == "DrawRender" }
+                .contains { $0.module.name == "DrawRender" && $0.module.moduleAliases?["Render"] == "DrawRender" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Render" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Render" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Utils" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingSameTargetFromUpstreamWithoutAlias() async throws {
@@ -3156,19 +3156,19 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+                .contains { $0.module.name == "Utils" && $0.module.moduleAliases?["Logging"] == "FooLogging" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+                .contains { $0.module.name == "FooLogging" && $0.module.moduleAliases?["Logging"] == "FooLogging" }
         )
         XCTAssertFalse(
             result.targetMap.values
-                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "Logging" && $0.module.moduleAliases == nil }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "MyLogging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "MyLogging" && $0.module.moduleAliases == nil }
         )
     }
 
@@ -3269,23 +3269,23 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+                .contains { $0.module.name == "FooLogging" && $0.module.moduleAliases?["Logging"] == "FooLogging" }
         )
         XCTAssertFalse(
             result.targetMap.values
-                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "Logging" && $0.module.moduleAliases == nil }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "CarLogging" && $0.target.moduleAliases?["Logging"] == "CarLogging" }
+                .contains { $0.module.name == "CarLogging" && $0.module.moduleAliases?["Logging"] == "CarLogging" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+                .contains { $0.module.name == "Utils" && $0.module.moduleAliases?["Logging"] == "FooLogging" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "MyLogging" && $0.target.moduleAliases == nil }
+                .contains { $0.module.name == "MyLogging" && $0.module.moduleAliases == nil }
         )
     }
 
@@ -3347,14 +3347,14 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkTargetsCount(4)
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "X" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+                .contains { $0.module.name == "X" && $0.module.moduleAliases?["Utils"] == "XUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+                .contains { $0.module.name == "XUtils" && $0.module.moduleAliases?["Utils"] == "XUtils" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Utils" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingProductTargetsWithSameName1() async throws {
@@ -3495,26 +3495,26 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkTargetsCount(6)
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "X" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+                .contains { $0.module.name == "X" && $0.module.moduleAliases?["Utils"] == "XUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+                .contains { $0.module.name == "XUtils" && $0.module.moduleAliases?["Utils"] == "XUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+                .contains { $0.module.name == "A" && $0.module.moduleAliases?["Utils"] == "AUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+                .contains { $0.module.name == "B" && $0.module.moduleAliases?["Utils"] == "AUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+                .contains { $0.module.name == "AUtils" && $0.module.moduleAliases?["Utils"] == "AUtils" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
+        XCTAssertFalse(result.targetMap.values.contains { $0.module.name == "Utils" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingUpstreamProductTargetsWithSameName2() async throws {
@@ -3669,26 +3669,26 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(7)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "X" && $0.module.moduleAliases == nil })
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+                .contains { $0.module.name == "XUtils" && $0.module.moduleAliases?["Utils"] == "XUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" }
+                .contains { $0.module.name == "YUtils" && $0.module.moduleAliases?["Utils"] == "YUtils" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "A" && $0.module.moduleAliases == nil })
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+                .contains { $0.module.name == "AUtils" && $0.module.moduleAliases?["Utils"] == "AUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "BUtils" && $0.target.moduleAliases?["Utils"] == "BUtils" }
+                .contains { $0.module.name == "BUtils" && $0.module.moduleAliases?["Utils"] == "BUtils" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
+        XCTAssertFalse(result.targetMap.values.contains { $0.module.name == "Utils" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingUpstreamProductTargetsWithSameName3() async throws {
@@ -3804,21 +3804,21 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(6)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "X" && $0.module.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Utils" && $0.module.moduleAliases == nil })
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" }
+                .contains { $0.module.name == "YUtils" && $0.module.moduleAliases?["Utils"] == "YUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+                .contains { $0.module.name == "A" && $0.module.moduleAliases?["Utils"] == "AUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+                .contains { $0.module.name == "AUtils" && $0.module.moduleAliases?["Utils"] == "AUtils" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingUpstreamProductTargetsWithSameName4() async throws {
@@ -3934,21 +3934,21 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(5)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "X" && $0.module.moduleAliases == nil })
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+                .contains { $0.module.name == "XUtils" && $0.module.moduleAliases?["Utils"] == "XUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" }
+                .contains { $0.module.name == "YUtils" && $0.module.moduleAliases?["Utils"] == "YUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+                .contains { $0.module.name == "AUtils" && $0.module.moduleAliases?["Utils"] == "AUtils" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
+        XCTAssertFalse(result.targetMap.values.contains { $0.module.name == "Utils" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingChainedAliases1() async throws {
@@ -4080,34 +4080,34 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" && $0.target
+                    $0.module.name == "A" && $0.module.moduleAliases?["Utils"] == "AUtils" && $0.module
                         .moduleAliases?["FooUtils"] == "AFooUtils"
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "X" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                    $0.module.name == "X" && $0.module.moduleAliases?["Utils"] == "XUtils" && $0.module
                         .moduleAliases?["FooUtils"] == "XFooUtils"
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+                .contains { $0.module.name == "AUtils" && $0.module.moduleAliases?["Utils"] == "AUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+                .contains { $0.module.name == "XUtils" && $0.module.moduleAliases?["Utils"] == "XUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "AFooUtils" && $0.target.moduleAliases?["Utils"] == "AFooUtils" }
+                .contains { $0.module.name == "AFooUtils" && $0.module.moduleAliases?["Utils"] == "AFooUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "XFooUtils" && $0.target.moduleAliases?["Utils"] == "XFooUtils" }
+                .contains { $0.module.name == "XFooUtils" && $0.module.moduleAliases?["Utils"] == "XFooUtils" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingChainedAliases2() async throws {
@@ -4254,28 +4254,28 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" && $0.target
+                    $0.module.name == "A" && $0.module.moduleAliases?["Utils"] == "AUtils" && $0.module
                         .moduleAliases?["FooUtils"] == "AFUtils"
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+                .contains { $0.module.name == "AUtils" && $0.module.moduleAliases?["Utils"] == "AUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "AFUtils" && $0.target.moduleAliases?["Utils"] == "AFUtils" }
+                .contains { $0.module.name == "AFUtils" && $0.module.moduleAliases?["Utils"] == "AFUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "X" && $0.target.moduleAliases?["FooUtils"] == "XFUtils" }
+                .contains { $0.module.name == "X" && $0.module.moduleAliases?["FooUtils"] == "XFUtils" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "Utils" && $0.module.moduleAliases == nil })
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "XFUtils" && $0.target.moduleAliases?["Utils"] == "XFUtils" }
+                .contains { $0.module.name == "XFUtils" && $0.module.moduleAliases?["Utils"] == "XFUtils" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingChainedAliases3() async throws {
@@ -4426,35 +4426,35 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" && $0.target
+                    $0.module.name == "A" && $0.module.moduleAliases?["Utils"] == "AUtils" && $0.module
                         .moduleAliases?["FooUtils"] == "AFooUtils"
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+                .contains { $0.module.name == "AUtils" && $0.module.moduleAliases?["Utils"] == "AUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "AFooUtils" && $0.target.moduleAliases?["Utils"] == "AFooUtils" }
+                .contains { $0.module.name == "AFooUtils" && $0.module.moduleAliases?["Utils"] == "AFooUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
                 .contains {
-                    $0.target.name == "X" && $0.target.moduleAliases?["ZUtils"] == "XUtils" && $0.target
+                    $0.module.name == "X" && $0.module.moduleAliases?["ZUtils"] == "XUtils" && $0.module
                         .moduleAliases?["FooUtils"] == "XFooUtils"
                 }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+                .contains { $0.module.name == "XUtils" && $0.module.moduleAliases?["Utils"] == "XUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "XFooUtils" && $0.target.moduleAliases?["Utils"] == "XFooUtils" }
+                .contains { $0.module.name == "XFooUtils" && $0.module.moduleAliases?["Utils"] == "XFooUtils" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
+        XCTAssertFalse(result.targetMap.values.contains { $0.module.name == "Utils" && $0.module.moduleAliases == nil })
     }
 
     func testModuleAliasingChainedAliases5() async throws {
@@ -4594,28 +4594,28 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkTargetsCount(6)
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "Utils" && $0.target.moduleAliases?["ZUtils"] == "YUtils" }
+                .contains { $0.module.name == "Utils" && $0.module.moduleAliases?["ZUtils"] == "YUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+                .contains { $0.module.name == "XUtils" && $0.module.moduleAliases?["Utils"] == "XUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" }
+                .contains { $0.module.name == "YUtils" && $0.module.moduleAliases?["Utils"] == "YUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "WUtils" && $0.target.moduleAliases?["Utils"] == "WUtils" }
+                .contains { $0.module.name == "WUtils" && $0.module.moduleAliases?["Utils"] == "WUtils" }
         )
         XCTAssertTrue(
             result.targetMap.values
-                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+                .contains { $0.module.name == "AUtils" && $0.module.moduleAliases?["Utils"] == "AUtils" }
         )
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.module.name == "App" && $0.module.moduleAliases == nil })
         XCTAssertFalse(
             result.targetMap.values
-                .contains { $0.target.name == "ZUtils" || $0.target.moduleAliases?["Utils"] == "ZUtils" }
+                .contains { $0.module.name == "ZUtils" || $0.module.moduleAliases?["Utils"] == "ZUtils" }
         )
     }
 


### PR DESCRIPTION
…o `module`

Looks like this was missed by previous refactorings.