### PR TITLE
Update package templates to use Swift Testing in the toolchain rather than as a package dependency.

### DIFF
--- a/Fixtures/Miscellaneous/TestDiscovery/SwiftTesting/Package.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/SwiftTesting/Package.swift
@@ -1,18 +1,9 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
     name: "SwiftTesting",
-    platforms: [
-      .macOS(.v13), .iOS(.v16), .watchOS(.v9), .tvOS(.v16), .visionOS(.v1)
-    ],
-    dependencies: [
-      .package(url: "https://github.com/apple/swift-testing.git", branch: "main"),
-    ],
     targets: [
-        .testTarget(
-            name: "SwiftTestingTests",
-            dependencies: [.product(name: "Testing", package: "swift-testing"),]
-        ),
+        .testTarget(name: "SwiftTestingTests"),
     ]
 )

--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -56,14 +56,16 @@ extension SwiftPackageCommand {
 
             let packageName = self.packageName ?? cwd.basename
 
-            // Which testing libraries should be used? XCTest is on by default,
-            // but Swift Testing must remain off by default until it is present
-            // in the Swift toolchain.
+            // Testing is on by default, with XCTest only enabled explicitly.
+            // For macros this is reversed, since we don't support testing
+            // macros with Swift Testing yet.
             var supportedTestingLibraries = Set<TestingLibrary>()
-            if testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
+            if testLibraryOptions.isExplicitlyEnabled(.xctest, swiftCommandState: swiftCommandState) ||
+                (initMode == .macro && testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState)) {
                 supportedTestingLibraries.insert(.xctest)
             }
-            if testLibraryOptions.isExplicitlyEnabled(.swiftTesting, swiftCommandState: swiftCommandState) {
+            if testLibraryOptions.isExplicitlyEnabled(.swiftTesting, swiftCommandState: swiftCommandState) ||
+                (initMode != .macro && testLibraryOptions.isEnabled(.swiftTesting, swiftCommandState: swiftCommandState)) {
                 supportedTestingLibraries.insert(.swiftTesting)
             }
 

--- a/Sources/PackageModelSyntax/AddTarget.swift
+++ b/Sources/PackageModelSyntax/AddTarget.swift
@@ -43,7 +43,7 @@ public struct AddTarget {
         case swiftTesting = "swift-testing"
 
         /// The default testing library to use.
-        public static var `default`: TestHarness = .xctest
+        public static var `default`: TestHarness = .swiftTesting
     }
 
     /// Additional configuration information to guide the package editing
@@ -83,11 +83,6 @@ public struct AddTarget {
             // Macro targets need to depend on a couple of libraries from
             // SwiftSyntax.
             target.dependencies.append(contentsOf: macroTargetDependencies)
-
-        case .test where configuration.testHarness == .swiftTesting:
-            // Testing targets using swift-testing need to depend on
-            // SwiftTesting from the swift-testing package.
-            target.dependencies.append(contentsOf: swiftTestingTestTargetDependencies)
 
         default:
             break;
@@ -163,17 +158,6 @@ public struct AddTarget {
                 }
             }
 
-        case .test where configuration.testHarness == .swiftTesting:
-            if !manifest.description.contains("swift-testing") {
-                newPackageCall = try AddPackageDependency
-                    .addPackageDependencyLocal(
-                        .swiftTesting(
-                          configuration: installedSwiftPMConfiguration
-                        ),
-                        to: newPackageCall
-                    )
-            }
-
         default: break;
         }
 
@@ -212,8 +196,7 @@ public struct AddTarget {
                 importModuleNames.append("XCTest")
 
             case .swiftTesting: 
-                // Import is handled by the added dependency.
-                break
+                importModuleNames.append("Testing")
             }
         }
 
