### PR TITLE
Add `OSFileSystem` to complement `MockFileSystem`

### DIFF
--- a/Sources/_AsyncFileSystem/MockFileSystem.swift
+++ b/Sources/_AsyncFileSystem/MockFileSystem.swift
@@ -45,6 +45,14 @@ package actor MockFileSystem: AsyncFileSystem {
         self.storage.content.keys.contains(path)
     }
 
+    /// Writes a sequence of bytes to a file. Any existing content is replaced with new content.
+    /// - Parameters:
+    ///   - path: absolute path of the file to write bytes to.
+    ///   - bytes: sequence of bytes to write to file's contents replacing old content.
+    func write(path: FilePath, bytes: some Sequence<UInt8>) {
+        storage.content[path] = Array(bytes)
+    }
+
     /// Appends a sequence of bytes to a file.
     /// - Parameters:
     ///   - path: absolute path of the file to append bytes to.

--- a/Sources/_AsyncFileSystem/OSFileSystem.swift
+++ b/Sources/_AsyncFileSystem/OSFileSystem.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+@preconcurrency package import SystemPackage
+
+public actor OSFileSystem: AsyncFileSystem {
+  public static let defaultChunkSize = 512 * 1024
+
+  let readChunkSize: Int
+  private let ioQueue = DispatchQueue(label: "org.swift.sdk-generator-io")
+
+  package init(readChunkSize: Int = defaultChunkSize) {
+    self.readChunkSize = readChunkSize
+  }
+
+  package func withOpenReadableFile<T: Sendable>(
+    _ path: FilePath,
+    _ body: (OpenReadableFile) async throws -> T
+  ) async throws -> T {
+    let fd = try FileDescriptor.open(path, .readOnly)
+    // Can't use ``FileDescriptor//closeAfter` here, as that doesn't support async closures.
+    do {
+      let result = try await body(.init(chunkSize: readChunkSize, fileHandle: .real(fd, self.ioQueue)))
+      try fd.close()
+      return result
+    } catch {
+      try fd.close()
+      throw error.attach(path)
+    }
+  }
+
+  package func withOpenWritableFile<T: Sendable>(
+    _ path: FilePath,
+    _ body: (OpenWritableFile) async throws -> T
+  ) async throws -> T {
+      let fd = try FileDescriptor.open(
+        path,
+        .writeOnly,
+        options: [.create, .truncate],
+        permissions: [
+            .groupRead,
+            .otherRead,
+            .ownerReadWrite
+        ]
+      )
+    do {
+      let result = try await body(.init(storage: .real(fd, self.ioQueue), path: path))
+      try fd.close()
+      return result
+    } catch {
+      try fd.close()
+      throw error.attach(path)
+    }
+  }
+
+  package func exists(_ path: SystemPackage.FilePath) async -> Bool {
+    FileManager.default.fileExists(atPath: path.string)
+  }
+}

--- a/Sources/_AsyncFileSystem/OpenWritableFile.swift
+++ b/Sources/_AsyncFileSystem/OpenWritableFile.swift
@@ -59,7 +59,7 @@ package actor OpenWritableFile: WritableStream {
                 }
             }
         case let .mock(storage):
-            await storage.append(path: self.path, bytes: bytes)
+            await storage.write(path: self.path, bytes: bytes)
         }
     }
 

--- a/Tests/_AsyncFileSystemTests/AsyncFileSystemTests.swift
+++ b/Tests/_AsyncFileSystemTests/AsyncFileSystemTests.swift
@@ -23,7 +23,12 @@ final class AsyncFileSystemTests: XCTestCase {
 
         let mockContent = "baz".utf8
 
-        try await fs.write(mockPath, bytes: "baz".utf8)
+        try await fs.write(mockPath, bytes: mockContent)
+
+        await XCTAssertAsyncTrue(await fs.exists(mockPath))
+
+        // Test overwriting
+        try await fs.write(mockPath, bytes: mockContent)
 
         await XCTAssertAsyncTrue(await fs.exists(mockPath))
 
@@ -32,5 +37,31 @@ final class AsyncFileSystemTests: XCTestCase {
         }
 
         XCTAssertEqual(bytes, Array(mockContent))
+    }
+    func testOSFileSystem() async throws {
+        try await testWithTemporaryDirectory { tmpDir in
+            let fs = OSFileSystem()
+
+            let mockPath = FilePath(tmpDir.appending("foo").pathString)
+
+            await XCTAssertAsyncFalse(await fs.exists(mockPath))
+
+            let mockContent = "baz".utf8
+
+            try await fs.write(mockPath, bytes: mockContent)
+
+            await XCTAssertAsyncTrue(await fs.exists(mockPath))
+
+            // Test overwriting
+            try await fs.write(mockPath, bytes: mockContent)
+
+            await XCTAssertAsyncTrue(await fs.exists(mockPath))
+
+            let bytes = try await fs.withOpenReadableFile(mockPath) { fileHandle in
+                try await fileHandle.read().reduce(into: []) { $0.append(contentsOf: $1) }
+            }
+
+            XCTAssertEqual(bytes, Array(mockContent))
+        }
     }
 }


### PR DESCRIPTION
This expands available `AsyncFileSystem` APIs and brings them in sync with `swift-sdk-generator` as implemented in https://github.com/swiftlang/swift-sdk-generator/pull/136.