### PR TITLE
#7975 Update "Getting Started" guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [SourceKit-LSP](https://github.com/swiftlang/sourcekit-lsp) project leverage
 
 ## Getting Started
 
-Please use [this guide](https://swift.org/getting-started/#using-the-package-manager) for learning package manager basics.
+Please use [this guide](https://www.swift.org/documentation/package-manager/) for learning package manager basics.
 
 ---
 


### PR DESCRIPTION
Update the "Getting Started" guide link.

### Motivation:

The README for this project was using an outdated link to the "Getting Started" page on swift.org

### Modifications:

Updated the link

### Result:

Link now points to the correct page
