### PR TITLE
Allow relative path with `swift package add-dependency` command

### DIFF
--- a/Sources/Commands/PackageCommands/AddDependency.swift
+++ b/Sources/Commands/PackageCommands/AddDependency.swift
@@ -66,24 +66,24 @@ extension SwiftPackageCommand {
                 throw StringError("unknown package")
             }
 
-            switch type {
+            switch self.type {
             case .url:
                 try self.createSourceControlPackage(
                     packagePath: packagePath,
                     workspace: workspace,
-                    url: dependency
+                    url: self.dependency
                 )
             case .path:
                 try self.createFileSystemPackage(
                     packagePath: packagePath,
                     workspace: workspace,
-                    directory: dependency
+                    directory: self.dependency
                 )
             case .registry:
                 try self.createRegistryPackage(
                     packagePath: packagePath,
                     workspace: workspace,
-                    id: dependency
+                    id: self.dependency
                 )
             }
         }
@@ -144,19 +144,10 @@ extension SwiftPackageCommand {
                 }
             }
 
-            let packageDependency: PackageDependency = .sourceControl(
-                identity: identity,
-                nameForTargetDependencyResolutionOnly: nil,
-                location: .remote(.init(url)),
-                requirement: requirement,
-                productFilter: .everything,
-                traits: []
-            )
-
-            try applyEdits(
+            try self.applyEdits(
                 packagePath: packagePath,
                 workspace: workspace,
-                packageDependency: packageDependency
+                packageDependency: .sourceControl(name: nil, location: url, requirement: requirement)
             )
         }
 
@@ -208,18 +199,10 @@ extension SwiftPackageCommand {
                 }
             }
 
-            let packageDependency: PackageDependency = .registry(
-                identity: identity,
-                requirement: requirement,
-                productFilter: .everything,
-                traits: []
-            )
-
-
-            try applyEdits(
+            try self.applyEdits(
                 packagePath: packagePath,
                 workspace: workspace,
-                packageDependency: packageDependency
+                packageDependency: .registry(id: id, requirement: requirement)
             )
         }
 
