### PR TITLE
[Tests] NFC: Remove overload of `GeneralizedTime.init(_:)`

### DIFF
--- a/Tests/PackageSigningTests/SigningTests.swift
+++ b/Tests/PackageSigningTests/SigningTests.swift
@@ -511,14 +511,14 @@ final class SigningTests: XCTestCase {
                     throw StringError("Missing OCSP request")
                 }
 
-                let ocspResponse = OCSPResponse.successful(try .signed(
+                let ocspResponse = try OCSPResponse.successful(.signed(
                     responderID: ResponderID.byName(intermediateName),
-                    producedAt: try GeneralizedTime(validationTime),
+                    producedAt: GeneralizedTime(validationTime),
                     responses: [OCSPSingleResponse(
                         certID: singleRequest.certID,
                         certStatus: .unknown,
-                        thisUpdate: try GeneralizedTime(validationTime - .days(1)),
-                        nextUpdate: try GeneralizedTime(validationTime + .days(1))
+                        thisUpdate: GeneralizedTime(validationTime - .days(1)),
+                        nextUpdate: GeneralizedTime(validationTime + .days(1))
                     )],
                     privateKey: intermediatePrivateKey,
                     responseExtensions: { nonce }
@@ -1173,21 +1173,6 @@ extension TimeInterval {
 
 private let gregorianCalendar = Calendar(identifier: .gregorian)
 private let utcTimeZone = TimeZone(identifier: "UTC")!
-
-extension GeneralizedTime {
-    init(_ date: Date) throws {
-        let components = gregorianCalendar.dateComponents(in: utcTimeZone, from: date)
-        try self.init(
-            year: components.year!,
-            month: components.month!,
-            day: components.day!,
-            hours: components.hour!,
-            minutes: components.minute!,
-            seconds: components.second!,
-            fractionalSeconds: 0.0
-        )
-    }
-}
 
 extension BasicOCSPResponse {
     static func signed(


### PR DESCRIPTION
### Motivation:

`swift-certificates` now implements initializer that accepts `Date` and doesn't throw which means this method is redundant but also incorrect because overloading only on `throws` is ambiguous in most cases due to throws checking not being part of the expression checking.

Uses of this overload type-checked only because it was always preferred before due to old type-checker hacks that we are trying to remove.

### Modifications:

- Removes `GeneralizedTime.init(_:) throws` that was added before `swift-certificates` introduced their own non-throwing version.

### Result:

No more duplicate code that is less safe than what `swift-certificates` vends.
