### PR TITLE
Keep loose compatibility with Swift 5.8 in AsyncFileSystem

### DIFF
--- a/Sources/_AsyncFileSystem/AsyncFileSystem.swift
+++ b/Sources/_AsyncFileSystem/AsyncFileSystem.swift
@@ -61,9 +61,9 @@ extension Error {
     /// - Returns: An ``AsyncFileSystemError`` value augmented by the given file path.
     func attach(_ path: FilePath) -> any Error {
         if let error = self as? Errno {
-            AsyncFileSystemError.systemError(path, error)
+            return AsyncFileSystemError.systemError(path, error)
         } else {
-            self
+            return self
         }
     }
 }

--- a/Sources/_AsyncFileSystem/OpenReadableFile.swift
+++ b/Sources/_AsyncFileSystem/OpenReadableFile.swift
@@ -36,7 +36,7 @@ package struct OpenReadableFile: Sendable {
     package func read() async throws -> ReadableFileStream {
         switch self.fileHandle {
         case let .real(fileDescriptor, ioQueue):
-            ReadableFileStream.real(
+            return ReadableFileStream.real(
                 .init(
                     fileDescriptor: fileDescriptor,
                     ioQueue: ioQueue,
@@ -45,7 +45,7 @@ package struct OpenReadableFile: Sendable {
             )
             
         case .mock(let array):
-            ReadableFileStream.mock(.init(bytes: array, chunkSize: self.chunkSize))
+            return ReadableFileStream.mock(.init(bytes: array, chunkSize: self.chunkSize))
         }
     }
 }

--- a/Sources/_AsyncFileSystem/ReadableFileStream.swift
+++ b/Sources/_AsyncFileSystem/ReadableFileStream.swift
@@ -28,9 +28,9 @@ package enum ReadableFileStream: AsyncSequence {
         package func next() async throws -> ArraySlice<UInt8>? {
             switch self {
             case .real(let local):
-                try await local.next()
+                return try await local.next()
             case .mock(let virtual):
-                try await virtual.next()
+                return try await virtual.next()
             }
         }
     }
@@ -38,9 +38,9 @@ package enum ReadableFileStream: AsyncSequence {
     package func makeAsyncIterator() -> Iterator {
         switch self {
         case .real(let real):
-            .real(real.makeAsyncIterator())
+            return .real(real.makeAsyncIterator())
         case .mock(let mock):
-            .mock(mock.makeAsyncIterator())
+            return .mock(mock.makeAsyncIterator())
         }
     }
 }


### PR DESCRIPTION
AsyncFileSystem is going to be vendored into swift-sdk-generator (https://github.com/swiftlang/swift-sdk-generator/pull/136), and the tool is built with bootstrapping toolchain that is Swift 5.8 on ci.swift.org. This commit makes the vendored AsyncFileSystem compatible with Swift 5.8 by avoiding the use of SE-0380
