### PR TITLE
Enable dynamic dispatch for package path manifest loading

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -99,10 +99,10 @@ extension ManifestParseError: CustomStringConvertible {
 
 /// Protocol for the manifest loader interface.
 public protocol ManifestLoaderProtocol {
-    /// Load the manifest for the package at `path`.
+    /// Load the manifest at `path`.
     ///
     /// - Parameters:
-    ///   - manifestPath: The root path of the package.
+    ///   - manifestPath: The path of the manifest file to load.
     ///   - manifestToolsVersion: The version of the tools the manifest supports.
     ///   - packageIdentity: the identity of the package
     ///   - packageKind: The kind of package the manifest is from.
@@ -112,6 +112,7 @@ public protocol ManifestLoaderProtocol {
     ///   - dependencyMapper: A helper to map dependencies.
     ///   - fileSystem: File system to load from.
     ///   - observabilityScope: Observability scope to emit diagnostics.
+    ///   - delegateQueue: The dispatch queue to perform the delegate callbacks on.
     ///   - callbackQueue: The dispatch queue to perform completion handler on.
     ///   - completion: The completion handler .
     func load(
@@ -121,6 +122,38 @@ public protocol ManifestLoaderProtocol {
         packageKind: PackageReference.Kind,
         packageLocation: String,
         packageVersion: (version: Version?, revision: String?)?,
+        identityResolver: IdentityResolver,
+        dependencyMapper: DependencyMapper,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        delegateQueue: DispatchQueue,
+        callbackQueue: DispatchQueue,
+        completion: @escaping (Result<Manifest, Error>) -> Void
+    )
+
+    /// Load the manifest for the package at `path`.
+    ///
+    /// - Parameters:
+    ///   - packagePath: The root path of the package.
+    ///   - packageIdentity: the identity of the package
+    ///   - packageKind: The kind of package the manifest is from.
+    ///   - packageLocation: The location the package the manifest was loaded from.
+    ///   - packageVersion: Optional. The version and revision of the package.
+    ///   - currentToolsVersion The current tools version.
+    ///   - identityResolver: A helper to resolve identities based on configuration.
+    ///   - dependencyMapper: A helper to map dependencies.
+    ///   - fileSystem: File system to load from.
+    ///   - observabilityScope: Observability scope to emit diagnostics.
+    ///   - delegateQueue: The dispatch queue to perform the delegate callbacks on.
+    ///   - callbackQueue: The dispatch queue to perform completion handler on.
+    ///   - completion: The completion handler .
+    func load(
+        packagePath: AbsolutePath,
+        packageIdentity: PackageIdentity,
+        packageKind: PackageReference.Kind,
+        packageLocation: String,
+        packageVersion: (version: Version?, revision: String?)?,
+        currentToolsVersion: ToolsVersion,
         identityResolver: IdentityResolver,
         dependencyMapper: DependencyMapper,
         fileSystem: FileSystem,


### PR DESCRIPTION
This PR elevates the default [ManifestLoaderProtocol.load(packagePath...](https://github.com/swiftlang/swift-package-manager/blob/4095b908832f25c492af72728dc6687924978604/Sources/PackageLoading/ManifestLoader.swift#L192-L234) implementation to a protocol requirement, enabling dynamic dispatch for types conforming to the protocol.

### Motivation:

The Workspace class provides a convenient way to fine-tune the manifest loading process by allowing the use of custom loaders. For example, [RegistryAwareManifestLoader](https://github.com/swiftlang/swift-package-manager/blob/4095b908832f25c492af72728dc6687924978604/Sources/Workspace/Workspace%2BRegistry.swift#L55) already enables loading manifests from registries. Similarly, it would be beneficial for other Workspace clients to implement their own manifest loaders to address their specific needs (if you'd like, I could go into the details of our specific need, but I believe it might be irrelevant in the context of this PR).

However, one of the default manifest loading [implementations](https://github.com/swiftlang/swift-package-manager/blob/4095b908832f25c492af72728dc6687924978604/Sources/PackageLoading/ManifestLoader.swift#L192-L234) used by [Workspace](https://github.com/swiftlang/swift-package-manager/blob/4095b908832f25c492af72728dc6687924978604/Sources/Workspace/Workspace%2BManifests.swift#L715-L728) (and other clients as well) is not currently reflected in the protocol requirements, making it impossible for implementers to override due to the static dispatch. To address this, I propose elevating the default implementation to a protocol requirement. This would enable dynamic dispatch for this method, providing greater flexibility for Workspace clients.

### Modifications:

This PR simply copies the signature of the default method implementation in question to the protocol body, while also fixing some outdated documentation along the way. This modification introduces no interface changes, so no adaptations are required at the calling sites.

### Result:

```swift
class MyCustomManifestLoader: ManifestLoaderProtocol { 

    func load(packagePath: AbsolutePath, packageIdentity: PackageIdentity...) {
        // I'll be called now since I'm already dynamically dispatched.
    }
    
    ...

}
```
