### PR TITLE
Fix discrepancies with usage of package display name/package identity in `swift package edit` command

### DIFF
--- a/Sources/Commands/PackageCommands/EditCommands.swift
+++ b/Sources/Commands/PackageCommands/EditCommands.swift
@@ -32,8 +32,8 @@ extension SwiftPackageCommand {
         @Option(help: "Create or use the checkout at this path")
         var path: AbsolutePath?
 
-        @Argument(help: "The name of the package to edit")
-        var packageName: String
+        @Argument(help: "The identity of the package to edit")
+        var packageIdentity: String
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {
             try await swiftCommandState.resolve()
@@ -41,7 +41,7 @@ extension SwiftPackageCommand {
 
             // Put the dependency in edit mode.
             await workspace.edit(
-                packageName: packageName,
+                packageIdentity: packageIdentity,
                 path: path,
                 revision: revision,
                 checkoutBranch: checkoutBranch,
@@ -61,15 +61,15 @@ extension SwiftPackageCommand {
               help: "Unedit the package even if it has uncommitted and unpushed changes")
         var shouldForceRemove: Bool = false
 
-        @Argument(help: "The name of the package to unedit")
-        var packageName: String
+        @Argument(help: "The identity of the package to unedit")
+        var packageIdentity: String
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {
             try await swiftCommandState.resolve()
             let workspace = try swiftCommandState.getActiveWorkspace()
 
             try await workspace.unedit(
-                packageName: packageName,
+                packageIdentity: packageIdentity,
                 forceRemove: shouldForceRemove,
                 root: swiftCommandState.getWorkspaceRoot(),
                 observabilityScope: swiftCommandState.observabilityScope

--- a/Sources/Commands/PackageCommands/EditCommands.swift
+++ b/Sources/Commands/PackageCommands/EditCommands.swift
@@ -32,8 +32,11 @@ extension SwiftPackageCommand {
         @Option(help: "Create or use the checkout at this path")
         var path: AbsolutePath?
 
-        @Argument(help: "The identity of the package to edit")
-        var packageIdentity: String
+        @Argument(help: .hidden)
+        var packageName: String?
+
+        @Argument(help: "The identity of the package to edit.")
+        var packageIdentity: String = ""
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {
             try await swiftCommandState.resolve()
@@ -47,6 +50,14 @@ extension SwiftPackageCommand {
                 checkoutBranch: checkoutBranch,
                 observabilityScope: swiftCommandState.observabilityScope
             )
+        }
+
+        mutating func validate() throws {
+            // Since packageName is deprecated, if it's assigned to a value then propagate
+            // that to packageIdentity.
+            if let packageName, packageIdentity.isEmpty {
+                self.packageIdentity = packageName
+            }
         }
     }
 

--- a/Sources/Commands/PackageCommands/EditCommands.swift
+++ b/Sources/Commands/PackageCommands/EditCommands.swift
@@ -32,11 +32,8 @@ extension SwiftPackageCommand {
         @Option(help: "Create or use the checkout at this path")
         var path: AbsolutePath?
 
-        @Argument(help: .hidden)
-        var packageName: String?
-
         @Argument(help: "The identity of the package to edit.")
-        var packageIdentity: String = ""
+        var packageIdentity: String
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {
             try await swiftCommandState.resolve()
@@ -51,14 +48,6 @@ extension SwiftPackageCommand {
                 observabilityScope: swiftCommandState.observabilityScope
             )
         }
-
-        mutating func validate() throws {
-            // Since packageName is deprecated, if it's assigned to a value then propagate
-            // that to packageIdentity.
-            if let packageName, packageIdentity.isEmpty {
-                self.packageIdentity = packageName
-            }
-        }
     }
 
     struct Unedit: AsyncSwiftCommand {
@@ -72,11 +61,8 @@ extension SwiftPackageCommand {
               help: "Unedit the package even if it has uncommitted and unpushed changes")
         var shouldForceRemove: Bool = false
 
-        @Argument(help: .hidden)
-        var packageName: String?
-
         @Argument(help: "The identity of the package to unedit.")
-        var packageIdentity: String = ""
+        var packageIdentity: String
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {
             try await swiftCommandState.resolve()
@@ -88,14 +74,6 @@ extension SwiftPackageCommand {
                 root: swiftCommandState.getWorkspaceRoot(),
                 observabilityScope: swiftCommandState.observabilityScope
             )
-        }
-
-        mutating func validate() throws {
-            // Since packageName is deprecated, if it's assigned to a value then propagate
-            // that to packageIdentity.
-            if let packageName, packageIdentity.isEmpty {
-                self.packageIdentity = packageName
-            }
         }
     }
 }

--- a/Sources/Commands/PackageCommands/EditCommands.swift
+++ b/Sources/Commands/PackageCommands/EditCommands.swift
@@ -72,8 +72,11 @@ extension SwiftPackageCommand {
               help: "Unedit the package even if it has uncommitted and unpushed changes")
         var shouldForceRemove: Bool = false
 
-        @Argument(help: "The identity of the package to unedit")
-        var packageIdentity: String
+        @Argument(help: .hidden)
+        var packageName: String?
+
+        @Argument(help: "The identity of the package to edit.")
+        var packageIdentity: String = ""
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {
             try await swiftCommandState.resolve()
@@ -85,6 +88,14 @@ extension SwiftPackageCommand {
                 root: swiftCommandState.getWorkspaceRoot(),
                 observabilityScope: swiftCommandState.observabilityScope
             )
+        }
+
+        mutating func validate() throws {
+            // Since packageName is deprecated, if it's assigned to a value then propagate
+            // that to packageIdentity.
+            if let packageName, packageIdentity.isEmpty {
+                self.packageIdentity = packageName
+            }
         }
     }
 }

--- a/Sources/Commands/PackageCommands/EditCommands.swift
+++ b/Sources/Commands/PackageCommands/EditCommands.swift
@@ -75,7 +75,7 @@ extension SwiftPackageCommand {
         @Argument(help: .hidden)
         var packageName: String?
 
-        @Argument(help: "The identity of the package to edit.")
+        @Argument(help: "The identity of the package to unedit.")
         var packageIdentity: String = ""
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {

--- a/Sources/Commands/PackageCommands/EditCommands.swift
+++ b/Sources/Commands/PackageCommands/EditCommands.swift
@@ -32,7 +32,7 @@ extension SwiftPackageCommand {
         @Option(help: "Create or use the checkout at this path")
         var path: AbsolutePath?
 
-        @Argument(help: "The identity of the package to edit.")
+        @Argument(help: "The identity of the package to edit")
         var packageIdentity: String
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {
@@ -61,7 +61,7 @@ extension SwiftPackageCommand {
               help: "Unedit the package even if it has uncommitted and unpushed changes")
         var shouldForceRemove: Bool = false
 
-        @Argument(help: "The identity of the package to unedit.")
+        @Argument(help: "The identity of the package to unedit")
         var packageIdentity: String
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -597,7 +597,7 @@ extension Workspace {
     /// Puts a dependency in edit mode creating a checkout in editables directory.
     ///
     /// - Parameters:
-    ///     - packageName: The name of the package to edit.
+    ///     - packageIdentity: The identity of the package to edit.
     ///     - path: If provided, creates or uses the checkout at this location.
     ///     - revision: If provided, the revision at which the dependency
     ///       should be checked out to otherwise current revision.
@@ -605,7 +605,7 @@ extension Workspace {
     ///       created from the revision provided.
     ///     - observabilityScope: The observability scope that reports errors, warnings, etc
     public func edit(
-        packageName: String,
+        packageIdentity: String,
         path: AbsolutePath? = nil,
         revision: Revision? = nil,
         checkoutBranch: String? = nil,
@@ -613,7 +613,7 @@ extension Workspace {
     ) async {
         do {
             try await self._edit(
-                packageName: packageName,
+                packageIdentity: packageIdentity,
                 path: path,
                 revision: revision,
                 checkoutBranch: checkoutBranch,
@@ -636,13 +636,13 @@ extension Workspace {
     ///     - root: The workspace root. This is used to resolve the dependencies post unediting.
     ///     - observabilityScope: The observability scope that reports errors, warnings, etc
     public func unedit(
-        packageName: String,
+        packageIdentity: String,
         forceRemove: Bool,
         root: PackageGraphRootInput,
         observabilityScope: ObservabilityScope
     ) async throws {
-        guard let dependency = self.state.dependencies[.plain(packageName)] else {
-            observabilityScope.emit(.dependencyNotFound(packageName: packageName))
+        guard let dependency = self.state.dependencies[.plain(packageIdentity)] else {
+            observabilityScope.emit(.dependencyNotFound(packageName: packageIdentity))
             return
         }
 

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -370,7 +370,7 @@ public final class MockWorkspace {
     }
 
     public func checkEdit(
-        packageName: String,
+        packageIdentity: String,
         path: AbsolutePath? = nil,
         revision: Revision? = nil,
         checkoutBranch: String? = nil,
@@ -380,7 +380,7 @@ public final class MockWorkspace {
         await observability.topScope.trap {
             let ws = try self.getOrCreateWorkspace()
             await ws.edit(
-                packageName: packageName,
+                packageIdentity: packageIdentity,
                 path: path,
                 revision: revision,
                 checkoutBranch: checkoutBranch,
@@ -391,7 +391,7 @@ public final class MockWorkspace {
     }
 
     public func checkUnedit(
-        packageName: String,
+        packageIdentity: String,
         roots: [String],
         forceRemove: Bool = false,
         _ result: ([Basics.Diagnostic]) -> Void
@@ -401,7 +401,7 @@ public final class MockWorkspace {
             let rootInput = PackageGraphRootInput(packages: try rootPaths(for: roots))
             let ws = try self.getOrCreateWorkspace()
             try await ws.unedit(
-                packageName: packageName,
+                packageIdentity: packageIdentity,
                 forceRemove: forceRemove,
                 root: rootInput,
                 observabilityScope: observability.topScope

--- a/Sources/_InternalTestSupport/PackageGraphTester.swift
+++ b/Sources/_InternalTestSupport/PackageGraphTester.swift
@@ -28,18 +28,8 @@ public final class PackageGraphResult {
         self.graph = graph
     }
 
-    // TODO: deprecate / transition to PackageIdentity
-    public func check(roots: String..., file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(graph.rootPackages.map{$0.manifest.displayName }.sorted(), roots.sorted(), file: file, line: line)
-    }
-
     public func check(roots: PackageIdentity..., file: StaticString = #file, line: UInt = #line) {
         XCTAssertEqual(graph.rootPackages.map{$0.identity }.sorted(), roots.sorted(), file: file, line: line)
-    }
-
-    // TODO: deprecate / transition to PackageIdentity
-    public func check(packages: String..., file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(graph.packages.map {$0.manifest.displayName }.sorted(), packages.sorted(), file: file, line: line)
     }
 
     public func check(packages: PackageIdentity..., file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
Fixes #7931

`swift package edit` was reliant on the user-passed `packageName` argument to be able to both find the dependency (which needs the identity) as well as to match the manifest display name.

Default to treating the user-passed argument as a package identity, and fix the comparisons made to the manifest by instead assuring that the canonical locations for the manifest and the dependency match. The display name was intended to be deprecated.

### Motivation:

The vscode-swift extension made use of of the package identities when listing dependencies in its UI. When a user would execute a `Use Local Version` on one of these dependencies, it would call `swift package edit <package-name>` under the hood, using the identity for the package-name argument. However, this would fail as the `edit` command would also treat the package name argument as the package's manifest `displayName`, which is not guaranteed to match the identity.

### Modifications:

Treat the user-passed argument as the package identity, and deprecate the usage of `displayName` in the `edit` command. Fix any necessary test cases to follow suite with this change.

### Result:

The`edit` command should now be using the package identity, and there should no longer be any discrepancies.
