### PR TITLE
Un-Revert "[Build] Free `BuildPlan` from `BuildTriple`"

### DIFF
--- a/Sources/Basics/Collections/IdentifiableSet.swift
+++ b/Sources/Basics/Collections/IdentifiableSet.swift
@@ -42,6 +42,10 @@ public struct IdentifiableSet<Element: Identifiable>: Collection {
         Index(storageIndex: self.storage.elements.endIndex)
     }
 
+    public var values: some Sequence<Element> {
+        self.storage.values
+    }
+
     public subscript(position: Index) -> Element {
         self.storage.elements[position.storageIndex].value
     }

--- a/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
@@ -42,6 +42,11 @@ public final class ClangModuleBuildDescription {
     /// The build parameters.
     let buildParameters: BuildParameters
 
+    /// The destination for while this module is built.
+    public var destination: BuildParameters.Destination {
+        self.buildParameters.destination
+    }
+
     /// The build environment.
     var buildEnvironment: BuildEnvironment {
         buildParameters.buildEnvironment
@@ -519,5 +524,19 @@ public final class ClangModuleBuildDescription {
             path: headerFile,
             string: headerContent
         )
+    }
+}
+
+extension ClangModuleBuildDescription {
+    package func dependencies(
+        using plan: BuildPlan
+    ) -> [ModuleBuildDescription.Dependency] {
+        ModuleBuildDescription.clang(self).dependencies(using: plan)
+    }
+
+    package func recursiveDependencies(
+        using plan: BuildPlan
+    ) -> [ModuleBuildDescription.Dependency] {
+        ModuleBuildDescription.clang(self).recursiveDependencies(using: plan)
     }
 }

--- a/Sources/Build/BuildDescription/ModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ModuleBuildDescription.swift
@@ -13,6 +13,7 @@
 import Basics
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
+import struct PackageGraph.ResolvedProduct
 import struct PackageModel.Resource
 import struct PackageModel.ToolsVersion
 import struct SPMBuildCore.BuildToolPluginInvocationResult
@@ -121,6 +122,15 @@ public enum ModuleBuildDescription: SPMBuildCore.ModuleBuildDescription {
         }
     }
 
+    var destination: BuildParameters.Destination {
+        switch self {
+        case .swift(let buildDescription):
+            buildDescription.destination
+        case .clang(let buildDescription):
+            buildDescription.destination
+        }
+    }
+
     var toolsVersion: ToolsVersion {
         switch self {
         case .swift(let buildDescription):
@@ -137,5 +147,49 @@ public enum ModuleBuildDescription: SPMBuildCore.ModuleBuildDescription {
         case .swift(let buildDescription): try buildDescription.symbolGraphExtractArguments()
         case .clang(let buildDescription): try buildDescription.symbolGraphExtractArguments()
         }
+    }
+}
+
+extension ModuleBuildDescription: Identifiable {
+    public struct ID: Hashable {
+        let moduleID: ResolvedModule.ID
+        let destination: BuildParameters.Destination
+    }
+
+    public var id: ID {
+        ID(moduleID: self.module.id, destination: self.destination)
+    }
+}
+
+extension ModuleBuildDescription {
+    package enum Dependency {
+        /// Not all of the modules and products have build descriptions
+        case product(ResolvedProduct, ProductBuildDescription?)
+        case module(ResolvedModule, ModuleBuildDescription?)
+    }
+
+    package func dependencies(using plan: BuildPlan) -> [Dependency] {
+        self.module
+            .dependencies(satisfying: self.buildParameters.buildEnvironment)
+            .map {
+                switch $0 {
+                case .product(let product, _):
+                    let productDescription = plan.description(for: product, context: self.destination)
+                    return .product(product, productDescription)
+                case .module(let module, _):
+                    let moduleDescription = plan.description(for: module, context: self.destination)
+                    return .module(module, moduleDescription)
+                }
+            }
+    }
+
+    package func recursiveDependencies(using plan: BuildPlan) -> [Dependency] {
+        var dependencies: [Dependency] = []
+        plan.traverseDependencies(of: self) { product, _, description in
+            dependencies.append(.product(product, description))
+        } onModule: { module, _, description in
+            dependencies.append(.module(module, description))
+        }
+        return dependencies
     }
 }

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -37,6 +37,11 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
     /// The build parameters.
     public let buildParameters: BuildParameters
 
