### PR TITLE
Remove redundant EXECUTABLE_NAME overrides in PIF

### DIFF
--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -447,7 +447,6 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         settings[.PRODUCT_NAME] = product.name
         settings[.PRODUCT_MODULE_NAME] = mainTarget.c99name
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = product.name
-        settings[.EXECUTABLE_NAME] = product.name
         settings[.CLANG_ENABLE_MODULES] = "YES"
         settings[.DEFINES_MODULE] = "YES"
 
@@ -584,7 +583,6 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             settings[.PRODUCT_NAME] = executableName
             settings[.PRODUCT_MODULE_NAME] = product.name
             settings[.PRODUCT_BUNDLE_IDENTIFIER] = product.name
-            settings[.EXECUTABLE_NAME] = executableName
             settings[.CLANG_ENABLE_MODULES] = "YES"
             settings[.DEFINES_MODULE] = "YES"
             settings[.SKIP_INSTALL] = "NO"
@@ -630,7 +628,11 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         settings[.PRODUCT_NAME] = "\(target.name).o"
         settings[.PRODUCT_MODULE_NAME] = target.c99name
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = target.name
+
+        // EXECUTABLE_NAME is normally EXECUTABLE_PREFIX + PRODUCT_NAME + EXECUTABLE_SUFFIX
+        // So we need to override EXECUTABLE_NAME in this case to avoid doubling up the file extension because it is also part of the product name.
         settings[.EXECUTABLE_NAME] = "\(target.name).o"
+
         settings[.CLANG_ENABLE_MODULES] = "YES"
         settings[.DEFINES_MODULE] = "YES"
         settings[.MACH_O_TYPE] = "mh_object"

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -525,7 +525,6 @@ final class PIFBuilderTests: XCTestCase {
                         configuration.checkAllBuildSettings { settings in
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "foo")
                             XCTAssertEqual(settings[.INSTALL_PATH], "/usr/local/bin")
                             XCTAssertEqual(
                                 settings[.LD_RUNPATH_SEARCH_PATHS],
@@ -551,7 +550,6 @@ final class PIFBuilderTests: XCTestCase {
                         configuration.checkAllBuildSettings { settings in
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "foo")
                             XCTAssertEqual(settings[.INSTALL_PATH], "/usr/local/bin")
                             XCTAssertEqual(
                                 settings[.LD_RUNPATH_SEARCH_PATHS],
@@ -590,7 +588,6 @@ final class PIFBuilderTests: XCTestCase {
                         configuration.checkAllBuildSettings { settings in
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "cfoo")
                             XCTAssertEqual(
                                 settings[.HEADER_SEARCH_PATHS],
                                 ["$(inherited)", "/Foo/Sources/cfoo/include"]
@@ -619,7 +616,6 @@ final class PIFBuilderTests: XCTestCase {
                         configuration.checkAllBuildSettings { settings in
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "cfoo")
                             XCTAssertEqual(
                                 settings[.HEADER_SEARCH_PATHS],
                                 ["$(inherited)", "/Foo/Sources/cfoo/include"]
@@ -664,7 +660,6 @@ final class PIFBuilderTests: XCTestCase {
                         configuration.checkAllBuildSettings { settings in
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "bar")
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "bar")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "bar")
@@ -684,7 +679,6 @@ final class PIFBuilderTests: XCTestCase {
                         configuration.checkAllBuildSettings { settings in
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "bar")
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "bar")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "bar")
@@ -718,7 +712,6 @@ final class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.CLANG_CXX_LANGUAGE_STANDARD], "c++14")
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "cbar")
                             XCTAssertEqual(settings[.GCC_C_LANGUAGE_STANDARD], "c11")
                             XCTAssertEqual(
                                 settings[.HEADER_SEARCH_PATHS],
@@ -743,7 +736,6 @@ final class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.CLANG_CXX_LANGUAGE_STANDARD], "c++14")
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "cbar")
                             XCTAssertEqual(settings[.GCC_C_LANGUAGE_STANDARD], "c11")
                             XCTAssertEqual(
                                 settings[.HEADER_SEARCH_PATHS],
@@ -874,7 +866,6 @@ final class PIFBuilderTests: XCTestCase {
                         configuration.checkAllBuildSettings { settings in
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "FooTests")
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], [
                                 "$(inherited)",
@@ -922,7 +913,6 @@ final class PIFBuilderTests: XCTestCase {
                         configuration.checkAllBuildSettings { settings in
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "FooTests")
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], [
                                 "$(inherited)",
@@ -981,7 +971,6 @@ final class PIFBuilderTests: XCTestCase {
                         configuration.checkAllBuildSettings { settings in
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "CFooTests")
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], [
                                 "$(inherited)",
@@ -1032,7 +1021,6 @@ final class PIFBuilderTests: XCTestCase {
                         configuration.checkAllBuildSettings { settings in
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "CFooTests")
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], [
                                 "$(inherited)",
@@ -1249,7 +1237,6 @@ final class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.CURRENT_PROJECT_VERSION], "1")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "BarLib")
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.INSTALL_PATH], "/usr/local/lib")
                             XCTAssertEqual(settings[.MARKETING_VERSION], "1.0")
@@ -1275,7 +1262,6 @@ final class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.CURRENT_PROJECT_VERSION], "1")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
-                            XCTAssertEqual(settings[.EXECUTABLE_NAME], "BarLib")
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.INSTALL_PATH], "/usr/local/lib")
                             XCTAssertEqual(settings[.MARKETING_VERSION], "1.0")


### PR DESCRIPTION
This setting shouldn't normally be overridden (except one edge case I'm leaving in for now because I haven't investigated to know whether it's safe to remove the ".o" suffix from the PRODUCT_NAME of library targets, which can be a separate step.