### PR TITLE
Stop disabling implicit import of _Concurrency and _StringProcessing in bootstrap

### DIFF
--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -217,11 +217,6 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
         let observabilityScope: ObservabilityScope
         let logLevel: Basics.Diagnostic.Severity
 
-        static let additionalSwiftBuildFlags = [
-            "-Xfrontend", "-disable-implicit-concurrency-module-import",
-            "-Xfrontend", "-disable-implicit-string-processing-module-import"
-        ]
-
         init(fileSystem: FileSystem, observabilityScope: ObservabilityScope, logLevel: Basics.Diagnostic.Severity) throws {
             self.identityResolver = DefaultIdentityResolver()
             self.dependencyMapper = DefaultDependencyMapper(identityResolver: self.identityResolver)
@@ -281,7 +276,6 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
             logLevel: Basics.Diagnostic.Severity
         ) throws -> BuildSystem {
             var buildFlags = buildFlags
-            buildFlags.swiftCompilerFlags += Self.additionalSwiftBuildFlags
 
             let dataPath = scratchDirectory.appending(
                 component: self.targetToolchain.targetTriple.platformBuildPathComponent(buildSystem: buildSystem)
@@ -349,7 +343,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
         }
 
         func createManifestLoader(manifestBuildFlags: [String]) -> ManifestLoader {
-            var extraManifestFlags = manifestBuildFlags + Self.additionalSwiftBuildFlags
+            var extraManifestFlags = manifestBuildFlags
             if self.logLevel <= .info {
                 extraManifestFlags.append("-v")
             }

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -668,9 +668,6 @@ def build_swiftpm_with_swiftpm(args, integrated_swift_driver):
         if os.path.exists("Package.resolved"):
             os.remove("Package.resolved")
 
-        swiftpm_args += ["-Xswiftc", "-Xfrontend", "-Xswiftc", "-disable-implicit-concurrency-module-import"]
-        swiftpm_args += ["-Xswiftc", "-Xfrontend", "-Xswiftc", "-disable-implicit-string-processing-module-import"]
-
     if integrated_swift_driver:
         swiftpm_args.append("--use-integrated-swift-driver")
 


### PR DESCRIPTION
These modules are well established now, so this hack should no longer be needed