### PR TITLE
Fix compiling test runners for Android by using the full overlay

### DIFF
--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -132,8 +132,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
         @_exported import WinSDK
         #elseif os(WASI)
         @_exported import WASILibc
-        #elseif canImport(Bionic)
-        @_exported import Bionic
+        #elseif canImport(Android)
+        @_exported import Android
         #else
         @_exported import Darwin.C
         #endif


### PR DESCRIPTION
### Motivation:

Compiling test runners with `import Bionic` worked till July, then the compiler started requiring the larger `import Android` overlay.

### Modifications:

`import Android` instead in the test runner

### Result:

Compiling the tests for Android works again.

This is part of a larger patch I needed to natively run SwiftPM 6 on Android, but I want to get this into the 6.0 patch releases quickly first because it also breaks cross-compilation of packages' tests to Android.

@bnbarham, can we get this into 6.0.2 next?