### PR TITLE
Fix direct `FilePath` hashing in `QueryEngine`

### DIFF
--- a/Sources/QueryEngine/CacheKey.swift
+++ b/Sources/QueryEngine/CacheKey.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -16,17 +16,21 @@ import struct SystemPackage.FilePath
 
 /// Indicates that values of a conforming type can be hashed with an arbitrary hashing function. Unlike `Hashable`,
 /// this protocol doesn't utilize random seed values and produces consistent hash values across process launches.
-package protocol CacheKey: Encodable {
+public protocol CacheKey: Encodable {}
+
+/// Types that cannot be decomposed more to be hashed
+protocol LeafCacheKey: CacheKey {
+  func hash(with hashFunction: inout some HashFunction)
 }
 
-extension Bool: CacheKey {
+extension Bool: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     hashFunction.update(data: self ? [1] : [0])
   }
 }
 
-extension Int: CacheKey {
+extension Int: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
@@ -35,7 +39,7 @@ extension Int: CacheKey {
   }
 }
 
-extension Int8: CacheKey {
+extension Int8: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
@@ -44,7 +48,7 @@ extension Int8: CacheKey {
   }
 }
 
-extension Int16: CacheKey {
+extension Int16: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
@@ -53,7 +57,7 @@ extension Int16: CacheKey {
   }
 }
 
-extension Int32: CacheKey {
+extension Int32: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
@@ -62,7 +66,7 @@ extension Int32: CacheKey {
   }
 }
 
-extension Int64: CacheKey {
+extension Int64: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
@@ -71,7 +75,7 @@ extension Int64: CacheKey {
   }
 }
 
-extension UInt: CacheKey {
+extension UInt: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
@@ -80,7 +84,7 @@ extension UInt: CacheKey {
   }
 }
 
-extension UInt8: CacheKey {
+extension UInt8: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
@@ -89,7 +93,7 @@ extension UInt8: CacheKey {
   }
 }
 
-extension UInt16: CacheKey {
+extension UInt16: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
@@ -98,7 +102,7 @@ extension UInt16: CacheKey {
   }
 }
 
-extension UInt32: CacheKey {
+extension UInt32: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
@@ -107,7 +111,7 @@ extension UInt32: CacheKey {
   }
 }
 
-extension UInt64: CacheKey {
+extension UInt64: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
@@ -116,7 +120,7 @@ extension UInt64: CacheKey {
   }
 }
 
-extension Float: CacheKey {
+extension Float: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
@@ -125,7 +129,7 @@ extension Float: CacheKey {
   }
 }
 
-extension Double: CacheKey {
+extension Double: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
@@ -134,7 +138,7 @@ extension Double: CacheKey {
   }
 }
 
-extension String: CacheKey {
+extension String: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     var t = String(reflecting: Self.self)
     t.withUTF8 {
@@ -147,21 +151,21 @@ extension String: CacheKey {
   }
 }
 
-extension FilePath: CacheKey {
+extension FilePath: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     self.string.hash(with: &hashFunction)
   }
 }
 
-extension FilePath.Component: CacheKey {
+extension FilePath.Component: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     self.string.hash(with: &hashFunction)
   }
 }
 
-extension URL: CacheKey {
+extension URL: LeafCacheKey {
   func hash(with hashFunction: inout some HashFunction) {
     String(reflecting: Self.self).hash(with: &hashFunction)
     self.description.hash(with: &hashFunction)

--- a/Sources/QueryEngine/Query.swift
+++ b/Sources/QueryEngine/Query.swift
@@ -1,3 +1,4 @@
+//===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift open source project
 //
@@ -9,11 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Crypto
 import struct SystemPackage.FilePath
 
-package protocol Query: CacheKey, Sendable {
+package protocol Query: Sendable {
+    associatedtype Key: CacheKey
+    var cacheKey: Key { get }
     func run(engine: QueryEngine) async throws -> FilePath
+}
+
+package protocol CachingQuery: Query, CacheKey where Self.Key == Self {}
+extension CachingQuery {
+    package var cacheKey: Key { self }
 }
 
 // SwiftPM has to be built with Swift 5.8 on CI and also needs to support CMake for bootstrapping on Windows.
@@ -25,32 +32,31 @@ final class HashEncoder<Hash: HashFunction>: Encoder {
     }
 
     var codingPath: [any CodingKey]
-    
-    var userInfo: [CodingUserInfoKey : Any]
-    
-    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-        String(reflecting: Key.self).hash(with: &self.hashFunction)
-        return .init(KeyedContainer(encoder: self))
+
+    var userInfo: [CodingUserInfoKey: Any]
+
+    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
+        .init(KeyedContainer(encoder: self))
     }
-    
+
     func unkeyedContainer() -> any UnkeyedEncodingContainer {
         self
     }
-    
+
     func singleValueContainer() -> any SingleValueEncodingContainer {
         self
     }
-    
+
     init() {
         self.hashFunction = Hash()
         self.codingPath = []
         self.userInfo = [:]
     }
-    
+
     fileprivate var hashFunction = Hash()
 
     func finalize() -> Hash.Digest {
-        hashFunction.finalize()
+        self.hashFunction.finalize()
     }
 }
 
@@ -67,64 +73,70 @@ extension HashEncoder: SingleValueEncodingContainer {
     func encode(_ value: Bool) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: String) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: Double) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: Float) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: Int) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: Int8) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: Int16) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: Int32) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: Int64) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: UInt) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: UInt8) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: UInt16) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: UInt32) throws {
         value.hash(with: &self.hashFunction)
     }