+    /// The destination for while this product is built.
+    public var destination: BuildParameters.Destination {
+        self.buildParameters.destination
+    }
+
     /// All object files to link into this product.
     ///
     // Computed during build planning.
@@ -394,6 +399,17 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
     func codeSigningArguments(plistPath: AbsolutePath, binaryPath: AbsolutePath) -> [String] {
         ["codesign", "--force", "--sign", "-", "--entitlements", plistPath.pathString, binaryPath.pathString]
+    }
+}
+
+extension ProductBuildDescription: Identifiable {
+    public struct ID: Hashable {
+        let productID: ResolvedProduct.ID
+        let destination: BuildParameters.Destination
+    }
+
+    public var id: ID {
+        ID(productID: self.product.id, destination: self.destination)
     }
 }
 

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -49,6 +49,11 @@ public final class SwiftModuleBuildDescription {
     /// The build parameters for this target.
     let buildParameters: BuildParameters
 
+    /// The destination for while this module is built.
+    public var destination: BuildParameters.Destination {
+        self.buildParameters.destination
+    }
+
     /// The build parameters for the macro dependencies of this target.
     let macroBuildParameters: BuildParameters
 
@@ -981,5 +986,19 @@ public final class SwiftModuleBuildDescription {
         }
 
         return arguments
+    }
+}
+
+extension SwiftModuleBuildDescription {
+    package func dependencies(
+        using plan: BuildPlan
+    ) -> [ModuleBuildDescription.Dependency] {
+        ModuleBuildDescription.swift(self).dependencies(using: plan)
+    }
+
+    package func recursiveDependencies(
+        using plan: BuildPlan
+    ) -> [ModuleBuildDescription.Dependency] {
+        ModuleBuildDescription.swift(self).recursiveDependencies(using: plan)
     }
 }

