### PR TITLE
Support separate modules for static and dynamic exporting symbols for Windows

### DIFF
--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -53,15 +53,15 @@ extension LLBuildManifestBuilder {
             )
         } else {
             try self.addCmdWithBuiltinSwiftTool(target, inputs: inputs, cmdOutputs: cmdOutputs)
-            if let exportTarget = target.windowsExportTarget {
+            if let dynamicTarget = target.windowsDynamicTarget {
                 // Generate dynamic module for Windows
-                let inputs = try self.computeSwiftCompileCmdInputs(exportTarget)
-                let objectNodes = exportTarget.buildParameters.prepareForIndexing == .off ? try exportTarget.objects.map(Node.file) : []
-                let moduleNode = Node.file(exportTarget.moduleOutputPath)
+                let inputs = try self.computeSwiftCompileCmdInputs(dynamicTarget)
+                let objectNodes = dynamicTarget.buildParameters.prepareForIndexing == .off ? try dynamicTarget.objects.map(Node.file) : []
+                let moduleNode = Node.file(dynamicTarget.moduleOutputPath)
                 let cmdOutputs = objectNodes + [moduleNode]
-                try self.addCmdWithBuiltinSwiftTool(exportTarget, inputs: inputs, cmdOutputs: cmdOutputs)
-                self.addTargetCmd(exportTarget, cmdOutputs: cmdOutputs)
-                try self.addModuleWrapCmd(exportTarget)
+                try self.addCmdWithBuiltinSwiftTool(dynamicTarget, inputs: inputs, cmdOutputs: cmdOutputs)
+                self.addTargetCmd(dynamicTarget, cmdOutputs: cmdOutputs)
+                try self.addModuleWrapCmd(dynamicTarget)
             }
         }
 
@@ -542,7 +542,7 @@ extension LLBuildManifestBuilder {
             inputs: cmdOutputs,
             outputs: [targetOutput]
         )
-        if self.plan.graph.isInRootPackages(target.target, satisfying: target.buildParameters.buildEnvironment), target.windowsTargetType != .exporting {
+        if self.plan.graph.isInRootPackages(target.target, satisfying: target.buildParameters.buildEnvironment), target.windowsTargetType != .dynamic {
             if !target.isTestTarget {
                 self.addNode(targetOutput, toTarget: .main)
             }
@@ -647,8 +647,8 @@ extension SwiftModuleBuildDescription {
 
     public func getLLBuildTargetName() -> String {
         let name = self.target.getLLBuildTargetName(buildParameters: self.buildParameters)
-        if self.windowsTargetType == .exporting {
-            return "export." + name
+        if self.windowsTargetType == .dynamic {
+            return "dynamic." + name
         } else {
             return name
         }

--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -104,11 +104,11 @@ extension BuildPlan {
         buildProduct.objects += try dependencies.staticTargets.flatMap {
             if buildProduct.product.type == .library(.dynamic),
                 case let .swift(swiftModule) = $0,
-                let exporting = swiftModule.windowsExportTarget,
+                let dynamic = swiftModule.windowsDynamicTarget,
                 buildProduct.product.modules.contains(id: swiftModule.target.id)
             {
                 // On Windows, export symbols from the direct swift targets of the DLL product
-                return try exporting.objects
+                return try dynamic.objects
             } else {
                 return try $0.objects
             }

--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -101,7 +101,18 @@ extension BuildPlan {
 
         buildProduct.staticTargets = dependencies.staticTargets.map(\.module)
         buildProduct.dylibs = dependencies.dylibs
-        buildProduct.objects += try dependencies.staticTargets.flatMap { try $0.objects }
+        buildProduct.objects += try dependencies.staticTargets.flatMap {
+            if buildProduct.product.type == .library(.dynamic),
+                case let .swift(swiftModule) = $0,
+                let exporting = swiftModule.windowsExportTarget,
+                buildProduct.product.modules.contains(id: swiftModule.target.id)
+            {
+                // On Windows, export symbols from the direct swift targets of the DLL product
+                return try exporting.objects
+            } else {
+                return try $0.objects
+            }
+        }
         buildProduct.libraryBinaryPaths = dependencies.libraryBinaryPaths
         buildProduct.availableTools = dependencies.availableTools
     }

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -537,6 +537,9 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
             switch buildTarget {
             case .swift(let target):
                 try self.plan(swiftTarget: target)
+                if let exportTarget = target.windowsExportTarget {
+                    try self.plan(swiftTarget: exportTarget)
+                }
             case .clang(let target):
                 try self.plan(clangTarget: target)
             }

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -537,8 +537,8 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
             switch buildTarget {
             case .swift(let target):
                 try self.plan(swiftTarget: target)
-                if let exportTarget = target.windowsExportTarget {
-                    try self.plan(swiftTarget: exportTarget)
+                if let dynamicTarget = target.windowsDynamicTarget {
+                    try self.plan(swiftTarget: dynamicTarget)
                 }
             case .clang(let target):
                 try self.plan(clangTarget: target)

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -66,6 +66,8 @@ extension Basics.Triple {
     public static let arm64Linux = try! Self("aarch64-unknown-linux-gnu")
     public static let arm64Android = try! Self("aarch64-unknown-linux-android")
     public static let windows = try! Self("x86_64-unknown-windows-msvc")
+    public static let x86_64Windows = try! Self("x86_64-unknown-windows-msvc")
+    public static let arm64Windows = try! Self("aarch64-unknown-windows-msvc")
     public static let wasi = try! Self("wasm32-unknown-wasi")
     public static let arm64iOS = try! Self("arm64-apple-ios")
 }

--- a/Tests/BuildTests/WindowsBuildPlanTests.swift
+++ b/Tests/BuildTests/WindowsBuildPlanTests.swift
@@ -14,6 +14,7 @@ import XCTest
 
 import Basics
 @testable import Build
+import LLBuildManifest
 import _InternalTestSupport
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
@@ -23,7 +24,8 @@ final class WindowsBuildPlanTests: XCTestCase {
     // Tests that our build plan is build correctly to handle separation
     // of object files that export symbols and ones that don't and to ensure
     // DLL products pick up the right ones.
-    func testDynamicSymbolHandling() async throws {
+
+    func doTest(triple: Triple) async throws {
         let fs = InMemoryFileSystem(emptyFiles: [
             "/libPkg/Sources/coreLib/coreLib.swift",
             "/libPkg/Sources/dllLib/dllLib.swift",
@@ -68,14 +70,71 @@ final class WindowsBuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        let plan = try await mockBuildPlan(
+        let label: String
+        let dylibPrefix: String
+        let dylibExtension: String
+        let dynamic: String
+        switch triple {
+        case Triple.x86_64Windows:
+            label = "x86_64-unknown-windows-msvc"
+            dylibPrefix = ""
+            dylibExtension = "dll"
+            dynamic = "/dynamic"
+        case Triple.x86_64MacOS:
+            label = "x86_64-apple-macosx"
+            dylibPrefix = "lib"
+            dylibExtension = "dylib"
+            dynamic = ""
+        case Triple.x86_64Linux:
+            label = "x86_64-unknown-linux-gnu"
+            dylibPrefix = "lib"
+            dylibExtension = "so"
+            dynamic = ""
+        default:
+            label = "fixme"
+            dylibPrefix = ""
+            dylibExtension = ""
+            dynamic = ""
+        }
+
+        let tools: [String: [String]] = [
+            "C.exe-\(label)-debug.exe": [
+                "/path/to/build/\(label)/debug/coreLib.build/coreLib.swift.o",
+                "/path/to/build/\(label)/debug/exe.build/main.swift.o",
+                "/path/to/build/\(label)/debug/objectLib.build/objectLib.swift.o",
+                "/path/to/build/\(label)/debug/staticLib.build/staticLib.swift.o",
+                "/path/to/build/\(label)/debug/\(dylibPrefix)DLLProduct.\(dylibExtension)",
+                "/path/to/build/\(label)/debug/exe.product/Objects.LinkFileList",
+            ] + (triple.isMacOSX ? [] : [
+                // modulewrap
+                "/path/to/build/\(label)/debug/coreLib.build/coreLib.swiftmodule.o",
+                "/path/to/build/\(label)/debug/exe.build/exe.swiftmodule.o",
+                "/path/to/build/\(label)/debug/objectLib.build/objectLib.swiftmodule.o",
+                "/path/to/build/\(label)/debug/staticLib.build/staticLib.swiftmodule.o",
+            ]),
+            "C.DLLProduct-\(label)-debug.dylib": [
+                "/path/to/build/\(label)/debug/coreLib.build/coreLib.swift.o",
+                "/path/to/build/\(label)/debug/dllLib.build\(dynamic)/dllLib.swift.o",
+                "/path/to/build/\(label)/debug/DLLProduct.product/Objects.LinkFileList",
+            ] + (triple.isMacOSX ? [] : [
+                "/path/to/build/\(label)/debug/coreLib.build/coreLib.swiftmodule.o",
+                "/path/to/build/\(label)/debug/dllLib.build/dllLib.swiftmodule.o",
+            ])
+        ]
+
+        let plan = try await BuildPlan(
+            destinationBuildParameters: mockBuildParameters(
+                destination: .target,
+                triple: triple
+            ),
+            toolsBuildParameters: mockBuildParameters(
+                destination: .host,
+                triple: triple
+            ),
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-
-        let result = try BuildPlanResult(plan: plan)
-        let exe = try result.buildProduct(for: "exe")
 
         let llbuild = LLBuildManifestBuilder(
             plan,
@@ -84,8 +143,23 @@ final class WindowsBuildPlanTests: XCTestCase {
         )
         try llbuild.generateManifest(at: "/manifest")
 
-        for command in llbuild.manifest.commands {
-            print(command.key)
+        for (name, inputNames) in tools {
+            let command = try XCTUnwrap(llbuild.manifest.commands[name])
+            XCTAssertEqual(Set(command.tool.inputs), Set(inputNames.map({ Node.file(.init($0)) })))
         }
+    }
+
+    func testWindows() async throws {
+        try await doTest(triple: .x86_64Windows)
+    }
+
+    // Make sure we didn't mess up macOS
+    func testMacOS() async throws {
+        try await doTest(triple: .x86_64MacOS)
+    }
+
+    // Make sure we didn't mess up linux
+    func testLinux() async throws {
+        try await doTest(triple: .x86_64Linux)
     }
 }

--- a/Tests/BuildTests/WindowsBuildPlanTests.swift
+++ b/Tests/BuildTests/WindowsBuildPlanTests.swift
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+import Basics
+@testable import Build
+import _InternalTestSupport
+
+@_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
+import PackageGraph
+
+final class WindowsBuildPlanTests: XCTestCase {
+    // Tests that our build plan is build correctly to handle separation
+    // of object files that export symbols and ones that don't and to ensure
+    // DLL products pick up the right ones.
+    func testDynamicSymbolHandling() async throws {
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/libPkg/Sources/coreLib/coreLib.swift",
+            "/libPkg/Sources/dllLib/dllLib.swift",
+            "/libPkg/Sources/staticLib/staticLib.swift",
+            "/libPkg/Sources/objectLib/objectLib.swift",
+            "/exePkg/Sources/exe/main.swift",
+        ])
+
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                .createFileSystemManifest(
+                    displayName: "libPkg",
+                    path: "/libPkg",
+                    products: [
+                        .init(name: "DLLProduct", type: .library(.dynamic), targets: ["dllLib"]),
+                        .init(name: "StaticProduct", type: .library(.static), targets: ["staticLib"]),
+                        .init(name: "ObjectProduct", type: .library(.automatic), targets: ["objectLib"]),
+                    ],
+                    targets: [
+                        .init(name: "coreLib", dependencies: []),
+                        .init(name: "dllLib", dependencies: ["coreLib"]),
+                        .init(name: "staticLib", dependencies: ["coreLib"]),
+                        .init(name: "objectLib", dependencies: ["coreLib"]),
+                    ]
+                ),
+                .createRootManifest(
+                    displayName: "exePkg",
+                    path: "/exePkg",
+                    dependencies: [.fileSystem(path: "/libPkg")],
+                    targets: [
+                        .init(name: "exe", dependencies: [
+                            .product(name: "DLLProduct", package: "libPkg"),
+                            .product(name: "StaticProduct", package: "libPkg"),
+                            .product(name: "ObjectProduct", package: "libPkg"),
+                        ]),
+                    ]
+                )
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let plan = try await mockBuildPlan(
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let result = try BuildPlanResult(plan: plan)
+        let exe = try result.buildProduct(for: "exe")
+
+        let llbuild = LLBuildManifestBuilder(
+            plan,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        try llbuild.generateManifest(at: "/manifest")
+
+        for command in llbuild.manifest.commands {
+            print(command.key)
+        }
+    }
+}


### PR DESCRIPTION
On Windows, there is a limit of around 64K to the number of symbols a DLL/EXE can export. We hit that regularly with large projects like SwiftPM itself. This hides those symbols and only exposes the ones requested for a DLL.

For Windows triples only, creates a parallel build graph for Swift modules, one for static linking using -static, and one for exporting linking which is the default. DLL products consume their direct target dependencies as exporting. All other dependencies use the static versions to eliminate unnecessary symbol exports.

The bulk of this is managed by the SwiftModuleBuildDescription which will create a duplicate of itself for the exporting case and set its own type to static linking. Both modules are fed to the planner to create llbuild swift command tasks. Code is added for dynamic libraries to hook up the correct inputs for exporting the symbols in the libraries targets.

This is WIP as we need to do a lot of testing to ensure we didn't break anything. Ensuring this only affects builds for Windows triples helps mitigate that.