### PR TITLE
Fix path handling for plugins on Windows

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(Basics
   SQLiteBackedCache.swift
   TestingLibrary.swift
   Triple+Basics.swift
+  URL.swift
   Version+Extensions.swift
   WritableByteStream+Extensions.swift
   Vendor/Triple.swift

--- a/Sources/Basics/URL.swift
+++ b/Sources/Basics/URL.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.URL
+
+extension URL {
+    /// Returns the path of the file URL.
+    ///
+    /// This should always be used whenever the file path equivalent of a URL is needed. DO NOT use ``path`` or ``path(percentEncoded:)``, as these deal in terms of the path portion of the URL representation per RFC8089, which on Windows would include a leading slash.
+    ///
+    /// - throws: ``FileURLError`` if the URL does not represent a file or its path is otherwise not representable.
+    public var filePath: AbsolutePath {
+        get throws {
+            guard isFileURL else {
+                throw FileURLError.notRepresentable(self)
+            }
+            return try withUnsafeFileSystemRepresentation { cString in
+                guard let cString else {
+                    throw FileURLError.notRepresentable(self)
+                }
+                return try AbsolutePath(validating: String(cString: cString))
+            }
+        }
+    }
+}
+
+fileprivate enum FileURLError: Error {
+    case notRepresentable(URL)
+}

--- a/Sources/PackagePlugin/Context.swift
+++ b/Sources/PackagePlugin/Context.swift
@@ -63,7 +63,7 @@ public struct PluginContext {
             if let triples = tool.triples, triples.isEmpty {
                 throw PluginContextError.toolNotSupportedOnTargetPlatform(name: name)
             }
-            return Tool(name: name, path: Path(url: tool.path), url: tool.path)
+            return try Tool(name: name, path: Path(url: tool.path), url: tool.path)
         } else {
             for dir in self.toolSearchDirectoryURLs {
                 #if os(Windows)
@@ -71,9 +71,10 @@ public struct PluginContext {
                 #else
                 let hostExecutableSuffix = ""
                 #endif
-                let path = dir.appendingPathComponent(name + hostExecutableSuffix)
-                if FileManager.default.isExecutableFile(atPath: path.path) {
-                    return Tool(name: name, path: Path(url: path), url: path)
+                let pathURL = dir.appendingPathComponent(name + hostExecutableSuffix)
+                let path = try Path(url: pathURL)
+                if FileManager.default.isExecutableFile(atPath: path.stringValue) {
+                    return Tool(name: name, path: path, url: pathURL)
                 }
             }
         }

--- a/Sources/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/PackagePlugin/PackageManagerProxy.swift
@@ -113,7 +113,7 @@ public struct PackageManager {
             /// Full path of the built artifact in the local file system.
             @available(_PackageDescription, deprecated: 6.0, renamed: "url")
             public var path: Path {
-                Path(url: self.url)
+                try! Path(url: self.url)
             }
 
             /// Full path of the built artifact in the local file system.
@@ -187,7 +187,7 @@ public struct PackageManager {
         /// `llvm-cov`, if `enableCodeCoverage` was set in the test parameters.
         @available(_PackageDescription, deprecated: 6.0, renamed: "codeCoverageDataFileURL")
         public var codeCoverageDataFile: Path? {
-            self.codeCoverageDataFileURL.map { Path(url: $0) }
+            self.codeCoverageDataFileURL.map { try! Path(url: $0) }
         }
 
         /// Path of a generated `.profdata` file suitable for processing using
@@ -275,7 +275,7 @@ public struct PackageManager {
         /// The directory that contains the symbol graph files for the target.
         @available(_PackageDescription, deprecated: 6.0, renamed: "directoryURL")
         public var directoryPath: Path {
-            Path(url: self.directoryURL)
+            try! Path(url: self.directoryURL)
         }
 
         /// The directory that contains the symbol graph files for the target.

--- a/Sources/PackagePlugin/Plugin.swift
+++ b/Sources/PackagePlugin/Plugin.swift
@@ -158,12 +158,12 @@ extension Plugin {
                     return (path, tool.triples)
                 }
 
-                context = PluginContext(
+                context = try PluginContext(
                     package: package,
                     pluginWorkDirectory: Path(url: pluginWorkDirectory),
                     pluginWorkDirectoryURL: pluginWorkDirectory,
                     accessibleTools: accessibleTools,
-                    toolSearchDirectories: toolSearchDirectories.map { Path(url: $0) },
+                    toolSearchDirectories: toolSearchDirectories.map { try Path(url: $0) },
                     toolSearchDirectoryURLs: toolSearchDirectories)
 
                 let pluginGeneratedSources = try generatedSources.map { try deserializer.url(for: $0) }
@@ -248,12 +248,12 @@ extension Plugin {
                     let path = try deserializer.url(for: tool.path)
                     return (path, tool.triples)
                 }
-                context = PluginContext(
+                context = try PluginContext(
                     package: package,
                     pluginWorkDirectory: Path(url: pluginWorkDirectory),
                     pluginWorkDirectoryURL: pluginWorkDirectory,
                     accessibleTools: accessibleTools,
-                    toolSearchDirectories: toolSearchDirectories.map { Path(url: $0) },
+                    toolSearchDirectories: toolSearchDirectories.map { try Path(url: $0) },
                     toolSearchDirectoryURLs: toolSearchDirectories)
             }
             catch {

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -272,12 +272,12 @@ extension PluginModule {
                     }
                     self.invocationDelegate.pluginDefinedBuildCommand(
                         displayName: config.displayName,
-                        executable: try AbsolutePath(validating: config.executable.path),
+                        executable: try config.executable.filePath,
                         arguments: config.arguments,
                         environment: config.environment,
-                        workingDirectory: try config.workingDirectory.map{ try AbsolutePath(validating: $0.path) },
-                        inputFiles: try inputFiles.map{ try AbsolutePath(validating: $0.path) },
-                        outputFiles: try outputFiles.map{ try AbsolutePath(validating: $0.path) })
+                        workingDirectory: try config.workingDirectory.map{ try $0.filePath },
+                        inputFiles: try inputFiles.map{ try $0.filePath },
+                        outputFiles: try outputFiles.map{ try $0.filePath })
 
                 case .definePrebuildCommand(let config, let outputFilesDir):
                     if config.version != 2 {
@@ -285,11 +285,11 @@ extension PluginModule {
                     }
                     let success = self.invocationDelegate.pluginDefinedPrebuildCommand(
                         displayName: config.displayName,
-                        executable: try AbsolutePath(validating: config.executable.path),
+                        executable: try config.executable.filePath,
                         arguments: config.arguments,
                         environment: config.environment,
-                        workingDirectory: try config.workingDirectory.map{ try AbsolutePath(validating: $0.path) },
-                        outputFilesDirectory: try AbsolutePath(validating: outputFilesDir.path))
+                        workingDirectory: try config.workingDirectory.map{ try $0.filePath },
+                        outputFilesDirectory: try outputFilesDir.filePath)
 
                     if !success {
                         exitEarly = true

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -193,11 +193,11 @@ final class PluginInvocationTests: XCTestCase {
                                 "configuration": {
                                     "version": 2,
                                     "displayName": "Do something",
-                                    "executable": "/bin/FooTool",
+                                    "executable": "file:///bin/FooTool",
                                     "arguments": [
                                         "-c", "/Foo/Sources/Foo/SomeFile.abc"
                                     ],
-                                    "workingDirectory": "/Foo/Sources/Foo",
+                                    "workingDirectory": "file:///Foo/Sources/Foo",
                                     "environment": {
                                         "X": "Y"
                                     },
@@ -216,6 +216,7 @@ final class PluginInvocationTests: XCTestCase {
                     callbackQueue.sync {
                         completion(.failure(error))
                     }
+                    return
                 }
 
                 // If we get this far we succeeded, so invoke the completion handler.


### PR DESCRIPTION
Due to RFC8089 compliance changes for Foundation.URL in Swift 6, URL.path does _NOT_ behave as one might expect, producing a path with a leading slash which will be interpreted by Windows as relative.

Closes #6851