### PR TITLE
Temporarily disable new Swift Testing tests

### DIFF
--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -276,7 +276,7 @@ final class TestCommandTests: CommandsTestCase {
     }
 
     func testBasicSwiftTestingIntegration() async throws {
-#if !canImport(Testing)
+#if !canImport(TestingDisabled)
         try XCTSkipUnless(
             nil != Environment.current["SWIFT_PM_SWIFT_TESTING_TESTS_ENABLED"],
             "Skipping \(#function) because swift-testing tests are not explicitly enabled"
@@ -292,7 +292,7 @@ final class TestCommandTests: CommandsTestCase {
     }
 
     func testBasicSwiftTestingIntegration_ExperimentalFlag() async throws {
-#if !canImport(Testing)
+#if !canImport(TestingDisabled)
         try XCTSkipUnless(
             nil != Environment.current["SWIFT_PM_SWIFT_TESTING_TESTS_ENABLED"],
             "Skipping \(#function) because swift-testing tests are not explicitly enabled"

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -182,7 +182,7 @@ final class InitTests: XCTestCase {
             XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
             XCTAssertNoMatch(testFileContents, .contains("func testExample() throws"))
 
-#if canImport(Testing)
+#if canImport(TestingDisabled)
             // Try building it
             await XCTAssertBuilds(path)
             let triple = try UserToolchain.default.targetTriple
@@ -219,7 +219,7 @@ final class InitTests: XCTestCase {
             XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
             XCTAssertMatch(testFileContents, .contains("func testExample() throws"))
 
-#if canImport(Testing)
+#if canImport(TestingDisabled)
             // Try building it
             await XCTAssertBuilds(path)
             let triple = try UserToolchain.default.targetTriple
@@ -255,7 +255,7 @@ final class InitTests: XCTestCase {
 
             XCTAssertNoSuchPath(path.appending("Tests"))
 
-#if canImport(Testing)
+#if canImport(TestingDisabled)
             // Try building it
             await XCTAssertBuilds(path)
             let triple = try UserToolchain.default.targetTriple


### PR DESCRIPTION
`canImport(Testing)` currently fails on the full toolchain test jobs due to various issues when building for both x86 and arm64. Temporarily remove this check until we can fix the underlying problems there.