### PR TITLE
Use `readData` to read data from a pipe instead of `availableData`

### DIFF
--- a/Sources/Basics/Concurrency/AsyncProcess.swift
+++ b/Sources/Basics/Concurrency/AsyncProcess.swift
@@ -501,7 +501,7 @@ package final class AsyncProcess {
 
             group.enter()
             stdoutPipe.fileHandleForReading.readabilityHandler = { (fh: FileHandle) in
-                let data = fh.availableData
+                let data = (try? fh.read(upToCount: Int.max)) ?? Data()
                 if data.count == 0 {
                     stdoutPipe.fileHandleForReading.readabilityHandler = nil
                     group.leave()
@@ -516,7 +516,7 @@ package final class AsyncProcess {
 
             group.enter()
             stderrPipe.fileHandleForReading.readabilityHandler = { (fh: FileHandle) in
-                let data = fh.availableData
+                let data = (try? fh.read(upToCount: Int.max)) ?? Data()
                 if data.count == 0 {
                     stderrPipe.fileHandleForReading.readabilityHandler = nil
                     group.leave()


### PR DESCRIPTION
Using `availableData` causes parallel XCTest execution to hang on Windows if the tests output significant data to stderr.
