### PR TITLE
Disable SwiftVersion development mode

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -59,7 +59,7 @@ extension SwiftVersion {
     /// The current version of the package manager.
     public static let current = SwiftVersion(
         version: (6, 0, 3),
-        isDevelopment: true,
+        isDevelopment: false,
         buildIdentifier: getBuildIdentifier()
     )
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -213,7 +213,10 @@ final class WorkspaceTests: XCTestCase {
                     """
                 )
 
-                XCTAssertMatch(ws.interpreterFlags(for: foo), [.equal("-swift-version"), .equal("6")])
+                XCTAssertMatch(
+                    ws.interpreterFlags(for: foo),
+                    (SwiftVersion.current.isDevelopment) ? [.equal("-swift-version"), .equal("6")] : []
+                )
             }
         }
     }
@@ -4015,7 +4018,7 @@ final class WorkspaceTests: XCTestCase {
                         .sourceControl(url: "https://localhost/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
                         .sourceControl(url: "https://localhost/org/bar", requirement: .upToNextMinor(from: "1.1.0"))
                     ],
-                    toolsVersion: .vNext // change to the one after 5.9
+                    toolsVersion: .v5_10
                 ),
             ],
             packages: [

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -23,6 +23,9 @@ export SWIFTCI_IS_SELF_HOSTED=1
 
 set -x
 
+# Display toolchain version
+swift --version
+
 # Perform package update in order to get the latest commits for the dependencies.
 swift package update
 swift build -c $CONFIGURATION


### PR DESCRIPTION
### Motivation:
Running `swift package --version` indicate it is in development mode, while `swift --release` does not.

```
❯ swift --version  
Apple Swift version 6.0.1 (swift-6.0.1-RELEASE)
Target: arm64-apple-macosx15.0

❯ swift package --version
Swift Package Manager - Swift 6.0.1-dev
```
### Modifications:

Toggling `isDevelopment` boolean to `false` in `SwiftVersion` struct extension.

### Result:
```
❯ swift build --show-bin-path
/Users/bkhouri/Documents/git/public/swiftlang/swift-package-manager/.build/arm64-apple-macosx/debug

❯ /Users/bkhouri/Documents/git/public/swiftlang/swift-package-manager/.build/arm64-apple-macosx/debug/swift-package --version
Swift Package Manager - Swift 6.0.2
```

