### PR TITLE
Test: ensure swift-[build|test] emit expected number of fatal error on console

### DIFF
--- a/Fixtures/Miscellaneous/Errors/FatalErrorInSingleXCTest/TypeLibrary/.gitignore
+++ b/Fixtures/Miscellaneous/Errors/FatalErrorInSingleXCTest/TypeLibrary/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Fixtures/Miscellaneous/Errors/FatalErrorInSingleXCTest/TypeLibrary/Package.swift
+++ b/Fixtures/Miscellaneous/Errors/FatalErrorInSingleXCTest/TypeLibrary/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TypeLibrary",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "TypeLibrary",
+            targets: ["TypeLibrary"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "TypeLibrary"),
+        .testTarget(
+            name: "TypeLibraryTests",
+            dependencies: ["TypeLibrary"]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Errors/FatalErrorInSingleXCTest/TypeLibrary/Sources/TypeLibrary/TypeLibrary.swift
+++ b/Fixtures/Miscellaneous/Errors/FatalErrorInSingleXCTest/TypeLibrary/Sources/TypeLibrary/TypeLibrary.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Fixtures/Miscellaneous/Errors/FatalErrorInSingleXCTest/TypeLibrary/Tests/TypeLibraryTests/TypeLibraryTests.swift
+++ b/Fixtures/Miscellaneous/Errors/FatalErrorInSingleXCTest/TypeLibrary/Tests/TypeLibraryTests/TypeLibraryTests.swift
@@ -1,0 +1,5 @@
+func testExample() throws {
+    let x = 0
+    let y = 1 / x
+    print(y)
+}

--- a/Package.swift
+++ b/Package.swift
@@ -873,7 +873,12 @@ if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] ==
                 "Basics",
             ]
         ),
