### PR TITLE
Remove `@MainActor` from XCTest glue.

### DIFF
--- a/Sources/Build/LLBuildCommands.swift
+++ b/Sources/Build/LLBuildCommands.swift
@@ -76,8 +76,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
 
                 fileprivate extension \#(className) {
                     @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
-                    @MainActor
-                    static let __allTests__\#(className) = [
+                    static nonisolated(unsafe) let __allTests__\#(className) = [
                         \#(testMethods.map(\.allTestsEntry).joined(separator: ",\n        "))
                     ]
                 }
@@ -88,13 +87,12 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
         content +=
             #"""
             @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
-            @MainActor
             func __\#(module)__allTests() -> [XCTestCaseEntry] {
                 return [
                     \#(
                         testsByClassNames.map { "testCase(\($0.key).__allTests__\($0.key))" }
                             .joined(separator: ",\n        ")
-            )
+                    )
                 ]
             }
             """#
@@ -163,7 +161,6 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
             import XCTest
 
             @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
-            @MainActor
             public func __allDiscoveredTests() -> [XCTestCaseEntry] {
                 \#(testsKeyword) tests = [XCTestCaseEntry]()
 


### PR DESCRIPTION
Removes `@MainActor` and adds `nonisolated(unsafe)` to suppress concurrency diagnostics in the XCTest glue code generated when using corelibs-xctest.

See also #7960.