### PR TITLE
Add descriptive error when attempting to list tests before building

### DIFF
--- a/Sources/Basics/Errors.swift
+++ b/Sources/Basics/Errors.swift
@@ -26,6 +26,27 @@ public struct InternalError: Error {
     }
 }
 
+/// Wraps another error and provides additional context when printed.
+/// This is useful for user facing errors that need to provide a user friendly message
+/// explaning why an error might have occured, while still showing the detailed underlying error.
+public struct ErrorWithContext<E: Error>: Error {
+    public let error: E
+    public let context: String
+    public init(_ error: E, _ context: String) {
+        self.error = error
+        self.context = context
+    }
+}
+
+extension ErrorWithContext: LocalizedError {
+    public var errorDescription: String? {
+        if let localizedError = error as? LocalizedError {
+            return "\(context)\n\(localizedError.errorDescription ?? localizedError.localizedDescription)"
+        }
+        return "\(context)\n\(error)"
+    }
+}
+
 extension Error {
     public var interpolationDescription: String {
         switch self {

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -284,6 +284,14 @@ final class TestCommandTests: CommandsTestCase {
         }
     }
 
+    func testListWithSkipBuildAndNoBuildArtifacts() async throws {
+        try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            await XCTAssertThrowsCommandExecutionError(try await SwiftPM.Test.execute(["list", "--skip-build"], packagePath: fixturePath)) { error in
+                XCTAssertMatch(error.stderr, .contains("Test build artifacts were not found in the build folder"))
+            }
+        }
+    }
+
     func testBasicSwiftTestingIntegration() async throws {
 #if !canImport(TestingDisabled)
         try XCTSkipUnless(


### PR DESCRIPTION
### Motivation:

Typically a build is performed before a `swift test list` command, but by passing the `--skip-build` flag it is possible to get a cryptic, unhelpful error message if the test artifacts haven't already been built.

### Modifications:

Add a descriptive error for this case, only checking for test artifact existence in the failure case to avoid any performance impact on the happy path.