--- a/Sources/Build/BuildPlan/BuildPlan+Clang.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Clang.swift
@@ -18,12 +18,12 @@ import class PackageModel.SystemLibraryModule
 extension BuildPlan {
     /// Plan a Clang target.
     func plan(clangTarget: ClangModuleBuildDescription) throws {
-        let dependencies = try clangTarget.target.recursiveDependencies(satisfying: clangTarget.buildEnvironment)
+        let dependencies = clangTarget.recursiveDependencies(using: self)
 
-        for case .module(let dependency, _) in dependencies {
+        for case .module(let dependency, let description) in dependencies {
             switch dependency.underlying {
             case is SwiftModule:
-                if case let .swift(dependencyTargetDescription)? = targetMap[dependency.id] {
+                if case let .swift(dependencyTargetDescription)? = description {
                     if let moduleMap = dependencyTargetDescription.moduleMap {
                         clangTarget.additionalFlags += ["-fmodule-map-file=\(moduleMap.pathString)"]
                     }
@@ -34,7 +34,7 @@ extension BuildPlan {
                 clangTarget.additionalFlags += ["-I", target.includeDir.pathString]
 
                 // Add the modulemap of the dependency if it has one.
-                if case let .clang(dependencyTargetDescription)? = targetMap[dependency.id] {
+                if case let .clang(dependencyTargetDescription)? = description {
                     if let moduleMap = dependencyTargetDescription.moduleMap {
                         clangTarget.additionalFlags += ["-fmodule-map-file=\(moduleMap.pathString)"]
                     }

--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -77,12 +77,12 @@ extension BuildPlan {
             }
         }
 
-        for target in dependencies.staticTargets {
-            switch target.underlying {
+        for module in dependencies.staticTargets {
+            switch module.underlying {
             case is SwiftModule:
                 // Swift targets are guaranteed to have a corresponding Swift description.
-                guard case .swift(let description) = self.targetMap[target.id] else {
-                    throw InternalError("unknown target \(target)")
+                guard case .swift(let description) = self.description(for: module, context: buildProduct.destination) else {
+                    throw InternalError("unknown module \(module)")
                 }
 
                 // Based on the debugging strategy, we either need to pass swiftmodule paths to the
@@ -103,16 +103,16 @@ extension BuildPlan {
 
         buildProduct.staticTargets = dependencies.staticTargets
         buildProduct.dylibs = try dependencies.dylibs.map {
-            guard let product = self.productMap[$0.id] else {
+            guard let product = self.description(for: $0, context: buildProduct.destination) else {
                 throw InternalError("unknown product \($0)")
             }
             return product
         }
-        buildProduct.objects += try dependencies.staticTargets.flatMap { targetName -> [AbsolutePath] in
-            guard let target = self.targetMap[targetName.id] else {
-                throw InternalError("unknown target \(targetName)")
+        buildProduct.objects += try dependencies.staticTargets.flatMap { module -> [AbsolutePath] in
+            guard let description = self.description(for: module, context: buildProduct.destination) else {
+                throw InternalError("unknown module \(module)")
             }
-            return try target.objects
+            return try description.objects
         }
         buildProduct.libraryBinaryPaths = dependencies.libraryBinaryPaths
 

--- a/Sources/Build/BuildPlan/BuildPlan+Swift.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Swift.swift
@@ -20,11 +20,10 @@ extension BuildPlan {
     func plan(swiftTarget: SwiftModuleBuildDescription) throws {
         // We need to iterate recursive dependencies because Swift compiler needs to see all the targets a target
         // depends on.
-        let environment = swiftTarget.buildParameters.buildEnvironment
-        for case .module(let dependency, _) in try swiftTarget.target.recursiveDependencies(satisfying: environment) {
+        for case .module(let dependency, let description) in swiftTarget.recursiveDependencies(using: self) {
             switch dependency.underlying {
             case let underlyingTarget as ClangModule where underlyingTarget.type == .library:
-                guard case let .clang(target)? = targetMap[dependency.id] else {
+                guard case let .clang(target)? = description else {
                     throw InternalError("unexpected clang target \(underlyingTarget)")
                 }
                 // Add the path to modulemap of the dependency. Currently we require that all Clang targets have a

--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -34,7 +34,7 @@ import protocol TSCBasic.FileSystem
 
 extension BuildPlan {
     static func makeDerivedTestTargets(
-        testProducts: [(product: ResolvedProduct, buildDescription: ProductBuildDescription)],
+        testProducts: [ProductBuildDescription],
         destinationBuildParameters: BuildParameters,
         toolsBuildParameters: BuildParameters,
         shouldDisableSandbox: Bool,
@@ -51,7 +51,8 @@ extension BuildPlan {
 
         var isDiscoveryEnabledRedundantly = explicitlyEnabledDiscovery && !isEntryPointPathSpecifiedExplicitly
         var result: [(ResolvedProduct, SwiftModuleBuildDescription?, SwiftModuleBuildDescription)] = []
-        for (testProduct, testBuildDescription) in testProducts {
+        for testBuildDescription in testProducts {
+            let testProduct = testBuildDescription.product
             let package = testBuildDescription.package
 
             isDiscoveryEnabledRedundantly = isDiscoveryEnabledRedundantly && nil == testProduct.testEntryPointModule

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -38,7 +38,7 @@ public struct BuildParameters: Encodable {
     }
 
     /// The destination for which code should be compiled for.
-    public enum Destination: Encodable {
+    public enum Destination: Hashable, Encodable {
         /// The destination for which build tools are compiled.
         case host
 

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -297,13 +297,7 @@ public struct BuildPlanResult {
         )
         self.targetMap = try Dictionary(
             throwingUniqueKeysWithValues: plan.targetMap.compactMap {
-                guard 
-                    let target = plan.graph.allModules[$0] ??
-                        IdentifiableSet(plan.derivedTestTargetsMap.values.flatMap { $0 })[$0]
-                else {
-                    throw BuildError.error("Target \($0) not found.")
-                }
-                return (target.id, $1)
+                ($0.module.id, $0)
             }
         )
     }

--- a/Sources/_InternalTestSupport/MockPackageGraphs.swift
+++ b/Sources/_InternalTestSupport/MockPackageGraphs.swift
@@ -137,6 +137,7 @@ package func macrosTestsPackageGraph() throws -> MockPackageGraph {
         "/swift-mmio/Sources/MMIOMacros/source.swift",
         "/swift-mmio/Sources/MMIOMacrosTests/source.swift",
         "/swift-mmio/Sources/MMIOMacro+PluginTests/source.swift",
+        "/swift-mmio/Sources/NOOPTests/source.swift",
         "/swift-syntax/Sources/SwiftSyntax/source.swift",
         "/swift-syntax/Sources/SwiftSyntaxMacrosTestSupport/source.swift",
         "/swift-syntax/Sources/SwiftSyntaxMacros/source.swift",
@@ -202,6 +203,11 @@ package func macrosTestsPackageGraph() throws -> MockPackageGraph {
                             .target(name: "MMIOPlugin"),
                             .target(name: "MMIOMacros")
                         ],
+                        type: .test
+                    ),
+                    TargetDescription(
+                        name: "NOOPTests",
+                        dependencies: [],
                         type: .test
                     )
                 ]

--- a/Tests/BuildTests/BuildPlanTraversalTests.swift
+++ b/Tests/BuildTests/BuildPlanTraversalTests.swift
@@ -143,4 +143,128 @@ final class BuildPlanTraversalTests: XCTestCase {
         XCTAssertEqual(self.getUniqueOccurrences(in: results, for: "SwiftSyntax", destination: .host), [2, 3, 4, 5, 6])
         XCTAssertEqual(self.getUniqueOccurrences(in: results, for: "HAL"), [1, 2, 3])
     }
+
+    func testRecursiveDependencyTraversal() async throws {
+        let destinationTriple = Triple.arm64Linux
+        let toolsTriple = Triple.x86_64MacOS
+
+        let (graph, fs, scope) = try macrosPackageGraph()
+        let plan = try await BuildPlan(
+            destinationBuildParameters: mockBuildParameters(
+                destination: .target,
+                triple: destinationTriple
+            ),
+            toolsBuildParameters: mockBuildParameters(
+                destination: .host,
+                triple: toolsTriple
+            ),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: scope
+        )
+
+        let mmioModule = try XCTUnwrap(plan.description(for: graph.module(for: "MMIO")!, context: .target))
+
+        var moduleDependencies: [(ResolvedModule, Dest, Build.ModuleBuildDescription?)] = []
+        plan.traverseDependencies(of: mmioModule) { product, destination, description in
+            XCTAssertEqual(product.name, "SwiftSyntax")
+            XCTAssertEqual(destination, .host)
+            XCTAssertNil(description)
+        } onModule: { module, destination, description in
+            moduleDependencies.append((module, destination, description))
+        }
+
+        XCTAssertEqual(moduleDependencies.count, 2)
+
+        // The ordering is guaranteed by the traversal
+
+        XCTAssertEqual(moduleDependencies[0].0.name, "MMIOMacros")
+        XCTAssertEqual(moduleDependencies[1].0.name, "SwiftSyntax")
+
+        for index in 0 ..< moduleDependencies.count {
+            XCTAssertEqual(moduleDependencies[index].1, .host)
+            XCTAssertNotNil(moduleDependencies[index].2)
+        }
+
+        let directDependencies = mmioModule.dependencies(using: plan)
+
+        XCTAssertEqual(directDependencies.count, 1)
+
+        let dependency = try XCTUnwrap(directDependencies.first)
+        if case .module(let module, let description) = dependency {
+            XCTAssertEqual(module.name, "MMIOMacros")
+            try XCTAssertEqual(XCTUnwrap(description).destination, .host)
+        } else {
+            XCTFail("Expected MMIOMacros module")
+        }
+
+        let dependencies = mmioModule.recursiveDependencies(using: plan)
+
+        XCTAssertEqual(dependencies.count, 3)
+
+        // MMIOMacros (module) -> SwiftSyntax (product) -> SwiftSyntax (module)
+
+        if case .module(let module, let description) = dependencies[0] {
+            XCTAssertEqual(module.name, "MMIOMacros")
+            try XCTAssertEqual(XCTUnwrap(description).destination, .host)
+        } else {
+            XCTFail("Expected MMIOMacros module")
+        }
+
+        if case .product(let product, let description) = dependencies[1] {
+            XCTAssertEqual(product.name, "SwiftSyntax")
+            XCTAssertNil(description)
+        } else {
+            XCTFail("Expected SwiftSyntax product")
+        }
+
+        if case .module(let module, let description) = dependencies[2] {
+            XCTAssertEqual(module.name, "SwiftSyntax")
+            try XCTAssertEqual(XCTUnwrap(description).destination, .host)
+        } else {
+            XCTFail("Expected SwiftSyntax module")
+        }
+    }
+
+    func testRecursiveDependencyTraversalWithDuplicates() async throws {
+        let destinationTriple = Triple.arm64Linux
+        let toolsTriple = Triple.x86_64MacOS
+
+        let (graph, fs, scope) = try macrosTestsPackageGraph()
+        let plan = try await BuildPlan(
+            destinationBuildParameters: mockBuildParameters(
+                destination: .target,
+                triple: destinationTriple
+            ),
+            toolsBuildParameters: mockBuildParameters(
+                destination: .host,
+                triple: toolsTriple
+            ),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: scope
+        )
+
+        let testModule = try XCTUnwrap(plan.description(for: graph.module(for: "MMIOMacrosTests")!, context: .host))
+
+        let dependencies = testModule.recursiveDependencies(using: plan)
+        XCTAssertEqual(dependencies.count, 9)
+
+        struct ModuleResult: Hashable {
+            let module: ResolvedModule
+            let destination: Dest
+        }
+
+        var uniqueModules = Set<ModuleResult>()
+        for dependency in dependencies {
+            if case .module(let module, let description) = dependency {
+                XCTAssertNotNil(description)
+                XCTAssertEqual(description!.destination, .host)
+                XCTAssertTrue(
+                    uniqueModules.insert(.init(module: module, destination: description!.destination))
+                        .inserted
+                )
+            }
+        }
+    }
 }

--- a/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
+++ b/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
@@ -295,9 +295,15 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: scope
         )
+
+        // Make sure that build plan doesn't have any "target" tests.
+        for description in plan.targetMap where description.module.underlying.type == .test {
+            XCTAssertEqual(description.buildParameters.destination, .host)
+        }
+
         let result = try BuildPlanResult(plan: plan)
         result.checkProductsCount(2)
-        result.checkTargetsCount(16)
+        result.checkTargetsCount(17)
 
         XCTAssertTrue(try result.allTargets(named: "SwiftSyntax")
             .map { try $0.swift() }

--- a/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
+++ b/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
@@ -116,7 +116,11 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
                 "SwiftSyntaxMacrosTestSupport",
                 "SwiftSyntaxMacrosTestSupport"
             )
-            result.check(testModules: "MMIOMacrosTests", "MMIOMacro+PluginTests")
+            // TODO: NOOPTests are mentioned twice because in the graph they appear
+            // as if they target both "tools" and "destination", see the test below.
+            // Once the `buildTriple` is gone, there is going to be only one mention
+            // left.
+            result.check(testModules: "MMIOMacrosTests", "MMIOMacro+PluginTests", "NOOPTests", "NOOPTests")
             result.checkTarget("MMIO") { result in
                 result.check(buildTriple: .destination)
                 result.check(dependencies: "MMIOMacros")
@@ -179,6 +183,13 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
                     XCTAssertEqual(result.target.packageIdentity, .plain("swift-syntax"))
                     XCTAssertEqual(graph.package(for: result.target)?.identity, .plain("swift-syntax"))
                 }
+            }
+
+            result.checkTargets("NOOPTests") { results in
+                XCTAssertEqual(results.count, 2)
+
+                XCTAssertEqual(results.filter({ $0.target.buildTriple == .tools }).count, 1)
+                XCTAssertEqual(results.filter({ $0.target.buildTriple == .destination }).count, 1)
             }
         }
     }

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -17,7 +17,8 @@ import Build
 import PackageGraph
 
 import PackageModel
-import SourceKitLSPAPI
+@testable import SourceKitLSPAPI
+import struct SPMBuildCore.BuildParameters
 import _InternalTestSupport
 import XCTest
 
@@ -90,7 +91,7 @@ final class SourceKitLSPAPITests: XCTestCase {
                 "-I", "/fake/manifestLib/path"
             ],
             isPartOfRootPackage: true,
-            destination: .tools
+            destination: .host
         )
     }
 
@@ -167,10 +168,10 @@ extension SourceKitLSPAPI.BuildDescription {
         graph: ModulesGraph,
         partialArguments: [String],
         isPartOfRootPackage: Bool,
-        destination: BuildTriple = .destination
+        destination: BuildParameters.Destination = .target
     ) throws -> Bool {
-        let target = try XCTUnwrap(graph.module(for: targetName, destination: destination))
-        let buildTarget = try XCTUnwrap(self.getBuildTarget(for: target, in: graph))
+        let target = try XCTUnwrap(graph.module(for: targetName))
+        let buildTarget = try XCTUnwrap(self.getBuildTarget(for: target, destination: destination))
 
         guard let file = buildTarget.sources.first else {
             XCTFail("build target \(targetName) contains no files")


### PR DESCRIPTION
Reverts swiftlang/swift-package-manager#7882

The CI problem associated with this revert actually stems from swift-foundation hard-coding a path that is no longer valid because some tests in `FoundationEssentialsTests` test macros which means that xctest bundle is going to be built for `host` and get `-tool` suffix for its resources directory. Using non-prefixed directory was incorrect because it's not related to the bundle that would actually be run.