### PR TITLE
[6.0.0][PackageModel] Inject swift-testing flags only if toolchain is target…

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -660,14 +660,15 @@ public final class UserToolchain: Toolchain {
         var swiftCompilerFlags: [String] = []
         var extraLinkerFlags: [String] = []
 
-        #if os(macOS)
-        let (swiftCFlags, linkerFlags) = Self.deriveMacOSSpecificSwiftTestingFlags(
-            derivedSwiftCompiler: swiftCompilers.compile,
-            fileSystem: fileSystem
-        )
-        swiftCompilerFlags += swiftCFlags
-        extraLinkerFlags += linkerFlags
-        #endif
+        if triple.isMacOSX {
+            let (swiftCFlags, linkerFlags) = Self.deriveMacOSSpecificSwiftTestingFlags(
+                derivedSwiftCompiler: swiftCompilers.compile,
+                fileSystem: fileSystem
+            )
+
+            swiftCompilerFlags += swiftCFlags
+            extraLinkerFlags += linkerFlags
+        }
 
         swiftCompilerFlags += try Self.deriveSwiftCFlags(
             triple: triple,


### PR DESCRIPTION
- Explanation:

  Fixes a bug where swift and linker flags for swift-testing were injected into `extraFlags` of a toolchain that was targeting WASM but used macOS to build.

- Main Branch PR: https://github.com/swiftlang/swift-package-manager/pull/7920
- 6.0 Branch PR: https://github.com/swiftlang/swift-package-manager/pull/7921

- Resolves: https://github.com/swiftlang/swift-package-manager/issues/7919

- Risk: Low (only affects cross-compilation to WASM).

- Reviewed By: @bnbarham 

- Testing: Manual testing since this is not currently possible to test automatically.
