### PR TITLE
[Build] Free `BuildPlan` from `BuildTriple`

### DIFF
--- a/Sources/Basics/Collections/IdentifiableSet.swift
+++ b/Sources/Basics/Collections/IdentifiableSet.swift
@@ -42,6 +42,10 @@ public struct IdentifiableSet<Element: Identifiable>: Collection {
         Index(storageIndex: self.storage.elements.endIndex)
     }
 
+    public var values: some Sequence<Element> {
+        self.storage.values
+    }
+
     public subscript(position: Index) -> Element {
         self.storage.elements[position.storageIndex].value
     }

--- a/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
@@ -42,6 +42,11 @@ public final class ClangModuleBuildDescription {
     /// The build parameters.
     let buildParameters: BuildParameters
 
+    /// The destination for while this module is built.
+    public var destination: BuildParameters.Destination {
+        self.buildParameters.destination
+    }
+
     /// The build environment.
     var buildEnvironment: BuildEnvironment {
         buildParameters.buildEnvironment

--- a/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
@@ -526,3 +526,17 @@ public final class ClangModuleBuildDescription {
         )
     }
 }
+
+extension ClangModuleBuildDescription {
+    package func dependencies(
+        using plan: BuildPlan
+    ) -> [ModuleBuildDescription.Dependency] {
+        ModuleBuildDescription.clang(self).dependencies(using: plan)
+    }
+
+    package func recursiveDependencies(
+        using plan: BuildPlan
+    ) -> [ModuleBuildDescription.Dependency] {
+        ModuleBuildDescription.clang(self).recursiveDependencies(using: plan)
+    }
+}

--- a/Sources/Build/BuildDescription/ModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ModuleBuildDescription.swift
@@ -13,6 +13,7 @@
 import Basics
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
+import struct PackageGraph.ResolvedProduct
 import struct PackageModel.Resource
 import struct PackageModel.ToolsVersion
 import struct SPMBuildCore.BuildToolPluginInvocationResult
@@ -157,5 +158,38 @@ extension ModuleBuildDescription: Identifiable {
 
     public var id: ID {
         ID(moduleID: self.module.id, destination: self.destination)
+    }
+}
+
+extension ModuleBuildDescription {
+    package enum Dependency {
+        /// Not all of the modules and products have build descriptions
+        case product(ResolvedProduct, ProductBuildDescription?)
+        case module(ResolvedModule, ModuleBuildDescription?)
+    }
+
+    package func dependencies(using plan: BuildPlan) -> [Dependency] {
+        self.module
+            .dependencies(satisfying: self.buildParameters.buildEnvironment)
+            .map {
+                switch $0 {
+                case .product(let product, _):
+                    let productDescription = plan.description(for: product, context: self.destination)
+                    return .product(product, productDescription)
+                case .module(let module, _):
+                    let moduleDescription = plan.description(for: module, context: self.destination)
+                    return .module(module, moduleDescription)
+                }
+            }
+    }
+
+    package func recursiveDependencies(using plan: BuildPlan) -> [Dependency] {
+        var dependencies: [Dependency] = []
+        plan.traverseDependencies(of: self) { product, _, description in
+            dependencies.append(.product(product, description))
+        } onModule: { module, _, description in
+            dependencies.append(.module(module, description))
+        }
+        return dependencies
     }
 }

--- a/Sources/Build/BuildDescription/ModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ModuleBuildDescription.swift
@@ -121,6 +121,15 @@ public enum ModuleBuildDescription: SPMBuildCore.ModuleBuildDescription {
         }
     }
 
+    var destination: BuildParameters.Destination {
+        switch self {
+        case .swift(let buildDescription):
+            buildDescription.destination
+        case .clang(let buildDescription):
+            buildDescription.destination
+        }
+    }
+
     var toolsVersion: ToolsVersion {
         switch self {
         case .swift(let buildDescription):
@@ -137,5 +146,16 @@ public enum ModuleBuildDescription: SPMBuildCore.ModuleBuildDescription {
         case .swift(let buildDescription): try buildDescription.symbolGraphExtractArguments()
         case .clang(let buildDescription): try buildDescription.symbolGraphExtractArguments()
         }
+    }
+}
+
+extension ModuleBuildDescription: Identifiable {
+    public struct ID: Hashable {
+        let moduleID: ResolvedModule.ID
+        let destination: BuildParameters.Destination
+    }
+
+    public var id: ID {
+        ID(moduleID: self.module.id, destination: self.destination)
     }
 }

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -37,6 +37,11 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
     /// The build parameters.
     public let buildParameters: BuildParameters
 
