### PR TITLE
Add an expectation of a warning diagnostic to tests that hide `libSwiftScan`.

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -662,6 +662,7 @@ final class MiscellaneousTestCase: XCTestCase {
         try await fixture(name: "Miscellaneous/RootPackageWithConditionals") { path in
             let (_, stderr) = try await SwiftPM.Build.execute(packagePath: path, env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"])
             let errors = stderr.components(separatedBy: .newlines).filter { !$0.contains("[logging] misuse") && !$0.isEmpty }
+                                                                  .filter { !$0.contains("Unable to locate libSwiftScan") }
             XCTAssertEqual(errors, [], "unexpected errors: \(errors)")
         }
     }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -236,7 +236,7 @@ final class PluginTests: XCTestCase {
 
             try createPackageUnderTest(packageDir: packageDir, toolsVersion: .v6_0)
             let (_, stderr2) = try await executeSwiftBuild(packageDir, env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"])
-            XCTAssertEqual("", stderr2)
+            XCTAssertFalse(stderr2.contains("error:"))
             XCTAssertTrue(localFileSystem.exists(pathOfGeneratedFile), "plugin did not run, generated file does not exist at \(pathOfGeneratedFile.pathString)")
         }
     }

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -177,7 +177,8 @@ final class ResourcesTests: XCTestCase {
 
             let (_, stderr) = try await executeSwiftBuild(packageDir, env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"])
             // Filter some unrelated output that could show up on stderr.
-            let filteredStderr = stderr.components(separatedBy: "\n").filter { !$0.contains("[logging]") }.joined(separator: "\n")
+            let filteredStderr = stderr.components(separatedBy: "\n").filter { !$0.contains("[logging]") }
+                                                                     .filter { !$0.contains("Unable to locate libSwiftScan") }.joined(separator: "\n")
             XCTAssertEqual(filteredStderr, "", "unexpectedly received error output: \(stderr)")
 
             let builtProductsDir = packageDir.appending(components: [".build", "debug"])


### PR DESCRIPTION
Such tests cause the driver to take a code-path that results in a warning: `warning: Unable to locate libSwiftScan. Fallback to `swift-frontend` dependency scanner invocation.`

This needs to be taken into account.
