### PR TITLE
Change swift-argument-parser dependency from 'upToNextMinor' to 'from'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -937,7 +937,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.4.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-driver.git", branch: relatedDependenciesBranch),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "3.0.0")),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: relatedDependenciesBranch),


### PR DESCRIPTION
upToNextMinor is no longer needed since swift-argument-parser reached 1.0.

### Motivation:

Unblocks downstream projects from adopting a newer swift-argument-parser.

### Modifications:

Change swift-argument-parser dependency from 'upToNextMinor' to 'from'

### Result:

SwiftPM and downstream packages can use a newer swift-argument-parser