-
+        .testTarget(
+            name: "_InternalTestSupportTests",
+            dependencies: [
+                "_InternalTestSupport"
+            ]
+        ),
         .testTarget(
             name: "CommandsTests",
             dependencies: [

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import Basics
 import struct Foundation.URL
 #if os(macOS)
@@ -465,3 +466,8 @@ extension PackageIdentity: @retroactive ExpressibleByStringInterpolation {}
 extension AbsolutePath: @retroactive ExpressibleByStringLiteral {}
 extension AbsolutePath: @retroactive ExpressibleByStringInterpolation {}
 #endif
+
+public func getNumberOfMatches(of match: String, in value: String) -> Int {
+    guard match.count != 0 else { return 0 }
+    return value.ranges(of: match).count
+}

--- a/Tests/_InternalTestSupportTests/Misc.swift
+++ b/Tests/_InternalTestSupportTests/Misc.swift
@@ -1,0 +1,119 @@
+import _InternalTestSupport
+import XCTest
+
+final class TestGetNumberOfMatches: XCTestCase {
+    func testEmptyStringMatchesOnEmptyStringZeroTimes() {
+        let matchOn = ""
+        let value = ""
+        let expectedNumMatches = 0
+
+        let actual = getNumberOfMatches(of: matchOn, in: value)
+
+        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
+    }
+
+    func testEmptyStringMatchesOnNonEmptySingleLineStringZeroTimes() {
+        let matchOn = ""
+        let value = "This is a non-empty string"
+        let expectedNumMatches = 0
+
+        let actual = getNumberOfMatches(of: matchOn, in: value)
+
+        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
+    }
+
+    func testEmptyStringMatchesOnNonEmptyMultilineStringWithNeLineCharacterZeroTimes() {
+        let matchOn = ""
+        let value = "This is a non-empty string\nThis is the second line"
+        let expectedNumMatches = 0
+
+        let actual = getNumberOfMatches(of: matchOn, in: value)
+
+        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
+    }
+
+    func testEmptyStringMatchesOnNonEmptyMultilineStringUsingTripleDoubleQuotesZeroTimes() {
+        let matchOn = ""
+        let value = """
+        This is a non-empty string
+        This is the second line
+        This is the third line
+        """
+        let expectedNumMatches = 0
+
+        let actual = getNumberOfMatches(of: matchOn, in: value)
+
+        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
+    }
+
+    func testNonEmptyStringMatchesOnEmptyStringReturnsZero() {
+        let matchOn = """
+        This is a non-empty string
+        This is the second line
+        This is the third line
+        """
+        let value = ""
+        let expectedNumMatches = 0
+
+        let actual = getNumberOfMatches(of: matchOn, in: value)
+
+        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
+    }
+
+    func testfatalErrorMatchesOnMultiLineWithTwoOccurencesReturnsTwo() {
+        let matchOn = "error: fatalError"
+        let value = """
+        > swift test                                                                                          25/10/24 10:44:14
+        Building for debugging...
+        /Users/arandomuser/Documents/personal/repro-swiftpm-6605/Tests/repro-swiftpm-6605Tests/repro_swiftpm_6605Tests.swift:7:19: error: division by zero
+                let y = 1 / x
+                        ^
+        error: fatalError
+
+        error: fatalError
+        """
+        let expectedNumMatches = 2
+
+        let actual = getNumberOfMatches(of: matchOn, in: value)
+
+        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
+    }
+
+    func testfatalErrorWithLeadingNewLineMatchesOnMultiLineWithTwoOccurencesReturnsTwo() {
+        let matchOn = "\nerror: fatalError"
+        let value = """
+        > swift test                                                                                          25/10/24 10:44:14
+        Building for debugging...
+        /Users/arandomuser/Documents/personal/repro-swiftpm-6605/Tests/repro-swiftpm-6605Tests/repro_swiftpm_6605Tests.swift:7:19: error: division by zero
+                let y = 1 / x
+                        ^
+        error: fatalError
+
+        error: fatalError
+        """
+        let expectedNumMatches = 2
+
+        let actual = getNumberOfMatches(of: matchOn, in: value)
+
+        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
+    }
+
+    func testfatalErrorWithLeadingAndTrailingNewLineMatchesOnMultiLineWithOneOccurencesReturnsOne() {
+        let matchOn = "\nerror: fatalError\n"
+        let value = """
+        > swift test                                                                                          25/10/24 10:44:14
+        Building for debugging...
+        /Users/arandomuser/Documents/personal/repro-swiftpm-6605/Tests/repro-swiftpm-6605Tests/repro_swiftpm_6605Tests.swift:7:19: error: division by zero
+                let y = 1 / x
+                        ^
+        error: fatalError
+
+        error: fatalError
+        """
+        let expectedNumMatches = 1
+
+        let actual = getNumberOfMatches(of: matchOn, in: value)
+
+        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
+    }
+}


### PR DESCRIPTION
Add an automated tests that ensures swift-build and swift-test emit the expected amount of `error: fatalError` message on the console output.

### Motivation:

Issue #6605  reported `error: fatalError` was emitted twice to the console output, and has since been fixed.  We should ensure the issue does not regress.

### Modifications:

Add an automated tests that verifies `swift-build` does not emit a `error: fatalError` in `stdout` or `stderr` when a building a test that does not compile.

### Result:

```
❯ swift test --filter TestGetNumberOfMatches --filter testFatalErrorDisplayedOnlyOnceWhenSingleXCTestHasFatalErrorInBuildCompilaation
Building for debugging...
[10/10] Linking SwiftPMPackageTests
Build complete! (9.88s)
Test Suite 'Selected tests' started at 2024-10-25 13:59:47.463.
Test Suite 'SwiftPMPackageTests.xctest' started at 2024-10-25 13:59:47.465.
Test Suite 'BuildCommandTests' started at 2024-10-25 13:59:47.465.
Test Case '-[CommandsTests.BuildCommandTests testFatalErrorDisplayedOnlyOnceWhenSingleXCTestHasFatalErrorInBuildCompilaation]' started.
Emitted by Test | /Users/bkhouri/Documents/git/public/swiftlang/swift-package-manager/Tests/CommandsTests/BuildCommandTests.swift:685 | INFO | GIVEN we have a Swift Package that has a fatalError building the tests
Emitted by Test | /Users/bkhouri/Documents/git/public/swiftlang/swift-package-manager/Tests/CommandsTests/BuildCommandTests.swift:687 | INFO | WHEN swift-build --build-tests is executed
Emitted by Test | /Users/bkhouri/Documents/git/public/swiftlang/swift-package-manager/Tests/CommandsTests/BuildCommandTests.swift:689 | INFO | THEN I expect a failure
Emitted by Test | /Users/bkhouri/Documents/git/public/swiftlang/swift-package-manager/Tests/CommandsTests/BuildCommandTests.swift:699 | DEBUG | stdout: "[0/1] Planning build\nBuilding for debugging...\n[0/7] /private/var/folders/1b/57vwczd16h733tf_gzsx7d8c0000gn/T/Miscellaneous_Errors_FatalErrorInSingleXCTest_TypeLibrary.JjD0VE/Miscellaneous_Errors_FatalErrorInSingleXCTest_TypeLibrary/.build/arm64-apple-macosx/debug/TypeLibraryPackageTests.derived/runner.swift\n[1/7] Write sources\n[4/7] Write swift-version-3DF09919E8911743.txt\n[6/9] Emitting module TypeLibrary\n[7/9] Compiling TypeLibrary TypeLibrary.swift\n[8/11] Emitting module TypeLibraryTests\n[9/11] Compiling TypeLibraryTests TypeLibraryTests.swift\n/private/var/folders/1b/57vwczd16h733tf_gzsx7d8c0000gn/T/Miscellaneous_Errors_FatalErrorInSingleXCTest_TypeLibrary.JjD0VE/Miscellaneous_Errors_FatalErrorInSingleXCTest_TypeLibrary/Tests/TypeLibraryTests/TypeLibraryTests.swift:10:15: error: division by zero\n 8 | func testExample() throws {\n 9 |     let x = 0\n10 |     let y = 1 / x\n   |               `- error: division by zero\n11 |     print(y)\n12 | }\n"
Emitted by Test | /Users/bkhouri/Documents/git/public/swiftlang/swift-package-manager/Tests/CommandsTests/BuildCommandTests.swift:700 | DEBUG | stderr: ""
Emitted by Test | /Users/bkhouri/Documents/git/public/swiftlang/swift-package-manager/Tests/CommandsTests/BuildCommandTests.swift:701 | DEBUG | number stdout matches: 0
Emitted by Test | /Users/bkhouri/Documents/git/public/swiftlang/swift-package-manager/Tests/CommandsTests/BuildCommandTests.swift:702 | DEBUG | number stderr matches: 0
Emitted by Test | /Users/bkhouri/Documents/git/public/swiftlang/swift-package-manager/Tests/CommandsTests/BuildCommandTests.swift:704 | INFO | AND a fatal error message is not printed to the console
Test Case '-[CommandsTests.BuildCommandTests testFatalErrorDisplayedOnlyOnceWhenSingleXCTestHasFatalErrorInBuildCompilaation]' passed (3.564 seconds).
Test Suite 'BuildCommandTests' passed at 2024-10-25 13:59:51.029.
         Executed 1 test, with 0 failures (0 unexpected) in 3.564 (3.564) seconds
Test Suite 'TestGetNumberOfMatches' started at 2024-10-25 13:59:51.029.
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testEmptyStringMatchesOnEmptyStringZeroTimes]' started.
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testEmptyStringMatchesOnEmptyStringZeroTimes]' passed (0.000 seconds).
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testEmptyStringMatchesOnNonEmptyMultilineStringUsingTripleDoubleQuotesZeroTimes]' started.
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testEmptyStringMatchesOnNonEmptyMultilineStringUsingTripleDoubleQuotesZeroTimes]' passed (0.000 seconds).
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testEmptyStringMatchesOnNonEmptyMultilineStringWithNeLineCharacterZeroTimes]' started.
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testEmptyStringMatchesOnNonEmptyMultilineStringWithNeLineCharacterZeroTimes]' passed (0.000 seconds).
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testEmptyStringMatchesOnNonEmptySingleLineStringZeroTimes]' started.
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testEmptyStringMatchesOnNonEmptySingleLineStringZeroTimes]' passed (0.000 seconds).
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testfatalErrorMatchesOnMultiLineWithTwoOccurencesReturnsTwo]' started.
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testfatalErrorMatchesOnMultiLineWithTwoOccurencesReturnsTwo]' passed (0.000 seconds).
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testfatalErrorWithLeadingAndTrailingNewLineMatchesOnMultiLineWithOneOccurencesReturnsOne]' started.
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testfatalErrorWithLeadingAndTrailingNewLineMatchesOnMultiLineWithOneOccurencesReturnsOne]' passed (0.000 seconds).
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testfatalErrorWithLeadingNewLineMatchesOnMultiLineWithTwoOccurencesReturnsTwo]' started.
Test Case '-[_InternalTestSupportTests.TestGetNumberOfMatches testfatalErrorWithLeadingNewLineMatchesOnMultiLineWithTwoOccurencesReturnsTwo]' passed (0.000 seconds).
Test Suite 'TestGetNumberOfMatches' passed at 2024-10-25 13:59:51.030.
         Executed 7 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'SwiftPMPackageTests.xctest' passed at 2024-10-25 13:59:51.030.
         Executed 8 tests, with 0 failures (0 unexpected) in 3.565 (3.566) seconds
Test Suite 'Selected tests' passed at 2024-10-25 13:59:51.030.
         Executed 8 tests, with 0 failures (0 unexpected) in 3.565 (3.567) seconds
◇ Test run started.
↳ Testing Library Version: 102 (arm64e-apple-macos13.0)
✔ Test run with 0 tests passed after 0.001 seconds.```