### PR TITLE
Ensure plug-in C modules don't mix with target ones.

### DIFF
--- a/Sources/Build/BuildDescription/ModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ModuleBuildDescription.swift
@@ -192,4 +192,17 @@ extension ModuleBuildDescription {
         }
         return dependencies
     }
+
+    package func recursiveLinkDependencies(using plan: BuildPlan) -> [Dependency] {
+        var dependencies: [Dependency] = []
+        plan.traverseDependencies(of: self) {
+            // Filter out plugin dependencies
+            $0.module?.type != .plugin
+        } onProduct: { product, _, description in
+            dependencies.append(.product(product, description))
+        } onModule: { module, _, description in
+            dependencies.append(.module(module, description))
+        }
+        return dependencies
+    }
 }

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -1018,4 +1018,10 @@ extension SwiftModuleBuildDescription {
     ) -> [ModuleBuildDescription.Dependency] {
         ModuleBuildDescription.swift(self).recursiveDependencies(using: plan)
     }
+
+    package func recursiveLinkDependencies(
+        using plan: BuildPlan
+    ) -> [ModuleBuildDescription.Dependency] {
+        ModuleBuildDescription.swift(self).recursiveLinkDependencies(using: plan)
+    }
 }

--- a/Sources/Build/BuildPlan/BuildPlan+Swift.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Swift.swift
@@ -20,16 +20,13 @@ extension BuildPlan {
     func plan(swiftTarget: SwiftModuleBuildDescription) throws {
         // We need to iterate recursive dependencies because Swift compiler needs to see all the targets a target
         // depends on.
-        for case .module(let dependency, let description) in swiftTarget.recursiveDependencies(using: self) {
+        for case .module(let dependency, let description) in swiftTarget.recursiveLinkDependencies(using: self) {
             switch dependency.underlying {
             case let underlyingTarget as ClangModule where underlyingTarget.type == .library:
                 guard case let .clang(target)? = description else {
                     throw InternalError("unexpected clang target \(underlyingTarget)")
                 }
-                // Only if the targets are for the same destination, i.e. not a plugin for a target target
-                guard target.buildParameters.destination == swiftTarget.buildParameters.destination else {
-                    break
-                }
+
                 // Add the path to modulemap of the dependency. Currently we require that all Clang targets have a
                 // modulemap but we may want to remove that requirement since it is valid for a target to exist without
                 // one. However, in that case it will not be importable in Swift targets. We may want to emit a warning

--- a/Sources/Build/BuildPlan/BuildPlan+Swift.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Swift.swift
@@ -26,6 +26,10 @@ extension BuildPlan {
                 guard case let .clang(target)? = description else {
                     throw InternalError("unexpected clang target \(underlyingTarget)")
                 }
+                // Only if the targets are for the same destination, i.e. not a plugin for a target target
+                guard target.buildParameters.destination == swiftTarget.buildParameters.destination else {
+                    break
+                }
                 // Add the path to modulemap of the dependency. Currently we require that all Clang targets have a
                 // modulemap but we may want to remove that requirement since it is valid for a target to exist without
                 // one. However, in that case it will not be importable in Swift targets. We may want to emit a warning

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -1142,6 +1142,7 @@ extension BuildPlan {
 
     package func traverseDependencies(
         of description: ModuleBuildDescription,
+        filter: (ResolvedModule.Dependency) -> Bool = { _ in true },
         onProduct: (ResolvedProduct, BuildParameters.Destination, ProductBuildDescription?) -> Void,
         onModule: (ResolvedModule, BuildParameters.Destination, ModuleBuildDescription?) -> Void
     ) {
@@ -1163,6 +1164,7 @@ extension BuildPlan {
         ) -> [TraversalNode] {
             module
                 .dependencies(satisfying: description.buildParameters.buildEnvironment)
+                .filter({ filter($0) })
                 .reduce(into: [TraversalNode]()) { partial, dependency in
                     switch dependency {
                     case .product(let product, _):

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -6799,5 +6799,11 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertTrue(exe.additionalFlags.contains(where: { $0.hasSuffix("CLibrary.build/module.modulemap")}))
         // Also ensure the include path isn't there twice
         XCTAssertEqual(exe.additionalFlags.filter({ $0 == "/Pkg/Sources/CLibrary/include" }).count, 1)
+
+        // And make sure the plugin does get the tool version
+        // Note, there are two Tools modules, one for host, one for target.
+        let pluginTool = try XCTUnwrap(result.targetMap.first(where: { $0.module.name == "Tool" && $0.destination == .host })).swift()
+        XCTAssertTrue(pluginTool.additionalFlags.contains(where: { $0.hasSuffix("CLibrary-tool.build/module.modulemap") }))
+        XCTAssertEqual(pluginTool.additionalFlags.filter({ $0 == "/Pkg/Sources/CLibrary/include" }).count, 1)
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -6737,7 +6737,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testHostTargetDontCross() async throws {
+    func testHostTargetCrossingStreams() async throws {
         let fs = InMemoryFileSystem(emptyFiles: [
             "/Pkg/Plugins/CCrossingStreams/plugin.swift",
             "/Pkg/Sources/CLibrary/lib.c",


### PR DESCRIPTION
When a Swift module depends on a C library that is also a dependent of plug-in that the module depends on, we were seeing includes of the module map for both versions of that library, host and target, causing types to be redefined.

This change filters out the plug-in version of these dependencies.
