### PR TITLE
Ensure a newline is printed after Planning build

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -770,7 +770,15 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         self.current = (buildSystem, tracker)
 
         // Build the package structure target which will re-generate the llbuild manifest, if necessary.
-        return buildSystem.build(target: "PackageStructure")
+        let buildSuccess = buildSystem.build(target: "PackageStructure")
+
+        // If progress has been printed this will add a newline to separate it from what could be
+        // the output of the command. For instance `swift test --skip-build` may print progress for
+        // the Planning Build stage, followed immediately by a list of tests. Without this finialize()
+        // call the first entry in the list appear on the same line as the Planning Build progress.
+        tracker.finalize(success: true)
+
+        return buildSuccess
     }
 
     /// Create the build system using the given build description.

--- a/Sources/Build/LLBuildProgressTracker.swift
+++ b/Sources/Build/LLBuildProgressTracker.swift
@@ -187,6 +187,12 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
         }
     }
 
+    public func finalize(success: Bool) {
+        self.queue.async {
+            self.progressAnimation.complete(success: success)
+        }
+    }
+
     // MARK: llbuildSwift.BuildSystemDelegate
 
     var fs: SPMLLBuild.FileSystem? {


### PR DESCRIPTION
If a PackageStructure build needs to occur during a `swift test list --skip-build` command there is no newline printed to the terminal, causing the first line of listed tests to appear on the same line as the progress, i.e:

`[1/1] Planning buildTestPackageTests.example()`

This doesn't occur when you omit `--skip-build` because there is code in the `LLBuildProgressTracker.swift` that calls
`progressAnimation.complete(success:)` when a build completes. Ideally I'd like to contain this logic to the LLBuildProgressTracker, however for a PackageStructure build the relevant buildComplete delegate method is never called.
