### PR TITLE
WIP: Introduce SwiftSetting API for controlling whether testability is enabled for a target

### DIFF
--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -954,15 +954,33 @@ public final class SwiftModuleBuildDescription {
 
     /// Testing arguments according to the build configuration.
     private var testingArguments: [String] {
+        let enableTesting: Bool
+
         if self.isTestTarget {
             // test targets must be built with -enable-testing
             // since its required for test discovery (the non objective-c reflection kind)
-            return ["-enable-testing"]
-        } else if self.buildParameters.testingParameters.enableTestability {
-            return ["-enable-testing"]
+            enableTesting = true
+        } else if let enableTestability = self.buildParameters.testingParameters.enableTestability {
+            // Let the command line flag override
+            enableTesting = enableTestability
         } else {
-            return []
+            // Use the target settings
+            let enableTestabilitySetting = self.buildParameters.createScope(for: self.target).evaluate(.ENABLE_TESTABILITY)
+            if !enableTestabilitySetting.isEmpty {
+                enableTesting = enableTestabilitySetting.contains(where: { $0 == "YES" })
+            } else {
+                // By default, decide on testability based on debug/release config
+                // the goals of this being based on the build configuration is
+                // that `swift build` followed by a `swift test` will need to do minimal rebuilding
+                // given that the default configuration for `swift build` is debug
+                // and that `swift test` requires building with testable enabled if @testable is being used.
+                // when building and testing in release mode, one can use the '--disable-testable-imports' flag
+                // to disable testability in `swift test`, but that requires that the tests do not use the @testable imports feature
+                enableTesting = self.buildParameters.configuration == .debug
+            }
         }
+
+        return enableTesting ? ["-enable-testing"] : []
     }
 
     /// Module cache arguments.

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -181,8 +181,8 @@ struct TestCommandOptions: ParsableArguments {
     var xUnitOutput: AbsolutePath?
 
     /// Generate LinuxMain entries and exit.
-    @Flag(name: .customLong("testable-imports"), inversion: .prefixedEnableDisable, help: "Enable or disable testable imports. Enabled by default.")
-    var enableTestableImports: Bool = true
+    @Flag(name: .customLong("testable-imports"), inversion: .prefixedEnableDisable, help: "Enable or disable testable imports. Based on target settings by default.")
+    var enableTestableImports: Bool?
 
     /// Whether to enable code coverage.
     @Flag(name: .customLong("code-coverage"),

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -270,7 +270,7 @@ extension SwiftCommandState {
         parameters.testingParameters.enableCodeCoverage = enableCodeCoverage
         // for test commands, we normally enable building with testability
         // but we let users override this with a flag
-        parameters.testingParameters.enableTestability = enableTestability ?? true
+        parameters.testingParameters.enableTestability = enableTestability
         parameters.shouldSkipBuilding = shouldSkipBuilding
         parameters.testingParameters.experimentalTestOutput = experimentalTestOutput
         return parameters

--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -441,6 +441,22 @@ public struct SwiftSetting: Sendable {
         return SwiftSetting(
             name: "swiftLanguageMode", value: [.init(describing: mode)], condition: condition)
     }
+
+    /// Whether `@testable` is enabled by passing the `-enable-testing` to the Swift compiler.
+    ///
+    /// - Since: First available in PackageDescription 6.1.
+    ///
+    /// - Parameters:
+    ///   - enable: Whether to enable `@testable`.
+    ///   - condition: A condition that restricts the application of the build setting.
+    @available(_PackageDescription, introduced: 6.1)
+    public static func enableTesting(
+        _ enable: Bool,
+        _ condition: BuildSettingCondition? = nil
+    ) -> SwiftSetting {
+        return SwiftSetting(
+            name: "enableTesting", value: [.init(describing: enable)], condition: condition)
+    }
 }
 
 /// A linker build setting.

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -554,6 +554,20 @@ extension TargetBuildSettingDescription.Kind {
             }
 
             return .swiftLanguageMode(version)
+        case "enableTesting":
+            guard let rawVersion = values.first else {
+                throw InternalError("invalid (empty) build settings value")
+            }
+
+            if values.count > 1 {
+                throw InternalError("invalid build settings value")
+            }
+
+            guard let value = Bool(rawVersion) else {
+                throw InternalError("invalid boolean value: \(rawVersion)")
+            }
+
+            return .enableTesting(value)
         default:
             throw InternalError("invalid build setting \(name)")
         }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1192,6 +1192,10 @@ public final class PackageBuilder {
                 }
 
                 values = [version.rawValue]
+
+            case .enableTesting(let enable):
+                decl = .ENABLE_TESTABILITY
+                values = enable ? ["YES"] : ["NO"]
             }
 
             // Create an assignment for this setting.

--- a/Sources/PackageModel/BuildSettings.swift
+++ b/Sources/PackageModel/BuildSettings.swift
@@ -14,6 +14,8 @@
 public enum BuildSettings {
     /// Build settings declarations.
     public struct Declaration: Hashable {
+        public static let ENABLE_TESTABILITY: Declaration = .init("ENABLE_TESTABILITY")
+
         // Swift.
         public static let SWIFT_ACTIVE_COMPILATION_CONDITIONS: Declaration =
             .init("SWIFT_ACTIVE_COMPILATION_CONDITIONS")

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -41,13 +41,15 @@ public enum TargetBuildSettingDescription {
 
         case swiftLanguageMode(SwiftLanguageVersion)
 
+        case enableTesting(Bool)
+
         public var isUnsafeFlags: Bool {
             switch self {
             case .unsafeFlags(let flags):
                 // If `.unsafeFlags` is used, but doesn't specify any flags, we treat it the same way as not specifying it.
                 return !flags.isEmpty
             case .headerSearchPath, .define, .linkedLibrary, .linkedFramework, .interoperabilityMode,
-                 .enableUpcomingFeature, .enableExperimentalFeature, .swiftLanguageMode:
+                 .enableUpcomingFeature, .enableExperimentalFeature, .swiftLanguageMode, .enableTesting:
                 return false
             }
         }

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -531,6 +531,12 @@ fileprivate extension SourceCodeFragment {
                 params.append(SourceCodeFragment(from: condition))
             }
             self.init(enum: setting.kind.name, subnodes: params)
+        case .enableTesting(let enable):
+            params.append(SourceCodeFragment(boolean: enable))
+            if let condition = setting.condition {
+                params.append(SourceCodeFragment(from: condition))
+            }
+            self.init(enum: setting.kind.name, subnodes: params)
         }
     }
 }
@@ -685,6 +691,8 @@ extension TargetBuildSettingDescription.Kind {
             return "enableExperimentalFeature"
         case .swiftLanguageMode:
             return "swiftLanguageMode"
+        case .enableTesting:
+            return "enableTesting"
         }
     }
 }

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Testing.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Testing.swift
@@ -78,7 +78,7 @@ extension BuildParameters {
         public var enableCodeCoverage: Bool
 
         /// Whether building for testability is enabled.
-        public var enableTestability: Bool
+        public var enableTestability: Bool?
 
         /// Whether or not to enable the experimental test output mode.
         public var experimentalTestOutput: Bool
@@ -97,14 +97,7 @@ extension BuildParameters {
         ) {
             self.enableCodeCoverage = enableCodeCoverage
             self.experimentalTestOutput = experimentalTestOutput
-            // decide on testability based on debug/release config
-            // the goals of this being based on the build configuration is
-            // that `swift build` followed by a `swift test` will need to do minimal rebuilding
-            // given that the default configuration for `swift build` is debug
-            // and that `swift test` normally requires building with testable enabled.
-            // when building and testing in release mode, one can use the '--disable-testable-imports' flag
-            // to disable testability in `swift test`, but that requires that the tests do not use the testable imports feature
-            self.enableTestability =  enableTestability ?? (.debug == configuration)
+            self.enableTestability = enableTestability
             self.testProductStyle = targetTriple.isDarwin() ? .loadableBundle : .entryPointExecutable(
                 explicitlyEnabledDiscovery: forceTestDiscovery,
                 explicitlySpecifiedPath: testEntryPointPath

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -30,7 +30,7 @@ struct PIFBuilderParameters {
     let isPackageAccessModifierSupported: Bool
 
     /// Whether or not build for testability is enabled.
-    let enableTestability: Bool
+    let enableTestability: Bool?
 
     /// Whether to create dylibs for dynamic library products.
     let shouldCreateDylibForDynamicProducts: Bool
@@ -343,7 +343,6 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         debugSettings[.GCC_OPTIMIZATION_LEVEL] = "0"
         debugSettings[.ONLY_ACTIVE_ARCH] = "YES"
         debugSettings[.SWIFT_OPTIMIZATION_LEVEL] = "-Onone"
-        debugSettings[.ENABLE_TESTABILITY] = "YES"
         debugSettings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS, default: []].append("DEBUG")
         debugSettings[.GCC_PREPROCESSOR_DEFINITIONS, default: ["$(inherited)"]].append("DEBUG=1")
         addBuildConfiguration(name: "Debug", settings: debugSettings)
@@ -353,10 +352,6 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         releaseSettings[.DEBUG_INFORMATION_FORMAT] = "dwarf-with-dsym"
         releaseSettings[.GCC_OPTIMIZATION_LEVEL] = "s"
         releaseSettings[.SWIFT_OPTIMIZATION_LEVEL] = "-Owholemodule"
-
-        if parameters.enableTestability {
-            releaseSettings[.ENABLE_TESTABILITY] = "YES"
-        }
 
         addBuildConfiguration(name: "Release", settings: releaseSettings)
 


### PR DESCRIPTION
This introduces a new `enableTesting` API in SwiftSetting which allows targets to explicitly control whether testability is enabled, as some projects do not want to use the @testable feature. This can also improve debug build performance as significantly fewer symbols will be exported from the binary in the case where @testable is disabled.

The default is equivalent to `enableTesting(true, .when(configuration: .debug))`, so there is no behavior change from today without explicitly adopting this new API.

The --enable-testable-imports/--disable-testable-imports command line flags now acts as overrides -- if specified, they will override any build settings configured at the target level, and if unspecified, the target-level settings will be respected.