### PR TITLE
[6.0] Disable part of a test that fails with Swift Testing in the toolchain.

### DIFF
--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -140,9 +140,6 @@ final class TestCommandTests: CommandsTestCase {
             let xUnitOutput = fixturePath.appending("result.xml")
             // Run tests in parallel with verbose output.
             let stdout = try await SwiftPM.Test.execute(["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString], packagePath: fixturePath).stdout
-            // in "swift test" test output goes to stdout
-            XCTAssertNoMatch(stdout, .contains("passed"))
-            XCTAssertNoMatch(stdout, .contains("failed"))
 
             // Check the xUnit output.
             XCTAssertFileExists(xUnitOutput)


### PR DESCRIPTION
**Explanation:** Disables a non-critical bit of a test that's now failing in CI due to the addition of Swift Testing.
**Scope:** Bug fix in unit test.
**Issue:** N/A
**Original PR:** https://github.com/swiftlang/swift-package-manager/pull/7885
**Risk:** Low
**Testing:** Self-testing.
**Reviewer:** @MaxDesiatov @bnbarham @rintaro