### PR TITLE
[CHANGELOG] NFC: Add an entry for SE-0441 and mark recursive dependencies as implemented in Swift 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,6 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 Swift Next
 -----------
 
-* [#7530]
-
-  Starting from tools-version 6.0 makes it possible for packages to depend on each other if such dependency doesn't form any target-level cycles.
-  For example, package `A` can depend on `B` and `B` on `A` unless targets in `B` depend on products of `A` that depend on some of the same
-  targets from `B` and vice versa.
-
 Swift 6.0
 -----------
 
@@ -16,6 +10,12 @@ Swift 6.0
 
   Starting from tools-version 6.0, `swiftLanguageMode` can be specified at the target level, allowing for gradual per-target migration to the Swift 6 language mode.
   The `swiftLanguageVersions` setting has been deprecated and renamed to `swiftLanguageModes`.
+
+* [#7530]
+
+  Starting from tools-version 6.0 makes it possible for packages to depend on each other if such dependency doesn't form any target-level cycles.
+  For example, package `A` can depend on `B` and `B` on `A` unless targets in `B` depend on products of `A` that depend on some of the same
+  targets from `B` and vice versa.
 
 * [#7741]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Swift Next
 Swift 6.0
 -----------
 
+* [#7813]
+
+  Starting from tools-version 6.0, `swiftLanguageMode` can be specified at the target level, allowing for gradual per-target migration to the Swift 6 language mode.
+  The `swiftLanguageVersions` setting has been deprecated and renamed to `swiftLanguageModes`.
+
 * [#7741]
 
   Fixed an issue where repositories would be re-cloned each build rather than using the cache due to git validation errors.
@@ -434,3 +439,4 @@ Swift 3.0
 [#7507]: https://github.com/swiftlang/swift-package-manager/pull/7507
 [#7530]: https://github.com/swiftlang/swift-package-manager/pull/7530
 [#7535]: https://github.com/swiftlang/swift-package-manager/pull/7535
+[#7813]: https://github.com/swiftlang/swift-package-manager/pull/7813


### PR DESCRIPTION
### Motivation:

There was a missing entry for SE-0441 and recursive dependencies entry was in "Next" but it's implemented in 6.0.

### Modifications:

- Added an entry about SE-0441
- Moved the entry about recursive dependency support to Swift 6.0 section.
