### PR TITLE
[WIP] Conditionally enable or disable XCTest/Swift Testing based on `swift build` arguments.

### DIFF
--- a/Sources/Basics/TestingLibrary.swift
+++ b/Sources/Basics/TestingLibrary.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The testing libraries supported by the package manager.
-public enum TestingLibrary: Sendable, CustomStringConvertible {
+public enum TestingLibrary: Sendable, CustomStringConvertible, Encodable {
   /// The XCTest library.
   ///
   /// This case represents both the open-source swift-corelibs-xctest
@@ -28,6 +28,11 @@ public enum TestingLibrary: Sendable, CustomStringConvertible {
     case .swiftTesting:
       "Swift Testing"
     }
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(String(describing: self))
   }
 }
 

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -99,8 +99,10 @@ struct BuildCommandOptions: ParsableArguments {
 
     /// Testing library options.
     ///
-    /// These options are no longer used but are needed by older versions of the
-    /// Swift VSCode plugin. They will be removed in a future update.
+    /// These options affect the generated main function of the package's test product(s). In general, developers
+    /// should not need to specify them, but any package (i.e. Foundation) that is a dependency of one testing library
+    /// or the other may need to specify them to avoid circular dependencies. If a developer's test code includes
+    /// references to one library or the other, that code will still be built.
     @OptionGroup(visibility: .private)
     var testLibraryOptions: TestLibraryOptions
 
@@ -162,6 +164,13 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
             productsBuildParameters.testingParameters.enableCodeCoverage = true
             toolsBuildParameters.testingParameters.enableCodeCoverage = true
         }
+
+        // Enable/disable building testing libraries based on command-line arguments.
+        var enabledTestingLibraries = [TestingLibrary.xctest, .swiftTesting].filter { library in
+            options.testLibraryOptions.isEnabled(library, swiftCommandState: swiftCommandState)
+        }
+        productsBuildParameters.testingParameters.enabledLibraries = enabledTestingLibraries
+        toolsBuildParameters.testingParameters.enabledLibraries = enabledTestingLibraries
 
         try await build(swiftCommandState, subset: subset, productsBuildParameters: productsBuildParameters, toolsBuildParameters: toolsBuildParameters)
     }

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Testing.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Testing.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import struct Basics.AbsolutePath
+import enum Basics.TestingLibrary
 import struct Basics.Triple
 import enum PackageModel.BuildConfiguration
 
@@ -86,6 +87,13 @@ extension BuildParameters {
         /// The style of test product to produce.
         public var testProductStyle: TestProductStyle
 
+        /// The set of testing libraries enabled in the current build.
+        ///
+        /// This property's value should reflect the testing libraries enabled
+        /// for _building_, not running or testing. In other words, typically
+        /// it is only set by `swift build`.
+        public var enabledLibraries: [TestingLibrary]
+
         public init(
             configuration: BuildConfiguration,
             targetTriple: Triple,
@@ -93,7 +101,8 @@ extension BuildParameters {
             enableTestability: Bool? = nil,
             experimentalTestOutput: Bool = false,
             forceTestDiscovery: Bool = false,
-            testEntryPointPath: AbsolutePath? = nil
+            testEntryPointPath: AbsolutePath? = nil,
+            enabledLibraries: [TestingLibrary] = [.xctest, .swiftTesting]
         ) {
             self.enableCodeCoverage = enableCodeCoverage
             self.experimentalTestOutput = experimentalTestOutput
@@ -109,6 +118,7 @@ extension BuildParameters {
                 explicitlyEnabledDiscovery: forceTestDiscovery,
                 explicitlySpecifiedPath: testEntryPointPath
             )
+            self.enabledLibraries = enabledLibraries
         }
     }
 }


### PR DESCRIPTION
This PR conditionally enables/disables the library-specific content added to a test product's synthesized main function based on what flags are passed to `swift build`. The exact effects of these flags are currently undocumented. This change will allow Foundation to explicitly opt out of linking to Swift Testing (which links to Foundation, producing a circular reference.)