### PR TITLE
Reenable testUsage() as testInvalidUsage()

### DIFF
--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -48,10 +48,9 @@ final class PackageCommandTests: CommandsTestCase {
         XCTAssertMatch(stdout, .contains("USAGE: swift package"))
     }
 
-    func testUsage() async throws {
-        throw XCTSkip("rdar://131126477")
+    func testInvalidUsage() async throws {
         do {
-            _ = try await execute(["-halp"])
+            _ = try await execute(["--xxx"])
             XCTFail("expecting `execute` to fail")
         } catch SwiftPMError.executionFailure(_, _, let stderr) {
             XCTAssertMatch(stderr, .contains("Usage: swift package"))
@@ -69,27 +68,27 @@ final class PackageCommandTests: CommandsTestCase {
         let stdout = try await execute(["--version"]).stdout
         XCTAssertMatch(stdout, .contains("Swift Package Manager"))
     }
-	
+
     func testCompletionTool() async throws {
         let stdout = try await execute(["completion-tool", "--help"]).stdout
         XCTAssertMatch(stdout, .contains("OVERVIEW: Completion command (for shell completions)"))
     }
 
-	func testInitOverview() async throws {
-		let stdout = try await execute(["init", "--help"]).stdout
-		XCTAssertMatch(stdout, .contains("OVERVIEW: Initialize a new package"))
-	}
-	
-	func testInitUsage() async throws {
-		let stdout = try await execute(["init", "--help"]).stdout
-		XCTAssertMatch(stdout, .contains("USAGE: swift package init [--type <type>] "))
-		XCTAssertMatch(stdout, .contains(" [--name <name>]"))
-	}
-	
-	func testInitOptionsHelp() async throws {
-		let stdout = try await execute(["init", "--help"]).stdout
-		XCTAssertMatch(stdout, .contains("OPTIONS:"))
-	}
+    func testInitOverview() async throws {
+        let stdout = try await execute(["init", "--help"]).stdout
+        XCTAssertMatch(stdout, .contains("OVERVIEW: Initialize a new package"))
+    }
+
+    func testInitUsage() async throws {
+        let stdout = try await execute(["init", "--help"]).stdout
+        XCTAssertMatch(stdout, .contains("USAGE: swift package init [--type <type>] "))
+        XCTAssertMatch(stdout, .contains(" [--name <name>]"))
+    }
+
+    func testInitOptionsHelp() async throws {
+        let stdout = try await execute(["init", "--help"]).stdout
+        XCTAssertMatch(stdout, .contains("OPTIONS:"))
+    }
 
     func testPlugin() async throws {
         await XCTAssertThrowsCommandExecutionError(try await execute(["plugin"])) { error in
@@ -2299,17 +2298,17 @@ final class PackageCommandTests: CommandsTestCase {
             }
 
             try await runPlugin(flags: [], diagnostics: ["print", "progress", "remark"]) { stdout, stderr in
-            	XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stdout, isOnlyPrint)
                 XCTAssertMatch(stderr, containsProgress)
             }
 
             try await runPlugin(flags: [], diagnostics: ["print", "progress", "remark", "warning"]) { stdout, stderr in
-            	XCTAssertMatch(stdout, isOnlyPrint)
-            	XCTAssertMatch(stderr, containsProgress)
+                XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stderr, containsProgress)
                 XCTAssertMatch(stderr, containsWarning)
             }
 
-         	try await runPluginWithError(flags: [], diagnostics: ["print", "progress", "remark", "warning", "error"]) { stdout, stderr in
+             try await runPluginWithError(flags: [], diagnostics: ["print", "progress", "remark", "warning", "error"]) { stdout, stderr in
                 XCTAssertMatch(stdout, isOnlyPrint)
                 XCTAssertMatch(stderr, containsProgress)
                 XCTAssertMatch(stderr, containsWarning)
@@ -2326,24 +2325,24 @@ final class PackageCommandTests: CommandsTestCase {
             }
 
             try await runPlugin(flags: ["-q"], diagnostics: ["print", "progress"]) { stdout, stderr in
-            	XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stdout, isOnlyPrint)
                 XCTAssertMatch(stderr, containsProgress)
             }
 
             try await runPlugin(flags: ["-q"], diagnostics: ["print", "progress", "remark"]) { stdout, stderr in
-            	XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stdout, isOnlyPrint)
                 XCTAssertMatch(stderr, containsProgress)
             }
 
             try await runPlugin(flags: ["-q"], diagnostics: ["print", "progress", "remark", "warning"]) { stdout, stderr in
-            	XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stdout, isOnlyPrint)
                 XCTAssertMatch(stderr, containsProgress)
             }
 
             try await runPluginWithError(flags: ["-q"], diagnostics: ["print", "progress", "remark", "warning", "error"]) { stdout, stderr in
-            	XCTAssertMatch(stdout, isOnlyPrint)
-            	XCTAssertMatch(stderr, containsProgress)
-            	XCTAssertNoMatch(stderr, containsRemark)
+                XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stderr, containsProgress)
+                XCTAssertNoMatch(stderr, containsRemark)
                 XCTAssertNoMatch(stderr, containsWarning)
                 XCTAssertMatch(stderr, containsError)
             }
@@ -2359,27 +2358,27 @@ final class PackageCommandTests: CommandsTestCase {
             }
 
             try await runPlugin(flags: ["-v"], diagnostics: ["print", "progress"]) { stdout, stderr in
-            	XCTAssertMatch(stdout, isOnlyPrint)
-            	XCTAssertMatch(stderr, containsProgress)
+                XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stderr, containsProgress)
             }
 
             try await runPlugin(flags: ["-v"], diagnostics: ["print", "progress", "remark"]) { stdout, stderr in
-            	XCTAssertMatch(stdout, isOnlyPrint)
-            	XCTAssertMatch(stderr, containsProgress)
+                XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stderr, containsProgress)
                 XCTAssertMatch(stderr, containsRemark)
             }
 
             try await runPlugin(flags: ["-v"], diagnostics: ["print", "progress", "remark", "warning"]) { stdout, stderr in
-            	XCTAssertMatch(stdout, isOnlyPrint)
-            	XCTAssertMatch(stderr, containsProgress)
+                XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stderr, containsProgress)
                 XCTAssertMatch(stderr, containsRemark)
                 XCTAssertMatch(stderr, containsWarning)
             }
 
             try await runPluginWithError(flags: ["-v"], diagnostics: ["print", "progress", "remark", "warning", "error"]) { stdout, stderr in
-            	XCTAssertMatch(stdout, isOnlyPrint)
-            	XCTAssertMatch(stderr, containsProgress)
-            	XCTAssertMatch(stderr, containsRemark)
+                XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stderr, containsProgress)
+                XCTAssertMatch(stderr, containsRemark)
                 XCTAssertMatch(stderr, containsWarning)
                 XCTAssertMatch(stderr, containsError)
             }


### PR DESCRIPTION
I believe its expected for the argument `-halp` to show the help string in swift-argument-parser, as if there is a `-h` or `--help` anywhere in the arguments all other inputs are disregarded and the help string is shown.

Instead use an invalid argument to drive the test and reenable it.
