### PR TITLE
Use `CaseIterable` to auto-generate CLI `--help` entries

### DIFF
--- a/Sources/Commands/PackageCommands/AddProduct.swift
+++ b/Sources/Commands/PackageCommands/AddProduct.swift
@@ -42,7 +42,7 @@ extension SwiftPackageCommand {
         @Argument(help: "The name of the new product")
         var name: String
 
-        @Option(help: "The type of target to add.")
+        @Option(help: "The type of target to add")
         var type: CommandProductType = .library
 
         @Option(

--- a/Sources/Commands/PackageCommands/AddProduct.swift
+++ b/Sources/Commands/PackageCommands/AddProduct.swift
@@ -25,7 +25,7 @@ extension SwiftPackageCommand {
     struct AddProduct: SwiftCommand {
         /// The package product type used for the command-line. This is a
         /// subset of `ProductType` that expands out the library types.
-        enum CommandProductType: String, Codable, ExpressibleByArgument {
+        enum CommandProductType: String, Codable, ExpressibleByArgument, CaseIterable {
             case executable
             case library
             case staticLibrary = "static-library"
@@ -42,7 +42,7 @@ extension SwiftPackageCommand {
         @Argument(help: "The name of the new product")
         var name: String
 
-        @Option(help: "The type of target to add, which can be one of 'executable', 'library', 'static-library', 'dynamic-library', or 'plugin'")
+        @Option(help: "The type of target to add.")
         var type: CommandProductType = .library
 
         @Option(

--- a/Sources/Commands/PackageCommands/AddTarget.swift
+++ b/Sources/Commands/PackageCommands/AddTarget.swift
@@ -26,7 +26,7 @@ extension AddTarget.TestHarness: ExpressibleByArgument { }
 extension SwiftPackageCommand {
     struct AddTarget: SwiftCommand {
         /// The type of target that can be specified on the command line.
-        enum TargetType: String, Codable, ExpressibleByArgument {
+        enum TargetType: String, Codable, ExpressibleByArgument, CaseIterable {
             case library
             case executable
             case test
@@ -42,7 +42,7 @@ extension SwiftPackageCommand {
         @Argument(help: "The name of the new target")
         var name: String
 
-        @Option(help: "The type of target to add, which can be one of 'library', 'executable', 'test', or 'macro'")
+        @Option(help: "The type of target to add.")
         var type: TargetType = .library
 
         @Option(

--- a/Sources/Commands/PackageCommands/AddTarget.swift
+++ b/Sources/Commands/PackageCommands/AddTarget.swift
@@ -42,7 +42,7 @@ extension SwiftPackageCommand {
         @Argument(help: "The name of the new target")
         var name: String
 
-        @Option(help: "The type of target to add.")
+        @Option(help: "The type of target to add")
         var type: TargetType = .library
 
         @Option(

--- a/Sources/Commands/PackageCommands/Describe.swift
+++ b/Sources/Commands/PackageCommands/Describe.swift
@@ -26,7 +26,7 @@ extension SwiftPackageCommand {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
         
-        @Option(help: "Set the output format.")
+        @Option(help: "Set the output format")
         var type: DescribeMode = .text
         
         func run(_ swiftCommandState: SwiftCommandState) async throws {

--- a/Sources/Commands/PackageCommands/Describe.swift
+++ b/Sources/Commands/PackageCommands/Describe.swift
@@ -26,7 +26,7 @@ extension SwiftPackageCommand {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
         
-        @Option(help: "json | text | mermaid")
+        @Option(help: "Set the output format.")
         var type: DescribeMode = .text
         
         func run(_ swiftCommandState: SwiftCommandState) async throws {
@@ -63,7 +63,7 @@ extension SwiftPackageCommand {
             print(String(decoding: data, as: UTF8.self))
         }
         
-        enum DescribeMode: String, ExpressibleByArgument {
+        enum DescribeMode: String, ExpressibleByArgument, CaseIterable {
             /// JSON format (guaranteed to be parsable and stable across time).
             case json
             /// Human readable format (not guaranteed to be parsable).

--- a/Sources/Commands/PackageCommands/ShowDependencies.swift
+++ b/Sources/Commands/PackageCommands/ShowDependencies.swift
@@ -28,7 +28,7 @@ extension SwiftPackageCommand {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Option(help: "Set the output format.")
+        @Option(help: "Set the output format")
         var format: ShowDependenciesMode = .text
 
         @Option(name: [.long, .customShort("o") ],

--- a/Sources/Commands/PackageCommands/ShowDependencies.swift
+++ b/Sources/Commands/PackageCommands/ShowDependencies.swift
@@ -28,7 +28,7 @@ extension SwiftPackageCommand {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Option(help: "text | dot | json | flatlist")
+        @Option(help: "Set the output format.")
         var format: ShowDependenciesMode = .text
 
         @Option(name: [.long, .customShort("o") ],
@@ -69,7 +69,7 @@ extension SwiftPackageCommand {
             stream.flush()
         }
 
-        enum ShowDependenciesMode: String, RawRepresentable, CustomStringConvertible, ExpressibleByArgument {
+        enum ShowDependenciesMode: String, RawRepresentable, CustomStringConvertible, ExpressibleByArgument, CaseIterable {
             case text, dot, json, flatlist
 
             public init?(rawValue: String) {

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -482,7 +482,7 @@ public struct BuildOptions: ParsableArguments {
     var _buildSystem: BuildSystemProvider.Kind = .native
 
     /// The Debug Information Format to use.
-    @Option(name: .customLong("debug-info-format", withSingleDash: true), help: "The Debug Information Format to use.")
+    @Option(name: .customLong("debug-info-format", withSingleDash: true), help: "The Debug Information Format to use")
     public var debugInfoFormat: DebugInfoFormat = .dwarf
 
     public var buildSystem: BuildSystemProvider.Kind {

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -162,7 +162,7 @@ public struct CachingOptions: ParsableArguments {
     /// Disables manifest caching.
     @Option(
         name: .customLong("manifest-cache"),
-        help: "Caching mode of Package.swift manifests (shared: shared cache, local: package's build directory, none: disabled"
+        help: "Caching mode of Package.swift manifests (shared: shared cache, local: package's build directory, none: disabled)"
     )
     public var manifestCachingMode: ManifestCachingMode = .shared
 
@@ -470,7 +470,7 @@ public struct BuildOptions: ParsableArguments {
 
     /// A flag that indicates this build should check whether targets only import
     /// their explicitly-declared dependencies
-    @Option()
+    @Option(help: "A flag that indicates this build should check whether targets only import their explicitly-declared dependencies")
     public var explicitTargetDependencyImportCheck: TargetDependencyImportCheckingMode = .none
 
     /// Whether to use the explicit module build flow (with the integrated driver)
@@ -482,7 +482,7 @@ public struct BuildOptions: ParsableArguments {
     var _buildSystem: BuildSystemProvider.Kind = .native
 
     /// The Debug Information Format to use.
-    @Option(name: .customLong("debug-info-format", withSingleDash: true))
+    @Option(name: .customLong("debug-info-format", withSingleDash: true), help: "The Debug Information Format to use.")
     public var debugInfoFormat: DebugInfoFormat = .dwarf
 
     public var buildSystem: BuildSystemProvider.Kind {
@@ -527,7 +527,7 @@ public struct BuildOptions: ParsableArguments {
         case disableIndexStore
     }
 
-    public enum TargetDependencyImportCheckingMode: String, Codable, ExpressibleByArgument {
+    public enum TargetDependencyImportCheckingMode: String, Codable, ExpressibleByArgument, CaseIterable {
         case none
         case warn
         case error
@@ -542,7 +542,7 @@ public struct BuildOptions: ParsableArguments {
     }
 
     /// See `BuildParameters.DebugInfoFormat` for details.
-    public enum DebugInfoFormat: String, Codable, ExpressibleByArgument {
+    public enum DebugInfoFormat: String, Codable, ExpressibleByArgument, CaseIterable {
         /// See `BuildParameters.DebugInfoFormat.dwarf` for details.
         case dwarf
         /// See `BuildParameters.DebugInfoFormat.codeview` for details.
@@ -747,20 +747,20 @@ extension URL {
 }
 
 #if compiler(<6.0)
-extension BuildConfiguration: ExpressibleByArgument {}
+extension BuildConfiguration: ExpressibleByArgument, CaseIterable {}
 extension AbsolutePath: ExpressibleByArgument {}
 extension WorkspaceConfiguration.CheckingMode: ExpressibleByArgument {}
 extension Sanitizer: ExpressibleByArgument {}
-extension BuildSystemProvider.Kind: ExpressibleByArgument {}
+extension BuildSystemProvider.Kind: ExpressibleByArgument, CaseIterable {}
 extension Version: ExpressibleByArgument {}
 extension PackageIdentity: ExpressibleByArgument {}
 extension URL: ExpressibleByArgument {}
 #else
-extension BuildConfiguration: @retroactive ExpressibleByArgument {}
+extension BuildConfiguration: @retroactive ExpressibleByArgument, CaseIterable {}
 extension AbsolutePath: @retroactive ExpressibleByArgument {}
 extension WorkspaceConfiguration.CheckingMode: @retroactive ExpressibleByArgument {}
 extension Sanitizer: @retroactive ExpressibleByArgument {}
-extension BuildSystemProvider.Kind: @retroactive ExpressibleByArgument {}
+extension BuildSystemProvider.Kind: @retroactive ExpressibleByArgument, CaseIterable {}
 extension Version: @retroactive ExpressibleByArgument {}
 extension PackageIdentity: @retroactive ExpressibleByArgument {}
 extension URL: @retroactive ExpressibleByArgument {}

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -118,7 +118,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
 
     /// An option that indicates this build should check whether targets only import
     /// their explicitly-declared dependencies
-    @Option(help: "An option that indicates this build should check whether targets only import their explicitly-declared dependencies")
+    @Option(help: "Check that targets only import their explicitly-declared dependencies")
     public var explicitTargetDependencyImportCheck: TargetDependencyImportCheckingMode = .none
 
     enum TargetDependencyImportCheckingMode: String, Codable, ExpressibleByArgument, CaseIterable {

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -116,12 +116,12 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
     @Flag()
     public var useIntegratedSwiftDriver: Bool = false
 
-    /// A flag that indicates this build should check whether targets only import
+    /// An option that indicates this build should check whether targets only import
     /// their explicitly-declared dependencies
-    @Option()
+    @Option(help: "An option that indicates this build should check whether targets only import their explicitly-declared dependencies")
     public var explicitTargetDependencyImportCheck: TargetDependencyImportCheckingMode = .none
 
-    enum TargetDependencyImportCheckingMode: String, Codable, ExpressibleByArgument {
+    enum TargetDependencyImportCheckingMode: String, Codable, ExpressibleByArgument, CaseIterable {
         case none
         case error
     }
@@ -473,10 +473,10 @@ extension BuildConfiguration {
 
 #if compiler(<6.0)
 extension AbsolutePath: ExpressibleByArgument {}
-extension BuildConfiguration: ExpressibleByArgument {}
+extension BuildConfiguration: ExpressibleByArgument, CaseIterable {}
 #else
 extension AbsolutePath: @retroactive ExpressibleByArgument {}
-extension BuildConfiguration: @retroactive ExpressibleByArgument {}
+extension BuildConfiguration: @retroactive ExpressibleByArgument, CaseIterable {}
 #endif
 
 public func topologicalSort<T: Hashable>(


### PR DESCRIPTION
The swift-argument-parser library will automatically show the available values for options that implement the CaseIterable protocol. There are options in SwiftPM that do either list the available values statically in the help message, which can be stale, or don't provide a list at all, which leaves the user to guess the value that they want. Sweep these options, removing the static list, sometimes adding the help message based on the swift documentation. Since the CaseIterable doesn't provide a description of each value, leave the options alone that provide detail for each of their available values.

The result of these changes is that the online help (and content assist) is able to automatically display all of the available values for certain options. Also, some of the options have a help description for the first time.