### PR TITLE
[BuildPlan] Add a way to traverse the graph and compute destinations for all modules

### DIFF
--- a/Sources/Basics/Graph/GraphAlgorithms.swift
+++ b/Sources/Basics/Graph/GraphAlgorithms.swift
@@ -86,3 +86,50 @@ public func depthFirstSearch<T: Hashable>(
         }
     }
 }
+
+private struct TraversalNode<T: Hashable>: Hashable {
+    let parent: T?
+    let curr: T
+    let depth: Int
+}
+
+/// Implements a pre-order depth-first search that traverses the whole graph and
+/// doesn't distinguish between unique and duplicate nodes. The method expects
+/// the graph to be acyclic but doesn't check that.
+///
+/// - Parameters:
+///   - nodes: The list of input nodes to sort.
+///   - successors: A closure for fetching the successors of a particular node.
+///   - onNext: A callback to indicate the node currently being processed
+///             including its parent (if any) and its depth.
+///
+/// - Complexity: O(v + e) where (v, e) are the number of vertices and edges
+/// reachable from the input nodes via the relation.
+public func depthFirstSearch<T: Hashable>(
+    _ nodes: [T],
+    successors: (T) throws -> [T],
+    onNext: (T, _ parent: T?, _ depth: Int) throws -> Void
+) rethrows {
+    var stack = OrderedSet<TraversalNode<T>>()
+
+    for node in nodes {
+        precondition(stack.isEmpty)
+        stack.append(TraversalNode(parent: nil, curr: node, depth: 0))
+
+        while !stack.isEmpty {
+            let node = stack.removeLast()
+
+            try onNext(node.curr, node.parent, node.depth)
+
+            for succ in try successors(node.curr) {
+                stack.append(
+                    TraversalNode(
+                        parent: node.curr,
+                        curr: succ,
+                        depth: node.depth + 1
+                    )
+                )
+            }
+        }
+    }
+}

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -904,6 +904,66 @@ extension BuildPlan {
 extension BuildPlan {
     fileprivate typealias Destination = BuildParameters.Destination
 
+    fileprivate enum TraversalNode: Hashable {
+        case package(ResolvedPackage)
+        case product(ResolvedProduct, BuildParameters.Destination)
+        case module(ResolvedModule, BuildParameters.Destination)
+
+        var destination: BuildParameters.Destination {
+            switch self {
+            case .package:
+                .target
+            case .product(_, let destination):
+                destination
+            case .module(_, let destination):
+                destination
+            }
+        }
+
+        init(
+            product: ResolvedProduct,
+            context destination: BuildParameters.Destination
+        ) {
+            switch product.type {
+            case .macro, .plugin:
+                self = .product(product, .host)
+            case .test:
+                self = .product(product, product.modules.contains(where: Self.hasMacroDependency) ? .host : destination)
+            default:
+                self = .product(product, destination)
+            }
+        }
+
+        init(
+            module: ResolvedModule,
+            context destination: BuildParameters.Destination
+        ) {
+            switch module.type {
+            case .macro, .plugin:
+                // Macros and plugins are ways built for host
+                self = .module(module, .host)
+            case .test:
+                self = .module(module, Self.hasMacroDependency(module: module) ? .host : destination)
+            default:
+                // By default assume the destination of the context.
+                // This means that i.e. test products that reference macros
+                // would force all of their successors to be `host`
+                self = .module(module, destination)
+            }
+        }
+
+        static func hasMacroDependency(module: ResolvedModule) -> Bool {
+            module.dependencies.contains(where: {
+                switch $0 {
+                case .product(let productDependency, _):
+                    productDependency.type == .macro
+                case .module(let moduleDependency, _):
+                    moduleDependency.type == .macro
+                }
+            })
+        }
+    }
+
     /// Traverse the modules graph and find a destination for every product and module.
     /// All non-macro/plugin products and modules have `target` destination with one
     /// notable exception - test products/modules with direct macro dependency.
@@ -912,57 +972,8 @@ extension BuildPlan {
         onProduct: (ResolvedProduct, Destination) throws -> Void,
         onModule: (ResolvedModule, Destination) async throws -> Void
     ) async rethrows {
-        enum Node: Hashable {
-            case package(ResolvedPackage)
-            case product(ResolvedProduct, Destination)
-            case module(ResolvedModule, Destination)
-
-            static func `for`(
-                product: ResolvedProduct,
-                context destination: Destination
-            ) -> Node {
-                switch product.type {
-                case .macro, .plugin:
-                    .product(product, .host)
-                case .test:
-                    .product(product, product.modules.contains(where: self.hasMacroDependency) ? .host : destination)
-                default:
-                    .product(product, destination)
-                }
-            }
-
-            static func `for`(
-                module: ResolvedModule,
-                context destination: Destination
-            ) -> Node {
-                switch module.type {
-                case .macro, .plugin:
-                    // Macros and plugins are ways built for host
-                    .module(module, .host)
-                case .test:
-                    .module(module, self.hasMacroDependency(module: module) ? .host : destination)
-                default:
-                    // By default assume the destination of the context.
-                    // This means that i.e. test products that reference macros
-                    // would force all of their successors to be `host`
-                    .module(module, destination)
-                }
-            }
-
-            static func hasMacroDependency(module: ResolvedModule) -> Bool {
-                module.dependencies.contains(where: {
-                    switch $0 {
-                    case .product(let productDependency, _):
-                        productDependency.type == .macro
-                    case .module(let moduleDependency, _):
-                        moduleDependency.type == .macro
-                    }
-                })
-            }
-        }
-
-        func successors(for package: ResolvedPackage) -> [Node] {
-            var successors: [Node] = []
+        func successors(for package: ResolvedPackage) -> [TraversalNode] {
+            var successors: [TraversalNode] = []
             for product in package.products {
                 if case .test = product.underlying.type,
                    !graph.rootPackages.contains(id: package.id)
@@ -970,7 +981,7 @@ extension BuildPlan {
                     continue
                 }
 
-                successors.append(.for(product: product, context: .target))
+                successors.append(.init(product: product, context: .target))
             }
 
             for module in package.modules {
@@ -980,7 +991,7 @@ extension BuildPlan {
                     continue
                 }
 
-                successors.append(.for(module: module, context: .target))
+                successors.append(.init(module: module, context: .target))
             }
 
             return successors
@@ -989,35 +1000,35 @@ extension BuildPlan {
         func successors(
             for product: ResolvedProduct,
             destination: Destination
-        ) -> [Node] {
+        ) -> [TraversalNode] {
             guard destination == .host else {
                 return []
             }
 
             return product.modules.map { module in
-                .for(module: module, context: destination)
+                TraversalNode(module: module, context: destination)
             }
         }
 
         func successors(
             for module: ResolvedModule,
             destination: Destination
-        ) -> [Node] {
+        ) -> [TraversalNode] {
             guard destination == .host else {
                 return []
             }
 
-            return module.dependencies.reduce(into: [Node]()) { partial, dependency in
+            return module.dependencies.reduce(into: [TraversalNode]()) { partial, dependency in
                 switch dependency {
                 case .product(let product, conditions: _):
-                    partial.append(.for(product: product, context: destination))
+                    partial.append(.init(product: product, context: destination))
                 case .module(let module, _):
-                    partial.append(.for(module: module, context: destination))
+                    partial.append(.init(module: module, context: destination))
                 }
             }
         }
 
-        try await depthFirstSearch(graph.packages.map { Node.package($0) }) { node in
+        try await depthFirstSearch(graph.packages.map { TraversalNode.package($0) }) { node in
             switch node {
             case .package(let package):
                 successors(for: package)
@@ -1038,6 +1049,71 @@ extension BuildPlan {
             }
         } onDuplicate: { _, _ in
             // No de-duplication is necessary we only want unique nodes.
+        }
+    }
+
+    /// Traverses the modules graph, computes destination of every module reference and
+    /// provides the data to the caller by means of `onModule` callback. The products
+    /// are completely transparent to this method and are represented by their module dependencies.
+    package func traverseModules(
+        _ onModule: (
+            (ResolvedModule, BuildParameters.Destination),
+            _ parent: (ResolvedModule, BuildParameters.Destination)?,
+            _ depth: Int
+        ) -> Void
+    ) {
+        func successors(for package: ResolvedPackage) -> [TraversalNode] {
+            package.modules.compactMap {
+                if case .test = $0.underlying.type,
+                   !self.graph.rootPackages.contains(id: package.id)
+                {
+                    return nil
+                }
+                return .init(module: $0, context: .target)
+            }
+        }
+
+        func successors(
+            for module: ResolvedModule,
+            destination: Destination
+        ) -> [TraversalNode] {
+            module.dependencies.reduce(into: [TraversalNode]()) { partial, dependency in
+                switch dependency {
+                case .product(let product, conditions: _):
+                    let parent = TraversalNode(product: product, context: destination)
+                    for module in product.modules {
+                        partial.append(.init(module: module, context: parent.destination))
+                    }
+                case .module(let module, _):
+                    partial.append(.init(module: module, context: destination))
+                }
+            }
+        }
+
+        depthFirstSearch(self.graph.packages.map { TraversalNode.package($0) }) {
+            switch $0 {
+            case .package(let package):
+                successors(for: package)
+            case .module(let module, let destination):
+                successors(for: module, destination: destination)
+            case .product:
+                []
+            }
+        } onNext: { current, parent, depth in
+            let parentModule: (ResolvedModule, BuildParameters.Destination)? = switch parent {
+            case .package, .product, nil:
+                nil
+            case .module(let module, let destination):
+                (module, destination)
+            }
+
+            switch current {
+            case .package, .product:
+                break
+
+            case .module(let module, let destination):
+                onModule((module, destination), parentModule, depth)
+            }
         }
     }
 }

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -107,14 +107,6 @@ public struct ModulesGraph {
     /// Returns all the modules in the graph, regardless if they are reachable from the root modules or not.
     public private(set) var allModules: IdentifiableSet<ResolvedModule>
 
-    /// Returns all modules within the graph in topological order, starting with low-level modules (that have no
-    /// dependencies).
-    package var allModulesInTopologicalOrder: [ResolvedModule] {
-        get throws {
-            try topologicalSort(Array(allModules)) { $0.dependencies.compactMap { $0.module } }.reversed()
-        }
-    }
-
     /// Returns all the products in the graph, regardless if they are reachable from the root modules or not.
     public private(set) var allProducts: IdentifiableSet<ResolvedProduct>
 

--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -39,6 +39,8 @@ struct PluginTargetBuildDescription: BuildTarget {
         return target.sources.paths.map { URL(fileURLWithPath: $0.pathString) }
     }
 
+    var headers: [URL] { [] }
+
     var name: String {
         return target.name
     }

--- a/Tests/BuildTests/BuildPlanTraversalTests.swift
+++ b/Tests/BuildTests/BuildPlanTraversalTests.swift
@@ -1,0 +1,146 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+import Basics
+@testable import Build
+
+import PackageGraph
+
+import _InternalTestSupport
+import SPMBuildCore
+
+final class BuildPlanTraversalTests: XCTestCase {
+    typealias Dest = BuildParameters.Destination
+
+    struct Result {
+        let parent: (ResolvedModule, Dest)?
+        let module: (ResolvedModule, Dest)
+        let depth: Int
+    }
+
+    func getResults(
+        for module: String,
+        with destination: Dest? = nil,
+        in results: [Result]
+    ) -> [Result] {
+        results.filter { result in
+            if result.module.0.name != module {
+                return false
+            }
+            guard let destination else {
+                return true
+            }
+
+            return result.module.1 == destination
+        }
+    }
+
+    func getParents(
+        in results: [Result],
+        for module: String,
+        destination: Dest? = nil
+    ) -> [String] {
+        self.getResults(
+            for: module,
+            with: destination,
+            in: results
+        ).reduce(into: Set<String>()) {
+            if let parent = $1.parent {
+                $0.insert(parent.0.name)
+            }
+        }.sorted()
+    }
+
+    func getUniqueOccurrences(
+        in results: [Result],
+        for module: String,
+        destination: Dest? = nil
+    ) -> [Int] {
+        self.getResults(
+            for: module,
+            with: destination,
+            in: results
+        ).reduce(into: Set<Int>()) {
+            $0.insert($1.depth)
+        }.sorted()
+    }
+
+    func testTrivialTraversal() async throws {
+        let destinationTriple = Triple.arm64Linux
+        let toolsTriple = Triple.x86_64MacOS
+
+        let (graph, fs, scope) = try trivialPackageGraph()
+        let plan = try await BuildPlan(
+            destinationBuildParameters: mockBuildParameters(
+                destination: .target,
+                triple: destinationTriple
+            ),
+            toolsBuildParameters: mockBuildParameters(
+                destination: .host,
+                triple: toolsTriple
+            ),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: scope
+        )
+
+        var results: [Result] = []
+        plan.traverseModules {
+            results.append(Result(parent: $1, module: $0, depth: $2))
+        }
+
+        XCTAssertEqual(self.getParents(in: results, for: "app"), [])
+        XCTAssertEqual(self.getParents(in: results, for: "lib"), ["app", "test"])
+        XCTAssertEqual(self.getParents(in: results, for: "test"), [])
+
+        XCTAssertEqual(self.getUniqueOccurrences(in: results, for: "app"), [1])
+        XCTAssertEqual(self.getUniqueOccurrences(in: results, for: "lib"), [1, 2])
+        XCTAssertEqual(self.getUniqueOccurrences(in: results, for: "test"), [1])
+    }
+
+    func testTraversalWithDifferentDestinations() async throws {
+        let destinationTriple = Triple.arm64Linux
+        let toolsTriple = Triple.x86_64MacOS
+
+        let (graph, fs, scope) = try macrosPackageGraph()
+        let plan = try await BuildPlan(
+            destinationBuildParameters: mockBuildParameters(
+                destination: .target,
+                triple: destinationTriple
+            ),
+            toolsBuildParameters: mockBuildParameters(
+                destination: .host,
+                triple: toolsTriple
+            ),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: scope
+        )
+
+        var results: [Result] = []
+        plan.traverseModules {
+            results.append(Result(parent: $1, module: $0, depth: $2))
+        }
+
+        XCTAssertEqual(self.getParents(in: results, for: "MMIO"), ["HAL"])
+        XCTAssertEqual(self.getParents(in: results, for: "SwiftSyntax", destination: .host), ["MMIOMacros"])
+        XCTAssertEqual(self.getParents(in: results, for: "HAL", destination: .target), ["Core", "HALTests"])
+        XCTAssertEqual(self.getParents(in: results, for: "HAL", destination: .host), [])
+
+        XCTAssertEqual(self.getUniqueOccurrences(in: results, for: "MMIO"), [1, 2, 3, 4])
+        XCTAssertEqual(self.getUniqueOccurrences(in: results, for: "SwiftSyntax", destination: .target), [1])
+        XCTAssertEqual(self.getUniqueOccurrences(in: results, for: "SwiftSyntax", destination: .host), [2, 3, 4, 5, 6])
+        XCTAssertEqual(self.getUniqueOccurrences(in: results, for: "HAL"), [1, 2, 3])
+    }
+}


### PR DESCRIPTION
### Motivation:

This is going to be used by sourcekit-lsp to build a graph/dictionary
of all the targets and depths they appear during package loading and
replaces the need for topological sort and `buildTriple`.

### Modifications:

- Introduces a new `depthFirstSearch` variant which traverses all of the nodes in the graph.
- Adds a new method to `BuildPlan` - `traverseModules` which goes over the graph, computes destinations and returns modules with their parents and depths they appear at (the method looks though products).

### Result:

This make it possible to switch sourcekit-lsp away from using topological sort and relying on `buildTriple`.

Paired with https://github.com/swiftlang/sourcekit-lsp/pull/1621
