### PR TITLE
[android] don't build test summary harness code for android target

### DIFF
--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -349,7 +349,7 @@ private struct _Toolchain: Encodable {
 
 extension Triple {
     public var supportsTestSummary: Bool {
-        return !self.isWindows()
+        return !self.isWindows() && !self.isAndroid()
     }
 }
 


### PR DESCRIPTION
when building tests for an Android target, SPM creates a test summary harness file as well. This file relies on test outpath that exists on the host machine, but not on the android device on which the test is actually running. Therefore, lets disable test observation for Android.

### Motivation:

Before this change the test runner code generated by SPM contains SwiftPMXCTestObserver that refers to the test output path on the host machine, which is incorrect, and doesn't work on Android device.

### Modifications:

Android target no longer supports test summary.

### Result:

After this change my tests work as expected on Android device without SwiftPMXCTestObserver issues.
