### PR TITLE
Use async `HTTPClient` in `BinaryArtifactsManager`

### DIFF
--- a/Sources/Basics/Concurrency/ThreadSafeBox.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeBox.swift
@@ -30,6 +30,12 @@ public final class ThreadSafeBox<Value> {
             self.underlying = value
         }
     }
+    
+    public func mutate(body: (inout Value?) throws -> ()) rethrows {
+        try self.lock.withLock {
+            try body(&self.underlying)
+        }
+    }
 
     @discardableResult
     public func memoize(body: () throws -> Value) rethrows -> Value {

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -123,59 +123,67 @@ extension Basics.Diagnostic {
     static func customDependencyMissing(packageName: String) -> Self {
         .warning("dependency '\(packageName)' is missing; retrieving again")
     }
+}
+
+struct BinaryArtifactsManagerError: Error, CustomStringConvertible {
+    let description: String
+
+    private init(description: String) {
+        self.description = description
+    }
 
     static func artifactInvalidArchive(artifactURL: URL, targetName: String) -> Self {
-        .error(
-            "invalid archive returned from '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)'"
+        .init(
+            description: "invalid archive returned from '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)'"
         )
     }
 
     static func artifactChecksumChanged(targetName: String) -> Self {
-        .error(
-            "artifact of binary target '\(targetName)' has changed checksum; this is a potential security risk so the new artifact won't be downloaded"
+        .init(
+            description: "artifact of binary target '\(targetName)' has changed checksum; this is a potential security risk so the new artifact won't be downloaded"
         )
     }
 
     static func artifactInvalidChecksum(targetName: String, expectedChecksum: String, actualChecksum: String?) -> Self {
-        .error(
-            "checksum of downloaded artifact of binary target '\(targetName)' (\(actualChecksum ?? "none")) does not match checksum specified by the manifest (\(expectedChecksum))"
+        .init(
+            description: "checksum of downloaded artifact of binary target '\(targetName)' (\(actualChecksum ?? "none")) does not match checksum specified by the manifest (\(expectedChecksum))"
         )
     }
 
     static func artifactFailedDownload(artifactURL: URL, targetName: String, reason: String) -> Self {
-        .error(
-            "failed downloading '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)': \(reason)"
+        .init(
+            description: "failed downloading '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)': \(reason)"
         )
     }
 
     static func artifactFailedValidation(artifactURL: URL, targetName: String, reason: String) -> Self {
-        .error(
-            "failed validating archive from '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)': \(reason)"
+        .init(
+            description: "failed validating archive from '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)': \(reason)"
         )
     }
 
     static func remoteArtifactFailedExtraction(artifactURL: URL, targetName: String, reason: String) -> Self {
-        .error(
-            "failed extracting '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)': \(reason)"
+        .init(
+            description: "failed extracting '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)': \(reason)"
         )
     }
 
     static func localArtifactFailedExtraction(artifactPath: AbsolutePath, targetName: String, reason: String) -> Self {
-        .error("failed extracting '\(artifactPath)' which is required by binary target '\(targetName)': \(reason)")
+        .init(description: "failed extracting '\(artifactPath)' which is required by binary target '\(targetName)': \(reason)")
     }
 
     static func remoteArtifactNotFound(artifactURL: URL, targetName: String) -> Self {
-        .error(
-            "downloaded archive of binary target '\(targetName)' from '\(artifactURL.absoluteString)' does not contain a binary artifact."
+        .init(
+            description: "downloaded archive of binary target '\(targetName)' from '\(artifactURL.absoluteString)' does not contain a binary artifact."
         )
     }
 
     static func localArchivedArtifactNotFound(archivePath: AbsolutePath, targetName: String) -> Self {
-        .error("local archive of binary target '\(targetName)' at '\(archivePath)' does not contain a binary artifact.")
+        .init(description: "local archive of binary target '\(targetName)' at '\(archivePath)' does not contain a binary artifact.")
     }
 
     static func localArtifactNotFound(artifactPath: AbsolutePath, targetName: String) -> Self {
-        .error("local binary target '\(targetName)' at '\(artifactPath)' does not contain a binary artifact.")
+        .init(description: "local binary target '\(targetName)' at '\(artifactPath)' does not contain a binary artifact.")
     }
 
     static func exhaustedAttempts(missing: [PackageReference]) -> Self {
@@ -189,8 +197,8 @@ extension Basics.Diagnostic {
                 return "'\($0.identity)' at \(path)"
             }
         }
-        return .error(
-            "exhausted attempts to resolve the dependencies graph, with the following dependencies unresolved:\n* \(missing.joined(separator: "\n* "))"
+        return .init(
+            description: "exhausted attempts to resolve the dependencies graph, with the following dependencies unresolved:\n* \(missing.joined(separator: "\n* "))"
         )
     }
 }

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -155,7 +155,10 @@ extension Workspace {
             if !indexFiles.isEmpty {
                 let errors = ThreadSafeArrayStore<Error>()
 
-                zipArtifacts.append(contentsOf: try await withThrowingTaskGroup(of: RemoteArtifact?.self, returning: [RemoteArtifact].self) { group in
+                zipArtifacts.append(contentsOf: try await withThrowingTaskGroup(
+                    of: RemoteArtifact?.self,
+                    returning: [RemoteArtifact].self
+                ) { group in
                     let jsonDecoder = JSONDecoder.makeWithDefaults()
                     for indexFile in indexFiles {
                         group.addTask {

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -164,7 +164,7 @@ extension Workspace {
         // If we have missing packages, something is fundamentally wrong with the resolution of the graph
         let stillMissingPackages = try updatedDependencyManifests.missingPackages
         guard stillMissingPackages.isEmpty else {
-            observabilityScope.emit(.exhaustedAttempts(missing: stillMissingPackages))
+            observabilityScope.emit(BinaryArtifactsManagerError.exhaustedAttempts(missing: stillMissingPackages))
             return nil
         }
 
@@ -600,7 +600,7 @@ extension Workspace {
         // If we still have missing packages, something is fundamentally wrong with the resolution of the graph
         let stillMissingPackages = try updatedDependencyManifests.missingPackages
         guard stillMissingPackages.isEmpty else {
-            observabilityScope.emit(.exhaustedAttempts(missing: stillMissingPackages))
+            observabilityScope.emit(BinaryArtifactsManagerError.exhaustedAttempts(missing: stillMissingPackages))
             return updatedDependencyManifests
         }
 

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -179,7 +179,7 @@ extension Workspace {
 
         // Update the binary target artifacts.
         let addedOrUpdatedPackages = packageStateChanges.compactMap { $0.1.isAddedOrUpdated ? $0.0 : nil }
-        try self.updateBinaryArtifacts(
+        try await self.updateBinaryArtifacts(
             manifests: updatedDependencyManifests,
             addedOrUpdatedPackages: addedOrUpdatedPackages,
             observabilityScope: observabilityScope
@@ -449,7 +449,7 @@ extension Workspace {
             observabilityScope: observabilityScope
         )
 
-        try self.updateBinaryArtifacts(
+        try await self.updateBinaryArtifacts(
             manifests: currentManifests,
             addedOrUpdatedPackages: [],
             observabilityScope: observabilityScope
@@ -548,7 +548,7 @@ extension Workspace {
                     observabilityScope: observabilityScope
                 )
 
-                try self.updateBinaryArtifacts(
+                try await self.updateBinaryArtifacts(
                     manifests: currentManifests,
                     addedOrUpdatedPackages: [],
                     observabilityScope: observabilityScope
@@ -614,7 +614,7 @@ extension Workspace {
         )
 
         let addedOrUpdatedPackages = packageStateChanges.compactMap { $0.1.isAddedOrUpdated ? $0.0 : nil }
-        try self.updateBinaryArtifacts(
+        try await self.updateBinaryArtifacts(
             manifests: updatedDependencyManifests,
             addedOrUpdatedPackages: addedOrUpdatedPackages,
             observabilityScope: observabilityScope

--- a/Sources/_InternalTestSupport/MockHTTPClient.swift
+++ b/Sources/_InternalTestSupport/MockHTTPClient.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -12,24 +12,20 @@
 
 import Basics
 
-extension LegacyHTTPClient {
-    public static func mock(fileSystem: FileSystem) -> LegacyHTTPClient {
-        let handler: LegacyHTTPClient.Handler = { request, _, completion in
+extension HTTPClient {
+    public static func mock(fileSystem: FileSystem) -> HTTPClient {
+        HTTPClient { request, _ in
             switch request.kind {
             case.generic:
-                completion(.success(.okay(body: request.url.absoluteString)))
+                return .okay(body: request.url.absoluteString)
+
             case .download(let fileSystem, let destination):
-                do {
-                    try fileSystem.writeFileContents(
-                        destination,
-                        string: request.url.absoluteString
-                    )
-                    completion(.success(.okay(body: request.url.absoluteString)))
-                } catch {
-                    completion(.failure(error))
-                }
+                try fileSystem.writeFileContents(
+                    destination,
+                    string: request.url.absoluteString
+                )
+                return .okay(body: request.url.absoluteString)
             }
         }
-        return LegacyHTTPClient(handler: handler)
     }
 }

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -128,7 +128,7 @@ public final class MockWorkspace {
         self.sourceControlToRegistryDependencyTransformation = sourceControlToRegistryDependencyTransformation
         self.defaultRegistry = defaultRegistry
         self.customBinaryArtifactsManager = customBinaryArtifactsManager ?? .init(
-            httpClient: LegacyHTTPClient.mock(fileSystem: fileSystem),
+            httpClient: HTTPClient.mock(fileSystem: fileSystem),
             archiver: MockArchiver()
         )
         self.customHostToolchain = try UserToolchain.mockHostToolchain(fileSystem)

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -6023,31 +6023,27 @@ final class WorkspaceTests: XCTestCase {
         let a5FrameworkName = "A5.xcframework"
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                let contents: [UInt8]
-                switch request.url.lastPathComponent {
-                case "a4.zip":
-                    contents = [0xA4]
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: ByteString(contents),
-                    atomically: true
-                )
-
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            let contents: [UInt8]
+            switch request.url.lastPathComponent {
+            case "a4.zip":
+                contents = [0xA4]
+            default:
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString(contents),
+                atomically: true
+            )
+
+            return .okay()
+        }
 
         // create a dummy xcframework directory (with a marker subdirectory) from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -6788,36 +6784,32 @@ final class WorkspaceTests: XCTestCase {
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                let contents: [UInt8]
-                switch request.url.lastPathComponent {
-                case "a1.zip":
-                    contents = [0xA1]
-                case "a2.zip":
-                    contents = [0xA2]
-                case "b.zip":
-                    contents = [0xB0]
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: ByteString(contents),
-                    atomically: true
-                )
-
-                downloads[request.url] = destination
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            let contents: [UInt8]
+            switch request.url.lastPathComponent {
+            case "a1.zip":
+                contents = [0xA1]
+            case "a2.zip":
+                contents = [0xA2]
+            case "b.zip":
+                contents = [0xB0]
+            default:
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString(contents),
+                atomically: true
+            )
+
+            downloads[request.url] = destination
+            return .okay()
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -6981,40 +6973,36 @@ final class WorkspaceTests: XCTestCase {
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                let contents: [UInt8]
-                switch request.url.lastPathComponent {
-                case "a1.zip":
-                    contents = [0xA1]
-                case "a2.zip":
-                    contents = [0xA2]
-                case "a3.zip":
-                    contents = [0xA3]
-                case "a7.zip":
-                    contents = [0xA7]
-                case "b.zip":
-                    contents = [0xB0]
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: ByteString(contents),
-                    atomically: true
-                )
-
-                downloads[request.url] = destination
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            let contents: [UInt8]
+            switch request.url.lastPathComponent {
+            case "a1.zip":
+                contents = [0xA1]
+            case "a2.zip":
+                contents = [0xA2]
+            case "a3.zip":
+                contents = [0xA3]
+            case "a7.zip":
+                contents = [0xA7]
+            case "b.zip":
+                contents = [0xB0]
+            default:
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString(contents),
+                atomically: true
+            )
+
+            downloads[request.url] = destination
+            return .okay()
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -7293,32 +7281,28 @@ final class WorkspaceTests: XCTestCase {
         let downloads = ThreadSafeArrayStore<(URL, AbsolutePath)>()
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                let contents: [UInt8]
-                switch request.url.lastPathComponent {
-                case "a1.zip":
-                    contents = [0xA1]
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: ByteString(contents),
-                    atomically: true
-                )
-
-                downloads.append((request.url, destination))
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            let contents: [UInt8]
+            switch request.url.lastPathComponent {
+            case "a1.zip":
+                contents = [0xA1]
+            default:
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString(contents),
+                atomically: true
+            )
+
+            downloads.append((request.url, destination))
+            return .okay()
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -7419,24 +7403,20 @@ final class WorkspaceTests: XCTestCase {
         try fs.createDirectory(sandbox, recursive: true)
         let artifactUrl = "https://a.com/a.zip"
 
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                // mimics URLSession behavior which write the file even if sends an error message
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: "not found",
-                    atomically: true
-                )
-
-                completion(.success(.notFound()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            // mimics URLSession behavior which write the file even if sends an error message
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: "not found",
+                atomically: true
+            )
+
+            return .notFound()
+        }
 
         let workspace = try await MockWorkspace(
             sandbox: sandbox,
@@ -7491,28 +7471,24 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                switch request.url {
-                case "https://a.com/a1.zip":
-                    completion(.success(.serverError()))
-                case "https://a.com/a2.zip":
-                    try fileSystem.writeFileContents(destination, bytes: ByteString([0xA2]))
-                    completion(.success(.okay()))
-                case "https://a.com/a3.zip":
-                    try fileSystem.writeFileContents(destination, bytes: "different contents = different checksum")
-                    completion(.success(.okay()))
-                default:
-                    throw StringError("unexpected url")
-                }
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            switch request.url {
+            case "https://a.com/a1.zip":
+                return .serverError()
+            case "https://a.com/a2.zip":
+                try fileSystem.writeFileContents(destination, bytes: ByteString([0xA2]))
+                return .okay()
+            case "https://a.com/a3.zip":
+                try fileSystem.writeFileContents(destination, bytes: "different contents = different checksum")
+                return .okay()
+            default:
+                throw StringError("unexpected url")
+            }
+        }
 
         let archiver = MockArchiver(handler: { _, _, destinationPath, completion in
             XCTAssertEqual(destinationPath.parentDirectory, AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A2"))
@@ -7582,29 +7558,25 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                switch request.url {
-                case "https://a.com/a1.zip":
-                    try fileSystem.writeFileContents(destination, bytes: ByteString([0xA1]))
-                    completion(.success(.okay()))
-                case "https://a.com/a2.zip":
-                    try fileSystem.writeFileContents(destination, bytes: ByteString([0xA2]))
-                    completion(.success(.okay()))
-                case "https://a.com/a3.zip":
-                    try fileSystem.writeFileContents(destination, bytes: ByteString([0xA3]))
-                    completion(.success(.okay()))
-                default:
-                    throw StringError("unexpected url")
-                }
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            switch request.url {
+            case "https://a.com/a1.zip":
+                try fileSystem.writeFileContents(destination, bytes: ByteString([0xA1]))
+                return .okay()
+            case "https://a.com/a2.zip":
+                try fileSystem.writeFileContents(destination, bytes: ByteString([0xA2]))
+                return .okay()
+            case "https://a.com/a3.zip":
+                try fileSystem.writeFileContents(destination, bytes: ByteString([0xA3]))
+                return .okay()
+            default:
+                throw StringError("unexpected url")
+            }
+        }
 
         let archiver = MockArchiver(
             extractionHandler: { archiver, archivePath, destinationPath, completion in
@@ -7694,23 +7666,19 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                switch request.url {
-                case "https://a.com/a1.zip":
-                    try fileSystem.writeFileContents(destination, bytes: ByteString([0xA1]))
-                    completion(.success(.okay()))
-                default:
-                    throw StringError("unexpected url")
-                }
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            switch request.url {
+            case "https://a.com/a1.zip":
+                try fileSystem.writeFileContents(destination, bytes: ByteString([0xA1]))
+                return .okay()
+            default:
+                throw StringError("unexpected url")
+            }
+        }
 
         let archiver = MockArchiver(
             extractionHandler: { _, archivePath, destinationPath, completion in
@@ -7769,23 +7737,19 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                switch request.url {
-                case "https://a.com/foo.zip":
-                    try fileSystem.writeFileContents(destination, bytes: ByteString([0xA1]))
-                    completion(.success(.okay()))
-                default:
-                    throw StringError("unexpected url")
-                }
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            switch request.url {
+            case "https://a.com/foo.zip":
+                try fileSystem.writeFileContents(destination, bytes: ByteString([0xA1]))
+                return .okay()
+            default:
+                throw StringError("unexpected url")
+            }
+        }
 
         let archiver = MockArchiver(
             extractionHandler: { _, archivePath, destinationPath, completion in
@@ -7919,9 +7883,9 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
-        let httpClient = LegacyHTTPClient(handler: { _, _, _ in
-            XCTFail("should not be called")
-        })
+        let httpClient = HTTPClient { _, _ in
+            throw StringError("should not be called")
+        }
 
         let workspace = try await MockWorkspace(
             sandbox: sandbox,
@@ -7971,33 +7935,29 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                let contents: [UInt8]
-                switch request.url.lastPathComponent {
-                case "a.zip":
-                    contents = [0xA1]
-                case "b.zip":
-                    contents = [0xB1]
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: ByteString(contents),
-                    atomically: true
-                )
-
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            let contents: [UInt8]
+            switch request.url.lastPathComponent {
+            case "a.zip":
+                contents = [0xA1]
+            case "b.zip":
+                contents = [0xB1]
+            default:
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString(contents),
+                atomically: true
+            )
+
+            return .okay()
+        }
 
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
             do {
@@ -8065,35 +8025,31 @@ final class WorkspaceTests: XCTestCase {
     func testArtifactDownloadAddsAcceptHeader() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
-        var acceptHeaders: [String] = []
+        let acceptHeaders = ThreadSafeBox([String]())
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-                acceptHeaders.append(request.headers.get("accept").first!)
-
-                let contents: [UInt8]
-                switch request.url.lastPathComponent {
-                case "a1.zip":
-                    contents = [0xA1]
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: ByteString(contents),
-                    atomically: true
-                )
-
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+            acceptHeaders.mutate { $0?.append(request.headers.get("accept").first!) }
+
+            let contents: [UInt8]
+            switch request.url.lastPathComponent {
+            case "a1.zip":
+                contents = [0xA1]
+            default:
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString(contents),
+                atomically: true
+            )
+
+            return .okay()
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -8136,7 +8092,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssertEqual(acceptHeaders, [
+            XCTAssertEqual(acceptHeaders.get(), [
                 "application/octet-stream",
             ])
         }
@@ -8145,35 +8101,31 @@ final class WorkspaceTests: XCTestCase {
     func testDownloadedArtifactNoCache() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
-        var downloads = 0
+        let downloads = ThreadSafeBox(0)
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                let contents: [UInt8]
-                switch request.url.lastPathComponent {
-                case "a1.zip":
-                    contents = [0xA1]
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: ByteString(contents),
-                    atomically: true
-                )
-
-                downloads += 1
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            let contents: [UInt8]
+            switch request.url.lastPathComponent {
+            case "a1.zip":
+                contents = [0xA1]
+            default:
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString(contents),
+                atomically: true
+            )
+
+            downloads.increment()
+            return .okay()
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -8218,55 +8170,51 @@ final class WorkspaceTests: XCTestCase {
         // should not come from cache
         try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssertEqual(downloads, 1)
+            XCTAssertEqual(downloads.get(), 1)
         }
 
         // state is there, should not come from local cache
         try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssertEqual(downloads, 1)
+            XCTAssertEqual(downloads.get(), 1)
         }
 
         // resetting state, should not come from global cache
         try workspace.resetState()
         try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssertEqual(downloads, 2)
+            XCTAssertEqual(downloads.get(), 2)
         }
     }
 
     func testDownloadedArtifactCache() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
-        var downloads = 0
+        let downloads = ThreadSafeBox(0)
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                let contents: [UInt8]
-                switch request.url.lastPathComponent {
-                case "a1.zip":
-                    contents = [0xA1]
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: ByteString(contents),
-                    atomically: true
-                )
-
-                downloads += 1
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            let contents: [UInt8]
+            switch request.url.lastPathComponent {
+            case "a1.zip":
+                contents = [0xA1]
+            default:
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString(contents),
+                atomically: true
+            )
+
+            downloads.increment()
+            return .okay()
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -8311,20 +8259,20 @@ final class WorkspaceTests: XCTestCase {
         // should not come from cache
         try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssertEqual(downloads, 1)
+            XCTAssertEqual(downloads.get(), 1)
         }
 
         // state is there, should not come from local cache
         try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssertEqual(downloads, 1)
+            XCTAssertEqual(downloads.get(), 1)
         }
 
         // resetting state, should come from global cache
         try workspace.resetState()
         try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssertEqual(downloads, 1)
+            XCTAssertEqual(downloads.get(), 1)
         }
 
         // delete global cache, should download again
@@ -8332,14 +8280,14 @@ final class WorkspaceTests: XCTestCase {
         try fs.removeFileTree(fs.swiftPMCacheDirectory)
         try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssertEqual(downloads, 2)
+            XCTAssertEqual(downloads.get(), 2)
         }
 
         // resetting state, should come from global cache again
         try workspace.resetState()
         try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssertEqual(downloads, 2)
+            XCTAssertEqual(downloads.get(), 2)
         }
     }
 
@@ -8349,35 +8297,31 @@ final class WorkspaceTests: XCTestCase {
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                let contents: [UInt8]
-                switch request.url.lastPathComponent {
-                case "a.zip":
-                    contents = [0xA]
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: ByteString(contents),
-                    atomically: true
-                )
-
-                if downloads[request.url] != nil {
-                    throw StringError("\(request.url) already requested")
-                }
-                downloads[request.url] = destination
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            let contents: [UInt8]
+            switch request.url.lastPathComponent {
+            case "a.zip":
+                contents = [0xA]
+            default:
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString(contents),
+                atomically: true
+            )
+
+            if downloads[request.url] != nil {
+                throw StringError("\(request.url) already requested")
+            }
+            downloads[request.url] = destination
+            return .okay()
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -8530,41 +8474,37 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                // this is to test the test's integrity, as it relied on internal knowledge of the destination path construction
-                guard expectedDownloadDestination == destination else {
-                    throw StringError("expected destination of \(expectedDownloadDestination)")
-                }
-
-                let contents: [UInt8]
-                switch request.url.lastPathComponent {
-                case "binary.zip":
-                    contents = [0x01]
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-
-                // in-memory fs does not check for this!
-                if fileSystem.exists(destination) {
-                    throw StringError("\(destination) already exists")
-                }
-
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: ByteString(contents),
-                    atomically: true
-                )
-
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            // this is to test the test's integrity, as it relied on internal knowledge of the destination path construction
+            guard expectedDownloadDestination == destination else {
+                throw StringError("expected destination of \(expectedDownloadDestination)")
+            }
+
+            let contents: [UInt8]
+            switch request.url.lastPathComponent {
+            case "binary.zip":
+                contents = [0x01]
+            default:
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            // in-memory fs does not check for this!
+            if fileSystem.exists(destination) {
+                throw StringError("\(destination) already exists")
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString(contents),
+                atomically: true
+            )
+
+            return .okay()
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -8637,42 +8577,34 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         let maxConcurrentRequests = 2
-        var concurrentRequests = 0
+        let concurrentRequests = ThreadSafeBox(0)
         let concurrentRequestsLock = NSLock()
 
-        var configuration = LegacyHTTPClient.Configuration()
+        var configuration = HTTPClient.Configuration()
         configuration.maxConcurrentRequests = maxConcurrentRequests
-        let httpClient = LegacyHTTPClient(configuration: configuration, handler: { request, _, completion in
+        let httpClient = HTTPClient(configuration: configuration) { request, _ in
             defer {
-                concurrentRequestsLock.withLock {
-                    concurrentRequests -= 1
-                }
+                concurrentRequests.decrement()
             }
 
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                concurrentRequestsLock.withLock {
-                    concurrentRequests += 1
-                    if concurrentRequests > maxConcurrentRequests {
-                        XCTFail("too many concurrent requests \(concurrentRequests), expected \(maxConcurrentRequests)")
-                    }
-                }
-
-                // returns a dummy zipfile for the requested artifact
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: [0x01],
-                    atomically: true
-                )
-
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            concurrentRequests.increment()
+            if concurrentRequests.get()! > maxConcurrentRequests {
+                XCTFail("too many concurrent requests \(concurrentRequests), expected \(maxConcurrentRequests)")
+            }
+
+            // returns a dummy zipfile for the requested artifact
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: [0x01],
+                atomically: true
+            )
+
+            return .okay()
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { _, archivePath, destinationPath, completion in
@@ -8759,36 +8691,32 @@ final class WorkspaceTests: XCTestCase {
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                let contents: [UInt8]
-                switch request.url.lastPathComponent {
-                case "flat.zip":
-                    contents = [0x01]
-                case "nested.zip":
-                    contents = [0x02]
-                case "nested2.zip":
-                    contents = [0x03]
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: ByteString(contents),
-                    atomically: true
-                )
-
-                downloads[request.url] = destination
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            let contents: [UInt8]
+            switch request.url.lastPathComponent {
+            case "flat.zip":
+                contents = [0x01]
+            case "nested.zip":
+                contents = [0x02]
+            case "nested2.zip":
+                contents = [0x03]
+            default:
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString(contents),
+                atomically: true
+            )
+
+            downloads[request.url] = destination
+            return .okay()
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -8923,34 +8851,30 @@ final class WorkspaceTests: XCTestCase {
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
         // returns a dummy zipfile for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                guard case .download(let fileSystem, let destination) = request.kind else {
-                    throw StringError("invalid request \(request.kind)")
-                }
-
-                let contents: [UInt8]
-                switch request.url.lastPathComponent {
-                case "a1.xcframework.zip":
-                    contents = [0xA1]
-                case "a2.zip.zip":
-                    contents = [0xA2]
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-
-                try fileSystem.writeFileContents(
-                    destination,
-                    bytes: ByteString(contents),
-                    atomically: true
-                )
-
-                downloads[request.url] = destination
-                completion(.success(.okay()))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
             }
-        })
+
+            let contents: [UInt8]
+            switch request.url.lastPathComponent {
+            case "a1.xcframework.zip":
+                contents = [0xA1]
+            case "a2.zip.zip":
+                contents = [0xA2]
+            default:
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString(contents),
+                atomically: true
+            )
+
+            downloads[request.url] = destination
+            return .okay()
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -9127,50 +9051,43 @@ final class WorkspaceTests: XCTestCase {
         let ariFilesChecksums = ariFiles.map { checksumAlgorithm.hash($0).hexadecimalRepresentation }
 
         // returns a dummy file for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
+        let httpClient = HTTPClient { request, _ in
             switch request.kind {
             case .generic:
-                do {
-                    let contents: String
-                    switch request.url.lastPathComponent {
-                    case "a1.artifactbundleindex":
-                        contents = ariFiles[0]
-                    case "a2.artifactbundleindex":
-                        contents = ariFiles[1]
-                    default:
-                        throw StringError("unexpected url \(request.url)")
-                    }
-                    completion(.success(.okay(body: contents)))
-                } catch {
-                    completion(.failure(error))
+                let contents: String
+                switch request.url.lastPathComponent {
+                case "a1.artifactbundleindex":
+                    contents = ariFiles[0]
+                case "a2.artifactbundleindex":
+                    contents = ariFiles[1]
+                default:
+                    throw StringError("unexpected url \(request.url)")
                 }
+                return .okay(body: contents)
+
             case .download(let fileSystem, let destination):
-                do {
-                    let contents: [UInt8]
-                    switch request.url.lastPathComponent {
-                    case "a1.zip":
-                        contents = [0xA1]
-                    case "a2.zip":
-                        contents = [0xA2]
-                    case "b.zip":
-                        contents = [0xB0]
-                    default:
-                        throw StringError("unexpected url \(request.url)")
-                    }
-
-                    try fileSystem.writeFileContents(
-                        destination,
-                        bytes: ByteString(contents),
-                        atomically: true
-                    )
-
-                    downloads[request.url] = destination
-                    completion(.success(.okay()))
-                } catch {
-                    completion(.failure(error))
+                let contents: [UInt8]
+                switch request.url.lastPathComponent {
+                case "a1.zip":
+                    contents = [0xA1]
+                case "a2.zip":
+                    contents = [0xA2]
+                case "b.zip":
+                    contents = [0xB0]
+                default:
+                    throw StringError("unexpected url \(request.url)")
                 }
+
+                try fileSystem.writeFileContents(
+                    destination,
+                    bytes: ByteString(contents),
+                    atomically: true
+                )
+
+                downloads[request.url] = destination
+                return .okay()
             }
-        })
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -9343,9 +9260,9 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         // returns a dummy files for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { _, _, completion in
-            completion(.success(.serverError()))
-        })
+        let httpClient = HTTPClient { _, _ in
+            return .serverError()
+        }
 
         let workspace = try await MockWorkspace(
             sandbox: sandbox,
@@ -9402,20 +9319,16 @@ final class WorkspaceTests: XCTestCase {
         let ariChecksums = checksumAlgorithm.hash(ari).hexadecimalRepresentation
 
         // returns a dummy files for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                let contents: String
-                switch request.url.lastPathComponent {
-                case "a.artifactbundleindex":
-                    contents = ari
-                default:
-                    throw StringError("unexpected url \(request.url)")
-                }
-                completion(.success(.okay(body: contents)))
-            } catch {
-                completion(.failure(error))
+        let httpClient = HTTPClient { request, _ in
+            let contents: String
+            switch request.url.lastPathComponent {
+            case "a.artifactbundleindex":
+                contents = ari
+            default:
+                throw StringError("unexpected url \(request.url)")
             }
-        })
+            return .okay(body: contents)
+        }
 
         let workspace = try await MockWorkspace(
             sandbox: sandbox,
@@ -9522,41 +9435,37 @@ final class WorkspaceTests: XCTestCase {
         let ariChecksums = checksumAlgorithm.hash(ari).hexadecimalRepresentation
 
         // returns a dummy files for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                switch request.kind {
-                case .generic:
-                    let contents: String
-                    switch request.url.lastPathComponent {
-                    case "a.artifactbundleindex":
-                        contents = ari
-                    default:
-                        throw StringError("unexpected url \(request.url)")
-                    }
-
-                    completion(.success(.okay(body: contents)))
-
-                case .download(let fileSystem, let destination):
-                    let contents: [UInt8]
-                    switch request.url.lastPathComponent {
-                    case "a.zip":
-                        contents = [0x42]
-                    default:
-                        throw StringError("unexpected url \(request.url)")
-                    }
-
-                    try fileSystem.writeFileContents(
-                        destination,
-                        bytes: ByteString(contents),
-                        atomically: true
-                    )
-
-                    completion(.success(.okay()))
+        let httpClient = HTTPClient { request, _ in
+            switch request.kind {
+            case .generic:
+                let contents: String
+                switch request.url.lastPathComponent {
+                case "a.artifactbundleindex":
+                    contents = ari
+                default:
+                    throw StringError("unexpected url \(request.url)")
                 }
-            } catch {
-                completion(.failure(error))
+
+                return .okay(body: contents)
+
+            case .download(let fileSystem, let destination):
+                let contents: [UInt8]
+                switch request.url.lastPathComponent {
+                case "a.zip":
+                    contents = [0x42]
+                default:
+                    throw StringError("unexpected url \(request.url)")
+                }
+
+                try fileSystem.writeFileContents(
+                    destination,
+                    bytes: ByteString(contents),
+                    atomically: true
+                )
+
+                return .okay()
             }
-        })
+        }
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -9633,26 +9542,22 @@ final class WorkspaceTests: XCTestCase {
         let ariChecksums = checksumAlgorithm.hash(ari).hexadecimalRepresentation
 
         // returns a dummy files for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
-                switch request.kind {
-                case .generic:
-                    let contents: String
-                    switch request.url.lastPathComponent {
-                    case "a.artifactbundleindex":
-                        contents = ari
-                    default:
-                        throw StringError("unexpected url \(request.url)")
-                    }
-                    completion(.success(.okay(body: contents)))
-
-                case .download:
-                    completion(.success(.notFound()))
+        let httpClient = HTTPClient { request, _ in
+            switch request.kind {
+            case .generic:
+                let contents: String
+                switch request.url.lastPathComponent {
+                case "a.artifactbundleindex":
+                    contents = ari
+                default:
+                    throw StringError("unexpected url \(request.url)")
                 }
-            } catch {
-                completion(.failure(error))
+                return .okay(body: contents)
+
+            case .download:
+                return .notFound()
             }
-        })
+        }
 
         let workspace = try await MockWorkspace(
             sandbox: sandbox,
@@ -9713,8 +9618,7 @@ final class WorkspaceTests: XCTestCase {
         let ariChecksum = checksumAlgorithm.hash(ari).hexadecimalRepresentation
 
         // returns a dummy files for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            do {
+        let httpClient = HTTPClient { request, _ in
                 let contents: String
                 switch request.url.lastPathComponent {
                 case "a.artifactbundleindex":
@@ -9722,11 +9626,8 @@ final class WorkspaceTests: XCTestCase {
                 default:
                     throw StringError("unexpected url \(request.url)")
                 }
-                completion(.success(.okay(body: contents)))
-            } catch {
-                completion(.failure(error))
-            }
-        })
+                return .okay(body: contents)
+        }
 
         let workspace = try await MockWorkspace(
             sandbox: sandbox,


### PR DESCRIPTION
### Motivation:

To adopt Swift concurrency in `ManifestLoader`, we need to convert `RegistryClient` first, which then would require use of `HTTPClient` instead of `LegacyHTTPClient`. That would also cascade to `BinaryArtifactsManager`, so I'm starting there first to make PRs smaller.

### Modifications:

Converted (and as a consequence, simplified) code in `Workspace+BinaryArtifacts.swift`, also adopted `HTTPClient` in `WorkspaceTests` to fix tests after the change.

Converted some error diagnostics to conform to `Error`, which makes control flow with `ObservabilityScope.trap` wrapper easier to write and read.

### Result:

One major previous adopter of `LegacyHTTPClient` is now compatible with Swift concurrency.

Since `BinaryArtifactsManager` was blocking Swift concurrency thread pool and also used `.sharedConcurrent` dispatch queue, this potentially fixes thread explosion/deadlocks that may have been caused by previously broken code.
