### PR TITLE
SE-0387: add `--toolset` option to build-related subcommands

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -130,7 +130,7 @@ public struct LocationOptions: ParsableArguments {
         help: "Specify to a toolset JSON file to use when building for the target platform",
         completion: .file(extensions: [".json"])
     )
-    public var toolsetPath: AbsolutePath?
+    public var toolsetPaths: [AbsolutePath] = []
 
     @Option(
         name: .customLong("pkg-config-path"),

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -127,7 +127,11 @@ public struct LocationOptions: ParsableArguments {
     
     @Option(
         name: .customLong("toolset"),
-        help: "Specify to a toolset JSON file to use when building for the target platform",
+        help: """
+            Specify to a toolset JSON file to use when building for the target platform. \
+            Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order \
+            they're specified into a single final toolset for the current build.
+            """,
         completion: .file(extensions: [".json"])
     )
     public var toolsetPaths: [AbsolutePath] = []

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -128,7 +128,7 @@ public struct LocationOptions: ParsableArguments {
     @Option(
         name: .customLong("toolset"),
         help: """
-            Specify to a toolset JSON file to use when building for the target platform. \
+            Specify a toolset JSON file to use when building for the target platform. \
             Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order \
             they're specified into a single final toolset for the current build.
             """,

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -124,6 +124,13 @@ public struct LocationOptions: ParsableArguments {
         completion: .directory
     )
     public var swiftSDKsDirectory: AbsolutePath?
+    
+    @Option(
+        name: .customLong("toolset"),
+        help: "Specify to a toolset JSON file to use when building for the target platform",
+        completion: .file(extensions: [".json"])
+    )
+    public var toolsetPath: AbsolutePath?
 
     @Option(
         name: .customLong("pkg-config-path"),

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -880,7 +880,7 @@ public final class SwiftCommandState {
             swiftSDK = try SwiftSDK.deriveTargetSwiftSDK(
                 hostSwiftSDK: hostSwiftSDK,
                 hostTriple: hostToolchain.targetTriple,
-                customToolset: options.locations.toolsetPath,
+                customToolsets: options.locations.toolsetPaths,
                 customCompileDestination: options.locations.customCompileDestination,
                 customCompileTriple: options.build.customCompileTriple,
                 customCompileToolchain: options.build.customCompileToolchain,

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -880,6 +880,7 @@ public final class SwiftCommandState {
             swiftSDK = try SwiftSDK.deriveTargetSwiftSDK(
                 hostSwiftSDK: hostSwiftSDK,
                 hostTriple: hostToolchain.targetTriple,
+                customToolset: options.locations.toolsetPath,
                 customCompileDestination: options.locations.customCompileDestination,
                 customCompileTriple: options.build.customCompileTriple,
                 customCompileToolchain: options.build.customCompileToolchain,

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -659,6 +659,7 @@ public struct SwiftSDK: Equatable {
     public static func deriveTargetSwiftSDK(
       hostSwiftSDK: SwiftSDK,
       hostTriple: Triple,
+      customToolset: AbsolutePath? = nil,
       customCompileDestination: AbsolutePath? = nil,
       customCompileTriple: Triple? = nil,
       customCompileToolchain: AbsolutePath? = nil,
@@ -671,6 +672,7 @@ public struct SwiftSDK: Equatable {
     ) throws -> SwiftSDK {
         var swiftSDK: SwiftSDK
         var isBasedOnHostSDK: Bool = false
+
         // Create custom toolchain if present.
         if let customDestination = customCompileDestination {
             let swiftSDKs = try SwiftSDK.decode(
@@ -699,11 +701,17 @@ public struct SwiftSDK: Equatable {
             swiftSDK = hostSwiftSDK
             isBasedOnHostSDK = true
         }
+
+        if let customToolset {
+            let toolset = try Toolset(from: customToolset, at: fileSystem, observabilityScope)
+            swiftSDK.toolset.merge(with: toolset)
+        }
+
         // Apply any manual overrides.
         if let triple = customCompileTriple {
             swiftSDK.targetTriple = triple
 
-            if isBasedOnHostSDK {
+            if isBasedOnHostSDK && customToolset == nil {
                 // Don't pick up extraCLIOptions for a custom triple, since those are only valid for the host triple.
                 for tool in swiftSDK.toolset.knownTools.keys {
                     swiftSDK.toolset.knownTools[tool]?.extraCLIOptions = []

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -659,7 +659,7 @@ public struct SwiftSDK: Equatable {
     public static func deriveTargetSwiftSDK(
       hostSwiftSDK: SwiftSDK,
       hostTriple: Triple,
-      customToolset: AbsolutePath? = nil,
+      customToolsets: [AbsolutePath] = [],
       customCompileDestination: AbsolutePath? = nil,
       customCompileTriple: Triple? = nil,
       customCompileToolchain: AbsolutePath? = nil,
@@ -702,16 +702,18 @@ public struct SwiftSDK: Equatable {
             isBasedOnHostSDK = true
         }
 
-        if let customToolset {
-            let toolset = try Toolset(from: customToolset, at: fileSystem, observabilityScope)
-            swiftSDK.toolset.merge(with: toolset)
+        if !customToolsets.isEmpty {
+            for toolsetPath in customToolsets {
+                let toolset = try Toolset(from: toolsetPath, at: fileSystem, observabilityScope)
+                swiftSDK.toolset.merge(with: toolset)
+            }
         }
 
         // Apply any manual overrides.
         if let triple = customCompileTriple {
             swiftSDK.targetTriple = triple
 
-            if isBasedOnHostSDK && customToolset == nil {
+            if isBasedOnHostSDK && customToolsets.isEmpty {
                 // Don't pick up extraCLIOptions for a custom triple, since those are only valid for the host triple.
                 for tool in swiftSDK.toolset.knownTools.keys {
                     swiftSDK.toolset.knownTools[tool]?.extraCLIOptions = []

--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -137,7 +137,7 @@ extension Toolset {
     /// of replacing them.
     /// - Parameter newToolset: new toolset to merge into the existing `self` toolset.
     public mutating func merge(with newToolset: Toolset) {
-        self.rootPaths.append(contentsOf: newToolset.rootPaths)
+        self.rootPaths.insert(contentsOf: newToolset.rootPaths, at: 0)
 
         for (newTool, newProperties) in newToolset.knownTools {
             if newProperties.path != nil {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -630,7 +630,7 @@ public final class UserToolchain: Toolchain {
                 pathString: environment[.path],
                 currentWorkingDirectory: fileSystem.currentWorkingDirectory
             )
-            self.useXcrun = true
+            self.useXcrun = !(fileSystem is InMemoryFileSystem)
         case .custom(let searchPaths, let useXcrun):
             self.envSearchPaths = searchPaths
             self.useXcrun = useXcrun

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -135,6 +135,7 @@ public final class UserToolchain: Toolchain {
             // Take the first match.
             break
         }
+
         guard let toolPath else {
             throw InvalidToolchainDiagnostic("could not find CLI tool `\(name)` at any of these directories: \(binDirectories)")
         }

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -26,9 +26,19 @@ extension UserToolchain {
     package static func mockHostToolchain(_ fileSystem: InMemoryFileSystem) throws -> UserToolchain {
         var hostSwiftSDK = try SwiftSDK.hostSwiftSDK(environment: .mockEnvironment, fileSystem: fileSystem)
         hostSwiftSDK.targetTriple = hostTriple
+
+        let env = Environment.mockEnvironment
+
         return try UserToolchain(
             swiftSDK: hostSwiftSDK,
-            environment: .mockEnvironment,
+            environment: env,
+            searchStrategy: .custom(
+                searchPaths: getEnvSearchPaths(
+                    pathString: env[.path],
+                    currentWorkingDirectory: fileSystem.currentWorkingDirectory
+                ),
+                useXcrun: true
+            ),
             fileSystem: fileSystem
         )
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4661,7 +4661,20 @@ final class BuildPlanTests: XCTestCase {
                 swiftStaticResourcesPath: "/fake/lib/swift_static"
             )
         )
-        let mockToolchain = try UserToolchain(swiftSDK: userSwiftSDK, environment: .mockEnvironment, fileSystem: fs)
+
+        let env = Environment.mockEnvironment
+        let mockToolchain = try UserToolchain(
+            swiftSDK: userSwiftSDK,
+            environment: env,
+            searchStrategy: .custom(
+                searchPaths: getEnvSearchPaths(
+                    pathString: env[.path],
+                    currentWorkingDirectory: fs.currentWorkingDirectory
+                ),
+                useXcrun: true
+            ),
+            fileSystem: fs
+        )
         let commonFlags = BuildFlags(
             cCompilerFlags: ["-clang-command-line-flag"],
             swiftCompilerFlags: ["-swift-command-line-flag"]
@@ -5078,6 +5091,7 @@ final class BuildPlanTests: XCTestCase {
         let env = Environment.mockEnvironment
         let toolchain = try UserToolchain(
             swiftSDK: swiftSDK,
+            environment: env,
             searchStrategy: .custom(
                 searchPaths: getEnvSearchPaths(
                     pathString: env[.path],

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4775,9 +4775,18 @@ final class BuildPlanTests: XCTestCase {
                 swiftStaticResourcesPath: "/fake/lib/swift_static"
             )
         )
+
+        let env = Environment.mockEnvironment
         let mockToolchain = try UserToolchain(
             swiftSDK: userSwiftSDK,
-            environment: .mockEnvironment,
+            environment: env,
+            searchStrategy: .custom(
+                searchPaths: getEnvSearchPaths(
+                    pathString: env[.path],
+                    currentWorkingDirectory: fs.currentWorkingDirectory
+                ),
+                useXcrun: true
+            ),
             fileSystem: fs
         )
 
@@ -5065,7 +5074,19 @@ final class BuildPlanTests: XCTestCase {
                 .swiftCompiler: .init(extraCLIOptions: ["-use-ld=lld"]),
             ])
         )
-        let toolchain = try UserToolchain(swiftSDK: swiftSDK, environment: .mockEnvironment, fileSystem: fileSystem)
+
+        let env = Environment.mockEnvironment
+        let toolchain = try UserToolchain(
+            swiftSDK: swiftSDK,
+            searchStrategy: .custom(
+                searchPaths: getEnvSearchPaths(
+                    pathString: env[.path],
+                    currentWorkingDirectory: fileSystem.currentWorkingDirectory
+                ),
+                useXcrun: true
+            ),
+            fileSystem: fileSystem
+        )
         let result = try await BuildPlanResult(plan: mockBuildPlan(
             toolchain: toolchain,
             graph: graph,

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -389,8 +389,8 @@ final class SwiftCommandStateTests: CommandsTestCase {
         let customTargetToolchain = AbsolutePath(targetToolchainPath)
         let hostSwiftcPath = AbsolutePath("/usr/bin/swiftc")
         let hostArPath = AbsolutePath("/usr/bin/ar")
-        let targetSwiftcPath = customTargetToolchain.appending(components: ["usr", "bin" , "swiftc"])
-        let targetArPath = customTargetToolchain.appending(components: ["usr", "bin", "llvm-ar"])
+        let targetSwiftcPath = customTargetToolchain.appending(components: ["swiftc"])
+        let targetArPath = customTargetToolchain.appending(components: ["llvm-ar"])
 
         let fs = InMemoryFileSystem(emptyFiles: [
             hostSwiftcPath.pathString,
@@ -422,9 +422,10 @@ final class SwiftCommandStateTests: CommandsTestCase {
 
         XCTAssertEqual(
             targetToolchain.swiftSDK.toolset.rootPaths,
-            hostToolchain.swiftSDK.toolset.rootPaths + [customTargetToolchain]
+            [customTargetToolchain] + hostToolchain.swiftSDK.toolset.rootPaths
         )
         XCTAssertEqual(targetToolchain.swiftCompilerPath, targetSwiftcPath)
+        XCTAssertEqual(targetToolchain.librarianPath, targetArPath)
     }
 }
 

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -388,6 +388,7 @@ final class SwiftSDKBundleTests: XCTestCase {
             observabilityScope: system.topScope,
             outputHandler: { _ in }
         )
+        
         for bundle in bundles {
             try await store.install(bundlePathOrURL: bundle.path, archiver)
         }

--- a/Tests/PackageModelTests/ToolsetTests.swift
+++ b/Tests/PackageModelTests/ToolsetTests.swift
@@ -208,4 +208,65 @@ final class ToolsetTests: XCTestCase {
             )
         )
     }
+
+    func testToolsetTargetToolchain() throws {
+        let fileSystem = InMemoryFileSystem()
+
+        for testFile in [compilersNoRoot, noValidToolsNoRoot, unknownToolsNoRoot, otherToolsNoRoot, someToolsWithRoot, someToolsWithRelativeRoot] {
+            try fileSystem.writeFileContents(testFile.path, string: testFile.json.underlying)
+        }
+
+        let hostSwiftSDK = try SwiftSDK.hostSwiftSDK(environment: [:])
+        let hostTriple = try! Triple("arm64-apple-macosx14.0")
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let store = SwiftSDKBundleStore(
+            swiftSDKsDirectory: "/",
+            fileSystem: fileSystem,
+            observabilityScope: observability.topScope,
+            outputHandler: { _ in }
+        )
+
+        do {
+            let targetSwiftSDK = try SwiftSDK.deriveTargetSwiftSDK(
+                hostSwiftSDK: hostSwiftSDK,
+                hostTriple: hostTriple,
+                customToolset: compilersNoRoot.path,
+                store: store,
+                observabilityScope: observability.topScope,
+                fileSystem: fileSystem
+            )
+
+            let targetToolset = try Toolset(from: compilersNoRoot.path, at: fileSystem, observability.topScope)
+
+            // By default, the target SDK paths configuration is the same as the host SDK.
+            XCTAssertEqual(targetSwiftSDK.pathsConfiguration, hostSwiftSDK.pathsConfiguration)
+
+            var expectedToolset = hostSwiftSDK.toolset
+            expectedToolset.merge(with: targetToolset)
+
+            XCTAssertEqual(targetSwiftSDK.toolset, expectedToolset)
+        }
+
+        do {
+            let targetSwiftSDK = try SwiftSDK.deriveTargetSwiftSDK(
+                hostSwiftSDK: hostSwiftSDK,
+                hostTriple: hostTriple,
+                customToolset: someToolsWithRoot.path,
+                store: store,
+                observabilityScope: observability.topScope,
+                fileSystem: fileSystem
+            )
+
+            let targetToolset = try Toolset(from: someToolsWithRoot.path, at: fileSystem, observability.topScope)
+
+            // By default, the target SDK paths configuration is the same as the host SDK.
+            XCTAssertEqual(targetSwiftSDK.pathsConfiguration, hostSwiftSDK.pathsConfiguration)
+
+            var expectedToolset = hostSwiftSDK.toolset
+            expectedToolset.merge(with: targetToolset)
+
+            XCTAssertEqual(targetSwiftSDK.toolset, expectedToolset)
+        }
+    }
 }

--- a/Tests/PackageModelTests/ToolsetTests.swift
+++ b/Tests/PackageModelTests/ToolsetTests.swift
@@ -231,7 +231,7 @@ final class ToolsetTests: XCTestCase {
             let targetSwiftSDK = try SwiftSDK.deriveTargetSwiftSDK(
                 hostSwiftSDK: hostSwiftSDK,
                 hostTriple: hostTriple,
-                customToolset: compilersNoRoot.path,
+                customToolsets: [compilersNoRoot.path],
                 store: store,
                 observabilityScope: observability.topScope,
                 fileSystem: fileSystem
@@ -252,7 +252,7 @@ final class ToolsetTests: XCTestCase {
             let targetSwiftSDK = try SwiftSDK.deriveTargetSwiftSDK(
                 hostSwiftSDK: hostSwiftSDK,
                 hostTriple: hostTriple,
-                customToolset: someToolsWithRoot.path,
+                customToolsets: [someToolsWithRoot.path],
                 store: store,
                 observabilityScope: observability.topScope,
                 fileSystem: fileSystem
@@ -265,6 +265,29 @@ final class ToolsetTests: XCTestCase {
 
             var expectedToolset = hostSwiftSDK.toolset
             expectedToolset.merge(with: targetToolset)
+
+            XCTAssertEqual(targetSwiftSDK.toolset, expectedToolset)
+        }
+
+        do {
+            let targetSwiftSDK = try SwiftSDK.deriveTargetSwiftSDK(
+                hostSwiftSDK: hostSwiftSDK,
+                hostTriple: hostTriple,
+                customToolsets: [compilersNoRoot.path, someToolsWithRoot.path],
+                store: store,
+                observabilityScope: observability.topScope,
+                fileSystem: fileSystem
+            )
+
+            let toolset1 = try Toolset(from: compilersNoRoot.path, at: fileSystem, observability.topScope)
+            let toolset2 = try Toolset(from: someToolsWithRoot.path, at: fileSystem, observability.topScope)
+
+            // By default, the target SDK paths configuration is the same as the host SDK.
+            XCTAssertEqual(targetSwiftSDK.pathsConfiguration, hostSwiftSDK.pathsConfiguration)
+
+            var expectedToolset = hostSwiftSDK.toolset
+            expectedToolset.merge(with: toolset1)
+            expectedToolset.merge(with: toolset2)
 
             XCTAssertEqual(targetSwiftSDK.toolset, expectedToolset)
         }


### PR DESCRIPTION
### Motivation:

The only feature proposed in [SE-0387](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0387-cross-compilation-destinations.md) that remains unimplemented is the `--toolset` CLI option:

> We propose that users also should be able to pass `--toolset <path_to_toolset.json>` option to `swift build`, `swift test`, and `swift run`.
>
> We'd like to allow using multiple toolset files at once. This way users can "assemble" toolchains on the fly out of tools that in certain scenarios may even come from different vendors. A toolset file can have an arbitrary name, and each file should be passed with a separate `--toolset` option, i.e. `swift build --toolset t1.json --toolset t2.json`.
>
> All of the properties related to names of the tools are optional, which allows merging configuration from multiple
toolset files. For example, consider `toolset1.json`:
>```json5
>{
>  "schemaVersion": "1.0",
>  "swiftCompiler": {
>    "path": "/usr/bin/swiftc",
>    "extraCLIOptions": ["-Xfrontend", "-enable-cxx-interop"]
>  },
>  "cCompiler": {
>    "path": "/usr/bin/clang",
>    "extraCLIOptions": ["-pedantic"]
>  }
>}
>```
>
> and `toolset2.json`:
>
> ```json5
>{
>  "schemaVersion": "1.0",
>  "swiftCompiler": {
>    "path": "/custom/swiftc"
>  }
>}
>```
>
> With multiple `--toolset` options, passing both of those files will merge them into a single configuration. Tools passed in subsequent `--toolset` options will shadow tools from previous options with the same names. That is, 
>`swift build --toolset toolset1.json --toolset toolset2.json` will build with `/custom/swiftc` and no extra flags, as specified in `toolset2.json`, but `/usr/bin/clang -pedantic` from `toolset1.json` will still be used.
>
> Tools not specified in any of the supplied toolset files will be looked up in existing implied search paths that are used without toolsets, even when `rootPath` is present. We'd like toolsets to be explicit in this regard: if a tool would like to participate in toolset path lookups, it must provide either a relative or an absolute path in a toolset.
>
> Tools that don't have `path` property but have `extraCLIOptions` present will append options from that property to a tool with the same name specified in a preceding toolset file. If no other toolset files were provided, these options will be appended to the default tool invocation.

### Modifications:

Added `toolsetPaths` on `LocationOptions`, which passes new `customToolsets` argument on `SwiftSDK.deriveTargetSwiftSDK`. Added corresponding tests.

### Result:

New `--toolset` option is able to accept toolset JSON files.
