### PR TITLE
[Build] NFC: Remove uses of `buildTriple` from `computeDependencies(of:)`

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -11,10 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 import struct Basics.AbsolutePath
-import struct Basics.Triple
+import func Basics.depthFirstSearch
 import struct Basics.InternalError
-import struct PackageGraph.ResolvedProduct
+import struct Basics.Triple
 import struct PackageGraph.ResolvedModule
+import struct PackageGraph.ResolvedProduct
 import class PackageModel.BinaryModule
 import class PackageModel.ClangModule
 
@@ -31,10 +32,7 @@ extension BuildPlan {
     /// Plan a product.
     func plan(buildProduct: ProductBuildDescription) throws {
         // Compute the product's dependency.
-        let dependencies = try computeDependencies(
-            of: buildProduct.product,
-            buildParameters: buildProduct.buildParameters
-        )
+        let dependencies = try computeDependencies(of: buildProduct)
 
         // Add flags for system targets.
         for systemModule in dependencies.systemModules {
@@ -62,8 +60,8 @@ extension BuildPlan {
         if !buildProduct.product.modules.contains(where: \.underlying.isEmbeddedSwiftTarget) {
             // Link C++ if needed.
             // Note: This will come from build settings in future.
-            for target in dependencies.staticTargets {
-                if case let target as ClangModule = target.underlying, target.isCXX {
+            for description in dependencies.staticTargets {
+                if case let target as ClangModule = description.module.underlying, target.isCXX {
                     let triple = buildProduct.buildParameters.triple
                     if triple.isDarwin() {
                         buildProduct.additionalFlags += ["-lc++"]
@@ -77,12 +75,12 @@ extension BuildPlan {
             }
         }
 
-        for module in dependencies.staticTargets {
-            switch module.underlying {
+        for description in dependencies.staticTargets {
+            switch description.module.underlying {
             case is SwiftModule:
                 // Swift targets are guaranteed to have a corresponding Swift description.
-                guard case .swift(let description) = self.description(for: module, context: buildProduct.destination) else {
-                    throw InternalError("unknown module \(module)")
+                guard case .swift(let description) = description else {
+                    throw InternalError("Expected a Swift module: \(description.module)")
                 }
 
                 // Based on the debugging strategy, we either need to pass swiftmodule paths to the
@@ -101,176 +99,231 @@ extension BuildPlan {
             }
         }
 
-        buildProduct.staticTargets = dependencies.staticTargets
-        buildProduct.dylibs = try dependencies.dylibs.map {
-            guard let product = self.description(for: $0, context: buildProduct.destination) else {
-                throw InternalError("unknown product \($0)")
-            }
-            return product
-        }
-        buildProduct.objects += try dependencies.staticTargets.flatMap { module -> [AbsolutePath] in
-            guard let description = self.description(for: module, context: buildProduct.destination) else {
-                throw InternalError("unknown module \(module)")
-            }
-            return try description.objects
-        }
+        buildProduct.staticTargets = dependencies.staticTargets.map(\.module)
+        buildProduct.dylibs = dependencies.dylibs
+        buildProduct.objects += try dependencies.staticTargets.flatMap { try $0.objects }
         buildProduct.libraryBinaryPaths = dependencies.libraryBinaryPaths
-
         buildProduct.availableTools = dependencies.availableTools
     }
 
     /// Computes the dependencies of a product.
     private func computeDependencies(
-        of product: ResolvedProduct,
-        buildParameters: BuildParameters
+        of productDescription: ProductBuildDescription
     ) throws -> (
-        dylibs: [ResolvedProduct],
-        staticTargets: [ResolvedModule],
+        dylibs: [ProductBuildDescription],
+        staticTargets: [ModuleBuildDescription],
         systemModules: [ResolvedModule],
         libraryBinaryPaths: Set<AbsolutePath>,
         availableTools: [String: AbsolutePath]
     ) {
+        let product = productDescription.product
         /* Prior to tools-version 5.9, we used to erroneously recursively traverse executable/plugin dependencies and statically include their
          targets. For compatibility reasons, we preserve that behavior for older tools-versions. */
-        let shouldExcludePlugins: Bool
-        if let toolsVersion = self.graph.package(for: product)?.manifest.toolsVersion {
-            shouldExcludePlugins = toolsVersion >= .v5_9
-        } else {
-            shouldExcludePlugins = false
-        }
+        let shouldExcludePlugins = productDescription.package.manifest.toolsVersion >= .v5_9
 
-        // For test targets, we need to consider the first level of transitive dependencies since the first level is always test targets.
-        let topLevelDependencies: [PackageModel.Module]
-        if product.type == .test {
-            topLevelDependencies = product.modules.flatMap { $0.underlying.dependencies }.compactMap {
+        // For test targets, we need to consider the first level of transitive dependencies since the first level is
+        // always test targets.
+        let topLevelDependencies: [PackageModel.Module] = if product.type == .test {
+            product.modules.flatMap(\.underlying.dependencies).compactMap {
                 switch $0 {
                 case .product:
-                    return nil
+                    nil
                 case .module(let target, _):
-                    return target
+                    target
                 }
             }
         } else {
-            topLevelDependencies = []
+            []
         }
 
         // get the dynamic libraries for explicitly linking rdar://108561857
-        func recursiveDynamicLibraries(for product: ResolvedProduct) throws -> [ResolvedProduct] {
-            let dylibs = try computeDependencies(of: product, buildParameters: buildParameters).dylibs
+        func recursiveDynamicLibraries(for description: ProductBuildDescription) throws -> [ProductBuildDescription] {
+            let dylibs = try computeDependencies(of: description).dylibs
             return try dylibs + dylibs.flatMap { try recursiveDynamicLibraries(for: $0) }
         }
 
         // Sort the product targets in topological order.
-        let nodes: [ResolvedModule.Dependency] = product.modules.map { .module($0, conditions: []) }
-        let allTargets = try topologicalSort(nodes, successors: { dependency in
-            switch dependency {
-            // Include all the dependencies of a target.
-            case .module(let target, _):
-                let isTopLevel = topLevelDependencies.contains(target.underlying) || product.modules.contains(id: target.id)
-                let topLevelIsMacro = isTopLevel && product.type == .macro
-                let topLevelIsPlugin = isTopLevel && product.type == .plugin
-                let topLevelIsTest = isTopLevel && product.type == .test
+        var allDependencies: [ModuleBuildDescription.Dependency] = []
 
-                if !topLevelIsMacro && !topLevelIsTest && target.type == .macro {
-                    return []
-                }
-                if shouldExcludePlugins, !topLevelIsPlugin && !topLevelIsTest && target.type == .plugin {
-                    return []
-                }
-                return target.dependencies.filter { $0.satisfies(buildParameters.buildEnvironment) }
-
-            // For a product dependency, we only include its content only if we
-            // need to statically link it.
-            case .product(let product, _):
-                guard dependency.satisfies(buildParameters.buildEnvironment) else {
-                    return []
+        do {
+            func successors(
+                for product: ResolvedProduct,
+                destination: BuildParameters.Destination
+            ) throws -> [TraversalNode] {
+                let productDependencies: [TraversalNode] = product.modules.map {
+                    .init(module: $0, context: destination)
                 }
 
-                let productDependencies: [ResolvedModule.Dependency] = product.modules.map { .module($0, conditions: []) }
                 switch product.type {
                 case .library(.automatic), .library(.static):
                     return productDependencies
                 case .plugin:
                     return shouldExcludePlugins ? [] : productDependencies
                 case .library(.dynamic):
-                    return try recursiveDynamicLibraries(for: product).map { .product($0, conditions: []) }
+                    guard let description = self.description(for: product, context: destination) else {
+                        throw InternalError("Could not find a description for product: \(product)")
+                    }
+                    return try recursiveDynamicLibraries(for: description).map { TraversalNode(
+                        product: $0.product,
+                        context: $0.destination
+                    ) }
                 case .test, .executable, .snippet, .macro:
                     return []
                 }
             }
-        })
+
+            func successors(
+                for module: ResolvedModule,
+                destination: BuildParameters.Destination
+            ) -> [TraversalNode] {
+                let isTopLevel = topLevelDependencies.contains(module.underlying) || product.modules
+                    .contains(id: module.id)
+                let topLevelIsMacro = isTopLevel && product.type == .macro
+                let topLevelIsPlugin = isTopLevel && product.type == .plugin
+                let topLevelIsTest = isTopLevel && product.type == .test
+
+                if !topLevelIsMacro && !topLevelIsTest && module.type == .macro {
+                    return []
+                }
+                if shouldExcludePlugins, !topLevelIsPlugin && !topLevelIsTest && module.type == .plugin {
+                    return []
+                }
+                return module.dependencies(satisfying: productDescription.buildParameters.buildEnvironment)
+                    .map {
+                        switch $0 {
+                        case .product(let product, _):
+                            .init(product: product, context: destination)
+                        case .module(let module, _):
+                            .init(module: module, context: destination)
+                        }
+                    }
+            }
+
+            let directDependencies = product.modules
+                .map { TraversalNode(module: $0, context: productDescription.destination) }
+
+            var uniqueNodes = Set<TraversalNode>(directDependencies)
+
+            try depthFirstSearch(directDependencies) {
+                let result: [TraversalNode] = switch $0 {
+                case .product(let product, let destination):
+                    try successors(for: product, destination: destination)
+                case .module(let module, let destination):
+                    successors(for: module, destination: destination)
+                case .package:
+                    []
+                }
+
+                return result.filter { uniqueNodes.insert($0).inserted }
+            } onNext: { node, _, _ in
+                switch node {
+                case .package: break
+                case .product(let product, let destination):
+                    allDependencies.append(.product(product, self.description(for: product, context: destination)))
+                case .module(let module, let destination):
+                    allDependencies.append(.module(module, self.description(for: module, context: destination)))
+                }
+            }
+        }
 
         // Create empty arrays to collect our results.
-        var linkLibraries = [ResolvedProduct]()
-        var staticTargets = [ResolvedModule]()
+        var linkLibraries = [ProductBuildDescription]()
+        var staticTargets = [ModuleBuildDescription]()
         var systemModules = [ResolvedModule]()
         var libraryBinaryPaths: Set<AbsolutePath> = []
         var availableTools = [String: AbsolutePath]()
 
-        for dependency in allTargets {
+        for dependency in allDependencies {
             switch dependency {
-            case .module(let target, _):
-                switch target.type {
+            case .module(let module, let description):
+                switch module.type {
                 // Executable target have historically only been included if they are directly in the product's
                 // target list.  Otherwise they have always been just build-time dependencies.
                 // In tool version .v5_5 or greater, we also include executable modules implemented in Swift in
                 // any test products... this is to allow testing of executables.  Note that they are also still
                 // built as separate products that the test can invoke as subprocesses.
                 case .executable, .snippet, .macro:
-                    if product.modules.contains(id: target.id) {
-                        staticTargets.append(target)
-                    } else if product.type == .test && (target.underlying as? SwiftModule)?.supportsTestableExecutablesFeature == true {
+                    if product.modules.contains(id: module.id) {
+                        guard let description else {
+                            throw InternalError("Could not find a description for module: \(module)")
+                        }
+                        staticTargets.append(description)
+                    } else if product.type == .test && (module.underlying as? SwiftModule)?
+                        .supportsTestableExecutablesFeature == true
+                    {
                         // Only "top-level" targets should really be considered here, not transitive ones.
-                        let isTopLevel = topLevelDependencies.contains(target.underlying) || product.modules.contains(id: target.id)
-                        if let toolsVersion = graph.package(for: product)?.manifest.toolsVersion, toolsVersion >= .v5_5, isTopLevel {
-                            staticTargets.append(target)
+                        let isTopLevel = topLevelDependencies.contains(module.underlying) || product.modules
+                            .contains(id: module.id)
+                        if let toolsVersion = graph.package(for: product)?.manifest.toolsVersion, toolsVersion >= .v5_5,
+                           isTopLevel
+                        {
+                            guard let description else {
+                                throw InternalError("Could not find a description for module: \(module)")
+                            }
+                            staticTargets.append(description)
                         }
                     }
                 // Test targets should be included only if they are directly in the product's target list.
                 case .test:
-                    if product.modules.contains(id: target.id) {
-                        staticTargets.append(target)
+                    if product.modules.contains(id: module.id) {
+                        guard let description else {
+                            throw InternalError("Could not find a description for module: \(module)")
+                        }
+                        staticTargets.append(description)
                     }
                 // Library targets should always be included for the same build triple.
                 case .library:
-                    if target.buildTriple == product.buildTriple {
-                        staticTargets.append(target)
+                    guard let description else {
+                        throw InternalError("Could not find a description for module: \(module)")
+                    }
+                    if description.destination == productDescription.destination {
+                        staticTargets.append(description)
                     }
                 // Add system target to system targets array.
                 case .systemModule:
-                    systemModules.append(target)
+                    systemModules.append(module)
                 // Add binary to binary paths set.
                 case .binary:
-                    guard let binaryTarget = target.underlying as? BinaryModule else {
-                        throw InternalError("invalid binary target '\(target.name)'")
+                    guard let binaryTarget = module.underlying as? BinaryModule else {
+                        throw InternalError("invalid binary target '\(module.name)'")
                     }
                     switch binaryTarget.kind {
                     case .xcframework:
-                        let libraries = try self.parseXCFramework(for: binaryTarget, triple: buildParameters.triple)
+                        let libraries = try self.parseXCFramework(
+                            for: binaryTarget,
+                            triple: productDescription.buildParameters.triple
+                        )
                         for library in libraries {
                             libraryBinaryPaths.insert(library.libraryPath)
                         }
                     case .artifactsArchive:
-                        let tools = try self.parseArtifactsArchive(for: binaryTarget, triple: buildParameters.triple)
-                        tools.forEach { availableTools[$0.name] = $0.executablePath  }
-                    case.unknown:
-                        throw InternalError("unknown binary target '\(target.name)' type")
+                        let tools = try self.parseArtifactsArchive(
+                            for: binaryTarget, triple: productDescription.buildParameters.triple
+                        )
+                        tools.forEach { availableTools[$0.name] = $0.executablePath }
+                    case .unknown:
+                        throw InternalError("unknown binary target '\(module.name)' type")
                     }
                 case .plugin:
                     continue
                 }
 
-            case .product(let product, _):
+            case .product(let product, let description):
                 // Add the dynamic products to array of libraries to link.
                 if product.type == .library(.dynamic) {
-                    linkLibraries.append(product)
+                    guard let description else {
+                        throw InternalError("Dynamic library product should have description: \(product)")
+                    }
+                    linkLibraries.append(description)
                 }
             }
         }
 
         // Add derived test targets, if necessary
         if product.type == .test, let derivedTestTargets = derivedTestTargetsMap[product.id] {
-            staticTargets.append(contentsOf: derivedTestTargets)
+            staticTargets.append(contentsOf: derivedTestTargets.compactMap {
+                self.description(for: $0, context: productDescription.destination)
+            })
         }
 
         return (linkLibraries, staticTargets, systemModules, libraryBinaryPaths, availableTools)
@@ -280,7 +333,7 @@ extension BuildPlan {
     private func parseArtifactsArchive(for binaryTarget: BinaryModule, triple: Triple) throws -> [ExecutableInfo] {
         try self.externalExecutablesCache.memoize(key: binaryTarget) {
             let execInfos = try binaryTarget.parseArtifactArchives(for: triple, fileSystem: self.fileSystem)
-            return execInfos.filter{!$0.supportedTriples.isEmpty}
+            return execInfos.filter { !$0.supportedTriples.isEmpty }
         }
     }
 }

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -934,7 +934,7 @@ extension BuildPlan {
 extension BuildPlan {
     fileprivate typealias Destination = BuildParameters.Destination
 
-    fileprivate enum TraversalNode: Hashable {
+    enum TraversalNode: Hashable {
         case package(ResolvedPackage)
         case product(ResolvedProduct, BuildParameters.Destination)
         case module(ResolvedModule, BuildParameters.Destination)


### PR DESCRIPTION
### Motivation:

Now that we have all the tools to compute destinations for dependencies of a product, 
we no longer need `buildTriple` here and dynamic/static library results could be represented
by build descriptions as a bonus.

### Modifications:

- `BuildPlan.computeDependencies(of:)` has been updated to take a `ProductBuildDescription` and use depth first scan that computes destination;
- Further, dynamic and static library dependencies are now presented by build descriptions which means that we no longer need to look stuff up while planning.

### Result:

One more use of `buildTriple` is gone.
