### PR TITLE
[6.0][PackageModel] UserToolchain: Add -F when building with CommandLineTools

### DIFF
--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -60,12 +60,12 @@ extension SwiftPackageCommand {
             // For macros this is reversed, since we don't support testing
             // macros with Swift Testing yet.
             var supportedTestingLibraries = Set<BuildParameters.Testing.Library>()
-            if testLibraryOptions.isExplicitlyEnabled(.xctest) ||
-                (initMode == .macro && testLibraryOptions.isEnabled(.xctest)) {
+            if testLibraryOptions.isExplicitlyEnabled(.xctest, swiftCommandState: swiftCommandState) ||
+                (initMode == .macro && testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState)) {
                 supportedTestingLibraries.insert(.xctest)
             }
-            if testLibraryOptions.isExplicitlyEnabled(.swiftTesting) ||
-                (initMode != .macro && testLibraryOptions.isEnabled(.swiftTesting)) {
+            if testLibraryOptions.isExplicitlyEnabled(.swiftTesting, swiftCommandState: swiftCommandState) ||
+                (initMode != .macro && testLibraryOptions.isEnabled(.swiftTesting, swiftCommandState: swiftCommandState)) {
                 supportedTestingLibraries.insert(.swiftTesting)
             }
 

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -25,6 +25,7 @@ import struct PackageModel.EnabledSanitizers
 import struct PackageModel.PackageIdentity
 import class PackageModel.Manifest
 import enum PackageModel.Sanitizer
+@_spi(SwiftPMInternal) import struct PackageModel.SwiftSDK
 
 import struct SPMBuildCore.BuildParameters
 
@@ -596,28 +597,30 @@ public struct TestLibraryOptions: ParsableArguments {
           help: .private)
     public var explicitlyEnableExperimentalSwiftTestingLibrarySupport: Bool?
 
-    private func isEnabled(_ library: BuildParameters.Testing.Library, `default`: Bool) -> Bool {
+    private func isEnabled(_ library: BuildParameters.Testing.Library, `default`: Bool, swiftCommandState: SwiftCommandState) -> Bool {
         switch library {
         case .xctest:
-            explicitlyEnableXCTestSupport ?? `default`
+            if let explicitlyEnableXCTestSupport {
+                return explicitlyEnableXCTestSupport
+            }
+            if let toolchain = try? swiftCommandState.getHostToolchain(),
+               toolchain.swiftSDK.xctestSupport == .supported {
+                return `default`
+            }
+            return false
         case .swiftTesting:
-            explicitlyEnableSwiftTestingLibrarySupport ?? explicitlyEnableExperimentalSwiftTestingLibrarySupport ?? `default`
+            return explicitlyEnableSwiftTestingLibrarySupport ?? explicitlyEnableExperimentalSwiftTestingLibrarySupport ?? `default`
         }
     }
 
     /// Test whether or not a given library is enabled.
-    public func isEnabled(_ library: BuildParameters.Testing.Library) -> Bool {
-        isEnabled(library, default: true)
+    public func isEnabled(_ library: BuildParameters.Testing.Library, swiftCommandState: SwiftCommandState) -> Bool {
+        isEnabled(library, default: true, swiftCommandState: swiftCommandState)
     }
 
     /// Test whether or not a given library was explicitly enabled by the developer.
-    public func isExplicitlyEnabled(_ library: BuildParameters.Testing.Library) -> Bool {
-        isEnabled(library, default: false)
-    }
-
-    /// The list of enabled testing libraries.
-    public var enabledTestingLibraries: [BuildParameters.Testing.Library] {
-        [.xctest, .swiftTesting].filter(isEnabled)
+    public func isExplicitlyEnabled(_ library: BuildParameters.Testing.Library, swiftCommandState: SwiftCommandState) -> Bool {
+        isEnabled(library, default: false, swiftCommandState: swiftCommandState)
     }
 }
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -411,6 +411,18 @@ public final class UserToolchain: Toolchain {
         derivedSwiftCompiler: AbsolutePath,
         fileSystem: any FileSystem
     ) -> (swiftCFlags: [String], linkerFlags: [String]) {
+        // If this is CommandLineTools all we need to add is a frameworks path.
+        if let frameworksPath = try? AbsolutePath(
+            validating: "../../Library/Developer/Frameworks",
+            relativeTo: resolveSymlinks(derivedSwiftCompiler).parentDirectory
+        ), fileSystem.exists(frameworksPath.appending("Testing.framework")) {
+            return (swiftCFlags: [
+                "-F", frameworksPath.pathString
+            ], linkerFlags: [
+                "-rpath", frameworksPath.pathString
+            ])
+        }
+
         guard let toolchainLibDir = try? toolchainLibDir(
             swiftCompilerPath: derivedSwiftCompiler
         ) else {


### PR DESCRIPTION
- Explanation:

  On macOS SwiftPM should use the swift-testing installed into a CommandLineTools when it exists and skip xctest if it isn't available.

- Main Branch PR: https://github.com/swiftlang/swift-package-manager/pull/7840 (was previously only partially cherry-picked) and https://github.com/swiftlang/swift-package-manager/pull/7805

- Resolves: rdar://136424541

- Risk: Low

- Reviewed By: @MaxDesiatov @rintaro 

- Testing: Existing tests and manual validation using new toolchain