### PR TITLE
Mark `LegacyHTTPClientRequest` as Sendable

### DIFF
--- a/Sources/Basics/HTTPClient/LegacyHTTPClientRequest.swift
+++ b/Sources/Basics/HTTPClient/LegacyHTTPClientRequest.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-public struct LegacyHTTPClientRequest {
+public struct LegacyHTTPClientRequest: Sendable {
     public let kind: Kind
     public let url: URL
     public var headers: HTTPClientHeaders
@@ -73,7 +73,7 @@ public struct LegacyHTTPClientRequest {
     public typealias FileMoveCompletion = @Sendable (Error?)
         -> Void
 
-    public enum Kind {
+    public enum Kind: Sendable {
         case generic(HTTPMethod)
         case download(fileSystem: FileSystem, destination: AbsolutePath)
     }


### PR DESCRIPTION
`LegacyHTTPClientRequest` can be trivially Sendable.

This suppresses some warnings in `LegacyHTTPClient` which itself should also be made concurrecy safe eventually, but it holds some static shared state and so isn't a straightforward conversion.
