### PR TITLE
[6.0] Remove `@MainActor` from XCTest glue.

### DIFF
--- a/Sources/Build/LLBuildCommands.swift
+++ b/Sources/Build/LLBuildCommands.swift
@@ -76,7 +76,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
 
                 fileprivate extension \#(className) {
                     @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
-                    static let __allTests__\#(className) = [
+                    static nonisolated(unsafe) let __allTests__\#(className) = [
                         \#(testMethods.map(\.allTestsEntry).joined(separator: ",\n        "))
                     ]
                 }

--- a/Sources/Build/LLBuildCommands.swift
+++ b/Sources/Build/LLBuildCommands.swift
@@ -76,7 +76,6 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
 
                 fileprivate extension \#(className) {
                     @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
-                    @MainActor
                     static let __allTests__\#(className) = [
                         \#(testMethods.map(\.allTestsEntry).joined(separator: ",\n        "))
                     ]
@@ -88,13 +87,12 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
         content +=
             #"""
             @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
-            @MainActor
             func __\#(module)__allTests() -> [XCTestCaseEntry] {
                 return [
                     \#(
                         testsByClassNames.map { "testCase(\($0.key).__allTests__\($0.key))" }
                             .joined(separator: ",\n        ")
-            )
+                    )
                 ]
             }
             """#
@@ -163,7 +161,6 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
             import XCTest
 
             @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
-            @MainActor
             public func __allDiscoveredTests() -> [XCTestCaseEntry] {
                 \#(testsKeyword) tests = [XCTestCaseEntry]()
 


### PR DESCRIPTION
**Explanation:** Remove `@MainActor` annotations from corelibs-xctest glue functions that are no longer needed.
**Scope:** corelibs-xctest glue code
**Issue:** [N/A](rdar://130066460)
**Original PR:** https://github.com/swiftlang/swift-package-manager/pull/7967
**Risk:** Unknown
**Testing:** Existing CI jobs
**Reviewer:** @bnbarham @briancroom @DougGregor @shahmishal