### PR TITLE
Plugin: Stop building with `-enable-testing` even with release config

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Package.swift
@@ -29,11 +29,27 @@ let package = Package(
                 .target(name: "plugintool")
             ]
         ),
+        .plugin(
+            name: "check-testability",
+            capability: .command(intent: .custom(
+                verb: "check-testability",
+                description: "Check testability of a target"
+            ))
+        ),
         .executableTarget(
             name: "placeholder"
         ),
         .executableTarget(
             name: "plugintool"
+        ),
+        .target(
+            name: "InternalModule"
+        ),
+        .testTarget(
+            name: "InternalModuleTests",
+            dependencies: [
+                .target(name: "InternalModule")
+            ]
         ),
     ]
 )

--- a/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Plugins/check-testability/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Plugins/check-testability/main.swift
@@ -1,0 +1,45 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct CheckTestability: CommandPlugin {
+    // This is a helper for testing target builds to ensure that they are testable.
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        // Parse the arguments: <targetName> <config> <shouldTestable>
+        guard arguments.count == 3 else {
+            fatalError("Usage: <targetName> <config> <shouldTestable>")
+        }
+        let rawSubsetName = arguments[0]
+        var subset: PackageManager.BuildSubset
+        switch rawSubsetName {
+        // Special subset names
+        case "all-with-tests":
+            subset = .all(includingTests: true)
+        // By default, treat the subset as a target name
+        default:
+            subset = .target(rawSubsetName)
+        }
+        guard let config = PackageManager.BuildConfiguration(rawValue: arguments[1]) else {
+            fatalError("Invalid configuration: \(arguments[1])")
+        }
+        let shouldTestable = arguments[2] == "true"
+
+        var parameters = PackageManager.BuildParameters()
+        parameters.configuration = config
+        parameters.logging = .verbose
+
+        // Perform the build
+        let result = try packageManager.build(subset, parameters: parameters)
+
+        // Check if the build was successful
+        guard result.succeeded else {
+            fatalError("Build failed: \(result.logText)")
+        }
+
+        // Check if the build log contains "-enable-testing" flag
+        let isTestable = result.logText.contains("-enable-testing")
+        if isTestable != shouldTestable {
+            fatalError("Testability mismatch: expected \(shouldTestable), but got \(isTestable):\n\(result.logText)")
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Sources/InternalModule/InternalModule.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Sources/InternalModule/InternalModule.swift
@@ -1,0 +1,3 @@
+internal func internalFunction() {
+    print("Internal function")
+}

--- a/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Tests/InternalModuleTests/InternalModuleTests.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Tests/InternalModuleTests/InternalModuleTests.swift
@@ -1,0 +1,1 @@
+@testable import InternalModule

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -205,7 +205,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             return []
         case .test:
             // Test products are bundle when using Objective-C, executable when using test entry point.
-            switch self.buildParameters.testingParameters.testProductStyle {
+            switch self.buildParameters.testProductStyle {
             case .loadableBundle:
                 args += ["-Xlinker", "-bundle"]
             case .entryPointExecutable:

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -955,7 +955,7 @@ public final class SwiftModuleBuildDescription {
             // test targets must be built with -enable-testing
             // since its required for test discovery (the non objective-c reflection kind)
             return ["-enable-testing"]
-        } else if self.buildParameters.testingParameters.enableTestability {
+        } else if self.buildParameters.enableTestability {
             return ["-enable-testing"]
         } else {
             return []

--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -43,7 +43,7 @@ extension BuildPlan {
     ) throws -> [(product: ResolvedProduct, discoveryTargetBuildDescription: SwiftModuleBuildDescription?, entryPointTargetBuildDescription: SwiftModuleBuildDescription)] {
         var explicitlyEnabledDiscovery = false
         var explicitlySpecifiedPath: AbsolutePath?
-        if case let .entryPointExecutable(caseExplicitlyEnabledDiscovery, caseExplicitlySpecifiedPath) = destinationBuildParameters.testingParameters.testProductStyle {
+        if case let .entryPointExecutable(caseExplicitlyEnabledDiscovery, caseExplicitlySpecifiedPath) = destinationBuildParameters.testProductStyle {
             explicitlyEnabledDiscovery = caseExplicitlyEnabledDiscovery
             explicitlySpecifiedPath = caseExplicitlySpecifiedPath
         }

--- a/Sources/Build/LLBuildCommands.swift
+++ b/Sources/Build/LLBuildCommands.swift
@@ -103,7 +103,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
     private func execute(fileSystem: Basics.FileSystem, tool: TestDiscoveryTool) throws {
         let outputs = tool.outputs.compactMap { try? AbsolutePath(validating: $0.name) }
 
-        if case .loadableBundle = context.productsBuildParameters.testingParameters.testProductStyle {
+        if case .loadableBundle = context.productsBuildParameters.testProductStyle {
             // When building an XCTest bundle, test discovery is handled by the
             // test harness process (i.e. this is the Darwin path.)
             for file in outputs {
@@ -222,7 +222,7 @@ final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
             testObservabilitySetup = ""
         }
 
-        let isXCTMainAvailable: String = switch buildParameters.testingParameters.testProductStyle {
+        let isXCTMainAvailable: String = switch buildParameters.testProductStyle {
         case .entryPointExecutable:
             "canImport(XCTest)"
         case .loadableBundle:

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -227,7 +227,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         // which ones they are until we've built them and can examine the binaries.
         let toolchain = try swiftCommandState.getHostToolchain()
         var toolsBuildParameters = try swiftCommandState.toolsBuildParameters
-        toolsBuildParameters.testingParameters.enableTestability = true
+        toolsBuildParameters.testingParameters.explicitlyEnabledTestability = true
         toolsBuildParameters.testingParameters.enableCodeCoverage = parameters.enableCodeCoverage
         let buildSystem = try await swiftCommandState.createBuildSystem(
             traitConfiguration: .init(),

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -147,6 +147,10 @@ final class PluginDelegate: PluginInvocationDelegate {
         switch subset {
         case .all(let includingTests):
             buildSubset = includingTests ? .allIncludingTests : .allExcludingTests
+            if includingTests {
+                // Enable testability if we're building tests explicitly.
+                buildParameters.testingParameters.explicitlyEnabledTestability = true
+            }
         case .product(let name):
             buildSubset = .product(name)
             explicitProduct = name

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -250,27 +250,10 @@ extension SwiftCommandState {
         experimentalTestOutput: Bool
     ) -> BuildParameters {
         var parameters = parameters
-
-        var explicitlyEnabledDiscovery = false
-        var explicitlySpecifiedPath: AbsolutePath?
-        if case let .entryPointExecutable(
-            explicitlyEnabledDiscoveryValue,
-            explicitlySpecifiedPathValue
-        ) = parameters.testingParameters.testProductStyle {
-            explicitlyEnabledDiscovery = explicitlyEnabledDiscoveryValue
-            explicitlySpecifiedPath = explicitlySpecifiedPathValue
-        }
-        parameters.testingParameters = .init(
-            configuration: parameters.configuration,
-            targetTriple: parameters.triple,
-            forceTestDiscovery: explicitlyEnabledDiscovery,
-            testEntryPointPath: explicitlySpecifiedPath
-        )
-
         parameters.testingParameters.enableCodeCoverage = enableCodeCoverage
         // for test commands, we normally enable building with testability
         // but we let users override this with a flag
-        parameters.testingParameters.enableTestability = enableTestability ?? true
+        parameters.testingParameters.explicitlyEnabledTestability = enableTestability ?? true
         parameters.shouldSkipBuilding = shouldSkipBuilding
         parameters.testingParameters.experimentalTestOutput = experimentalTestOutput
         return parameters

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -36,7 +36,7 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
         observabilityScope: ObservabilityScope?
     ) async throws -> any BuildSystem {
         _ = try await swiftCommandState.getRootPackageInformation()
-        let testEntryPointPath = productsBuildParameters?.testingParameters.testProductStyle.explicitlySpecifiedEntryPointPath
+        let testEntryPointPath = productsBuildParameters?.testProductStyle.explicitlySpecifiedEntryPointPath
         return try BuildOperation(
             productsBuildParameters: try productsBuildParameters ?? self.swiftCommandState.productsBuildParameters,
             toolsBuildParameters: try toolsBuildParameters ?? self.swiftCommandState.toolsBuildParameters,

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -826,8 +826,6 @@ public final class SwiftCommandState {
                 isVerbose: self.logLevel <= .info
             ),
             testingParameters: .init(
-                configuration: options.build.configuration ?? self.preferredBuildConfiguration,
-                targetTriple: triple,
                 forceTestDiscovery: options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
                 testEntryPointPath: options.build.testEntryPointPath
             )

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -163,7 +163,7 @@ public struct BuildParameters: Encodable {
         driverParameters: Driver = .init(),
         linkingParameters: Linking = .init(),
         outputParameters: Output = .init(),
-        testingParameters: Testing? = nil
+        testingParameters: Testing = .init()
     ) throws {
         let triple = try triple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompilerPath)
         self.debuggingParameters = debuggingParameters ?? .init(
@@ -218,7 +218,7 @@ public struct BuildParameters: Encodable {
         self.driverParameters = driverParameters
         self.linkingParameters = linkingParameters
         self.outputParameters = outputParameters
-        self.testingParameters = testingParameters ?? .init(configuration: configuration, targetTriple: triple)
+        self.testingParameters = testingParameters
     }
 
     /// The path to the build directory (inside the data directory).

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -371,7 +371,7 @@ extension PIFBuilderParameters {
         self.init(
             triple: buildParameters.triple,
             isPackageAccessModifierSupported: buildParameters.driverParameters.isPackageAccessModifierSupported,
-            enableTestability: buildParameters.testingParameters.enableTestability,
+            enableTestability: buildParameters.enableTestability,
             shouldCreateDylibForDynamicProducts: buildParameters.shouldCreateDylibForDynamicProducts,
             toolchainLibDir: (try? buildParameters.toolchain.toolchainLibDir) ?? .root,
             pkgConfigDirectories: buildParameters.pkgConfigDirectories,

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2448,6 +2448,35 @@ final class PackageCommandTests: CommandsTestCase {
         }
     }
 
+    func testCommandPluginBuildTestability() async throws {
+        // Plugin arguments: check-testability <targetName> <config> <shouldTestable>
+
+        // Overall configuration: debug, plugin build request: debug -> without testability
+        try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+            try await XCTAssertAsyncNoThrow(try await SwiftPM.Package.execute(["-c", "debug", "check-testability", "InternalModule", "debug", "true"], packagePath: fixturePath))
+        }
+
+        // Overall configuration: debug, plugin build request: release -> without testability
+        try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+            try await XCTAssertAsyncNoThrow(try await SwiftPM.Package.execute(["-c", "debug", "check-testability", "InternalModule", "release", "false"], packagePath: fixturePath))
+        }
+
+        // Overall configuration: release, plugin build request: debug -> with testability
+        try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+            try await XCTAssertAsyncNoThrow(try await SwiftPM.Package.execute(["-c", "release", "check-testability", "InternalModule", "debug", "true"], packagePath: fixturePath))
+        }
+
+        // Overall configuration: release, plugin build request: release -> with testability
+        try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+            try await XCTAssertAsyncNoThrow(try await SwiftPM.Package.execute(["-c", "release", "check-testability", "InternalModule", "release", "false"], packagePath: fixturePath))
+        }
+
+        // Overall configuration: release, plugin build request: release including tests -> with testability
+        try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+            try await XCTAssertAsyncNoThrow(try await SwiftPM.Package.execute(["-c", "release", "check-testability", "all-with-tests", "release", "true"], packagePath: fixturePath))
+        }
+    }
+
     // Test logging of builds initiated by a command plugin
     func testCommandPluginBuildLogs() async throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -85,6 +85,15 @@ final class TestCommandTests: CommandsTestCase {
         }
     }
 
+    func testWithReleaseConfiguration() async throws {
+        try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
+            do {
+                let result = try await execute(["-c", "release", "--vv"], packagePath: fixturePath)
+                XCTAssertMatch(result.stderr, .contains("-enable-testing"))
+            }
+        }
+    }
+
     func testSwiftTestParallel() async throws {
         try await fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
             // First try normal serial testing.

--- a/Tests/SPMBuildCoreTests/BuildParametersTests.swift
+++ b/Tests/SPMBuildCoreTests/BuildParametersTests.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@testable import SPMBuildCore
+import Basics
+import struct PackageModel.BuildEnvironment
+import _InternalTestSupport
+import XCTest
+
+final class BuildParametersTests: XCTestCase {
+    func testConfigurationDependentProperties() throws {
+        // Ensure that properties that depend on the "configuration" property are
+        // correctly updated after modifying the configuration.
+        var parameters = mockBuildParameters(
+            destination: .host,
+            environment: BuildEnvironment(platform: .linux, configuration: .debug)
+        )
+        XCTAssertEqual(parameters.enableTestability, true)
+        parameters.configuration = .release
+        XCTAssertEqual(parameters.enableTestability, false)
+    }
+}


### PR DESCRIPTION
### Motivation:

When building a SwiftPM target through PackagePlugin APIs and overall configuration is debug, they were built with `-enable-testing` even with plugins requests building with release configuration.

This mis-configuration led performance and code size regression only when building through package plugins.

The root problem is that some of the properties under `BuildParameters` store values derived from other properties. 
`buildParameters.testing.enableTestability` was one of them. It depends on `configuration` but it's computed only in `BuildParameters.Testing` initializer. Therefore the property was not updated after `PluginDelegate` modifies `configuration` for requested builds.

https://github.com/swiftlang/swift-package-manager/blob/23fa2816afb930d98f529026f4809cc781fb2e2f/Sources/Commands/Utilities/PluginDelegate.swift#L118-L127
https://github.com/swiftlang/swift-package-manager/blob/23fa2816afb930d98f529026f4809cc781fb2e2f/Sources/SPMBuildCore/BuildParameters/BuildParameters%2BTesting.swift#L107

For those who want an immediate workaround: One of the workaround was to set the overall configuration as release, but it forces building plugins as release too.

### Modifications:

This PR made those properties that depend on other stored properties as computed properties rather than stored ones.

There are still some properties having the same issue (`BuildParameters.Debugging`), so I'll fix them in a follow-up PR separately.

### Result:

Release builds requested through package plugins are truly built as release mode even if the overall configuration is debug.