### PR TITLE
Disable part of a test that fails with Swift Testing in the toolchain.

### DIFF
--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -140,9 +140,6 @@ final class TestCommandTests: CommandsTestCase {
             let xUnitOutput = fixturePath.appending("result.xml")
             // Run tests in parallel with verbose output.
             let stdout = try await SwiftPM.Test.execute(["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString], packagePath: fixturePath).stdout
-            // in "swift test" test output goes to stdout
-            XCTAssertNoMatch(stdout, .contains("passed"))
-            XCTAssertNoMatch(stdout, .contains("failed"))
 
             // Check the xUnit output.
             XCTAssertFileExists(xUnitOutput)


### PR DESCRIPTION
Remove some assertions from `testSwiftTestXMLOutputWhenEmpty()` that aren't strictly necessary and which have started to fail as we add Swift Testing to the toolchain.