### PR TITLE
Fixup warnings in tests

### DIFF
--- a/Tests/BasicsTests/AsyncProcessTests.swift
+++ b/Tests/BasicsTests/AsyncProcessTests.swift
@@ -434,7 +434,7 @@ final class AsyncProcessTests: XCTestCase {
 
             group.addTask {
                 var counter = 0
-                for await output in stderrStream {
+                for await _ in stderrStream {
                     counter += 1
                 }
 
@@ -477,7 +477,7 @@ final class AsyncProcessTests: XCTestCase {
             },
             stderr: { stderr in
                 var counter = 0
-                for await output in stderr {
+                for await _ in stderr {
                     counter += 1
                 }
 

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -139,7 +139,7 @@ final class TestCommandTests: CommandsTestCase {
         try await fixture(name: "Miscellaneous/EmptyTestsPkg") { fixturePath in
             let xUnitOutput = fixturePath.appending("result.xml")
             // Run tests in parallel with verbose output.
-            let stdout = try await SwiftPM.Test.execute(["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString], packagePath: fixturePath).stdout
+            _ = try await SwiftPM.Test.execute(["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString], packagePath: fixturePath).stdout
 
             // Check the xUnit output.
             XCTAssertFileExists(xUnitOutput)

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -537,7 +537,8 @@ final class PluginTests: XCTestCase {
                     )
 
                     let toolSearchDirectories = [try UserToolchain.default.swiftCompilerPath.parentDirectory]
-                    let success = try await withCheckedThrowingContinuation { plugin.invoke(
+                    let success = try await withCheckedThrowingContinuation { continuation in
+                      plugin.invoke(
                         action: .performCommand(package: package, arguments: arguments),
                         buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                         scriptRunner: scriptRunner,
@@ -555,7 +556,10 @@ final class PluginTests: XCTestCase {
                         observabilityScope: observability.topScope,
                         callbackQueue: delegateQueue,
                         delegate: delegate,
-                        completion: $0.resume(with:))
+                        completion: {
+                          continuation.resume(with: $0)
+                        }
+                      )
                     }
                     if expectFailure {
                         XCTAssertFalse(success, "expected command to fail, but it succeeded", file: file, line: line)

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -3840,14 +3840,16 @@ extension RegistryClient {
         package: PackageIdentity.RegistryIdentity,
         version: Version
     ) async throws -> PackageVersionMetadata {
-        return try await withCheckedThrowingContinuation {
+        return try await withCheckedThrowingContinuation { continuation in
             self.getPackageVersionMetadata(
                 package: package.underlying,
                 version: version,
                 fileSystem: InMemoryFileSystem(),
                 observabilityScope: ObservabilitySystem.NOOP,
                 callbackQueue: .sharedConcurrent,
-                completion: $0.resume(with:)
+                completion: {
+                  continuation.resume(with: $0)
+                }
             )
         }
     }

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -698,7 +698,7 @@ extension RepositoryManager {
         updateStrategy: RepositoryUpdateStrategy = .always,
         observabilityScope: ObservabilityScope
     ) async throws -> RepositoryHandle {
-        return try await withCheckedThrowingContinuation {
+        return try await withCheckedThrowingContinuation { continuation in
             self.lookup(
                 package: .init(url: SourceControlURL(repository.url)),
                 repository: repository,
@@ -706,7 +706,9 @@ extension RepositoryManager {
                 observabilityScope: observabilityScope,
                 delegateQueue: .sharedConcurrent,
                 callbackQueue: .sharedConcurrent,
-                completion: $0.resume(with:)
+                completion: {
+                  continuation.resume(with: $0)
+                }
             )
         }
     }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -155,7 +155,7 @@ final class InitTests: XCTestCase {
     }
 
     func testInitPackageLibraryWithSwiftTestingOnly() async throws {
-        try await testWithTemporaryDirectory { tmpPath in
+        try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("Foo")
             let name = path.basename
@@ -192,7 +192,7 @@ final class InitTests: XCTestCase {
     }
 
     func testInitPackageLibraryWithBothSwiftTestingAndXCTest() async throws {
-        try await testWithTemporaryDirectory { tmpPath in
+        try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("Foo")
             let name = path.basename
@@ -231,7 +231,7 @@ final class InitTests: XCTestCase {
     func testInitPackageLibraryWithNoTests() async throws {
         try UserToolchain.default.skipUnlessAtLeastSwift6()
 
-        try await testWithTemporaryDirectory { tmpPath in
+        try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("Foo")
             let name = path.basename

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -728,13 +728,15 @@ extension PackageContainerProvider {
         for package: PackageReference,
         updateStrategy: ContainerUpdateStrategy = .always
     ) async throws -> PackageContainer {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.getContainer(
                 for: package,
                 updateStrategy: updateStrategy,
                 observabilityScope: ObservabilitySystem.NOOP,
                 on: .global(),
-                completion: $0.resume(with:)
+                completion: {
+                  continuation.resume(with: $0)
+                }
             )
         }
     }


### PR DESCRIPTION
Fixes up a few different types of warnings in the tests:

- Unused variables are replaced with `_`
- Continuation handlers are not passed through directly (follows on from #7961)
- Removes unnecessary `await`s from functions that are now synchronous