@@ -376,39 +359,6 @@ fileprivate extension PackageDependency {
             nameForTargetDependencyResolutionOnly: nil,
             location: .remote(swiftSyntaxURL),
             requirement: .range(.upToNextMajor(from: swiftSyntaxVersion)),
-            productFilter: .everything,
-            traits: []
-        )
-    }
-}
-
-/// The set of dependencies we need to introduce to a newly-created macro
-/// target.
-fileprivate let swiftTestingTestTargetDependencies: [TargetDescription.Dependency] = [
-    .product(name: "Testing", package: "swift-testing"),
-]
-
-
-/// The package dependency for swift-testing, for use in test files.
-fileprivate extension PackageDependency {
-    /// Source control URL for the swift-syntax package.
-    static var swiftTestingURL: SourceControlURL {
-        "https://github.com/apple/swift-testing.git"
-    }
-
-    /// Package dependency on the swift-testing package.
-    static func swiftTesting(
-      configuration: InstalledSwiftPMConfiguration
-    ) -> PackageDependency {
-        let swiftTestingVersionDefault =
-            configuration.swiftTestingVersionForTestTemplate
-        let swiftTestingVersion = Version(swiftTestingVersionDefault.description)!
-
-        return .sourceControl(
-            identity: PackageIdentity(url: swiftTestingURL),
-            nameForTargetDependencyResolutionOnly: nil,
-            location: .remote(swiftTestingURL),
-            requirement: .range(.upToNextMajor(from: swiftTestingVersion)),
             productFilter: .everything,
             traits: []
         )

--- a/Sources/PackageModelSyntax/AddTarget.swift
+++ b/Sources/PackageModelSyntax/AddTarget.swift
@@ -43,7 +43,7 @@ public struct AddTarget {
         case swiftTesting = "swift-testing"
 
         /// The default testing library to use.
-        public static var `default`: TestHarness = .swiftTesting
+        public static var `default`: TestHarness = .xctest
     }
 
     /// Additional configuration information to guide the package editing

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -432,7 +432,7 @@ extension InitPackage {
     public convenience init(
         name: String,
         packageType: PackageType,
-        supportedTestingLibraries: Set<TestingLibrary> = [.xctest],
+        supportedTestingLibraries: Set<TestingLibrary> = [.swiftTesting],
         destinationPath: AbsolutePath,
         fileSystem: FileSystem
     ) throws {

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -279,6 +279,11 @@ final class TestCommandTests: CommandsTestCase {
     }
 
     func testBasicSwiftTestingIntegration() async throws {
+        try XCTSkipUnless(
+            nil != Environment.current["SWIFT_PM_SWIFT_TESTING_TESTS_ENABLED"],
+            "Skipping \(#function) because swift-testing tests are not explicitly enabled"
+        )
+
         try await fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
             do {
                 let (stdout, _) = try await SwiftPM.Test.execute(["--enable-swift-testing", "--disable-xctest"], packagePath: fixturePath)
@@ -288,6 +293,11 @@ final class TestCommandTests: CommandsTestCase {
     }
 
     func testBasicSwiftTestingIntegration_ExperimentalFlag() async throws {
+        try XCTSkipUnless(
+            nil != Environment.current["SWIFT_PM_SWIFT_TESTING_TESTS_ENABLED"],
+            "Skipping \(#function) because swift-testing tests are not explicitly enabled"
+        )
+
         try await fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
             do {
                 let (stdout, _) = try await SwiftPM.Test.execute(["--enable-experimental-swift-testing", "--disable-xctest"], packagePath: fixturePath)

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -279,11 +279,15 @@ final class TestCommandTests: CommandsTestCase {
     }
 
     func testBasicSwiftTestingIntegration() async throws {
-        try XCTSkipUnless(
-            nil != Environment.current["SWIFT_PM_SWIFT_TESTING_TESTS_ENABLED"],
-            "Skipping \(#function) because swift-testing tests are not explicitly enabled"
-        )
+        try await fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
+            do {
+                let (stdout, _) = try await SwiftPM.Test.execute(["--enable-swift-testing", "--disable-xctest"], packagePath: fixturePath)
+                XCTAssertMatch(stdout, .contains(#"Test "SOME TEST FUNCTION" started"#))
+            }
+        }
+    }
 
+    func testBasicSwiftTestingIntegration_ExperimentalFlag() async throws {
         try await fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
             do {
                 let (stdout, _) = try await SwiftPM.Test.execute(["--enable-experimental-swift-testing", "--disable-xctest"], packagePath: fixturePath)

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -279,7 +279,7 @@ final class TestCommandTests: CommandsTestCase {
     }
 
     func testBasicSwiftTestingIntegration() async throws {
-#if compiler(<6) || !canImport(Testing)
+#if !canImport(Testing)
         try XCTSkipUnless(
             nil != Environment.current["SWIFT_PM_SWIFT_TESTING_TESTS_ENABLED"],
             "Skipping \(#function) because swift-testing tests are not explicitly enabled"
@@ -295,7 +295,7 @@ final class TestCommandTests: CommandsTestCase {
     }
 
     func testBasicSwiftTestingIntegration_ExperimentalFlag() async throws {
-#if compiler(<6) || !canImport(Testing)
+#if !canImport(Testing)
         try XCTSkipUnless(
             nil != Environment.current["SWIFT_PM_SWIFT_TESTING_TESTS_ENABLED"],
             "Skipping \(#function) because swift-testing tests are not explicitly enabled"

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -279,7 +279,7 @@ final class TestCommandTests: CommandsTestCase {
     }
 
     func testBasicSwiftTestingIntegration() async throws {
-#if compiler(<6)
+#if compiler(<6) || !canImport(Testing)
         try XCTSkipUnless(
             nil != Environment.current["SWIFT_PM_SWIFT_TESTING_TESTS_ENABLED"],
             "Skipping \(#function) because swift-testing tests are not explicitly enabled"
@@ -295,7 +295,7 @@ final class TestCommandTests: CommandsTestCase {
     }
 
     func testBasicSwiftTestingIntegration_ExperimentalFlag() async throws {
-#if compiler(<6)
+#if compiler(<6) || !canImport(Testing)
         try XCTSkipUnless(
             nil != Environment.current["SWIFT_PM_SWIFT_TESTING_TESTS_ENABLED"],
             "Skipping \(#function) because swift-testing tests are not explicitly enabled"

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -279,10 +279,12 @@ final class TestCommandTests: CommandsTestCase {
     }
 
     func testBasicSwiftTestingIntegration() async throws {
+#if compiler(<6)
         try XCTSkipUnless(
             nil != Environment.current["SWIFT_PM_SWIFT_TESTING_TESTS_ENABLED"],
             "Skipping \(#function) because swift-testing tests are not explicitly enabled"
         )
+#endif
 
         try await fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
             do {
@@ -293,10 +295,12 @@ final class TestCommandTests: CommandsTestCase {
     }
 
     func testBasicSwiftTestingIntegration_ExperimentalFlag() async throws {
+#if compiler(<6)
         try XCTSkipUnless(
             nil != Environment.current["SWIFT_PM_SWIFT_TESTING_TESTS_ENABLED"],
             "Skipping \(#function) because swift-testing tests are not explicitly enabled"
         )
+#endif
 
         try await fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
             do {

--- a/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
+++ b/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
@@ -618,7 +618,7 @@ class ManifestEditTests: XCTestCase {
             let package = Package(
                 name: "packages",
                 dependencies: [
-                    .package(url: "https://github.com/apple/swift-testing.git", from: "0.8.0"),
+                    .package(url: "https://github.com/swiftlang/swift-example.git", from: "1.2.3"),
                 ],
                 targets: [
                     .testTarget(
@@ -632,20 +632,20 @@ class ManifestEditTests: XCTestCase {
             let package = Package(
                 name: "packages",
                 dependencies: [
-                    .package(url: "https://github.com/apple/swift-testing.git", from: "0.8.0"),
+                    .package(url: "https://github.com/swiftlang/swift-example.git", from: "1.2.3"),
                 ],
                 targets: [
                     .testTarget(
                         name: "MyTest",
                         dependencies: [
-                            .product(name: "Testing", package: "swift-testing"),
+                            .product(name: "SomethingOrOther", package: "swift-example"),
                         ]
                     ),
                 ]
             )
             """) { manifest in
             try AddTargetDependency.addTargetDependency(
-                .product(name: "Testing", package: "swift-testing"),
+                .product(name: "SomethingOrOther", package: "swift-example"),
                 targetName: "MyTest",
                 to: manifest
             )

--- a/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
+++ b/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
@@ -581,14 +581,8 @@ class ManifestEditTests: XCTestCase {
             // swift-tools-version: 5.5
             let package = Package(
                 name: "packages",
-                dependencies: [
-                    .package(url: "https://github.com/apple/swift-testing.git", from: "0.8.0"),
-                ],
                 targets: [
-                    .testTarget(
-                        name: "MyTest",
-                        dependencies: [ .product(name: "Testing", package: "swift-testing") ]
-                    ),
+                    .testTarget(name: "MyTest"),
                 ]
             )
             """,

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -154,8 +154,8 @@ final class InitTests: XCTestCase {
         }
     }
 
-    func testInitPackageLibraryWithSwiftTestingOnly() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testInitPackageLibraryWithSwiftTestingOnly() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("Foo")
             let name = path.basename
@@ -182,15 +182,15 @@ final class InitTests: XCTestCase {
             XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
             XCTAssertNoMatch(testFileContents, .contains("func testExample() throws"))
 
-            // Try building it -- DISABLED because we cannot pull the swift-testing repository from CI.
-//            XCTAssertBuilds(path)
-//            let triple = try UserToolchain.default.targetTriple
-//            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
+            // Try building it
+            await XCTAssertBuilds(path)
+            let triple = try UserToolchain.default.targetTriple
+            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
         }
     }
 
-    func testInitPackageLibraryWithBothSwiftTestingAndXCTest() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testInitPackageLibraryWithBothSwiftTestingAndXCTest() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("Foo")
             let name = path.basename
@@ -217,10 +217,12 @@ final class InitTests: XCTestCase {
             XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
             XCTAssertMatch(testFileContents, .contains("func testExample() throws"))
 
-            // Try building it -- DISABLED because we cannot pull the swift-testing repository from CI.
-            //            XCTAssertBuilds(path)
-            //            let triple = try UserToolchain.default.targetTriple
-            //            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
+#if compiler(>=6)
+            // Try building it
+            await XCTAssertBuilds(path)
+            let triple = try UserToolchain.default.targetTriple
+            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
+#endif
         }
     }
 
@@ -251,10 +253,12 @@ final class InitTests: XCTestCase {
 
             XCTAssertNoSuchPath(path.appending("Tests"))
 
+#if compiler(>=6)
             // Try building it
             await XCTAssertBuilds(path)
             let triple = try UserToolchain.default.targetTriple
             XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
+#endif
         }
     }
 

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -182,10 +182,12 @@ final class InitTests: XCTestCase {
             XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
             XCTAssertNoMatch(testFileContents, .contains("func testExample() throws"))
 
+#if compiler(>=6)
             // Try building it
             await XCTAssertBuilds(path)
             let triple = try UserToolchain.default.targetTriple
             XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
+#endif
         }
     }
 

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -182,7 +182,7 @@ final class InitTests: XCTestCase {
             XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
             XCTAssertNoMatch(testFileContents, .contains("func testExample() throws"))
 
-#if compiler(>=6)
+#if canImport(Testing)
             // Try building it
             await XCTAssertBuilds(path)
             let triple = try UserToolchain.default.targetTriple
@@ -219,7 +219,7 @@ final class InitTests: XCTestCase {
             XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
             XCTAssertMatch(testFileContents, .contains("func testExample() throws"))
 
-#if compiler(>=6)
+#if canImport(Testing)
             // Try building it
             await XCTAssertBuilds(path)
             let triple = try UserToolchain.default.targetTriple
@@ -255,7 +255,7 @@ final class InitTests: XCTestCase {
 
             XCTAssertNoSuchPath(path.appending("Tests"))
 
-#if compiler(>=6)
+#if canImport(Testing)
             // Try building it
             await XCTAssertBuilds(path)
             let triple = try UserToolchain.default.targetTriple

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -113,6 +113,7 @@ final class InitTests: XCTestCase {
             let initPackage = try InitPackage(
                 name: name,
                 packageType: .library,
+                supportedTestingLibraries: [.xctest],
                 destinationPath: path,
                 fileSystem: localFileSystem
             )
@@ -153,8 +154,8 @@ final class InitTests: XCTestCase {
         }
     }
 
-    func testInitPackageLibraryWithSwiftTestingOnly() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testInitPackageLibraryWithSwiftTestingOnly() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("Foo")
             let name = path.basename
@@ -173,31 +174,23 @@ final class InitTests: XCTestCase {
             // Verify basic file system content that we expect in the package
             let manifest = path.appending("Package.swift")
             XCTAssertFileExists(manifest)
-            let manifestContents: String = try localFileSystem.readFileContents(manifest)
-            XCTAssertMatch(manifestContents, .contains(#".macOS(.v10_15)"#))
-            XCTAssertMatch(manifestContents, .contains(#".iOS(.v13)"#))
-            XCTAssertMatch(manifestContents, .contains(#".tvOS(.v13)"#))
-            XCTAssertMatch(manifestContents, .contains(#".watchOS(.v6)"#))
-            XCTAssertMatch(manifestContents, .contains(#".macCatalyst(.v13)"#))
-            XCTAssertMatch(manifestContents, .contains(#"swift-testing.git", from: "0.11.0""#))
-            XCTAssertMatch(manifestContents, .contains(#".product(name: "Testing", package: "swift-testing")"#))
 
             let testFile = path.appending("Tests").appending("FooTests").appending("FooTests.swift")
             let testFileContents: String = try localFileSystem.readFileContents(testFile)
             XCTAssertMatch(testFileContents, .contains(#"import Testing"#))
             XCTAssertNoMatch(testFileContents, .contains(#"import XCTest"#))
-            XCTAssertMatch(testFileContents, .contains(#"@Test func example() throws"#))
+            XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
             XCTAssertNoMatch(testFileContents, .contains("func testExample() throws"))
 
-            // Try building it -- DISABLED because we cannot pull the swift-testing repository from CI.
-//            XCTAssertBuilds(path)
-//            let triple = try UserToolchain.default.targetTriple
-//            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
+            // Try building it
+            await XCTAssertBuilds(path)
+            let triple = try UserToolchain.default.targetTriple
+            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
         }
     }
 
-    func testInitPackageLibraryWithBothSwiftTestingAndXCTest() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testInitPackageLibraryWithBothSwiftTestingAndXCTest() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("Foo")
             let name = path.basename
@@ -216,26 +209,18 @@ final class InitTests: XCTestCase {
             // Verify basic file system content that we expect in the package
             let manifest = path.appending("Package.swift")
             XCTAssertFileExists(manifest)
-            let manifestContents: String = try localFileSystem.readFileContents(manifest)
-            XCTAssertMatch(manifestContents, .contains(#".macOS(.v10_15)"#))
-            XCTAssertMatch(manifestContents, .contains(#".iOS(.v13)"#))
-            XCTAssertMatch(manifestContents, .contains(#".tvOS(.v13)"#))
-            XCTAssertMatch(manifestContents, .contains(#".watchOS(.v6)"#))
-            XCTAssertMatch(manifestContents, .contains(#".macCatalyst(.v13)"#))
-            XCTAssertMatch(manifestContents, .contains(#"swift-testing.git", from: "0.11.0""#))
-            XCTAssertMatch(manifestContents, .contains(#".product(name: "Testing", package: "swift-testing")"#))
 
             let testFile = path.appending("Tests").appending("FooTests").appending("FooTests.swift")
             let testFileContents: String = try localFileSystem.readFileContents(testFile)
             XCTAssertMatch(testFileContents, .contains(#"import Testing"#))
             XCTAssertMatch(testFileContents, .contains(#"import XCTest"#))
-            XCTAssertMatch(testFileContents, .contains(#"@Test func example() throws"#))
-            XCTAssertNoMatch(testFileContents, .contains("func testExample() throws"))
+            XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
+            XCTAssertMatch(testFileContents, .contains("func testExample() throws"))
 
-            // Try building it -- DISABLED because we cannot pull the swift-testing repository from CI.
-            //            XCTAssertBuilds(path)
-            //            let triple = try UserToolchain.default.targetTriple
-            //            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
+            // Try building it
+            await XCTAssertBuilds(path)
+            let triple = try UserToolchain.default.targetTriple
+            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
         }
     }
 
@@ -262,8 +247,6 @@ final class InitTests: XCTestCase {
             let manifest = path.appending("Package.swift")
             XCTAssertFileExists(manifest)
             let manifestContents: String = try localFileSystem.readFileContents(manifest)
-            XCTAssertNoMatch(manifestContents, .contains(#"swift-testing.git", from: "0.11.0""#))
-            XCTAssertNoMatch(manifestContents, .contains(#".product(name: "Testing", package: "swift-testing")"#))
             XCTAssertNoMatch(manifestContents, .contains(#".testTarget"#))
 
             XCTAssertNoSuchPath(path.appending("Tests"))
@@ -399,7 +382,7 @@ final class InitTests: XCTestCase {
 
     func testPlatforms() throws {
         try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
-            var options = InitPackage.InitPackageOptions(packageType: .library)
+            var options = InitPackage.InitPackageOptions(packageType: .library, supportedTestingLibraries: [])
             options.platforms = [
                 .init(platform: .macOS, version: PlatformVersion("10.15")),
                 .init(platform: .iOS, version: PlatformVersion("12")),

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -154,8 +154,8 @@ final class InitTests: XCTestCase {
         }
     }
 
-    func testInitPackageLibraryWithSwiftTestingOnly() async throws {
-        try await testWithTemporaryDirectory { tmpPath in
+    func testInitPackageLibraryWithSwiftTestingOnly() throws {
+        try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("Foo")
             let name = path.basename
@@ -182,15 +182,15 @@ final class InitTests: XCTestCase {
             XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
             XCTAssertNoMatch(testFileContents, .contains("func testExample() throws"))
 
-            // Try building it
-            await XCTAssertBuilds(path)
-            let triple = try UserToolchain.default.targetTriple
-            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
+            // Try building it -- DISABLED because we cannot pull the swift-testing repository from CI.
+//            XCTAssertBuilds(path)
+//            let triple = try UserToolchain.default.targetTriple
+//            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
         }
     }
 
-    func testInitPackageLibraryWithBothSwiftTestingAndXCTest() async throws {
-        try await testWithTemporaryDirectory { tmpPath in
+    func testInitPackageLibraryWithBothSwiftTestingAndXCTest() throws {
+        try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("Foo")
             let name = path.basename
@@ -217,10 +217,10 @@ final class InitTests: XCTestCase {
             XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
             XCTAssertMatch(testFileContents, .contains("func testExample() throws"))
 
-            // Try building it
-            await XCTAssertBuilds(path)
-            let triple = try UserToolchain.default.targetTriple
-            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
+            // Try building it -- DISABLED because we cannot pull the swift-testing repository from CI.
+            //            XCTAssertBuilds(path)
+            //            let triple = try UserToolchain.default.targetTriple
+            //            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
         }
     }
 


### PR DESCRIPTION
This PR updates the package templates used by `swift package init` to use Swift Testing by default where possible, and to not add a package dependency on the Swift Testing open-source repository since it is now building in the toolchain.

Resolves rdar://128272585.