+    /// The destination for while this product is built.
+    public var destination: BuildParameters.Destination {
+        self.buildParameters.destination
+    }
+
     /// All object files to link into this product.
     ///
     // Computed during build planning.
@@ -394,6 +399,17 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
     func codeSigningArguments(plistPath: AbsolutePath, binaryPath: AbsolutePath) -> [String] {
         ["codesign", "--force", "--sign", "-", "--entitlements", plistPath.pathString, binaryPath.pathString]
+    }
+}
+
+extension ProductBuildDescription: Identifiable {
+    public struct ID: Hashable {
+        let productID: ResolvedProduct.ID
+        let destination: BuildParameters.Destination
+    }
+
+    public var id: ID {
+        ID(productID: self.product.id, destination: self.destination)
     }
 }
 

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -49,6 +49,11 @@ public final class SwiftModuleBuildDescription {
     /// The build parameters for this target.
     let buildParameters: BuildParameters
 
+    /// The destination for while this module is built.
+    public var destination: BuildParameters.Destination {
+        self.buildParameters.destination
+    }
+
     /// The build parameters for the macro dependencies of this target.
     let macroBuildParameters: BuildParameters
 

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -988,3 +988,17 @@ public final class SwiftModuleBuildDescription {
         return arguments
     }
 }
+
+extension SwiftModuleBuildDescription {
+    package func dependencies(
+        using plan: BuildPlan
+    ) -> [ModuleBuildDescription.Dependency] {
+        ModuleBuildDescription.swift(self).dependencies(using: plan)
+    }
+
+    package func recursiveDependencies(
+        using plan: BuildPlan
+    ) -> [ModuleBuildDescription.Dependency] {
+        ModuleBuildDescription.swift(self).recursiveDependencies(using: plan)
+    }
+}

