### PR TITLE
directoryURL is missing from the Target protocol in the PackagePlugin APIs

### DIFF
--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -178,7 +178,12 @@ public protocol Target {
     var name: String { get }
 
     /// The absolute path of the target directory in the local file system.
+    @available(_PackageDescription, deprecated: 6.1, renamed: "directoryURL")
     var directory: Path { get }
+
+    /// The absolute path of the target directory in the local file system.
+    @available(_PackageDescription, introduced: 6.1)
+    var directoryURL: URL { get }
 
     /// Any other targets on which this target depends, in the same order as
     /// they are specified in the package manifest. Conditional dependencies


### PR DESCRIPTION
The directoryURL property was added to all of the concrete Target implementations, such as SwiftSourceModuleTarget, ClangSourceModuleTarget, and so on, but not to the base protocol itself.

This means you need a bunch of conditional casts when trying to access the directoryURL in a package plugin.

Closes: #8001