### PR TITLE
Fix target toolsets polluted with host toolset extra CLI options

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -702,7 +702,15 @@ public struct SwiftSDK: Equatable {
         // Apply any manual overrides.
         if let triple = customCompileTriple {
             swiftSDK.targetTriple = triple
+
+            if isBasedOnHostSDK {
+                // Don't pick up extraCLIOptions for a custom triple, since those are only valid for the host triple.
+                for tool in swiftSDK.toolset.knownTools.keys {
+                    swiftSDK.toolset.knownTools[tool]?.extraCLIOptions = []
+                }
+            }
         }
+
         if let binDir = customCompileToolchain {
             if !fileSystem.exists(binDir) {
                 observabilityScope.emit(
@@ -726,7 +734,10 @@ public struct SwiftSDK: Equatable {
             // Append the host toolchain's toolset paths at the end for the case the target Swift SDK
             // doesn't have some of the tools (e.g. swift-frontend might be shared between the host and
             // target Swift SDKs).
-            hostSwiftSDK.toolset.rootPaths.forEach { swiftSDK.append(toolsetRootPath: $0) }
+            let rootPaths = swiftSDK.toolset.rootPaths
+            for rootPath in hostSwiftSDK.toolset.rootPaths where !rootPaths.contains(rootPath) {
+                swiftSDK.append(toolsetRootPath: rootPath)
+            }
         }
 
         return swiftSDK

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -734,7 +734,7 @@ public struct SwiftSDK: Equatable {
             // Append the host toolchain's toolset paths at the end for the case the target Swift SDK
             // doesn't have some of the tools (e.g. swift-frontend might be shared between the host and
             // target Swift SDKs).
-            let rootPaths = swiftSDK.toolset.rootPaths
+            let rootPaths = Set(swiftSDK.toolset.rootPaths)
             for rootPath in hostSwiftSDK.toolset.rootPaths where !rootPaths.contains(rootPath) {
                 swiftSDK.append(toolsetRootPath: rootPath)
             }

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -408,6 +408,23 @@ final class SwiftSDKBundleTests: XCTestCase {
             let targetSwiftSDK = try SwiftSDK.deriveTargetSwiftSDK(
                 hostSwiftSDK: hostSwiftSDK,
                 hostTriple: hostTriple,
+                customCompileTriple: .arm64Linux,
+                store: store,
+                observabilityScope: system.topScope,
+                fileSystem: fileSystem
+            )
+
+            // With a custom target triple, toolset extra CLI options should be empty
+            XCTAssertEqual(targetSwiftSDK.toolset.rootPaths, hostSwiftSDK.toolset.rootPaths)
+            for tool in targetSwiftSDK.toolset.knownTools.values {
+                XCTAssertEqual(tool.extraCLIOptions, [])
+            }
+        }
+
+        do {
+            let targetSwiftSDK = try SwiftSDK.deriveTargetSwiftSDK(
+                hostSwiftSDK: hostSwiftSDK,
+                hostTriple: hostTriple,
                 swiftSDKSelector: "\(testArtifactID)1",
                 store: store,
                 observabilityScope: system.topScope,


### PR DESCRIPTION
### Motivation:

When cross-compiling with `--triple` CLI option, an implicit toolset is created as an exact copy of the host Swift SDK toolset.  This is wrong, since CLI options used for the host toolset don't always make sense for the target toolset. `-fPIC` is one example, which is an option always used for both host and target toolchains even when cross-compiling. Embedded targets, like `wasm32-unknown-none-wasm` don't support certain codegen features (like `-mreference-types`) when `-fPIC` is enabled.

### Modifications:

With this patch, host toolchains still pass `-fPIC` to clang, but target options for clang and other tools are empty by default and are no longer populated with host toolset extra CLI options, when `--triple` CLI option is specified.

### Result:

Cross-compiling with `--triple wasm32-unknown-none-wasm` and `-Xcc -mreference-types` no longer crashes Clang due to unsupported codegen features. When cross-compiling to other platforms using `--triple`, `-fPIC` needs to be passed explicitly via CLI, Swift SDKs, or toolsets (this one is to be implemented in a future PR).

Also gets rid of warnings caused by unused options, a typical one when building Embedded Swift packages on macOS with SwiftPM is:

```
clang: warning: argument unused during compilation:
'-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks'
[-Wunused-command-line-argument]
```