### PR TITLE
Enable WMO for Embedded targets automatically

### DIFF
--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -391,7 +391,7 @@ extension LLBuildManifestBuilder {
             sources: target.sources,
             fileList: target.sourcesFileListPath,
             isLibrary: isLibrary,
-            wholeModuleOptimization: target.buildParameters.configuration == .release,
+            wholeModuleOptimization: target.useWholeModuleOptimization,
             outputFileMapPath: try target.writeOutputFileMap(), // FIXME: Eliminate side effect.
             prepareForIndexing: target.buildParameters.prepareForIndexing != .off
         )

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -347,20 +347,6 @@ private struct _Toolchain: Encodable {
     }
 }
 
-extension BuildParameters {
-    /// Whether to build Swift code with whole module optimization (WMO)
-    /// enabled.
-    public var useWholeModuleOptimization: Bool {
-        switch configuration {
-        case .debug:
-            return false
-
-        case .release:
-            return true
-        }
-    }
-}
-
 extension Triple {
     public var supportsTestSummary: Bool {
         return !self.isWindows()


### PR DESCRIPTION
Updates SwiftPM to enable WMO for targets with experimental-feature Embedded. Unifies the logic to enable WMO into
SwiftModuleBuildDescription.