@@ -228,29 +211,17 @@ extension SwiftPackageCommand {
             workspace: Workspace,
             directory: String
         ) throws {
-            guard let path = try? Basics.AbsolutePath(validating: directory) else {
-                throw StringError("Package path not found")
-            }
-            let identity = PackageIdentity(path: path)
-            let packageDependency: PackageDependency = .fileSystem(
-                identity: identity,
-                nameForTargetDependencyResolutionOnly: nil,
-                path: path,
-                productFilter: .everything,
-                traits: []
-            )
-
-            try applyEdits(
+            try self.applyEdits(
                 packagePath: packagePath,
                 workspace: workspace,
-                packageDependency: packageDependency
+                packageDependency: .fileSystem(name: nil, path: directory)
             )
         }
 
         private func applyEdits(
             packagePath: Basics.AbsolutePath,
             workspace: Workspace,
-            packageDependency: PackageDependency
+            packageDependency: MappablePackageDependency.Kind
         ) throws {
             // Load the manifest file
             let fileSystem = workspace.fileSystem

--- a/Sources/PackageModelSyntax/AddPackageDependency.swift
+++ b/Sources/PackageModelSyntax/AddPackageDependency.swift
@@ -18,7 +18,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 
 /// Add a package dependency to a manifest's source code.
-public struct AddPackageDependency {
+public enum AddPackageDependency {
     /// The set of argument labels that can occur after the "dependencies"
     /// argument in the Package initializers.
     ///
@@ -28,13 +28,13 @@ public struct AddPackageDependency {
         "targets",
         "swiftLanguageVersions",
         "cLanguageStandard",
-        "cxxLanguageStandard"
+        "cxxLanguageStandard",
     ]
 
     /// Produce the set of source edits needed to add the given package
     /// dependency to the given manifest file.
     public static func addPackageDependency(
-        _ dependency: PackageDependency,
+        _ dependency: MappablePackageDependency.Kind,
         to manifest: SourceFileSyntax
     ) throws -> PackageEditResult {
         // Make sure we have a suitable tools version in the manifest.
@@ -50,19 +50,19 @@ public struct AddPackageDependency {
 
         return PackageEditResult(
             manifestEdits: [
-                .replace(packageCall, with: newPackageCall.description)
+                .replace(packageCall, with: newPackageCall.description),
             ]
         )
     }
 
     /// Implementation of adding a package dependency to an existing call.
     static func addPackageDependencyLocal(
-        _ dependency: PackageDependency,
+        _ dependency: MappablePackageDependency.Kind,
         to packageCall: FunctionCallExprSyntax
     ) throws -> FunctionCallExprSyntax {
         try packageCall.appendingToArrayArgument(
             label: "dependencies",
-            trailingLabels: Self.argumentLabelsAfterDependencies,
+            trailingLabels: self.argumentLabelsAfterDependencies,
             newElement: dependency.asSyntax()
         )
     }

--- a/Sources/PackageModelSyntax/PackageDependency+Syntax.swift
+++ b/Sources/PackageModelSyntax/PackageDependency+Syntax.swift
@@ -16,38 +16,16 @@ import SwiftParser
 import SwiftSyntax
 import struct TSCUtility.Version
 
-extension PackageDependency: ManifestSyntaxRepresentable {
+extension MappablePackageDependency.Kind: ManifestSyntaxRepresentable {
     func asSyntax() -> ExprSyntax {
         switch self {
-        case .fileSystem(let filesystem): filesystem.asSyntax()
-        case .sourceControl(let sourceControl): sourceControl.asSyntax()
-        case .registry(let registry): registry.asSyntax()
+        case .fileSystem(name: _, path: let path):
+            ".package(path: \(literal: path.description))"
+        case .sourceControl(name: _, location: let location, requirement: let requirement):
+            ".package(url: \(literal: location.description), \(requirement.asSyntax()))"
+        case .registry(id: let id, requirement: let requirement):
+            ".package(id: \(literal: id.description), \(requirement.asSyntax()))"
         }
-    }
-}
-
-extension PackageDependency.FileSystem: ManifestSyntaxRepresentable {
-    func asSyntax() -> ExprSyntax {
-        ".package(path: \(literal: path.description))"
-    }
-}
-
-extension PackageDependency.SourceControl: ManifestSyntaxRepresentable {
-    func asSyntax() -> ExprSyntax {
-        // TODO: Not handling identity, nameForTargetDependencyResolutionOnly,
-        // or productFilter yet.
-        switch location {
-        case .local:
-            fatalError()
-        case .remote(let url):
-            ".package(url: \(literal: url.description), \(requirement.asSyntax()))"
-        }
-    }
-}
-
-extension PackageDependency.Registry: ManifestSyntaxRepresentable {
-    func asSyntax() -> ExprSyntax {
-        ".package(id: \(literal: identity.description), \(requirement.asSyntax()))"
     }
 }
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -890,8 +890,32 @@ final class PackageCommandTests: CommandsTestCase {
                 [
                     "add-dependency",
                     "https://github.com/swiftlang/swift-syntax.git",
+                    "--from",
+                    "2.0.0",
+                    "--to",
+                    "2.2.0",
+                ],
+                packagePath: path
+            )
+
+            _ = try await execute(
+                [
+                    "add-dependency",
+                    "https://github.com/swiftlang/swift-syntax.git",
                     "--up-to-next-minor-from",
                     "1.0.0",
+                ],
+                packagePath: path
+            )
+
+            _ = try await execute(
+                [
+                    "add-dependency",
+                    "https://github.com/swiftlang/swift-syntax.git",
+                    "--up-to-next-minor-from",
+                    "3.0.0",
+                    "--to",
+                    "3.3.0",
                 ],
                 packagePath: path
             )
@@ -905,7 +929,9 @@ final class PackageCommandTests: CommandsTestCase {
             XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", branch: "main"),"#))
             XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", revision: "58e9de4e7b79e67c72a46e164158e3542e570ab6"),"#))
             XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", from: "1.0.0"),"#))
+            XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", "2.0.0" ..< "2.2.0"),"#))
             XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", "1.0.0" ..< "1.1.0"),"#))
+            XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", "3.0.0" ..< "3.3.0"),"#))
         }
     }
 
@@ -929,10 +955,19 @@ final class PackageCommandTests: CommandsTestCase {
             _ = try await execute(
                 [
                     "add-dependency",
-                    "/directory",
+                    "/absolute",
                     "--type",
                     "path"
+                ],
+                packagePath: path
+            )
 
+            _ = try await execute(
+                [
+                    "add-dependency",
+                    "../relative",
+                    "--type",
+                    "path"
                 ],
                 packagePath: path
             )
@@ -941,7 +976,8 @@ final class PackageCommandTests: CommandsTestCase {
             XCTAssertFileExists(manifest)
             let contents: String = try fs.readFileContents(manifest)
 
-            XCTAssertMatch(contents, .contains(#".package(path: "/directory"),"#))
+            XCTAssertMatch(contents, .contains(#".package(path: "/absolute"),"#))
+            XCTAssertMatch(contents, .contains(#".package(path: "../relative"),"#))
         }
     }
 
@@ -992,8 +1028,36 @@ final class PackageCommandTests: CommandsTestCase {
                     "scope.name",
                     "--type",
                     "registry",
+                    "--from",
+                    "2.0.0",
+                    "--to",
+                    "2.2.0",
+                ],
+                packagePath: path
+            )
+
+            _ = try await execute(
+                [
+                    "add-dependency",
+                    "scope.name",
+                    "--type",
+                    "registry",
                     "--up-to-next-minor-from",
                     "1.0.0",
+                ],
+                packagePath: path
+            )
+
+            _ = try await execute(
+                [
+                    "add-dependency",
+                    "scope.name",
+                    "--type",
+                    "registry",
+                    "--up-to-next-minor-from",
+                    "3.0.0",
+                    "--to",
+                    "3.3.0",
                 ],
                 packagePath: path
             )
@@ -1004,7 +1068,9 @@ final class PackageCommandTests: CommandsTestCase {
 
             XCTAssertMatch(contents, .contains(#".package(id: "scope.name", exact: "1.0.0"),"#))
             XCTAssertMatch(contents, .contains(#".package(id: "scope.name", from: "1.0.0"),"#))
+            XCTAssertMatch(contents, .contains(#".package(id: "scope.name", "2.0.0" ..< "2.2.0"),"#))
             XCTAssertMatch(contents, .contains(#".package(id: "scope.name", "1.0.0" ..< "1.1.0"),"#))
+            XCTAssertMatch(contents, .contains(#".package(id: "scope.name", "3.0.0" ..< "3.3.0"),"#))
         }
     }
 

--- a/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
+++ b/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
@@ -67,15 +67,12 @@ func assertManifestRefactor(
 }
 
 class ManifestEditTests: XCTestCase {
-    static let swiftSystemURL: SourceControlURL = "https://github.com/apple/swift-system.git"
-    static let swiftSystemPackageDependency = PackageDependency.remoteSourceControl(
-            identity: PackageIdentity(url: swiftSystemURL),
-            nameForTargetDependencyResolutionOnly: nil,
-            url: swiftSystemURL,
-            requirement: .branch("main"), productFilter: .nothing,
-            traits: []
-        )
-
+    static let swiftSystemURL: String = "https://github.com/apple/swift-system.git"
+    static let swiftSystemPackageDependency: MappablePackageDependency.Kind = .sourceControl(
+        name: nil,
+        location: swiftSystemURL,
+        requirement: .branch("main")
+    )
     func testAddPackageDependencyExistingComma() throws {
         try assertManifestRefactor("""
             // swift-tools-version: 5.5
@@ -96,13 +93,7 @@ class ManifestEditTests: XCTestCase {
             )
             """) { manifest in
                 try AddPackageDependency.addPackageDependency(
-                    PackageDependency.remoteSourceControl(
-                        identity: PackageIdentity(url: Self.swiftSystemURL),
-                        nameForTargetDependencyResolutionOnly: nil,
-                        url: Self.swiftSystemURL,
-                        requirement: .branch("main"), productFilter: .nothing,
-                        traits:[]
-                    ),
+                    .sourceControl(name: nil, location: Self.swiftSystemURL, requirement: .branch("main")),
                     to: manifest
                 )
             }
@@ -128,14 +119,7 @@ class ManifestEditTests: XCTestCase {
             )
             """) { manifest in
                 try AddPackageDependency.addPackageDependency(
-                    PackageDependency.remoteSourceControl(
-                        identity: PackageIdentity(url: Self.swiftSystemURL),
-                        nameForTargetDependencyResolutionOnly: nil,
-                        url: Self.swiftSystemURL,
-                        requirement: .exact("510.0.0"),
-                        productFilter: .nothing,
-                        traits: []
-                    ),
+                    .sourceControl(name: nil, location: Self.swiftSystemURL, requirement: .exact("510.0.0")),
                     to: manifest
                 )
             }
@@ -163,14 +147,7 @@ class ManifestEditTests: XCTestCase {
                 let versionRange = Range<Version>.upToNextMajor(from: Version(510, 0, 0))
 
                 return try AddPackageDependency.addPackageDependency(
-                    PackageDependency.remoteSourceControl(
-                        identity: PackageIdentity(url: Self.swiftSystemURL),
-                        nameForTargetDependencyResolutionOnly: nil,
-                        url: Self.swiftSystemURL,
-                        requirement: .range(versionRange),
-                        productFilter: .nothing,
-                        traits: []
-                    ),
+                    .sourceControl(name: nil, location: Self.swiftSystemURL, requirement: .range(versionRange)),
                     to: manifest
                 )
         }
@@ -193,14 +170,7 @@ class ManifestEditTests: XCTestCase {
                 let versionRange = Range<Version>.upToNextMajor(from: Version(510, 0, 0))
 
                 return try AddPackageDependency.addPackageDependency(
-                    PackageDependency.remoteSourceControl(
-                        identity: PackageIdentity(url: Self.swiftSystemURL),
-                        nameForTargetDependencyResolutionOnly: nil,
-                        url: Self.swiftSystemURL,
-                        requirement: .range(versionRange),
-                        productFilter: .nothing,
-                        traits: []
-                    ),
+                    .sourceControl(name: nil, location: Self.swiftSystemURL, requirement: .range(versionRange)),
                     to: manifest
                 )
         }
@@ -223,14 +193,7 @@ class ManifestEditTests: XCTestCase {
             )
             """) { manifest in
             try AddPackageDependency.addPackageDependency(
-                    PackageDependency.remoteSourceControl(
-                        identity: PackageIdentity(url: Self.swiftSystemURL),
-                        nameForTargetDependencyResolutionOnly: nil,
-                        url: Self.swiftSystemURL,
-                        requirement: .range(Version(508,0,0)..<Version(510,0,0)),
-                        productFilter: .nothing,
-                        traits: []
-                    ),
+                .sourceControl(name: nil, location: Self.swiftSystemURL, requirement: .range(Version(508,0,0)..<Version(510,0,0))),
                 to: manifest
             )
         }


### PR DESCRIPTION
Enable passing relative path into `swift package add-dependency`

### Motivation:
Currently only `AbsolutePath`s are supported with `--type path` flag
```bash
swift package add-dependency /packagePath --type path
```
There is a need to support `RelativePath` because it's not uncommon to have a package structure inside of an xcodeproj as shown below.

```bash
LocalPackages
├── ChildPackage
│   ├── .gitignore
│   ├── .swiftpm
│   ├── Package.swift
│   ├── Sources
│   └── Tests
└── ParentPackage
    ├── .build
    ├── .gitignore
    ├── .swiftpm
    ├── Package.swift
    ├── Sources
    └── Tests
```

If we want to open `ParentPackage` by itself, it will not be able to resolve that package.


This pr allows for the user to add a package with a `RelativePath` path via the `swift package add-dependency --type path` command.

Access level for 
- `.package(name:url:requirement:traits:)`
- `.package(name:url:requirement:)`
- `.package(id:requirement:traits:)`

were upgraded from `private` to `package` allowing access to these functions from the `PackageCommands` module.

### Modifications:
- Enable passing relative path into `swift package add-dependency`
- Add unit test coverage

### Result:
Both of the following commands are valid

```bash
swift package add-dependency ../relative --type path
```

```bash
swift package add-dependency /absolute --type path
```

