### PR TITLE
When generating manifest the type should be before the targets

### DIFF
--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -201,7 +201,7 @@ fileprivate extension SourceCodeFragment {
         else {
             var params: [SourceCodeFragment] = []
             params.append(SourceCodeFragment(key: "name", string: product.name))
-            if !product.targets.isEmpty {
+            if !product.targets.isEmpty && !product.type.isLibrary {
                 params.append(SourceCodeFragment(key: "targets", strings: product.targets))
             }
             switch product.type {
@@ -209,21 +209,24 @@ fileprivate extension SourceCodeFragment {
                 if type != .automatic {
                     params.append(SourceCodeFragment(key: "type", enum: type.rawValue))
                 }
-	            self.init(enum: "library", subnodes: params, multiline: true)
-	        case .executable:
-	            self.init(enum: "executable", subnodes: params, multiline: true)
-	        case .snippet:
-	            self.init(enum: "sample", subnodes: params, multiline: true)
-	        case .plugin:
-	            self.init(enum: "plugin", subnodes: params, multiline: true)
-	        case .test:
-	            self.init(enum: "test", subnodes: params, multiline: true)
+                if !product.targets.isEmpty {
+                    params.append(SourceCodeFragment(key: "targets", strings: product.targets))
+                }
+                self.init(enum: "library", subnodes: params, multiline: true)
+            case .executable:
+                self.init(enum: "executable", subnodes: params, multiline: true)
+            case .snippet:
+                self.init(enum: "sample", subnodes: params, multiline: true)
+            case .plugin:
+                self.init(enum: "plugin", subnodes: params, multiline: true)
+            case .test:
+                self.init(enum: "test", subnodes: params, multiline: true)
             case .macro:
                 self.init(enum: "macro", subnodes: params, multiline: true)
             }
         }
     }
-    
+
     /// Instantiates a SourceCodeFragment to represent a single target.
     init(from target: TargetDescription) {
         var params: [SourceCodeFragment] = []

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -156,6 +156,45 @@ final class ManifestSourceGenerationTests: XCTestCase {
         try await testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_3)
     }
 
+    func testDynamicLibraryType() async throws {
+        let manifestContents = """
+            // swift-tools-version:5.3
+            // The swift-tools-version declares the minimum version of Swift required to build this package.
+
+            import PackageDescription
+
+            let package = Package(
+                name: "MyPackage",
+                platforms: [
+                    .macOS(.v10_14),
+                    .iOS(.v13)
+                ],
+                products: [
+                    // Products define the executables and libraries a package produces, and make them visible to other packages.
+                    .library(
+                        name: "MyPackage",
+                        type: .dynamic,
+                        targets: ["MyPackage"]),
+                ],
+                dependencies: [
+                    // Dependencies declare other packages that this package depends on.
+                    // .package(url: /* package url */, from: "1.0.0"),
+                ],
+                targets: [
+                    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+                    // Targets can depend on other targets in this package, and on products in packages this package depends on.
+                    .target(
+                        name: "MyPackage",
+                        dependencies: []),
+                    .testTarget(
+                        name: "MyPackageTests",
+                        dependencies: ["MyPackage"]),
+                ]
+            )
+            """
+        try await testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_3)
+    }
+
     func testCustomPlatform() async throws {
         let manifestContents = """
             // swift-tools-version:5.6


### PR DESCRIPTION
Method [generateManifestFileContents(packageDirectory:)](https://github.com/swiftlang/swift-package-manager/blob/80b1e179bef19e6eb71b0d20b2cb471053ae1b2c/Sources/PackageModel/ManifestSourceGeneration.swift#L33) is generating invalid manifest if the manifest has a ProductDescription with a library with dynamic type.

Specificaly the in the generated Manifest it places the type: .dynamic, after the targets.

The problem in [here](https://github.com/swiftlang/swift-package-manager/blob/80b1e179bef19e6eb71b0d20b2cb471053ae1b2c/Sources/PackageModel/ManifestSourceGeneration.swift#L204) where the code that adds the dynamic type is after the code that adds the targets.