### PR TITLE
Update completion-list help string

### DIFF
--- a/Sources/Commands/PackageCommands/CompletionCommand.swift
+++ b/Sources/Commands/PackageCommands/CompletionCommand.swift
@@ -49,7 +49,7 @@ extension SwiftPackageCommand {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Argument(help: "generate-bash-script | generate-zsh-script |\ngenerate-fish-script | list-dependencies | list-executables")
+        @Argument(help: "Type of completions to list")
         var mode: Mode
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {


### PR DESCRIPTION
Follow on to #8045 to make the completion-list tool use the CaseIterable support in swift-argument-parser to automatically enumerate the options.

`list-snippets` was missing from the list, and is now added.
