### PR TITLE
Use `SWIFTCI_USE_LOCAL_DEPS` as the CI check

### DIFF
--- a/Sources/_InternalTestSupport/XCTAssertHelpers.swift
+++ b/Sources/_InternalTestSupport/XCTAssertHelpers.swift
@@ -44,7 +44,7 @@ public func XCTAssertEqual<T:Equatable, U:Equatable> (_ lhs:(T,U), _ rhs:(T,U), 
 }
 
 public func XCTSkipIfCI(file: StaticString = #filePath, line: UInt = #line) throws {
-    if let ci = ProcessInfo.processInfo.environment["CI"] as? NSString, ci.boolValue {
+    if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] != nil {
         throw XCTSkip("Skipping because the test is being run on CI", file: file, line: line)
     }
 }


### PR DESCRIPTION
Unsure where `CI` is being set, but it doesn't seem to be on Linux at the very least. `SWIFTCI_USE_LOCAL_DEPS` is definitely set everywhere, use it instead.