--- a/Sources/Build/BuildPlan/BuildPlan+Clang.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Clang.swift
@@ -18,12 +18,12 @@ import class PackageModel.SystemLibraryModule
 extension BuildPlan {
     /// Plan a Clang target.
     func plan(clangTarget: ClangModuleBuildDescription) throws {
-        let dependencies = try clangTarget.target.recursiveDependencies(satisfying: clangTarget.buildEnvironment)
+        let dependencies = clangTarget.recursiveDependencies(using: self)
 
-        for case .module(let dependency, _) in dependencies {
+        for case .module(let dependency, let description) in dependencies {
             switch dependency.underlying {
             case is SwiftModule:
-                if case let .swift(dependencyTargetDescription)? = targetMap[dependency.id] {
+                if case let .swift(dependencyTargetDescription)? = description {
                     if let moduleMap = dependencyTargetDescription.moduleMap {
                         clangTarget.additionalFlags += ["-fmodule-map-file=\(moduleMap.pathString)"]
                     }
@@ -34,7 +34,7 @@ extension BuildPlan {
                 clangTarget.additionalFlags += ["-I", target.includeDir.pathString]
 
                 // Add the modulemap of the dependency if it has one.
-                if case let .clang(dependencyTargetDescription)? = targetMap[dependency.id] {
+                if case let .clang(dependencyTargetDescription)? = description {
                     if let moduleMap = dependencyTargetDescription.moduleMap {
                         clangTarget.additionalFlags += ["-fmodule-map-file=\(moduleMap.pathString)"]
                     }

--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -77,12 +77,12 @@ extension BuildPlan {
             }
         }
 
-        for target in dependencies.staticTargets {
-            switch target.underlying {
+        for module in dependencies.staticTargets {
+            switch module.underlying {
             case is SwiftModule:
                 // Swift targets are guaranteed to have a corresponding Swift description.
-                guard case .swift(let description) = self.targetMap[target.id] else {
-                    throw InternalError("unknown target \(target)")
+                guard case .swift(let description) = self.description(for: module, context: buildProduct.destination) else {
+                    throw InternalError("unknown module \(module)")
                 }
 
                 // Based on the debugging strategy, we either need to pass swiftmodule paths to the
@@ -103,16 +103,16 @@ extension BuildPlan {
 
         buildProduct.staticTargets = dependencies.staticTargets
         buildProduct.dylibs = try dependencies.dylibs.map {
-            guard let product = self.productMap[$0.id] else {
+            guard let product = self.description(for: $0, context: buildProduct.destination) else {
                 throw InternalError("unknown product \($0)")
             }
             return product
         }
-        buildProduct.objects += try dependencies.staticTargets.flatMap { targetName -> [AbsolutePath] in
-            guard let target = self.targetMap[targetName.id] else {
-                throw InternalError("unknown target \(targetName)")
+        buildProduct.objects += try dependencies.staticTargets.flatMap { module -> [AbsolutePath] in
+            guard let description = self.description(for: module, context: buildProduct.destination) else {
+                throw InternalError("unknown module \(module)")
             }
-            return try target.objects
+            return try description.objects
         }
         buildProduct.libraryBinaryPaths = dependencies.libraryBinaryPaths
 

--- a/Sources/Build/BuildPlan/BuildPlan+Swift.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Swift.swift
@@ -20,11 +20,10 @@ extension BuildPlan {
     func plan(swiftTarget: SwiftModuleBuildDescription) throws {
         // We need to iterate recursive dependencies because Swift compiler needs to see all the targets a target
         // depends on.
-        let environment = swiftTarget.buildParameters.buildEnvironment
-        for case .module(let dependency, _) in try swiftTarget.target.recursiveDependencies(satisfying: environment) {
+        for case .module(let dependency, let description) in swiftTarget.recursiveDependencies(using: self) {
             switch dependency.underlying {
             case let underlyingTarget as ClangModule where underlyingTarget.type == .library:
-                guard case let .clang(target)? = targetMap[dependency.id] else {
+                guard case let .clang(target)? = description else {
                     throw InternalError("unexpected clang target \(underlyingTarget)")
                 }
                 // Add the path to modulemap of the dependency. Currently we require that all Clang targets have a

--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -34,7 +34,7 @@ import protocol TSCBasic.FileSystem
 
 extension BuildPlan {
     static func makeDerivedTestTargets(
-        testProducts: [(product: ResolvedProduct, buildDescription: ProductBuildDescription)],
+        testProducts: [ProductBuildDescription],
         destinationBuildParameters: BuildParameters,
         toolsBuildParameters: BuildParameters,
         shouldDisableSandbox: Bool,
@@ -51,7 +51,8 @@ extension BuildPlan {
 
         var isDiscoveryEnabledRedundantly = explicitlyEnabledDiscovery && !isEntryPointPathSpecifiedExplicitly
         var result: [(ResolvedProduct, SwiftModuleBuildDescription?, SwiftModuleBuildDescription)] = []
-        for (testProduct, testBuildDescription) in testProducts {
+        for testBuildDescription in testProducts {
+            let testProduct = testBuildDescription.product
             let package = testBuildDescription.package
 
             isDiscoveryEnabledRedundantly = isDiscoveryEnabledRedundantly && nil == testProduct.testEntryPointModule

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -1137,12 +1137,15 @@ extension BuildPlan {
         onProduct: (ResolvedProduct, BuildParameters.Destination, ProductBuildDescription?) -> Void,
         onModule: (ResolvedModule, BuildParameters.Destination, ModuleBuildDescription?) -> Void
     ) {
+        var visited = Set<TraversalNode>()
         func successors(
             for product: ResolvedProduct,
             destination: Destination
         ) -> [TraversalNode] {
             product.modules.map { module in
                 TraversalNode(module: module, context: destination)
+            }.filter {
+                visited.insert($0).inserted
             }
         }
 
@@ -1159,6 +1162,8 @@ extension BuildPlan {
                     case .module(let module, _):
                         partial.append(.init(module: module, context: destination))
                     }
+                }.filter {
+                    visited.insert($0).inserted
                 }
         }
 

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -706,6 +706,20 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         }
         return inputs
     }
+
+    public func description(
+        for product: ResolvedProduct,
+        context: BuildParameters.Destination
+    ) -> ProductBuildDescription? {
+        return self.productMap[product.id]
+    }
+
+    public func description(
+        for module: ResolvedModule,
+        context: BuildParameters.Destination
+    ) -> ModuleBuildDescription? {
+        return self.targetMap[module.id]
+    }
 }
 
 extension BuildPlan {
@@ -1114,6 +1128,59 @@ extension BuildPlan {
 
             case .module(let module, let destination):
                 onModule((module, destination), parentModule, depth)
+            }
+        }
+    }
+
+    package func traverseDependencies(
+        of description: ModuleBuildDescription,
+        onProduct: (ResolvedProduct, BuildParameters.Destination, ProductBuildDescription?) -> Void,
+        onModule: (ResolvedModule, BuildParameters.Destination, ModuleBuildDescription?) -> Void
+    ) {
+        func successors(
+            for product: ResolvedProduct,
+            destination: Destination
+        ) -> [TraversalNode] {
+            product.modules.map { module in
+                TraversalNode(module: module, context: destination)
+            }
+        }
+
+        func successors(
+            for module: ResolvedModule,
+            destination: Destination
+        ) -> [TraversalNode] {
+            module
+                .dependencies(satisfying: description.buildParameters.buildEnvironment)
+                .reduce(into: [TraversalNode]()) { partial, dependency in
+                    switch dependency {
+                    case .product(let product, _):
+                        partial.append(.init(product: product, context: destination))
+                    case .module(let module, _):
+                        partial.append(.init(module: module, context: destination))
+                    }
+                }
+        }
+
+        depthFirstSearch(successors(for: description.module, destination: description.destination)) {
+            switch $0 {
+            case .module(let module, let destination):
+                successors(for: module, destination: destination)
+            case .product(let product, let destination):
+                successors(for: product, destination: destination)
+            case .package:
+                []
+            }
+        } onNext: { module, _, _ in
+            switch module {
+            case .package:
+                break
+
+            case .product(let product, let destination):
+                onProduct(product, destination, self.description(for: product, context: destination))
+
+            case .module(let module, let destination):
+                onModule(module, destination, self.description(for: module, context: destination))
             }
         }
     }

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -38,7 +38,7 @@ public struct BuildParameters: Encodable {
     }
 
     /// The destination for which code should be compiled for.
-    public enum Destination: Encodable {
+    public enum Destination: Hashable, Encodable {
         /// The destination for which build tools are compiled.
         case host
 

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -297,13 +297,7 @@ public struct BuildPlanResult {
         )
         self.targetMap = try Dictionary(
             throwingUniqueKeysWithValues: plan.targetMap.compactMap {
-                guard 
-                    let target = plan.graph.allModules[$0] ??
-                        IdentifiableSet(plan.derivedTestTargetsMap.values.flatMap { $0 })[$0]
-                else {
-                    throw BuildError.error("Target \($0) not found.")
-                }
-                return (target.id, $1)
+                ($0.module.id, $0)
             }
         )
     }

--- a/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
+++ b/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
@@ -297,7 +297,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         )
 
         // Make sure that build plan doesn't have any "target" tests.
-        for (_, description) in plan.targetMap where description.module.underlying.type == .test {
+        for description in plan.targetMap where description.module.underlying.type == .test {
             XCTAssertEqual(description.buildParameters.destination, .host)
         }
 

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -17,7 +17,8 @@ import Build
 import PackageGraph
 
 import PackageModel
-import SourceKitLSPAPI
+@testable import SourceKitLSPAPI
+import struct SPMBuildCore.BuildParameters
 import _InternalTestSupport
 import XCTest
 
@@ -90,7 +91,7 @@ final class SourceKitLSPAPITests: XCTestCase {
                 "-I", "/fake/manifestLib/path"
             ],
             isPartOfRootPackage: true,
-            destination: .tools
+            destination: .host
         )
     }
 
@@ -167,10 +168,10 @@ extension SourceKitLSPAPI.BuildDescription {
         graph: ModulesGraph,
         partialArguments: [String],
         isPartOfRootPackage: Bool,
-        destination: BuildTriple = .destination
+        destination: BuildParameters.Destination = .target
     ) throws -> Bool {
-        let target = try XCTUnwrap(graph.module(for: targetName, destination: destination))
-        let buildTarget = try XCTUnwrap(self.getBuildTarget(for: target, in: graph))
+        let target = try XCTUnwrap(graph.module(for: targetName))
+        let buildTarget = try XCTUnwrap(self.getBuildTarget(for: target, destination: destination))
 
         guard let file = buildTarget.sources.first else {
             XCTFail("build target \(targetName) contains no files")


### PR DESCRIPTION
### Motivation:

This is yet another step (if not the last one) on the path to remove
`buildTriple` from `Resolved{Product, Module}` identifiers and switch
everything that requires destination to use information from the build
plan.

### Modifications:

- Makes build descriptions identifiable just like `Resolved{Product, Module}.ID`
- Adds a way to traverse module  (both direct and recursive) dependencies starting from a module build description.
- Switches `BuildPlan.{target, product}Map` to `IdentifiableSet<{Product, Module}BuildDescription`.

### Result:

`BuildTriple` is no longer used for build related operations such as planning and forming llbuild manifests.
