### PR TITLE
[PackageModel] Inject swift-testing flags only if toolchain is target…

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -672,14 +672,15 @@ public final class UserToolchain: Toolchain {
         var swiftCompilerFlags: [String] = []
         var extraLinkerFlags: [String] = []
 
-        #if os(macOS)
-        let (swiftCFlags, linkerFlags) = Self.deriveMacOSSpecificSwiftTestingFlags(
-            derivedSwiftCompiler: swiftCompilers.compile,
-            fileSystem: fileSystem
-        )
-        swiftCompilerFlags += swiftCFlags
-        extraLinkerFlags += linkerFlags
-        #endif
+        if triple.isMacOSX {
+            let (swiftCFlags, linkerFlags) = Self.deriveMacOSSpecificSwiftTestingFlags(
+                derivedSwiftCompiler: swiftCompilers.compile,
+                fileSystem: fileSystem
+            )
+
+            swiftCompilerFlags += swiftCFlags
+            extraLinkerFlags += linkerFlags
+        }
 
         swiftCompilerFlags += try Self.deriveSwiftCFlags(
             triple: triple,


### PR DESCRIPTION
…ting macOS

### Motivation:

Fixes a bug where swift and linker flags for swift-testing were injected into `extraFlags` of a toolchain that was targeting WASM but used macOS to build.

### Modifications:

- Replace `#if os(macOS)` with `if triple.isMacOSX` while deriving swift-testing flags for a toolchain.

### Result:

Resolves: https://github.com/swiftlang/swift-package-manager/issues/7919
Resolves: rdar://134714404
