### PR TITLE
Address concurrency warnings

### DIFF
--- a/Sources/Basics/Concurrency/AsyncProcess.swift
+++ b/Sources/Basics/Concurrency/AsyncProcess.swift
@@ -786,7 +786,9 @@ package final class AsyncProcess {
     package func waitUntilExit() async throws -> AsyncProcessResult {
         try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.processConcurrent.async {
-                self.waitUntilExit(continuation.resume(with:))
+                self.waitUntilExit({
+                    continuation.resume(with: $0)
+                })
             }
         }
     }

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -189,13 +189,16 @@ public extension PackageContainerProvider {
         observabilityScope: ObservabilityScope,
         on queue: DispatchQueue
     ) async throws -> PackageContainer {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.getContainer(
                 for: package,
                 updateStrategy: updateStrategy,
                 observabilityScope: observabilityScope,
                 on: queue,
-                completion: $0.resume(with:))
+                completion: {
+                    continuation.resume(with: $0)
+                }
+            )
         }
     }
 }

--- a/Sources/PackageRegistry/ChecksumTOFU.swift
+++ b/Sources/PackageRegistry/ChecksumTOFU.swift
@@ -46,7 +46,7 @@ struct PackageVersionChecksumTOFU {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.validateSourceArchive(
                 registry: registry,
                 package: package,
@@ -55,11 +55,13 @@ struct PackageVersionChecksumTOFU {
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }
-    
+
     @available(*, noasync, message: "Use the async alternative")
     func validateSourceArchive(
         registry: Registry,

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -144,20 +144,22 @@ public final class RegistryClient: Cancellable {
             observabilityScope: observabilityScope
         )
     }
-    
+
     public func getPackageMetadata(
         package: PackageIdentity,
         timeout: DispatchTimeInterval? = .none,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> PackageMetadata {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.getPackageMetadata(
                 package: package,
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }
@@ -275,7 +277,7 @@ public final class RegistryClient: Cancellable {
             )
         }
     }
-    
+
     public func getPackageVersionMetadata(
         package: PackageIdentity,
         version: Version,
@@ -284,7 +286,7 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> PackageVersionMetadata {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.getPackageVersionMetadata(
                 package: package,
                 version: version,
@@ -292,7 +294,9 @@ public final class RegistryClient: Cancellable {
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }
@@ -382,13 +386,15 @@ public final class RegistryClient: Cancellable {
                         }
                         let configuration = self.configuration.signing(for: package, registry: registry)
 
-                        let result = try? await withCheckedThrowingContinuation { completion in
+                        let result = try? await withCheckedThrowingContinuation { continuation in
                             SignatureValidation.extractSigningEntity(
                                 signature: [UInt8](signatureData),
                                 signatureFormat: signatureFormat,
                                 configuration: configuration,
                                 fileSystem: fileSystem,
-                                completion: completion.resume(with:)
+                                completion: {
+                                    continuation.resume(with: $0)
+                                }
                             )
                         }
                         resourceSigning.append((resource, result))
@@ -513,18 +519,20 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> [String: (toolsVersion: ToolsVersion, content: String?)]{
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.getAvailableManifests(
                 package: package,
                 version: version,
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }
-    
+
     @available(*, noasync, message: "Use the async alternative")
     public func getAvailableManifests(
         package: PackageIdentity,
@@ -758,19 +766,21 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> String {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.getManifestContent(
                 package: package,
                 version: version,
-                customToolsVersion: customToolsVersion, 
+                customToolsVersion: customToolsVersion,
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }
-    
+
     @available(*, noasync, message: "Use the async alternative")
     public func getManifestContent(
         package: PackageIdentity,
@@ -987,7 +997,7 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.downloadSourceArchive(
                 package: package,
                 version: version,
@@ -997,7 +1007,9 @@ public final class RegistryClient: Cancellable {
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }
@@ -1293,20 +1305,22 @@ public final class RegistryClient: Cancellable {
             }
         }
     }
-    
+
     public func lookupIdentities(
         scmURL: SourceControlURL,
         timeout: DispatchTimeInterval? = .none,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> Set<PackageIdentity> {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.lookupIdentities(
                 scmURL: scmURL,
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }
@@ -1416,20 +1430,22 @@ public final class RegistryClient: Cancellable {
             )
         }
     }
-    
+
     public func login(
         loginURL: URL,
         timeout: DispatchTimeInterval? = .none,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.login(
                 loginURL: loginURL,
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }
@@ -1471,7 +1487,7 @@ public final class RegistryClient: Cancellable {
             }
         }
     }
-    
+
     public func publish(
         registryURL: URL,
         packageIdentity: PackageIdentity,
@@ -1486,7 +1502,7 @@ public final class RegistryClient: Cancellable {
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> PublishResult  {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.publish(
                 registryURL: registryURL,
                 packageIdentity: packageIdentity,
@@ -1500,7 +1516,9 @@ public final class RegistryClient: Cancellable {
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }
@@ -1673,20 +1691,22 @@ public final class RegistryClient: Cancellable {
             )
         }
     }
-    
+
     func checkAvailability(
         registry: Registry,
         timeout: DispatchTimeInterval? = .none,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue
     ) async throws -> AvailabilityStatus {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.checkAvailability(
                 registry: registry,
                 timeout: timeout,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -63,7 +63,7 @@ extension PluginModule {
         callbackQueue: DispatchQueue,
         delegate: PluginInvocationDelegate
     ) async throws -> Bool {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.invoke(
                 action: action,
                 buildEnvironment: buildEnvironment,
@@ -82,7 +82,9 @@ extension PluginModule {
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
                 delegate: delegate,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }
@@ -157,7 +159,7 @@ extension PluginModule {
             }
             let actionMessage: HostToPluginMessage
             switch action {
-                
+
             case .createBuildToolCommands(let package, let target, let pluginGeneratedSources, let pluginGeneratedResources):
                 let rootPackageId = try serializer.serialize(package: package)
                 guard let targetId = try serializer.serialize(target: target) else {
@@ -200,38 +202,38 @@ extension PluginModule {
         catch {
             return callbackQueue.async { completion(.failure(PluginEvaluationError.couldNotSerializePluginInput(underlyingError: error))) }
         }
-        
+
         // Handle messages and output from the plugin.
         class ScriptRunnerDelegate: PluginScriptCompilerDelegate, PluginScriptRunnerDelegate {
             /// Delegate that should be told about events involving the plugin.
             let invocationDelegate: PluginInvocationDelegate
-            
+
             /// Observability scope for the invoking of the plugin. Diagnostics from the plugin itself are sent through the delegate.
             let observabilityScope: ObservabilityScope
-            
+
             /// Whether at least one error has been reported; this is used to make sure there is at least one error if the plugin fails.
             var hasReportedError = false
 
             /// If this is true, we exited early with an error.
             var exitEarly = false
-            
+
             init(invocationDelegate: PluginInvocationDelegate, observabilityScope: ObservabilityScope) {
                 self.invocationDelegate = invocationDelegate
                 self.observabilityScope = observabilityScope
             }
-            
+
             func willCompilePlugin(commandLine: [String], environment: [String: String]) {
                 invocationDelegate.pluginCompilationStarted(commandLine: commandLine, environment: environment)
             }
-            
+
             func didCompilePlugin(result: PluginCompilationResult) {
                 invocationDelegate.pluginCompilationEnded(result: result)
             }
-            
+
             func skippedCompilingPlugin(cachedResult: PluginCompilationResult) {
                 invocationDelegate.pluginCompilationWasSkipped(cachedResult: cachedResult)
             }
-            
+
             /// Invoked when the plugin emits arbitrary data on its stdout/stderr. There is no guarantee that the data is split on UTF-8 character encoding boundaries etc.  The script runner delegate just passes it on to the invocation delegate.
             func handleOutput(data: Data) {
                 invocationDelegate.pluginEmittedOutput(data)
@@ -241,7 +243,7 @@ extension PluginModule {
             func handleMessage(data: Data, responder: @escaping (Data) -> Void) throws {
                 let message = try PluginToHostMessage(data)
                 switch message {
-                    
+
                 case .emitDiagnostic(let severity, let message, let file, let line):
                     let metadata: ObservabilityMetadata? = file.map {
                         var metadata = ObservabilityMetadata()
@@ -343,7 +345,7 @@ extension PluginModule {
             }
         }
         let runnerDelegate = ScriptRunnerDelegate(invocationDelegate: delegate, observabilityScope: observabilityScope)
-        
+
         // Call the plugin script runner to actually invoke the plugin.
         scriptRunner.runPluginScript(
             sourceFiles: sources.paths,
@@ -391,7 +393,7 @@ extension PluginModule {
         modulesGraph: ModulesGraph,
         observabilityScope: ObservabilityScope
     ) async throws -> BuildToolPluginInvocationResult {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.invoke(
                 module: module,
                 action: action,
@@ -409,7 +411,9 @@ extension PluginModule {
                 fileSystem: fileSystem,
                 modulesGraph: modulesGraph,
                 observabilityScope: observabilityScope,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }
@@ -749,13 +753,13 @@ public protocol PluginInvocationDelegate {
 
     /// Called after a plugin is compiled. This call always follows a `pluginCompilationStarted()`, but is mutually exclusive with `pluginCompilationWasSkipped()` (which is called if the plugin didn't need to be recompiled).
     func pluginCompilationEnded(result: PluginCompilationResult)
-    
+
     /// Called if a plugin didn't need to be recompiled. This call is always mutually exclusive with `pluginCompilationStarted()` and `pluginCompilationEnded()`.
     func pluginCompilationWasSkipped(cachedResult: PluginCompilationResult)
-    
+
     /// Called for each piece of textual output data emitted by the plugin. Note that there is no guarantee that the data begins and ends on a UTF-8 byte sequence boundary (much less on a line boundary) so the delegate should buffer partial data as appropriate.
     func pluginEmittedOutput(_: Data)
-    
+
     /// Called when a plugin emits a diagnostic through the PackagePlugin APIs.
     func pluginEmittedDiagnostic(_: Basics.Diagnostic)
 

--- a/Sources/SPMBuildCore/Plugins/PluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginScriptRunner.swift
@@ -72,7 +72,7 @@ public extension PluginScriptRunner {
         callbackQueue: DispatchQueue,
         delegate: PluginScriptCompilerDelegate
     ) async throws -> PluginCompilationResult {
-        try await withCheckedThrowingContinuation {
+        try await withCheckedThrowingContinuation { continuation in
             self.compilePluginScript(
                 sourceFiles: sourceFiles,
                 pluginName: pluginName,
@@ -80,7 +80,9 @@ public extension PluginScriptRunner {
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
                 delegate: delegate,
-                completion: $0.resume(with:)
+                completion: {
+                  continuation.resume(with: $0)
+                }
             )
         }
     }

--- a/Sources/Workspace/PackageContainer/FileSystemPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/FileSystemPackageContainer.swift
@@ -79,7 +79,7 @@ public struct FileSystemPackageContainer: PackageContainer {
 
             // Load the manifest.
             // FIXME: this should not block
-            return try await withCheckedThrowingContinuation {
+            return try await withCheckedThrowingContinuation { continuation in
                 manifestLoader.load(
                     packagePath: packagePath,
                     packageIdentity: self.package.identity,
@@ -93,7 +93,9 @@ public struct FileSystemPackageContainer: PackageContainer {
                     observabilityScope: self.observabilityScope,
                     delegateQueue: .sharedConcurrent,
                     callbackQueue: .sharedConcurrent,
-                    completion: $0.resume(with:)
+                    completion: {
+                        continuation.resume(with: $0)
+                    }
                 )
             }
         }

--- a/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
@@ -396,7 +396,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     private func loadManifest(fileSystem: FileSystem, version: Version?, revision: String) async throws -> Manifest {
         // Load the manifest.
         // FIXME: this should not block
-        return try await withCheckedThrowingContinuation {
+        return try await withCheckedThrowingContinuation { continuation in
             self.manifestLoader.load(
                 packagePath: .root,
                 packageIdentity: self.package.identity,
@@ -410,7 +410,9 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
                 observabilityScope: self.observabilityScope,
                 delegateQueue: .sharedConcurrent,
                 callbackQueue: .sharedConcurrent,
-                completion: $0.resume(with:)
+                completion: {
+                    continuation.resume(with: $0)
+                }
             )
         }
     }

--- a/Sources/Workspace/Workspace+Editing.swift
+++ b/Sources/Workspace/Workspace+Editing.swift
@@ -71,7 +71,9 @@ extension Workspace {
                     packagePath: destination,
                     packageLocation: dependency.packageRef.locationString,
                     observabilityScope: observabilityScope,
-                    completion: continuation.resume(with:)
+                    completion: {
+                      continuation.resume(with: $0)
+                    }
                 )
             }
 

--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -879,7 +879,9 @@ extension Workspace {
                     updateStrategy: .never,
                     observabilityScope: observabilityScope,
                     on: .sharedConcurrent,
-                    completion: continuation.resume(with:)
+                    completion: {
+                        continuation.resume(with: $0)
+                    }
                 )
             }
             guard let customContainer = container as? CustomPackageContainer else {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1183,14 +1183,16 @@ extension Workspace {
         }
         return importList
     }
-    
+
     public func loadPackage(
         with identity: PackageIdentity,
         packageGraph: ModulesGraph,
         observabilityScope: ObservabilityScope
     ) async throws -> Package {
-        try await withCheckedThrowingContinuation {
-            self.loadPackage(with: identity, packageGraph: packageGraph, observabilityScope: observabilityScope, completion: $0.resume(with:))
+        try await withCheckedThrowingContinuation { continuation in
+            self.loadPackage(with: identity, packageGraph: packageGraph, observabilityScope: observabilityScope, completion: {
+                continuation.resume(with: $0)
+            })
         }
     }
 


### PR DESCRIPTION
Fix the rest of the concurrency warnings caused by directly passing a continuation's resume method.

Follow on to #7961
