### PR TITLE
Change `traverseModules` to return modules with their dependencies

### DIFF
--- a/Sources/Basics/Graph/GraphAlgorithms.swift
+++ b/Sources/Basics/Graph/GraphAlgorithms.swift
@@ -90,7 +90,6 @@ public func depthFirstSearch<T: Hashable>(
 private struct TraversalNode<T: Hashable>: Hashable {
     let parent: T?
     let curr: T
-    let depth: Int
 }
 
 /// Implements a pre-order depth-first search that traverses the whole graph and
@@ -108,25 +107,24 @@ private struct TraversalNode<T: Hashable>: Hashable {
 public func depthFirstSearch<T: Hashable>(
     _ nodes: [T],
     successors: (T) throws -> [T],
-    onNext: (T, _ parent: T?, _ depth: Int) throws -> Void
+    onNext: (T, _ parent: T?) throws -> Void
 ) rethrows {
     var stack = OrderedSet<TraversalNode<T>>()
 
     for node in nodes {
         precondition(stack.isEmpty)
-        stack.append(TraversalNode(parent: nil, curr: node, depth: 0))
+        stack.append(TraversalNode(parent: nil, curr: node))
 
         while !stack.isEmpty {
             let node = stack.removeLast()
 
-            try onNext(node.curr, node.parent, node.depth)
+            try onNext(node.curr, node.parent)
 
             for succ in try successors(node.curr) {
                 stack.append(
                     TraversalNode(
                         parent: node.curr,
-                        curr: succ,
-                        depth: node.depth + 1
+                        curr: succ
                     )
                 )
             }

--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -215,7 +215,7 @@ extension BuildPlan {
                 }
 
                 return result.filter { uniqueNodes.insert($0).inserted }
-            } onNext: { node, _, _ in
+            } onNext: { node, _ in
                 switch node {
                 case .package: break
                 case .product(let product, let destination):

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -1074,12 +1074,16 @@ extension BuildPlan {
     package func traverseModules(
         _ onModule: (
             (ResolvedModule, BuildParameters.Destination),
-            _ parent: (ResolvedModule, BuildParameters.Destination)?,
-            _ depth: Int
+            _ parent: (ResolvedModule, BuildParameters.Destination)?
         ) -> Void
     ) {
+        var visited = Set<TraversalNode>()
+
         func successors(for package: ResolvedPackage) -> [TraversalNode] {
-            package.modules.compactMap {
+            guard visited.insert(.package(package)).inserted else {
+                return []
+            }
+            return package.modules.compactMap {
                 if case .test = $0.underlying.type,
                    !self.graph.rootPackages.contains(id: package.id)
                 {
@@ -1093,7 +1097,10 @@ extension BuildPlan {
             for module: ResolvedModule,
             destination: Destination
         ) -> [TraversalNode] {
-            module.dependencies.reduce(into: [TraversalNode]()) { partial, dependency in
+            guard visited.insert(.module(module, destination)).inserted else {
+                return []
+            }
+            return module.dependencies.reduce(into: [TraversalNode]()) { partial, dependency in
                 switch dependency {
                 case .product(let product, conditions: _):
                     let parent = TraversalNode(product: product, context: destination)
@@ -1115,7 +1122,7 @@ extension BuildPlan {
             case .product:
                 []
             }
-        } onNext: { current, parent, depth in
+        } onNext: { current, parent in
             let parentModule: (ResolvedModule, BuildParameters.Destination)? = switch parent {
             case .package, .product, nil:
                 nil
@@ -1128,7 +1135,7 @@ extension BuildPlan {
                 break
 
             case .module(let module, let destination):
-                onModule((module, destination), parentModule, depth)
+                onModule((module, destination), parentModule)
             }
         }
     }
@@ -1177,7 +1184,7 @@ extension BuildPlan {
             case .package:
                 []
             }
-        } onNext: { module, _, _ in
+        } onNext: { module, _ in
             switch module {
             case .package:
                 break

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -162,9 +162,9 @@ public struct BuildDescription {
     }
 
     public func traverseModules(
-        callback: (any BuildTarget, _ parent: (any BuildTarget)?, _ depth: Int) -> Void
+        callback: (any BuildTarget, _ parent: (any BuildTarget)?) -> Void
     ) {
-        self.buildPlan.traverseModules { module, parent, depth in
+        self.buildPlan.traverseModules { module, parent in
             let parentDescription: (any BuildTarget)? = if let parent {
                 getBuildTarget(for: parent.0, destination: parent.1)
             } else {
@@ -172,7 +172,7 @@ public struct BuildDescription {
             }
 
             if let description = getBuildTarget(for: module.0, destination: module.1) {
-                callback(description, parentDescription, depth)
+                callback(description, parentDescription)
             }
         }
     }


### PR DESCRIPTION
Companion of https://github.com/swiftlang/sourcekit-lsp/pull/1683

---

Opening the SourceKit-LSP workspace using a debug build of sourcekit-lsp takes about 35s because `traverseModules` generates about 800,000 callback calls. All SourceKit-LSP needs now are the modules and their dependencies, so we can refactor `traverseModules` to just return that information avoid visiting the same modules multiple times. With theses changes getting all modules and their dependencies only takes ~0.013s.

rdar://136107035
