### PR TITLE
Don’t write output file map when getting compiler arguments for SourceKit-LSP

### DIFF
--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -719,9 +719,14 @@ public final class SwiftModuleBuildDescription {
         return []
     }
 
-    /// When `scanInvocation` argument is set to `true`, omit the side-effect producing arguments
-    /// such as emitting a module or supplementary outputs.
-    public func emitCommandLine(scanInvocation: Bool = false) throws -> [String] {
+    /// - Parameters:
+    ///   - scanInvocation: When `true`, omit the side-effect producing arguments such as emitting a module or
+    ///     supplementary outputs.
+    ///   - writeOutputFileMap: When `false`, we assume that an output file map for this command line already exists at
+    ///     the expected location on disk. This is intended for SourceKit-LSP to get build settings for a file without
+    ///     writing out an output file map as a side effect. We expect that preparation of the module has already
+    ///     created the output file map.
+    public func emitCommandLine(scanInvocation: Bool = false, writeOutputFileMap: Bool = true) throws -> [String] {
         var result: [String] = []
         result.append(self.buildParameters.toolchain.swiftCompilerPath.pathString)
 
@@ -742,8 +747,12 @@ public final class SwiftModuleBuildDescription {
             result.append(self.moduleOutputPath.pathString)
 
             result.append("-output-file-map")
-            // FIXME: Eliminate side effect.
-            result.append(try self.writeOutputFileMap().pathString)
+            let outputFileMapPath = self.tempsPath.appending("output-file-map.json")
+            if writeOutputFileMap {
+                // FIXME: Eliminate side effect.
+                try self.writeOutputFileMap(to: outputFileMapPath)
+            }
+            result.append(outputFileMapPath.pathString)
         }
 
         if self.useWholeModuleOptimization {
@@ -769,8 +778,7 @@ public final class SwiftModuleBuildDescription {
         self.buildParameters.triple.isDarwin() && self.target.type == .library
     }
 
-    func writeOutputFileMap() throws -> AbsolutePath {
-        let path = self.tempsPath.appending("output-file-map.json")
+    func writeOutputFileMap(to path: AbsolutePath) throws {
         let masterDepsPath = self.tempsPath.appending("master.swiftdeps")
 
         var content =
@@ -852,7 +860,6 @@ public final class SwiftModuleBuildDescription {
 
         try fileSystem.createDirectory(path.parentDirectory, recursive: true)
         try self.fileSystem.writeFileContents(path, bytes: .init(encodingAsUTF8: content), atomically: true)
-        return path
     }
 
     /// Generates the module map for the Swift target and returns its path.

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -376,6 +376,9 @@ extension LLBuildManifestBuilder {
         let cmdName = target.getCommandName()
 
         self.manifest.addWriteSourcesFileListCommand(sources: target.sources, sourcesFileListPath: target.sourcesFileListPath)
+        let outputFileMapPath = target.tempsPath.appending("output-file-map.json")
+        // FIXME: Eliminate side effect.
+        try target.writeOutputFileMap(to: outputFileMapPath)
         self.manifest.addSwiftCmd(
             name: cmdName,
             inputs: inputs + [Node.file(target.sourcesFileListPath)],
@@ -392,7 +395,7 @@ extension LLBuildManifestBuilder {
             fileList: target.sourcesFileListPath,
             isLibrary: isLibrary,
             wholeModuleOptimization: target.useWholeModuleOptimization,
-            outputFileMapPath: try target.writeOutputFileMap(), // FIXME: Eliminate side effect.
+            outputFileMapPath: outputFileMapPath,
             prepareForIndexing: target.buildParameters.prepareForIndexing != .off
         )
     }

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -116,7 +116,7 @@ private struct WrappedSwiftTargetBuildDescription: BuildTarget {
     func compileArguments(for fileURL: URL) throws -> [String] {
         // Note: we ignore the `fileURL` here as the expectation is that we get a command line for the entire target
         // in case of Swift.
-        let commandLine = try description.emitCommandLine(scanInvocation: false)
+        let commandLine = try description.emitCommandLine(scanInvocation: false, writeOutputFileMap: false)
         // First element on the command line is the compiler itself, not an argument.
         return Array(commandLine.dropFirst())
     }


### PR DESCRIPTION
We currently always write the output file map when calling `SwiftModuleBuildDescription.emitCommandLine`. This means that every time SourceKit-LSP queries build settings for a source file, we write the output file map. This is causing issues in SourceKit-LSP on Windows because we might be running a build (eg. for target preparation), which writes an output file map and at the same time try to get build settings for that file inside SourceKit-LSP, which calls into `emitCommandLine`, also trying to write an output file map, which fails because the output file map is exclusively opened by the build and thus cannot also write the output file map.

While this might seem like a more theoretical race condition, this caused multiple tests to fail when running SourceKit-LSP tests locally on my machine.

Work around this by adding a `writeOutputFileMap` argument to `emitCommandLine`, which we can set to `true` for calls from `SourceKitLSPAPI` to avoid writing out the output file map.

Works around #8038.
rdar://137963946
