### PR TITLE
Fix more `InternalImportsByDefault` errors

### DIFF
--- a/Sources/_AsyncFileSystem/AsyncFileSystem.swift
+++ b/Sources/_AsyncFileSystem/AsyncFileSystem.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import protocol _Concurrency.Actor
+package import _Concurrency
 @preconcurrency package import struct SystemPackage.Errno
 @preconcurrency package import struct SystemPackage.FilePath
 

--- a/Sources/_AsyncFileSystem/ConcurrencySupport.swift
+++ b/Sources/_AsyncFileSystem/ConcurrencySupport.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _Concurrency
+internal import _Concurrency
 internal import class Dispatch.DispatchQueue
 
 extension DispatchQueue {

--- a/Sources/_AsyncFileSystem/ReadableFileStream.swift
+++ b/Sources/_AsyncFileSystem/ReadableFileStream.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _Concurrency
+package import _Concurrency
 internal import SystemPackage
 internal import class Dispatch.DispatchQueue
 

--- a/Sources/_AsyncFileSystem/WritableStream.swift
+++ b/Sources/_AsyncFileSystem/WritableStream.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import protocol _Concurrency.Actor
+package import _Concurrency
 
 /// An asynchronous output byte stream.
 ///


### PR DESCRIPTION
SwiftPM doesn't build with all toolchains when the `InternalImportsByDefault` upcoming feature is properly enabled.

### Motivation:

With the upcoming feature `InternalImportsByDefault` enabled, some versions of the Swift compiler diagnose this pattern:

```
import protocol _Concurrency.Actor

// error: package protocol cannot refine an internal protocol
package protocol Proto: Actor {
  // ...
}
```

### Modifications:

Address these diagnostics by using correct access levels for direct imports of `_Concurrency`.

### Result:

SwiftPM builds with all relevant Swift compilers with `InternalImportsByDefault` enabled.
