### PR TITLE
Add a fallback extension none os dylibs

### DIFF
--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -146,7 +146,9 @@ extension Triple {
         case .wasi:
             return ".wasm"
         default:
-            fatalError("Cannot create dynamic libraries for os \"\(os)\".")
+            // Fallback to a nonsense extension for operating systems with
+            // unknown conventions.
+            return ".dynamiclibrary"
         }
     }
 

--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -133,7 +133,7 @@ extension Triple {
     /// The file extension for dynamic libraries (eg. `.dll`, `.so`, or `.dylib`)
     public var dynamicLibraryExtension: String {
         guard let os = self.os else {
-            fatalError("Cannot create dynamic libraries unknown os.")
+            fatalError("Cannot create dynamic libraries for unknown os.")
         }
 
         switch os {
@@ -146,9 +146,24 @@ extension Triple {
         case .wasi:
             return ".wasm"
         default:
-            // Fallback to a nonsense extension for operating systems with
-            // unknown conventions.
-            return ".dynamiclibrary"
+          break
+        }
+
+        guard let objectFormat = self.objectFormat else {
+            fatalError("Cannot create dynamic libraries for unknown object format.")
+        }
+
+        switch objectFormat {
+        case .coff:
+            return ".coff"
+        case .elf:
+            return ".elf"
+        case .macho:
+            return ".macho"
+        case .wasm:
+            return ".wasm"
+        case .xcoff:
+            return ".xcoff"
         }
     }
 

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -214,6 +214,14 @@ final class TripleTests: XCTestCase {
         _ = wasi.dynamicLibraryExtension
     }
 
+    func testNoneOSDynamicLibrary() throws {
+      let noneOS = try Triple("armv7em-apple-none-macho")
+
+      // Dynamic libraries aren't actually supported for OS none, but swiftpm
+      // wants an extension to avoid crashing during build planning.
+      XCTAssertEqual(noneOS.dynamicLibraryExtension, ".dynamiclibrary")
+    }
+
     func testIsRuntimeCompatibleWith() throws {
         try XCTAssertTrue(Triple("x86_64-apple-macosx").isRuntimeCompatible(with: Triple("x86_64-apple-macosx")))
         try XCTAssertTrue(Triple("x86_64-unknown-linux").isRuntimeCompatible(with: Triple("x86_64-unknown-linux")))

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -209,17 +209,31 @@ final class TripleTests: XCTestCase {
     func testWASI() throws {
         let wasi = try Triple("wasm32-unknown-wasi")
 
+
+
         // WASI dynamic libraries are only experimental,
         // but SwiftPM requires this property not to crash.
         _ = wasi.dynamicLibraryExtension
     }
 
     func testNoneOSDynamicLibrary() throws {
-      let noneOS = try Triple("armv7em-apple-none-macho")
-
       // Dynamic libraries aren't actually supported for OS none, but swiftpm
       // wants an extension to avoid crashing during build planning.
-      XCTAssertEqual(noneOS.dynamicLibraryExtension, ".dynamiclibrary")
+      try XCTAssertEqual(
+          Triple("armv7em-unknown-none-coff").dynamicLibraryExtension,
+          ".coff")
+      try XCTAssertEqual(
+          Triple("armv7em-unknown-none-elf").dynamicLibraryExtension,
+          ".elf")
+      try XCTAssertEqual(
+          Triple("armv7em-unknown-none-macho").dynamicLibraryExtension,
+          ".macho")
+      try XCTAssertEqual(
+          Triple("armv7em-unknown-none-wasm").dynamicLibraryExtension,
+          ".wasm")
+      try XCTAssertEqual(
+          Triple("armv7em-unknown-none-xcoff").dynamicLibraryExtension,
+          ".xcoff")
     }
 
     func testIsRuntimeCompatibleWith() throws {


### PR DESCRIPTION
Adds a fake extension for none os dynamic libraries to avoid a SwiftPM crash during build planning when cross compiling to none OS with a dylib product in the graph.

Fixes #7893
