### PR TITLE
Tests: Convert some WorkspaceTests module tests to Swift Testing

### DIFF
--- a/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
+++ b/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
@@ -13,10 +13,11 @@
 import Basics
 import _InternalTestSupport
 import Workspace
-import XCTest
+import Testing
 
-final class MirrorsConfigurationTests: XCTestCase {
-    func testLoadingSchema1() throws {
+fileprivate struct MirrorsConfigurationTests {
+    @Test
+    func loadingSchema1() throws {
         let fs = InMemoryFileSystem()
         let configFile = AbsolutePath("/config/mirrors.json")
 
@@ -42,30 +43,33 @@ final class MirrorsConfigurationTests: XCTestCase {
         let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
         let mirrors = try config.get()
 
-        XCTAssertEqual(mirrors.mirror(for: originalURL),mirrorURL)
-        XCTAssertEqual(mirrors.original(for: mirrorURL), originalURL)
+        #expect(mirrors.mirror(for: originalURL) == mirrorURL)
+        #expect(mirrors.original(for: mirrorURL) == originalURL)
     }
 
-    func testThrowsWhenNotFound() throws {
+    @Test
+    func throwsWhenNotFound() throws {
+        let gitUrl = "https://github.com/apple/swift-argument-parser.git"
         let fs = InMemoryFileSystem()
         let configFile = AbsolutePath("/config/mirrors.json")
 
         let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
         let mirrors = try config.get()
 
-        XCTAssertThrows(StringError("Mirror not found for 'https://github.com/apple/swift-argument-parser.git'")) {
-            try mirrors.unset(originalOrMirror: "https://github.com/apple/swift-argument-parser.git")
+        #expect(throws: StringError("Mirror not found for '\(gitUrl)'")) {
+            try mirrors.unset(originalOrMirror: gitUrl)
         }
     }
 
-    func testDeleteWhenEmpty() throws {
+    @Test
+    func deleteWhenEmpty() throws {
         let fs = InMemoryFileSystem()
         let configFile = AbsolutePath("/config/mirrors.json")
 
         let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
 
         try config.apply{ _ in }
-        XCTAssertFalse(fs.exists(configFile))
+        #expect(!fs.exists(configFile))
 
         let originalURL = "https://github.com/apple/swift-argument-parser.git"
         let mirrorURL = "https://github.com/mona/swift-argument-parser.git"
@@ -73,22 +77,23 @@ final class MirrorsConfigurationTests: XCTestCase {
         try config.apply{ mirrors in
             try mirrors.set(mirror: mirrorURL, for: originalURL)
         }
-        XCTAssertTrue(fs.exists(configFile))
+        #expect(fs.exists(configFile))
 
         try config.apply{ mirrors in
             try mirrors.unset(originalOrMirror: originalURL)
         }
-        XCTAssertFalse(fs.exists(configFile))
+        #expect(!fs.exists(configFile))
     }
 
-    func testDontDeleteWhenEmpty() throws {
+    @Test
+    func dontDeleteWhenEmpty() throws {
         let fs = InMemoryFileSystem()
         let configFile = AbsolutePath("/config/mirrors.json")
 
         let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: false)
 
         try config.apply{ _ in }
-        XCTAssertFalse(fs.exists(configFile))
+        #expect(!fs.exists(configFile))
 
         let originalURL = "https://github.com/apple/swift-argument-parser.git"
         let mirrorURL = "https://github.com/mona/swift-argument-parser.git"
@@ -96,16 +101,17 @@ final class MirrorsConfigurationTests: XCTestCase {
         try config.apply{ mirrors in
             try mirrors.set(mirror: mirrorURL, for: originalURL)
         }
-        XCTAssertTrue(fs.exists(configFile))
+        #expect(fs.exists(configFile))
 
         try config.apply{ mirrors in
             try mirrors.unset(originalOrMirror: originalURL)
         }
-        XCTAssertTrue(fs.exists(configFile))
-        XCTAssertTrue(try config.get().isEmpty)
+        #expect(fs.exists(configFile))
+        #expect(try config.get().isEmpty)
     }
 
-    func testLocalAndShared() throws {
+    @Test
+    func localAndShared() throws {
         let fs = InMemoryFileSystem()
         let localConfigFile = AbsolutePath("/config/local-mirrors.json")
         let sharedConfigFile = AbsolutePath("/config/shared-mirrors.json")
@@ -125,9 +131,9 @@ final class MirrorsConfigurationTests: XCTestCase {
             try mirrors.set(mirror: mirror1URL, for: original1URL)
         }
 
-        XCTAssertEqual(config.mirrors.count, 1)
-        XCTAssertEqual(config.mirrors.mirror(for: original1URL), mirror1URL)
-        XCTAssertEqual(config.mirrors.original(for: mirror1URL), original1URL)
+        #expect(config.mirrors.count == 1)
+        #expect(config.mirrors.mirror(for: original1URL) == mirror1URL)
+        #expect(config.mirrors.original(for: mirror1URL) == original1URL)
 
         // now write to local location
 
@@ -138,12 +144,12 @@ final class MirrorsConfigurationTests: XCTestCase {
             try mirrors.set(mirror: mirror2URL, for: original2URL)
         }
 
-        XCTAssertEqual(config.mirrors.count, 1)
-        XCTAssertEqual(config.mirrors.mirror(for: original2URL), mirror2URL)
-        XCTAssertEqual(config.mirrors.original(for: mirror2URL), original2URL)
+        #expect(config.mirrors.count == 1)
+        #expect(config.mirrors.mirror(for: original2URL) == mirror2URL)
+        #expect(config.mirrors.original(for: mirror2URL) == original2URL)
 
         // should not see the shared any longer
-        XCTAssertEqual(config.mirrors.mirror(for: original1URL), nil)
-        XCTAssertEqual(config.mirrors.original(for: mirror1URL), nil)
+        #expect(config.mirrors.mirror(for: original1URL) == nil)
+        #expect(config.mirrors.original(for: mirror1URL) == nil)
     }
 }

--- a/Tests/WorkspaceTests/ToolsVersionSpecificationGenerationTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionSpecificationGenerationTests.swift
@@ -9,36 +9,45 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 ///
 /// This file tests the generation of a Swift tools version specification from a known version.
 ///
 
-import XCTest
+import Testing
 import PackageModel
 
 import struct TSCUtility.Version
 
 /// Test cases for the generation of Swift tools version specifications.
-class ToolsVersionSpecificationGenerationTests: XCTestCase {
+fileprivate struct ToolsVersionSpecificationGenerationTests {
     /// Tests the generation of Swift tools version specifications.
-    func testToolsVersionSpecificationGeneration() throws {
+    @Test
+    func toolsVersionSpecificationGeneration() throws {
         let versionWithNonZeroPatch = ToolsVersion(version: Version(4, 3, 2))
-        XCTAssertEqual(versionWithNonZeroPatch.specification(), "// swift-tools-version:4.3.2")
-        XCTAssertEqual(versionWithNonZeroPatch.specification(roundedTo: .automatic), "// swift-tools-version:4.3.2")
-        XCTAssertEqual(versionWithNonZeroPatch.specification(roundedTo: .minor), "// swift-tools-version:4.3")
-        XCTAssertEqual(versionWithNonZeroPatch.specification(roundedTo: .patch), "// swift-tools-version:4.3.2")
-        
+        #expect(versionWithNonZeroPatch.specification() == "// swift-tools-version:4.3.2")
+        #expect(versionWithNonZeroPatch.specification(roundedTo: .automatic) == "// swift-tools-version:4.3.2")
+        #expect(versionWithNonZeroPatch.specification(roundedTo: .minor) == "// swift-tools-version:4.3")
+        #expect(versionWithNonZeroPatch.specification(roundedTo: .patch) == "// swift-tools-version:4.3.2")
+
         let versionWithZeroPatch = ToolsVersion.v5_3 // 5.3.0
-        XCTAssertEqual(versionWithZeroPatch.specification(), "// swift-tools-version:5.3")
-        XCTAssertEqual(versionWithZeroPatch.specification(roundedTo: .automatic), "// swift-tools-version:5.3")
-        XCTAssertEqual(versionWithZeroPatch.specification(roundedTo: .minor), "// swift-tools-version:5.3")
-        XCTAssertEqual(versionWithZeroPatch.specification(roundedTo: .patch), "// swift-tools-version:5.3.0")
-        
+        #expect(versionWithZeroPatch.specification() == "// swift-tools-version:5.3")
+        #expect(versionWithZeroPatch.specification(roundedTo: .automatic) == "// swift-tools-version:5.3")
+        #expect(versionWithZeroPatch.specification(roundedTo: .minor) == "// swift-tools-version:5.3")
+        #expect(versionWithZeroPatch.specification(roundedTo: .patch) == "// swift-tools-version:5.3.0")
+
         let newMajorVersion = ToolsVersion.v5 // 5.0.0
-        XCTAssertEqual(newMajorVersion.specification(), "// swift-tools-version:5.0")
-        XCTAssertEqual(newMajorVersion.specification(roundedTo: .automatic), "// swift-tools-version:5.0")
-        XCTAssertEqual(newMajorVersion.specification(roundedTo: .minor), "// swift-tools-version:5.0")
-        XCTAssertEqual(newMajorVersion.specification(roundedTo: .patch), "// swift-tools-version:5.0.0")
+        #expect(newMajorVersion.specification() == "// swift-tools-version:5.0")
+        #expect(newMajorVersion.specification(roundedTo: .automatic) == "// swift-tools-version:5.0")
+        #expect(newMajorVersion.specification(roundedTo: .minor) == "// swift-tools-version:5.0")
+        #expect(newMajorVersion.specification(roundedTo: .patch) == "// swift-tools-version:5.0.0")
+
+        let allZeroVersion = ToolsVersion(version: Version(0, 0, 0))
+        #expect(allZeroVersion.specification() == "// swift-tools-version:0.0")
+        #expect(allZeroVersion.specification(roundedTo: .automatic) == "// swift-tools-version:0.0")
+        #expect(allZeroVersion.specification(roundedTo: .minor) == "// swift-tools-version:0.0")
+        #expect(allZeroVersion.specification(roundedTo: .patch) == "// swift-tools-version:0.0.0")
     }
+
 }

--- a/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
@@ -17,185 +17,170 @@
 import Basics
 import PackageModel
 @testable import Workspace
-import XCTest
+import Testing
 
 /// Test cases for `rewriteToolsVersionSpecification(toDefaultManifestIn:specifying:fileSystem:)`
-final class ToolsVersionSpecificationRewriterTests: XCTestCase {
-    
-    /// Tests `rewriteToolsVersionSpecification(toDefaultManifestIn:specifying:fileSystem:)`.
-    func testNonVersionSpecificManifests() throws {
-        // Empty file.
-        rewriteToolsVersionSpecificationToDefaultManifest(content: "") { result in
-            XCTAssertEqual(result, "// swift-tools-version:4.1.2\n")
-        }
+fileprivate struct ToolsVersionSpecificationRewriterTests {
 
-        // File with just a new line.
-        rewriteToolsVersionSpecificationToDefaultManifest(content: "\n") { result in
-            XCTAssertEqual(result, "// swift-tools-version:4.1.2\n\n")
-        }
-
-        // File with some contents.
-        rewriteToolsVersionSpecificationToDefaultManifest(content: "let package = ... \n") { result in
-            XCTAssertEqual(result, "// swift-tools-version:4.1.2\nlet package = ... \n")
-        }
-
-        // File already having a valid version specifier.
-        let content = """
-            // swift-tools-version:3.1.2
-            ...
-            """
-
-        rewriteToolsVersionSpecificationToDefaultManifest(content: content) { result in
-            XCTAssertEqual(result, "// swift-tools-version:4.1.2\n...")
-        }
-
-        // Write a version with zero in patch number.
-        rewriteToolsVersionSpecificationToDefaultManifest(
-            content: """
-            // swift-tools-version:3.1.2
-            ...
-            """,
-            version: ToolsVersion(version: "2.1.0")
-        ) { result in
-            XCTAssertEqual(result, "// swift-tools-version:2.1\n...")
-        }
-
-        // Contents with invalid tools version specification (ignoring the validity of the version specifier).
-        rewriteToolsVersionSpecificationToDefaultManifest(
-            content: """
-            // swift-tool-version:3.1.2
-            ...
-            """
-        ) { result in
-            XCTAssertEqual(result, "// swift-tools-version:4.1.2\n// swift-tool-version:3.1.2\n...")
-        }
-
-        // Contents with invalid version specifier.
-        rewriteToolsVersionSpecificationToDefaultManifest(
-            content: """
-            // swift-tools-version:3.1.2
-            ...
-            """
-        ) { result in
-            XCTAssertEqual(result, "// swift-tools-version:4.1.2\n...")
-        }
-
-        // Contents with invalid version specifier and some meta data.
-        rewriteToolsVersionSpecificationToDefaultManifest(
-            content: """
-            // swift-tools-version:3.1.2
-            ...
-            """
-        ) { result in
-            // Note: Right now we lose the metadata but if we ever start using it, we should preserve it.
-            XCTAssertEqual(result, "// swift-tools-version:4.1.2\n...")
-        }
-
-        // Try to write a version with prerelease and build meta data.
-        let toolsVersion = ToolsVersion(version: "4.1.2-alpha.beta+sha.1234")
-        rewriteToolsVersionSpecificationToDefaultManifest(
-            content: "let package = ... \n",
-            version: toolsVersion
-        ) { result in
-            XCTAssertEqual(result, "// swift-tools-version:4.1.2\nlet package = ... \n")
-        }
+    struct NonVersionSpecificManifestTestData: Identifiable {
+        let id: String
+        let content: String
+        let version: ToolsVersion
+        let expected: String
     }
-    
-    func testManifestAccessFailures() throws {
+    @Test(
+        arguments:[
+            NonVersionSpecificManifestTestData(
+                id: "Empty file.",
+                content: "",
+                version: ToolsVersion(version: "4.1.2"),
+                expected: "// swift-tools-version:4.1.2\n"
+            ),
+            NonVersionSpecificManifestTestData(
+                id: "File with just a new line.",
+                content: "\n",
+                version: ToolsVersion(version: "4.1.2"),
+                expected: "// swift-tools-version:4.1.2\n\n"
+            ),
+            NonVersionSpecificManifestTestData(
+                id: "File with some contents.",
+                content: "let package = ... \n",
+                version: ToolsVersion(version: "4.1.2"),
+                expected: "// swift-tools-version:4.1.2\nlet package = ... \n"
+            ),
+            NonVersionSpecificManifestTestData(
+                id: "File already having a valid version specifier.",
+                content: """
+                // swift-tools-version:3.1.2
+                ...
+                """,
+                version: ToolsVersion(version: "4.1.2"),
+                expected: "// swift-tools-version:4.1.2\n..."
+            ),
+            NonVersionSpecificManifestTestData(
+                id: "File already having a valid version specifier.",
+                content: """
+                // swift-tools-version:3.1.2
+                ...
+                """,
+                version: ToolsVersion(version: "2.1.0"),
+                expected: "// swift-tools-version:2.1\n..."
+            ),
+            NonVersionSpecificManifestTestData(
+                id: "Contents with invalid tools version specification (ignoring the validity of the version specifier).",
+                content: """
+                // swift-tool-version:3.1.2
+                ...
+                """,
+                version: ToolsVersion(version: "4.1.2"),
+                expected:  "// swift-tools-version:4.1.2\n// swift-tool-version:3.1.2\n..."
+            ),
+            NonVersionSpecificManifestTestData(
+                id: "Contents with invalid version specifier.",
+                content: """
+                // swift-tools-version:3.1.2
+                ...
+                """,
+                version: ToolsVersion(version: "4.1.2"),
+                expected: "// swift-tools-version:4.1.2\n..."
+            ),
+            NonVersionSpecificManifestTestData(
+                id: "Contents with invalid version specifier and some meta data.",
+                content: """
+                // swift-tools-version:3.1.2
+                ...
+                """,
+                version: ToolsVersion(version: "4.1.2"),
+                expected: "// swift-tools-version:4.1.2\n..."
+            ),
+            NonVersionSpecificManifestTestData(
+                id: "Try to write a version with prerelease and build meta data.",
+                content: "let package = ... \n",
+                version: ToolsVersion(version: "4.1.2-alpha.beta+sha.1234"),
+                expected: "// swift-tools-version:4.1.2\nlet package = ... \n"
+            )
+        ]
+    )
+    func nonVersionSpecificManifests(_ data: NonVersionSpecificManifestTestData) throws {
+        let content = data.content
+        let version = data.version
+        let expected =  data.expected
+
+        let inMemoryFileSystem = InMemoryFileSystem()
+
+        let manifestFilePath = AbsolutePath("/pkg/Package.swift")
+
+        try inMemoryFileSystem.createDirectory(manifestFilePath.parentDirectory, recursive: true)
+        try inMemoryFileSystem.writeFileContents(manifestFilePath, string: content)
+
+        try ToolsVersionSpecificationWriter.rewriteSpecification(
+            manifestDirectory: manifestFilePath.parentDirectory,
+            toolsVersion: version,
+            fileSystem: inMemoryFileSystem
+        )
+
+        // resultHandler(try inMemoryFileSystem.readFileContents(manifestFilePath))
+        let actual = try #require(try inMemoryFileSystem.readFileContents(manifestFilePath))
+        #expect(actual.validDescription == expected, "Actual is not expected")
+    }
+
+    @Test
+    func manifestAccessFailures() throws {
         let toolsVersion = ToolsVersion.v5_3
-        
+
         let inMemoryFileSystem = InMemoryFileSystem()
         let manifestFilePath = AbsolutePath("/pkg/Package.swift/Package.swift")
         try inMemoryFileSystem.createDirectory(manifestFilePath.parentDirectory, recursive: true) // /pkg/Package.swift/
-        
+
         // Test `ManifestAccessError.Kind.isADirectory`
-        XCTAssertThrowsError(
+
+        #expect{
             try ToolsVersionSpecificationWriter.rewriteSpecification(
                 manifestDirectory: manifestFilePath.parentDirectory.parentDirectory, // /pkg/
                 toolsVersion: toolsVersion,
                 fileSystem: inMemoryFileSystem
-            ),
-            "'/pkg/Package.swift' is a directory, and an error should've been thrown"
-        ) { error in
-            guard let error = error as? ToolsVersionSpecificationWriter.ManifestAccessError else {
-                XCTFail("a ManifestAccessError should've been thrown")
-                return
-            }
-            XCTAssertEqual(
-                error.kind,
-                .isADirectory
             )
-            XCTAssertEqual(
-                error.description,
-                "no accessible Swift Package Manager manifest file found at '\(manifestFilePath.parentDirectory)'; the path is a directory; a file is expected" // /pkg/Package.swift/
+        } throws: { error in
+            let error = try #require(
+                error as? ToolsVersionSpecificationWriter.ManifestAccessError,
+                "a ManifestAccessError should've been thrown"
             )
+            let isExpectedKind = (error.kind == .isADirectory)
+            let isExpectedDescription = (error.description == "no accessible Swift Package Manager manifest file found at '\(manifestFilePath.parentDirectory)'; the path is a directory; a file is expected")
+
+            return isExpectedKind && isExpectedDescription
         }
-        
+
         // Test `ManifestAccessError.Kind.noSuchFileOrDirectory`
-        XCTAssertThrowsError(
+        #expect {
             try ToolsVersionSpecificationWriter.rewriteSpecification(
                 manifestDirectory: manifestFilePath.parentDirectory, // /pkg/Package.swift/
                 toolsVersion: toolsVersion,
                 fileSystem: inMemoryFileSystem
-            ),
-            "'/pkg/Package.swift' is a directory, and an error should've been thrown"
-        ) { error in
-            guard let error = error as? ToolsVersionSpecificationWriter.ManifestAccessError else {
-                XCTFail("a ManifestAccessError should've been thrown")
-                return
-            }
-            XCTAssertEqual(
-                error.kind,
-                .noSuchFileOrDirectory
             )
-            XCTAssertEqual(
-                error.description,
-                "no accessible Swift Package Manager manifest file found at '\(manifestFilePath)'; a component of the path does not exist, or the path is an empty string" // /pkg/Package.swift/Package.swift
+        } throws: { error in
+            let error = try #require(
+                error as? ToolsVersionSpecificationWriter.ManifestAccessError,
+                "a ManifestAccessError should've been thrown"
             )
+            let isExpectedKind = (error.kind == .noSuchFileOrDirectory)
+            let isExpectedDescription = (error.description == "no accessible Swift Package Manager manifest file found at '\(manifestFilePath)'; a component of the path does not exist, or the path is an empty string")
+
+            return isExpectedKind && isExpectedDescription
         }
-        
-        // TODO: Test `ManifestAccessError.Kind.unknown`
     }
-    
+
     // Private functions are not run in tests.
-    private func testVersionSpecificManifests() throws {
-        // TODO: Add the functionality and tests for version-specific manifests too.
+    @Test
+    func versionSpecificManifests() throws {
+
     }
 
-    func testZeroedPatchVersion() {
-        XCTAssertEqual(ToolsVersion(version: "4.2.1").zeroedPatch.description, "4.2.0")
-        XCTAssertEqual(ToolsVersion(version: "4.2.0").zeroedPatch.description, "4.2.0")
-        XCTAssertEqual(ToolsVersion(version: "6.0.129").zeroedPatch.description, "6.0.0")
+    @Test
+    func zeroedPatchVersion() {
+        #expect(ToolsVersion(version: "4.2.1").zeroedPatch.description == "4.2.0")
+        #expect(ToolsVersion(version: "4.2.0").zeroedPatch.description == "4.2.0")
+        #expect(ToolsVersion(version: "6.0.129").zeroedPatch.description == "6.0.0")
     }
-    
-    /// Does the boilerplate filesystem preparations, then calls `rewriteToolsVersionSpecification(toDefaultManifestIn:specifying:fileSystem:)`, for `testNonVersionSpecificManifests()`.
-    /// - Parameters:
-    ///   - stream: The stream to read from and write to the filesystem.
-    ///   - version: The Swift tools version to specify.
-    ///   - resultHandler: The result handler.
-    func rewriteToolsVersionSpecificationToDefaultManifest(
-        content: String,
-        version: ToolsVersion = ToolsVersion(version: "4.1.2"),
-        resultHandler: (String) -> Void
-    ) {
-        do {
-            let inMemoryFileSystem = InMemoryFileSystem()
 
-            let manifestFilePath = AbsolutePath("/pkg/Package.swift")
-
-            try inMemoryFileSystem.createDirectory(manifestFilePath.parentDirectory, recursive: true)
-            try inMemoryFileSystem.writeFileContents(manifestFilePath, string: content)
-
-            try ToolsVersionSpecificationWriter.rewriteSpecification(
-                manifestDirectory: manifestFilePath.parentDirectory,
-                toolsVersion: version,
-                fileSystem: inMemoryFileSystem
-            )
-
-            resultHandler(try inMemoryFileSystem.readFileContents(manifestFilePath))
-        } catch {
-            XCTFail("Failed with error \(error)")
-        }
-    }
-    
 }

--- a/Tests/WorkspaceTests/WorkspaceStateTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceStateTests.swift
@@ -9,13 +9,13 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-
 import Basics
 @testable import Workspace
-import XCTest
+import Testing
 
-final class WorkspaceStateTests: XCTestCase {
-    func testV4Format() async throws {
+fileprivate struct WorkspaceStateTests {
+    @Test
+    func v4Format() async throws {
         let fs = InMemoryFileSystem()
 
         let buildDir = AbsolutePath("/.build")
@@ -83,12 +83,13 @@ final class WorkspaceStateTests: XCTestCase {
         )
 
         let dependencies = await WorkspaceState(fileSystem: fs, storageDirectory: buildDir).dependencies
-        XCTAssertTrue(dependencies.contains(where: { $0.packageRef.identity == .plain("yams") }))
-        XCTAssertTrue(dependencies.contains(where: { $0.packageRef.identity == .plain("swift-tools-support-core") }))
-        XCTAssertTrue(dependencies.contains(where: { $0.packageRef.identity == .plain("swift-argument-parser") }))
+        #expect(dependencies.contains(where: { $0.packageRef.identity == .plain("yams") }))
+        #expect(dependencies.contains(where: { $0.packageRef.identity == .plain("swift-tools-support-core") }))
+        #expect(dependencies.contains(where: { $0.packageRef.identity == .plain("swift-argument-parser") }))
     }
 
-    func testV4FormatWithPath() async throws {
+    @Test
+    func v4FormatWithPath() async throws {
         let fs = InMemoryFileSystem()
 
         let buildDir = AbsolutePath("/.build")
@@ -156,12 +157,13 @@ final class WorkspaceStateTests: XCTestCase {
         )
 
         let dependencies = await WorkspaceState(fileSystem: fs, storageDirectory: buildDir).dependencies
-        XCTAssertTrue(dependencies.contains(where: { $0.packageRef.identity == .plain("yams") }))
-        XCTAssertTrue(dependencies.contains(where: { $0.packageRef.identity == .plain("swift-tools-support-core") }))
-        XCTAssertTrue(dependencies.contains(where: { $0.packageRef.identity == .plain("swift-argument-parser") }))
+        #expect(dependencies.contains(where: { $0.packageRef.identity == .plain("yams") }))
+        #expect(dependencies.contains(where: { $0.packageRef.identity == .plain("swift-tools-support-core") }))
+        #expect(dependencies.contains(where: { $0.packageRef.identity == .plain("swift-argument-parser") }))
     }
 
-    func testV5Format() async throws {
+    @Test
+    func v5Format() async throws {
         let fs = InMemoryFileSystem()
 
         let buildDir = AbsolutePath("/.build")
@@ -229,12 +231,13 @@ final class WorkspaceStateTests: XCTestCase {
         )
 
         let dependencies = await WorkspaceState(fileSystem: fs, storageDirectory: buildDir).dependencies
-        XCTAssertTrue(dependencies.contains(where: { $0.packageRef.identity == .plain("yams") }))
-        XCTAssertTrue(dependencies.contains(where: { $0.packageRef.identity == .plain("swift-tools-support-core") }))
-        XCTAssertTrue(dependencies.contains(where: { $0.packageRef.identity == .plain("swift-argument-parser") }))
+        #expect(dependencies.contains(where: { $0.packageRef.identity == .plain("yams") }))
+        #expect(dependencies.contains(where: { $0.packageRef.identity == .plain("swift-tools-support-core") }))
+        #expect(dependencies.contains(where: { $0.packageRef.identity == .plain("swift-argument-parser") }))
     }
 
-    func testSavedDependenciesAreSorted() async throws {
+    @Test
+    func savedDependenciesAreSorted() async throws {
         let fs = InMemoryFileSystem()
 
         let buildDir = AbsolutePath("/.build")
@@ -292,13 +295,14 @@ final class WorkspaceStateTests: XCTestCase {
 
         let serialized: String = try fs.readFileContents(statePath)
 
-        let argpRange = try XCTUnwrap(serialized.range(of: "swift-argument-parser"))
-        let yamsRange = try XCTUnwrap(serialized.range(of: "yams"))
+        let argpRange = try #require(serialized.range(of: "swift-argument-parser"))
+        let yamsRange = try #require(serialized.range(of: "yams"))
 
-        XCTAssertTrue(argpRange.lowerBound < yamsRange.lowerBound)
+        #expect(argpRange.lowerBound < yamsRange.lowerBound)
     }
 
-    func testArtifacts() async throws {
+    @Test
+    func artifacts() async throws {
         let fs = InMemoryFileSystem()
 
         let buildDir = AbsolutePath("/.build")
@@ -363,13 +367,14 @@ final class WorkspaceStateTests: XCTestCase {
         )
 
         let artifacts = await WorkspaceState(fileSystem: fs, storageDirectory: buildDir).artifacts
-        XCTAssertTrue(artifacts.contains(where: { $0.packageRef.identity == .plain("foo") && $0.targetName == "foo" }))
-        XCTAssertTrue(artifacts.contains(where: { $0.packageRef.identity == .plain("foo") && $0.targetName == "bar" }))
-        XCTAssertTrue(artifacts.contains(where: { $0.packageRef.identity == .plain("bar") && $0.targetName == "bar" }))
+        #expect(artifacts.contains(where: { $0.packageRef.identity == .plain("foo") && $0.targetName == "foo" }))
+        #expect(artifacts.contains(where: { $0.packageRef.identity == .plain("foo") && $0.targetName == "bar" }))
+        #expect(artifacts.contains(where: { $0.packageRef.identity == .plain("bar") && $0.targetName == "bar" }))
     }
 
     // rdar://86857825
-    func testDuplicateDependenciesDoNotCrash() async throws {
+    @Test
+    func duplicateDependenciesDoNotCrash() async throws {
         let fs = InMemoryFileSystem()
 
         let buildDir = AbsolutePath("/.build")
@@ -425,11 +430,12 @@ final class WorkspaceStateTests: XCTestCase {
         let dependencies = await WorkspaceState(fileSystem: fs, storageDirectory: buildDir).dependencies
         // empty since we have dups so we warn and fail the loading
         // TODO: test for diagnostics when we can get them from the WorkspaceState initializer
-        XCTAssertTrue(dependencies.isEmpty)
+        #expect(dependencies.isEmpty)
     }
 
     // rdar://86857825
-    func testDuplicateArtifactsDoNotCrash() async throws {
+    @Test
+    func duplicateArtifactsDoNotCrash() async throws {
         let fs = InMemoryFileSystem()
 
         let buildDir = AbsolutePath("/.build")
@@ -481,7 +487,7 @@ final class WorkspaceStateTests: XCTestCase {
         let artifacts = await WorkspaceState(fileSystem: fs, storageDirectory: buildDir).artifacts
         // empty since we have dups so we warn and fail the loading
         // TODO: test for diagnostics when we can get them from the WorkspaceState initializer
-        XCTAssertTrue(artifacts.isEmpty)
+        #expect(artifacts.isEmpty)
     }
 }
 


### PR DESCRIPTION
Convert most of the WorkspaceTests from XCTests to Swift Testing to make use of parallelism and, in some cases, test parameterization.

### Motivation:

The XCTest run, by default, sequentially.  Convert most of the WorkspaceTests from XCTests to Swift Testing to make use of parallelism, and in some cases, parameterized test cases.

Not all Test Suites in WorkspaceTests have been converted as some use helpers in swift-tools-core-support, which don't have a matching Swift Testing helper.


### Modifications:

Convert XCTests to Swift Testing

### Result:

Ran the equivalent of 
```
for _ in $(seq 0 100); 
do
    swift test --enable-swift-testing --disable-xctest
done
```
 and ensured there were no test-related failures.

Blocked by #8137 
Blocked on https://github.com/swiftlang/swift/pull/78300
Blocked on https://github.com/swiftlang/swift/pull/81217