-    
+
     func encode(_ value: UInt64) throws {
         value.hash(with: &self.hashFunction)
     }
-    
-    func encode<T>(_ value: T) throws where T : Encodable {
+
+    func encode<T>(_ value: T) throws where T: Encodable {
+        if let leaf = value as? LeafCacheKey {
+            leaf.hash(with: &self.hashFunction)
+            return
+        }
+
         guard value is CacheKey else {
             throw Error.noCacheKeyConformance(T.self)
         }
 
+        try String(describing: T.self).encode(to: self)
         try value.encode(to: self)
     }
 }
@@ -133,15 +145,16 @@ extension HashEncoder: UnkeyedEncodingContainer {
     var count: Int {
         0
     }
-    
-    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+
+    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey>
+    where NestedKey: CodingKey {
         KeyedEncodingContainer(KeyedContainer(encoder: self))
     }
-    
+
     func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
         self
     }
-    
+
     func superEncoder() -> any Encoder {
         fatalError()
     }
@@ -160,82 +173,87 @@ extension HashEncoder {
                 self.encoder.hashFunction.update(data: $0)
             }
         }
-        
+
         mutating func encode(_ value: Bool, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: String, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: Double, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: Float, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: Int, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: Int8, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: Int16, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: Int32, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: Int64, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: UInt, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: UInt8, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: UInt16, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: UInt32, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
+
         mutating func encode(_ value: UInt64, forKey key: K) throws {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             value.hash(with: &self.encoder.hashFunction)
         }
-        
-        mutating func encode<T>(_ value: T, forKey key: K) throws where T : Encodable {
+
+        mutating func encode<T>(_ value: T, forKey key: K) throws where T: Encodable {
+            if let leaf = value as? LeafCacheKey {
+                leaf.hash(with: &self.encoder.hashFunction)
+                return
+            }
             guard value is CacheKey else {
                 throw Error.noCacheKeyConformance(T.self)
             }
 
+            try String(reflecting: T.self).encode(to: self.encoder)
             key.stringValue.hash(with: &self.encoder.hashFunction)
             try value.encode(to: self.encoder)
         }
@@ -243,7 +261,7 @@ extension HashEncoder {
         mutating func nestedContainer<NestedKey>(
             keyedBy keyType: NestedKey.Type,
             forKey key: K
-        ) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        ) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
             key.stringValue.hash(with: &self.encoder.hashFunction)
             return self.encoder.nestedContainer(keyedBy: keyType)
         }

--- a/Sources/QueryEngine/QueryEngine.swift
+++ b/Sources/QueryEngine/QueryEngine.swift
@@ -83,7 +83,7 @@ package actor QueryEngine {
     package subscript(_ query: some Query) -> FileCacheRecord {
         get async throws {
             let hashEncoder = HashEncoder<SHA512>()
-            try query.encode(to: hashEncoder)
+            try hashEncoder.encode(query.cacheKey)
             let key = hashEncoder.finalize()
 
             if let fileRecord = try resultsCache.get(blobKey: key) {


### PR DESCRIPTION
This vendors fixes to `HashEncoder` from `swift-sdk-generator` introduced in https://github.com/swiftlang/swift-sdk-generator/pull/97 and https://github.com/swiftlang/swift-sdk-generator/pull/134.
