### PR TITLE
Tests: Fix always succeeding `XCTAssertAsyncNoThrow`

### DIFF
--- a/Fixtures/Miscellaneous/CheckTestLibraryEnvironmentVariable/Tests/CheckTestLibraryEnvironmentVariableTests/CheckTestLibraryEnvironmentVariableTests.swift
+++ b/Fixtures/Miscellaneous/CheckTestLibraryEnvironmentVariable/Tests/CheckTestLibraryEnvironmentVariableTests/CheckTestLibraryEnvironmentVariableTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 final class CheckTestLibraryEnvironmentVariableTests: XCTestCase {
     func testEnviromentVariable() throws {
-        let envvar = ProcessInfo.processInfo.environment["SWIFT_PM_TEST_LIBRARY"]
-        XCTAssertEqual(envvar, "XCTest")
+        let envvar = ProcessInfo.processInfo.environment["SWIFT_TESTING_ENABLED"]
+        XCTAssertEqual(envvar, "0")
     }
 }

--- a/Sources/_InternalTestSupport/XCTAssertHelpers.swift
+++ b/Sources/_InternalTestSupport/XCTAssertHelpers.swift
@@ -74,7 +74,7 @@ package func XCTAssertAsyncNoThrow<T>(
     do {
         _ = try await expression()
     } catch {
-        XCTAssertNoThrow({ throw error }, message(), file: file, line: line)
+        XCTAssertNoThrow(try { throw error }(), message(), file: file, line: line)
     }
 }
 

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -327,11 +327,14 @@ final class TestCommandTests: CommandsTestCase {
     }
 #endif
 
+#if os(macOS)
+    // "SWIFT_TESTING_ENABLED" is set only on macOS, skip the check on other platforms.
     func testLibraryEnvironmentVariable() async throws {
         try await fixture(name: "Miscellaneous/CheckTestLibraryEnvironmentVariable") { fixturePath in
             await XCTAssertAsyncNoThrow(try await SwiftPM.Test.execute(packagePath: fixturePath))
         }
     }
+#endif
 
     func testXCTestOnlyDoesNotLogAboutNoMatchingTests() async throws {
         try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in


### PR DESCRIPTION
The autoclosure expression `{ throw error }` just creates a closure that won't be executed. It leads to the test always succeeding even if the `expression` throws an error.

Fortunately, I didn't find any issue to enable the assertion except for a single case (https://github.com/swiftlang/swift-package-manager/pull/8026/commits/ab1e7849216aba671ed031993972c03f643649cf)
