### PR TITLE
Fix `InternalImportsByDefault` diagnostics in _AsyncFileSystem

### DIFF
--- a/Sources/_AsyncFileSystem/AsyncFileSystem.swift
+++ b/Sources/_AsyncFileSystem/AsyncFileSystem.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import protocol _Concurrency.Actor
-@preconcurrency import struct SystemPackage.Errno
-@preconcurrency import struct SystemPackage.FilePath
+@preconcurrency package import struct SystemPackage.Errno
+@preconcurrency package import struct SystemPackage.FilePath
 
 /// An abstract file system protocol with first-class support for Swift Concurrency.
 package protocol AsyncFileSystem: Actor {

--- a/Sources/_AsyncFileSystem/MockFileSystem.swift
+++ b/Sources/_AsyncFileSystem/MockFileSystem.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@preconcurrency import struct SystemPackage.FilePath
+@preconcurrency package import struct SystemPackage.FilePath
 
 /// In-memory implementation of `AsyncFileSystem` for mocking and testing purposes.
 package actor MockFileSystem: AsyncFileSystem {

--- a/Sources/_AsyncFileSystem/OpenReadableFile.swift
+++ b/Sources/_AsyncFileSystem/OpenReadableFile.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 internal import class Dispatch.DispatchQueue
-import struct SystemPackage.FileDescriptor
+internal import struct SystemPackage.FileDescriptor
 
 /// A read-only thread-safe handle to an open file.
 package struct OpenReadableFile: Sendable {

--- a/Sources/_AsyncFileSystem/OpenWritableFile.swift
+++ b/Sources/_AsyncFileSystem/OpenWritableFile.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 internal import class Dispatch.DispatchQueue
-@preconcurrency import struct SystemPackage.FileDescriptor
-import struct SystemPackage.FilePath
+@preconcurrency internal import struct SystemPackage.FileDescriptor
+internal import struct SystemPackage.FilePath
 
 /// A write-only thread-safe handle to an open file.
 package actor OpenWritableFile: WritableStream {

--- a/Sources/_AsyncFileSystem/ReadableFileStream.swift
+++ b/Sources/_AsyncFileSystem/ReadableFileStream.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import _Concurrency
-import SystemPackage
+internal import SystemPackage
 internal import class Dispatch.DispatchQueue
 
 /// Type-erasure wrapper over underlying file system readable streams.


### PR DESCRIPTION
Address some `InternalImportsByDefault` diagnostics in the `_AsyncFileSystem` which have crept in because the Swift 6 toolchain isn't enforcing `.enableExperimentalFeature("InternalImportsByDefault")`.

### Motivation:

 Both the `StrictConcurrency` and `InternalImportsByDefault` features became "upcoming" features instead of "experimental" features in the Swift 6 compiler. This means that specifying those features with `.enableExperimentalFeature()` no longer works with newer toolchains, and therefore these settings in SwiftPM's `Package.swift` have become inactive. I'm making the compiler more lenient, so that `-enable-experimental-feature` will enable the corresponding upcoming feature if relevant (https://github.com/swiftlang/swift/pull/75962) but in the meantime it appears that some of the code in SwiftPM needs some fixes to continue to be accepted by the compiler with these features on.


### Modifications:

Adjusted access level on a number of import statements in files belonging to the `_AsyncFileSystem` target.

### Result:

`_AsyncFileSystem` builds successfully when `InternalImportsByDefault` is actually enabled with the Swift 6 toolchain.