### PR TITLE
Make deriveTargetSwiftSDK public

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -656,7 +656,6 @@ public struct SwiftSDK: Equatable {
     }
 
     /// Computes the target Swift SDK for the given options.
-    @_spi(SwiftPMInternal)
     public static func deriveTargetSwiftSDK(
       hostSwiftSDK: SwiftSDK,
       hostTriple: Triple,


### PR DESCRIPTION
Used by https://github.com/swiftlang/sourcekit-lsp/pull/1643

### Motivation:

Allows us to achieve parity between sourcekit-lsp's configuration options and SwiftPM's `--triple`/`--swift-sdk`.

### Modifications:

Make `SwiftSDK.deriveTargetSwiftSDK` public

### Result:

See https://github.com/swiftlang/sourcekit-lsp/pull/1643
