### PR TITLE
Fix link in `CHANGELOG.md`, add `swift sdk install --checksum` item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,7 @@ Swift 6.0
 
 * [#7722]
 
-  For `swift sdk install` subcommand passed remote URLs as arguments, an additional `--checksum` option is now required, through which users of a Swift SDK can specify a checksum provided by
-  a publisher of the SDK. The latter can produce a checksum by running `swift package compute-checksum` command (introduced in [SE-0272]) with the Swift SDK bundle archive as an argument.
+  An additional `--checksum` option  is now required for `swift sdk install` subcommand with remote URLs as arguments. `--checksum` allows users of a Swift SDK to specify a checksum provided by the SDK publisher. A checksum can be produced by running `swift package compute-checksum` command (introduced in [SE-0272]) with the Swift SDK bundle archive as an argument.
 
 * [#7535]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,16 @@ Swift 6.0
   `--experimental-swift-sdks-path` options on `swift build` are deprecated with replacements that don't have the
   `experimental` prefix.
 
+* [#7722]
+
+  For `swift sdk install` subcommand passed remote URLs as arguments, an additional `--checksum` option is now required, through which users of a Swift SDK can specify a checksum provided by
+  a publisher of the SDK. The latter can produce a checksum by running `swift package compute-checksum` command (introduced in [SE-0272]) with the Swift SDK bundle archive as an argument.
+
 * [#7535]
 
   The `swift sdk configuration` subcommand is deprecated with a replacement named `configure` that has options that exactly match
   [SE-0387 proposal text].
+
 
 * [#7202]
 
@@ -377,6 +383,7 @@ Swift 3.0
 [SE-0201]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0201-package-manager-local-dependencies.md
 [SE-0208]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0208-package-manager-system-library-targets.md
 [SE-0209]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0209-package-manager-swift-lang-version-update.md
+[SE-0272]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0272-swiftpm-binary-dependencies.md
 [SE-0292]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0292-package-registry-service.md
 [SE-0303]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0303-swiftpm-extensible-build-tools.md
 [SE-0332]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0332-swiftpm-command-plugins.md
@@ -439,4 +446,6 @@ Swift 3.0
 [#7507]: https://github.com/swiftlang/swift-package-manager/pull/7507
 [#7530]: https://github.com/swiftlang/swift-package-manager/pull/7530
 [#7535]: https://github.com/swiftlang/swift-package-manager/pull/7535
+[#7722]: https://github.com/swiftlang/swift-package-manager/pull/7722
+[#7741]: https://github.com/swiftlang/swift-package-manager/pull/7741
 [#7813]: https://github.com/swiftlang/swift-package-manager/pull/7813


### PR DESCRIPTION
`CHANGELOG.md` had a broken link. Additionally, `swift sdk install --checksum` change introduced in #7722 seems to be changelog-worthy, but was previously missing.
