### PR TITLE
[6.0.3] Fix compiling test runners for Android by using the full overlay

### DIFF
--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -132,8 +132,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
         @_exported import WinSDK
         #elseif os(WASI)
         @_exported import WASILibc
-        #elseif canImport(Bionic)
-        @_exported import Bionic
+        #elseif canImport(Android)
+        @_exported import Android
         #else
         @_exported import Darwin.C
         #endif


### PR DESCRIPTION
__Explanation:__ Compiling test runners with `import Bionic` worked till July, then the compiler started requiring the larger `import Android` overlay.

__Scope:__ Only affects Android

__Issue:__ None

__Original PR:__ #8018

__Risk:__ None

__Testing:__ I built and ran the SwiftPM tests natively on Android with this patch.

__Reviewer:__ @bnbarham

I will submit for 6.0.2 next, if that's okay.