### PR TITLE
[SourceKitLSP] Start using SwiftPM independent `BuildDestination` typ…

### DIFF
--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -23,10 +23,12 @@ import class Build.ClangModuleBuildDescription
 import class Build.SwiftModuleBuildDescription
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ModulesGraph
-import enum PackageGraph.BuildTriple
 internal import class PackageModel.UserToolchain
 
-public typealias BuildTriple = PackageGraph.BuildTriple
+public enum BuildDestination {
+    case host
+    case target
+}
 
 public protocol BuildTarget {
     /// Source files in the target
@@ -38,7 +40,7 @@ public protocol BuildTarget {
     /// The name of the target. It should be possible to build a target by passing this name to `swift build --target`
     var name: String { get }
 
-    var buildTriple: BuildTriple { get }
+    var destination: BuildDestination { get }
 
     /// Whether the target is part of the root package that the user opened or if it's part of a package dependency.
     var isPartOfRootPackage: Bool { get }
@@ -70,8 +72,8 @@ private struct WrappedClangTargetBuildDescription: BuildTarget {
         return description.clangTarget.name
     }
 
-    public var buildTriple: BuildTriple {
-        return description.target.buildTriple
+    public var destination: BuildDestination {
+        return description.destination == .host ? .host : .target
     }
 
     public func compileArguments(for fileURL: URL) throws -> [String] {
@@ -95,8 +97,8 @@ private struct WrappedSwiftTargetBuildDescription: BuildTarget {
         return description.target.name
     }
 
-    public var buildTriple: BuildTriple {
-        return description.target.buildTriple
+    public var destination: BuildDestination {
+        return description.destination == .host ? .host : .target
     }
 
     var sources: [URL] {

--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -19,7 +19,6 @@ import struct PackageGraph.ResolvedModule
 private import class PackageLoading.ManifestLoader
 internal import struct PackageModel.ToolsVersion
 internal import protocol PackageModel.Toolchain
-import enum PackageGraph.BuildTriple
 
 struct PluginTargetBuildDescription: BuildTarget {
     private let target: ResolvedModule
@@ -45,8 +44,9 @@ struct PluginTargetBuildDescription: BuildTarget {
         return target.name
     }
 
-    var buildTriple: BuildTriple {
-        return target.buildTriple
+    var destination: BuildDestination {
+        // Plugins are always built for the host.
+        .host
     }
 
     func compileArguments(for fileURL: URL) throws -> [String] {


### PR DESCRIPTION
…e in `BuildTarget` API

### Motivation:

`BuildTriple` is going away to it's as good time as any to introduce a new type to be used by SourceKit-LSP.

### Modifications:

- Adds a new `BuildDestination` API to be used by SourceKit-LSP instead of `BuildTriple`
- Removes `BuildTriple` use from `BuildTarget`

### Result:

`BuildTriple` is no longer used by SourceKit-LSP.
