### PR TITLE
[Build] BuildPlan: Use `Destination` instead of `BuildTriple` to form…

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -351,6 +351,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 if let pluginConfiguration, !buildParameters.shouldSkipBuilding {
                     let pluginInvocationResults = try await Self.invokeBuildToolPlugins(
                         for: module,
+                        destination: destination,
                         configuration: pluginConfiguration,
                         buildParameters: toolsBuildParameters,
                         modulesGraph: graph,
@@ -752,6 +753,7 @@ extension BuildPlan {
     /// structures for later showing to the user, and not added directly to the diagnostics engine.
     static func invokeBuildToolPlugins(
         for module: ResolvedModule,
+        destination: BuildParameters.Destination,
         configuration: PluginConfiguration,
         buildParameters: BuildParameters,
         modulesGraph: ModulesGraph,
@@ -786,7 +788,7 @@ extension BuildPlan {
                 components: [
                     package.identity.description,
                     module.name,
-                    module.buildTriple.rawValue,
+                    destination == .host ? "tools" : "destination",
                     plugin.name,
                 ]
             )

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -1356,6 +1356,7 @@ final class PluginInvocationTests: XCTestCase {
 
             let results = try await BuildPlan.invokeBuildToolPlugins(
                 for: module,
+                destination: .target,
                 configuration: pluginConfiguration,
                 buildParameters: buildParameters,
                 modulesGraph: graph,


### PR DESCRIPTION
… per-module plugin output directory

### Motivation:

This is an NFC since there are no observable differences here from user perspective, just a different mechanism is used to get the same information.

### Modifications:

- `computeDestinations` provides a destination that should be used to invoke build tool plugins per module.

### Result:

Removes one of the last places where `BuildTriple` was still used.
