### PR TITLE
Improve displayVersion and scmRevision description exposed by PluginContextSerializer

### DIFF
--- a/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
@@ -236,11 +236,11 @@ internal struct PluginContextSerializer {
             case .fileSystem(let path):
                 return .local(path: try serialize(path: path))
             case .localSourceControl(let path):
-                return .repository(url: path.asURL.absoluteString, displayVersion: String(describing: package.manifest.version), scmRevision: String(describing: package.manifest.revision))
+                return .repository(url: path.asURL.absoluteString, displayVersion: package.manifest.version?.description ?? "nil", scmRevision: package.manifest.revision ?? "nil")
             case .remoteSourceControl(let url):
-                return .repository(url: url.absoluteString, displayVersion: String(describing: package.manifest.version), scmRevision: String(describing: package.manifest.revision))
+                return .repository(url: url.absoluteString, displayVersion: package.manifest.version?.description ?? "nil", scmRevision: package.manifest.revision ?? "nil")
             case .registry(let identity):
-                return .registry(identity: identity.description, displayVersion: String(describing: package.manifest.version))
+                return .registry(identity: identity.description, displayVersion: package.manifest.version?.description ?? "nil")
             }
         }
 

--- a/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
@@ -236,11 +236,11 @@ internal struct PluginContextSerializer {
             case .fileSystem(let path):
                 return .local(path: try serialize(path: path))
             case .localSourceControl(let path):
-                return .repository(url: path.asURL.absoluteString, displayVersion: package.manifest.version?.description ?? "nil", scmRevision: package.manifest.revision ?? "nil")
+                return .repository(url: path.asURL.absoluteString, displayVersion: package.manifest.version?.description ?? "no version", scmRevision: package.manifest.revision ?? "no revision")
             case .remoteSourceControl(let url):
-                return .repository(url: url.absoluteString, displayVersion: package.manifest.version?.description ?? "nil", scmRevision: package.manifest.revision ?? "nil")
+                return .repository(url: url.absoluteString, displayVersion: package.manifest.version?.description ?? "no version", scmRevision: package.manifest.revision ?? "no revision")
             case .registry(let identity):
-                return .registry(identity: identity.description, displayVersion: package.manifest.version?.description ?? "nil")
+                return .registry(identity: identity.description, displayVersion: package.manifest.version?.description ?? "no version")
             }
         }
 


### PR DESCRIPTION
Avoid using `String(describing:)` to create strings that can be utilized by consumers.

### Motivation:

Version and revision strings with `Optional(...)` in them look less-than-great

### Modifications:

Utilized `thing?.description ?? "nil"` rather than `String(describing: thing)`.

### Result:

Improved the readability of `displayVersion` and `scmRevision` in a `Package`'s `origin: PackagePlugin.PackageOrigin`.