### PR TITLE
Fix initial manifest caching with nested scratch dir and local cache

### DIFF
--- a/Sources/Basics/SQLiteBackedCache.swift
+++ b/Sources/Basics/SQLiteBackedCache.swift
@@ -238,7 +238,7 @@ package final class SQLiteBackedCache<Value: Codable>: Closable {
         switch self.location {
         case .path(let path):
             if !self.fileSystem.exists(path.parentDirectory) {
-                try self.fileSystem.createDirectory(path.parentDirectory)
+                try self.fileSystem.createDirectory(path.parentDirectory, recursive: true)
             }
             return try self.fileSystem.withLock(on: path, type: .exclusive, body)
         case .memory, .temporary:

--- a/Tests/BasicsTests/SQLiteBackedCacheTests.swift
+++ b/Tests/BasicsTests/SQLiteBackedCacheTests.swift
@@ -182,6 +182,24 @@ final class SQLiteBackedCacheTests: XCTestCase {
             }
         }
     }
+
+    func testInitialFileCreation() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let paths = [
+                tmpPath.appending("foo", "test.db"),
+                // Ensure it works recursively.
+                tmpPath.appending("bar", "baz", "test.db"),
+            ]
+
+            for path in paths {
+                let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)
+                // Put an entry to ensure the file is created.
+                XCTAssertNoThrow(try cache.put(key: "foo", value: "bar"))
+                XCTAssertNoThrow(try cache.close())
+                XCTAssertTrue(localFileSystem.exists(path), "expected file to be created at \(path)")
+            }
+        }
+    }
 }
 
 private func makeMockData(fileSystem: FileSystem, rootPath: AbsolutePath, count: Int = Int.random(in: 50 ..< 100)) throws -> [String: String] {


### PR DESCRIPTION
### Motivation:

When `--scratch-path` is set to a directory whose parent directory does not exist and `--manifest-cache local` is set, the initial manifest cache creation fails with the following warning:

```
warning: 'tmp.vulugm1mqv': failed loading cached manifest for 'tmp.vulugm1mqv': Error Domain=NSCocoaErrorDomain Code=4 "The file “check” doesn’t exist." UserInfo={NSFilePath=/private/var/folders/k2/q6yzck31253_q1j4kxkzq5jh0000gn/T/tmp.vUlUgM1Mqv/.build/check, NSUnderlyingError=0x600001072ac0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
warning: 'tmp.vulugm1mqv': failed storing manifest for 'tmp.vulugm1mqv' in cache: Error Domain=NSCocoaErrorDomain Code=4 "The file “check” doesn’t exist." UserInfo={NSFilePath=/private/var/folders/k2/q6yzck31253_q1j4kxkzq5jh0000gn/T/tmp.vUlUgM1Mqv/.build/check, NSUnderlyingError=0x600001078060 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
warning: 'tmp.vulugm1mqv': failed closing manifest db cache: Error Domain=NSCocoaErrorDomain Code=4 "The file “check” doesn’t exist." UserInfo={NSFilePath=/private/var/folders/k2/q6yzck31253_q1j4kxkzq5jh0000gn/T/tmp.vUlUgM1Mqv/.build/check, NSUnderlyingError=0x600001078360 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
```

This is because directory creation in the manifest.db file creation process is not recursive. 

### Modifications:

This patch fixes the issue by making the directory creation recursive.

### Result:

The following command sequence should work without warnings.

```console
$ swift package init
$ swift package dump-package --manifest-cache local  --scratch-path .build/check
```