### PR TITLE
Tests: Convert some tests BasicsTests to Swift Testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -788,7 +788,12 @@ let package = Package(
 
         .testTarget(
             name: "BasicsTests",
-            dependencies: ["Basics", "_InternalTestSupport", "tsan_utils"],
+            dependencies: [
+                "Basics",
+                "_InternalTestSupport",
+                "tsan_utils",
+               .product(name: "Numerics", package: "swift-numerics"),
+            ],
             exclude: [
                 "Archiver/Inputs/archive.tar.gz",
                 "Archiver/Inputs/archive.zip",
@@ -1028,6 +1033,8 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-collections.git", "1.0.1" ..< "1.2.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", "1.0.1" ..< "1.6.0"),
         .package(url: "https://github.com/swiftlang/swift-toolchain-sqlite.git", from: "1.0.0"),
+        // Test Dependencies
+        .package(url: "https://github.com/apple/swift-numerics", exact: "1.0.2")
     ]
 } else {
     package.dependencies += [
@@ -1040,6 +1047,8 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-collections"),
         .package(path: "../swift-certificates"),
         .package(path: "../swift-toolchain-sqlite"),
+        // Test Dependencies
+        .package(path: "../swift-numerics"),
     ]
 }
 

--- a/Sources/_InternalTestSupport/XCTAssertHelpers.swift
+++ b/Sources/_InternalTestSupport/XCTAssertHelpers.swift
@@ -44,8 +44,12 @@ public func XCTAssertEqual<T:Equatable, U:Equatable> (_ lhs:(T,U), _ rhs:(T,U), 
     TSCTestSupport.XCTAssertEqual(lhs, rhs, file: file, line: line)
 }
 
+public func isRunninginCI(file: StaticString = #filePath, line: UInt = #line) -> Bool {
+    return (ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] != nil || ProcessInfo.processInfo.environment["CI"] != nil)
+}
+
 public func XCTSkipIfCI(file: StaticString = #filePath, line: UInt = #line) throws {
-    if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] != nil {
+    if isRunninginCI() {
         throw XCTSkip("Skipping because the test is being run on CI", file: file, line: line)
     }
 }

--- a/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
@@ -105,15 +105,15 @@ final class ZipArchiverTests: XCTestCase {
         #endif
 
          try await testWithTemporaryDirectory { tmpdir in
-             let archiver = ZipArchiver(fileSystem: localFileSystem)
+            let archiver = ZipArchiver(fileSystem: localFileSystem)
 
-             let rootDir = tmpdir.appending(component: UUID().uuidString)
-             try localFileSystem.createDirectory(rootDir)
-             try localFileSystem.writeFileContents(rootDir.appending("file1.txt"), string: "Hello World!")
+            let rootDir = tmpdir.appending(component: UUID().uuidString)
+            try localFileSystem.createDirectory(rootDir)
+            try localFileSystem.writeFileContents(rootDir.appending("file1.txt"), string: "Hello World!")
 
-             let dir1 = rootDir.appending("dir1")
-             try localFileSystem.createDirectory(dir1)
-             try localFileSystem.writeFileContents(dir1.appending("file2.txt"), string: "Hello World 2!")
+            let dir1 = rootDir.appending("dir1")
+            try localFileSystem.createDirectory(dir1)
+            try localFileSystem.writeFileContents(dir1.appending("file2.txt"), string: "Hello World 2!")
 
              let dir2 = dir1.appending("dir2")
              try localFileSystem.createDirectory(dir2)
@@ -121,28 +121,28 @@ final class ZipArchiverTests: XCTestCase {
              try localFileSystem.writeFileContents(dir2.appending("file4.txt"), string: "Hello World 4!")
              try localFileSystem.createSymbolicLink(dir2.appending("file5.txt"), pointingAt: dir1.appending("file2.txt"), relative: true)
 
-             let archivePath = tmpdir.appending(component: UUID().uuidString + ".zip")
-             try await archiver.compress(directory: rootDir, to: archivePath)
-             XCTAssertFileExists(archivePath)
+            let archivePath = tmpdir.appending(component: UUID().uuidString + ".zip")
+            try await archiver.compress(directory: rootDir, to: archivePath)
+            XCTAssertFileExists(archivePath)
 
-             let extractRootDir = tmpdir.appending(component: UUID().uuidString)
-             try localFileSystem.createDirectory(extractRootDir)
-             try await archiver.extract(from: archivePath, to: extractRootDir)
-             try localFileSystem.stripFirstLevel(of: extractRootDir)
+            let extractRootDir = tmpdir.appending(component: UUID().uuidString)
+            try localFileSystem.createDirectory(extractRootDir)
+            try await archiver.extract(from: archivePath, to: extractRootDir)
+            try localFileSystem.stripFirstLevel(of: extractRootDir)
 
-             XCTAssertFileExists(extractRootDir.appending("file1.txt"))
-             XCTAssertEqual(
-                 try? localFileSystem.readFileContents(extractRootDir.appending("file1.txt")),
-                 "Hello World!"
-             )
+            XCTAssertFileExists(extractRootDir.appending("file1.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractRootDir.appending("file1.txt")),
+                "Hello World!"
+            )
 
-             let extractedDir1 = extractRootDir.appending("dir1")
-             XCTAssertDirectoryExists(extractedDir1)
-             XCTAssertFileExists(extractedDir1.appending("file2.txt"))
-             XCTAssertEqual(
-                 try? localFileSystem.readFileContents(extractedDir1.appending("file2.txt")),
-                 "Hello World 2!"
-             )
+            let extractedDir1 = extractRootDir.appending("dir1")
+            XCTAssertDirectoryExists(extractedDir1)
+            XCTAssertFileExists(extractedDir1.appending("file2.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir1.appending("file2.txt")),
+                "Hello World 2!"
+            )
 
              let extractedDir2 = extractedDir1.appending("dir2")
              XCTAssertDirectoryExists(extractedDir2)

--- a/Tests/BasicsTests/ByteStringExtensionsTests.swift
+++ b/Tests/BasicsTests/ByteStringExtensionsTests.swift
@@ -9,18 +9,20 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import Basics
-import XCTest
+import Testing
 
 import struct TSCBasic.ByteString
 
-final class ByteStringExtensionsTests: XCTestCase {
-    func testSHA256Checksum() {
+struct ByteStringExtensionsTests {
+    @Test
+    func sHA256Checksum() {
         let byteString = ByteString(encodingAsUTF8: "abc")
-        XCTAssertEqual(byteString.contents, [0x61, 0x62, 0x63])
+        #expect(byteString.contents == [0x61, 0x62, 0x63])
 
         // See https://csrc.nist.gov/csrc/media/projects/cryptographic-standards-and-guidelines/documents/examples/sha_all.pdf
-        XCTAssertEqual(byteString.sha256Checksum, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+        #expect(byteString.sha256Checksum == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
     }
 }

--- a/Tests/BasicsTests/ConcurrencyHelpersTests.swift
+++ b/Tests/BasicsTests/ConcurrencyHelpersTests.swift
@@ -9,15 +9,17 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @testable import Basics
 import TSCTestSupport
-import XCTest
+import Testing
 
-final class ConcurrencyHelpersTest: XCTestCase {
+struct ConcurrencyHelpersTest {
     let queue = DispatchQueue(label: "ConcurrencyHelpersTest", attributes: .concurrent)
 
-    func testThreadSafeKeyValueStore() {
+    @Test
+    func threadSafeKeyValueStore() throws {
         for _ in 0 ..< 100 {
             let sync = DispatchGroup()
 
@@ -41,18 +43,15 @@ final class ConcurrencyHelpersTest: XCTestCase {
                 }
             }
 
-            switch sync.wait(timeout: .now() + .seconds(2)) {
-            case .timedOut:
-                XCTFail("timeout")
-            case .success:
-                expected.forEach { key, value in
-                    XCTAssertEqual(cache[key], value)
-                }
+            try #require(sync.wait(timeout: .now() + .seconds(2)) == .success)
+            expected.forEach { key, value in
+                #expect(cache[key] == value)
             }
         }
     }
 
-    func testThreadSafeArrayStore() {
+    @Test
+    func threadSafeArrayStore() throws {
         for _ in 0 ..< 100 {
             let sync = DispatchGroup()
 
@@ -71,18 +70,15 @@ final class ConcurrencyHelpersTest: XCTestCase {
                 }
             }
 
-            switch sync.wait(timeout: .now() + .seconds(2)) {
-            case .timedOut:
-                XCTFail("timeout")
-            case .success:
-                let expectedSorted = expected.sorted()
-                let resultsSorted = cache.get().sorted()
-                XCTAssertEqual(expectedSorted, resultsSorted)
-            }
+            try #require(sync.wait(timeout: .now() + .seconds(2)) == .success)
+            let expectedSorted = expected.sorted()
+            let resultsSorted = cache.get().sorted()
+            #expect(expectedSorted == resultsSorted)
         }
     }
 
-    func testThreadSafeBox() {
+    @Test
+    func threadSafeBox() throws {
         for _ in 0 ..< 100 {
             let sync = DispatchGroup()
 
@@ -108,12 +104,8 @@ final class ConcurrencyHelpersTest: XCTestCase {
                 }
             }
 
-            switch sync.wait(timeout: .now() + .seconds(2)) {
-            case .timedOut:
-                XCTFail("timeout")
-            case .success:
-                XCTAssertEqual(cache.get(), winner)
-            }
+            try #require(sync.wait(timeout: .now() + .seconds(2)) == .success)
+            #expect(cache.get() == winner)
         }
     }
 }

--- a/Tests/BasicsTests/DictionaryTest.swift
+++ b/Tests/BasicsTests/DictionaryTest.swift
@@ -11,26 +11,27 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Basics
-import XCTest
+import Testing
 
-final class DictionaryTests: XCTestCase {
-    func testThrowingUniqueKeysWithValues() throws {
+struct DictionaryTests {
+    @Test
+    func throwingUniqueKeysWithValues() throws {
         do {
             let keysWithValues = [("key1", "value1"), ("key2", "value2")]
             let dictionary = try Dictionary(throwingUniqueKeysWithValues: keysWithValues)
-            XCTAssertEqual(dictionary["key1"], "value1")
-            XCTAssertEqual(dictionary["key2"], "value2")
+            #expect(dictionary["key1"] == "value1")
+            #expect(dictionary["key2"] == "value2")
         }
         do {
             let keysWithValues = [("key1", "value"), ("key2", "value")]
             let dictionary = try Dictionary(throwingUniqueKeysWithValues: keysWithValues)
-            XCTAssertEqual(dictionary["key1"], "value")
-            XCTAssertEqual(dictionary["key2"], "value")
+            #expect(dictionary["key1"] == "value")
+            #expect(dictionary["key2"] == "value")
         }
         do {
             let keysWithValues = [("key", "value1"), ("key", "value2")]
-            XCTAssertThrowsError(try Dictionary(throwingUniqueKeysWithValues: keysWithValues)) { error in
-                XCTAssertEqual(error as? StringError, StringError("duplicate key found: 'key'"))
+            #expect(throws: StringError("duplicate key found: 'key'")) {
+                try Dictionary(throwingUniqueKeysWithValues: keysWithValues)
             }
         }
     }

--- a/Tests/BasicsTests/DispatchTimeTests.swift
+++ b/Tests/BasicsTests/DispatchTimeTests.swift
@@ -9,30 +9,33 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import Basics
-import XCTest
+import Testing
 
-final class DispatchTimeTests: XCTestCase {
-    func testDifferencePositive() {
+struct DispatchTimeTests {
+    @Test
+    func differencePositive() {
         let point: DispatchTime = .now()
         let future: DispatchTime = point + .seconds(10)
 
         let diff1: DispatchTimeInterval = point.distance(to: future)
-        XCTAssertEqual(diff1.seconds(), 10)
+        #expect(diff1.seconds() == 10)
 
         let diff2: DispatchTimeInterval = future.distance(to: point)
-        XCTAssertEqual(diff2.seconds(), -10)
+        #expect(diff2.seconds() == -10)
     }
 
-    func testDifferenceNegative() {
+    @Test
+    func differenceNegative() {
         let point: DispatchTime = .now()
         let past: DispatchTime = point - .seconds(10)
 
         let diff1: DispatchTimeInterval = point.distance(to: past)
-        XCTAssertEqual(diff1.seconds(), -10)
+        #expect(diff1.seconds() == -10)
 
         let diff2: DispatchTimeInterval = past.distance(to: point)
-        XCTAssertEqual(diff2.seconds(), 10)
+        #expect(diff2.seconds() == 10)
     }
 }

--- a/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
@@ -9,84 +9,93 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @testable import Basics
-import XCTest
+import Testing
 
-final class EnvironmentKeyTests: XCTestCase {
-    func test_comparable() {
+struct EnvironmentKeyTests {
+    @Test
+    func comparable() {
         let key0 = EnvironmentKey("Test")
         let key1 = EnvironmentKey("Test1")
-        XCTAssertLessThan(key0, key1)
+        #expect(key0 < key1)
 
         let key2 = EnvironmentKey("test")
-        XCTAssertLessThan(key0, key2)
+        #expect(key0 < key2)
     }
 
-    func test_customStringConvertible() {
+    @Test
+    func customStringConvertible() {
         let key = EnvironmentKey("Test")
-        XCTAssertEqual(key.description, "Test")
+        #expect(key.description == "Test")
     }
 
-    func test_encodable() throws {
+    @Test
+    func encodable() throws {
         let key = EnvironmentKey("Test")
         let data = try JSONEncoder().encode(key)
         let string = String(data: data, encoding: .utf8)
-        XCTAssertEqual(string, #""Test""#)
+        #expect(string == #""Test""#)
     }
 
-    func test_equatable() {
+    @Test
+    func equatable() {
         let key0 = EnvironmentKey("Test")
         let key1 = EnvironmentKey("Test")
-        XCTAssertEqual(key0, key1)
+        #expect(key0 == key1)
 
         let key2 = EnvironmentKey("Test2")
-        XCTAssertNotEqual(key0, key2)
+        #expect(key0 != key2)
 
-        #if os(Windows)
+#if os(Windows)
         // Test case insensitivity on windows
         let key3 = EnvironmentKey("teSt")
-        XCTAssertEqual(key0, key3)
-        #endif
+        #expect(key0 == key3)
+#endif
     }
 
-    func test_expressibleByStringLiteral() {
+    @Test
+    func expressibleByStringLiteral() {
         let key0 = EnvironmentKey("Test")
-        XCTAssertEqual(key0, "Test")
+        #expect(key0 == "Test")
     }
 
-    func test_decodable() throws {
+    @Test
+    func decodable() throws {
         let jsonString = #""Test""#
         let data = jsonString.data(using: .utf8)!
         let key = try JSONDecoder().decode(EnvironmentKey.self, from: data)
-        XCTAssertEqual(key.rawValue, "Test")
+        #expect(key.rawValue == "Test")
     }
 
-    func test_hashable() {
+    @Test
+    func hashable() {
         var set = Set<EnvironmentKey>()
         let key0 = EnvironmentKey("Test")
-        XCTAssertTrue(set.insert(key0).inserted)
+        #expect(set.insert(key0).inserted)
 
         let key1 = EnvironmentKey("Test")
-        XCTAssertTrue(set.contains(key1))
-        XCTAssertFalse(set.insert(key1).inserted)
+        #expect(set.contains(key1))
+        #expect(!set.insert(key1).inserted)
 
         let key2 = EnvironmentKey("Test2")
-        XCTAssertFalse(set.contains(key2))
-        XCTAssertTrue(set.insert(key2).inserted)
+        #expect(!set.contains(key2))
+        #expect(set.insert(key2).inserted)
 
-        #if os(Windows)
+#if os(Windows)
         // Test case insensitivity on windows
         let key3 = EnvironmentKey("teSt")
-        XCTAssertTrue(set.contains(key3))
-        XCTAssertFalse(set.insert(key3).inserted)
-        #endif
+        #expect(set.contains(key3))
+        #expect(!set.insert(key3).inserted)
+#endif
 
-        XCTAssertEqual(set, ["Test", "Test2"])
+        #expect(set == ["Test", "Test2"])
     }
 
-    func test_rawRepresentable() {
+    @Test
+    func rawRepresentable() {
         let key = EnvironmentKey(rawValue: "Test")
-        XCTAssertEqual(key?.rawValue, "Test")
+        #expect(key?.rawValue == "Test")
     }
 }

--- a/Tests/BasicsTests/Environment/EnvironmentTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentTests.swift
@@ -9,193 +9,213 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @_spi(SwiftPMInternal)
 @testable
 import Basics
 
-import XCTest
+import Testing
 
-final class EnvironmentTests: XCTestCase {
-    func test_init() {
+struct EnvironmentTests {
+    @Test
+    func initialize() {
         let environment = Environment()
-        XCTAssertTrue(environment.isEmpty)
+        #expect(environment.isEmpty)
     }
 
-    func test_subscript() {
+    @Test
+    func setting_and_accessing_via_subscript() {
         var environment = Environment()
         let key = EnvironmentKey("TestKey")
         environment[key] = "TestValue"
-        XCTAssertEqual(environment[key], "TestValue")
+        #expect(environment[key] == "TestValue")
     }
 
-    func test_initDictionaryFromSelf() {
+    @Test
+    func initDictionaryFromSelf() {
         let dictionary = [
             "TestKey": "TestValue",
             "testKey": "TestValue2",
         ]
         let environment = Environment(dictionary)
-        #if os(Windows)
-        XCTAssertEqual(environment["TestKey"], "TestValue2") // uppercase sorts before lowercase, so the second value overwrites the first
-        XCTAssertEqual(environment.count, 1)
-        #else
-        XCTAssertEqual(environment["TestKey"], "TestValue")
-        XCTAssertEqual(environment.count, 2)
-        #endif
+        let expectedValue: String
+        let expectedCount: Int
+#if os(Windows)
+        expectedValue = "TestValue2" // uppercase sorts before lowercase, so the second value overwrites the first
+        expectedCount = 1
+#else
+        expectedValue = "TestValue"
+        expectedCount = 2
+#endif
+        #expect(environment["TestKey"] == expectedValue, "Actual value is not as expected")
+        #expect(environment.count == expectedCount, "Actual count is not as expected")
     }
 
-    func test_initSelfFromDictionary() {
+    @Test
+    func initSelfFromDictionary() {
         let dictionary = ["TestKey": "TestValue"]
         let environment = Environment(dictionary)
-        XCTAssertEqual(environment["TestKey"], "TestValue")
+        #expect(environment["TestKey"] == "TestValue")
     }
 
     func path(_ components: String...) -> String {
         components.joined(separator: Environment.pathEntryDelimiter)
     }
 
-    func test_prependPath() {
+    @Test
+    func prependPath() {
         var environment = Environment()
         let key = EnvironmentKey(UUID().uuidString)
-        XCTAssertNil(environment[key])
+        #expect(environment[key] == nil)
 
         environment.prependPath(key: key, value: "/bin")
-        XCTAssertEqual(environment[key], path("/bin"))
+        #expect(environment[key] == path("/bin"))
 
         environment.prependPath(key: key, value: "/usr/bin")
-        XCTAssertEqual(environment[key], path("/usr/bin", "/bin"))
+        #expect(environment[key] == path("/usr/bin", "/bin"))
 
         environment.prependPath(key: key, value: "/usr/local/bin")
-        XCTAssertEqual(environment[key], path("/usr/local/bin", "/usr/bin", "/bin"))
+        #expect(environment[key] == path("/usr/local/bin", "/usr/bin", "/bin"))
 
         environment.prependPath(key: key, value: "")
-        XCTAssertEqual(environment[key], path("/usr/local/bin", "/usr/bin", "/bin"))
+        #expect(environment[key] == path("/usr/local/bin", "/usr/bin", "/bin"))
     }
 
-    func test_appendPath() {
+    @Test
+    func appendPath() {
         var environment = Environment()
         let key = EnvironmentKey(UUID().uuidString)
-        XCTAssertNil(environment[key])
+        #expect(environment[key] == nil)
 
         environment.appendPath(key: key, value: "/bin")
-        XCTAssertEqual(environment[key], path("/bin"))
+        #expect(environment[key] == path("/bin"))
 
         environment.appendPath(key: key, value: "/usr/bin")
-        XCTAssertEqual(environment[key], path("/bin", "/usr/bin"))
+        #expect(environment[key] == path("/bin", "/usr/bin"))
 
         environment.appendPath(key: key, value: "/usr/local/bin")
-        XCTAssertEqual(environment[key], path("/bin", "/usr/bin", "/usr/local/bin"))
+        #expect(environment[key] == path("/bin", "/usr/bin", "/usr/local/bin"))
 
         environment.appendPath(key: key, value: "")
-        XCTAssertEqual(environment[key], path("/bin", "/usr/bin", "/usr/local/bin"))
+        #expect(environment[key] == path("/bin", "/usr/bin", "/usr/local/bin"))
     }
 
-    func test_pathEntryDelimiter() {
-        #if os(Windows)
-        XCTAssertEqual(Environment.pathEntryDelimiter, ";")
-        #else
-        XCTAssertEqual(Environment.pathEntryDelimiter, ":")
-        #endif
-    }
-
-    /// Important: This test is inherently race-prone, if it is proven to be
-    /// flaky, it should run in a singled threaded environment/removed entirely.
-    func test_current() {
-        XCTAssertEqual(
-            Environment.current["PATH"],
-            ProcessInfo.processInfo.environment["PATH"])
+    @Test
+    func pathEntryDelimiter() {
+#if os(Windows)
+        #expect(Environment.pathEntryDelimiter == ";")
+#else
+        #expect(Environment.pathEntryDelimiter == ":")
+#endif
     }
 
     /// Important: This test is inherently race-prone, if it is proven to be
     /// flaky, it should run in a singled threaded environment/removed entirely.
-    func test_makeCustom() async throws {
+    @Test
+    func current() {
+        #expect(Environment.current["PATH"] == ProcessInfo.processInfo.environment["PATH"])
+    }
+
+    /// Important: This test is inherently race-prone, if it is proven to be
+    /// flaky, it should run in a singled threaded environment/removed entirely.
+    @Test
+    func makeCustom() async throws {
         let key = EnvironmentKey(UUID().uuidString)
         let value = "TestValue"
 
         var customEnvironment = Environment()
         customEnvironment[key] = value
 
-        XCTAssertNil(Environment.current[key])
+        #expect(Environment.current[key] == nil)
         try Environment.makeCustom(customEnvironment) {
-            XCTAssertEqual(Environment.current[key], value)
+            #expect(Environment.current[key] == value)
         }
-        XCTAssertNil(Environment.current[key])
+        #expect(Environment.current[key] == nil)
     }
 
     /// Important: This test is inherently race-prone, if it is proven to be
     /// flaky, it should run in a singled threaded environment/removed entirely.
-    func testProcess() throws {
+    @Test
+    func process() throws {
         let key = EnvironmentKey(UUID().uuidString)
         let value = "TestValue"
 
         var environment = Environment.current
-        XCTAssertNil(environment[key])
+        #expect(environment[key] == nil)
 
         try Environment.set(key: key, value: value)
         environment = Environment.current // reload
-        XCTAssertEqual(environment[key], value)
+        #expect(environment[key] == value)
 
         try Environment.set(key: key, value: nil)
-        XCTAssertEqual(environment[key], value) // this is a copy!
+        #expect(environment[key] == value) // this is a copy!
 
         environment = Environment.current // reload
-        XCTAssertNil(environment[key])
+        #expect(environment[key] == nil)
     }
 
-    func test_cachable() {
+    @Test
+    func cachable() {
         let term = EnvironmentKey("TERM")
         var environment = Environment()
         environment[.path] = "/usr/bin"
         environment[term] = "xterm-256color"
 
         let cachableEnvironment = environment.cachable
-        XCTAssertNotNil(cachableEnvironment[.path])
-        XCTAssertNil(cachableEnvironment[term])
+        #expect(cachableEnvironment[.path] != nil)
+        #expect(cachableEnvironment[term] == nil)
     }
 
-    func test_collection() {
+    @Test
+    func collection() {
         let environment: Environment = ["TestKey": "TestValue"]
-        XCTAssertEqual(environment.count, 1)
-        XCTAssertEqual(environment.first?.key, EnvironmentKey("TestKey"))
-        XCTAssertEqual(environment.first?.value, "TestValue")
+        #expect(environment.count == 1)
+        #expect(environment.first?.key == EnvironmentKey("TestKey"))
+        #expect(environment.first?.value == "TestValue")
     }
 
-    func test_description() {
+    @Test
+    func description() {
         var environment = Environment()
         environment[EnvironmentKey("TestKey")] = "TestValue"
-        XCTAssertEqual(environment.description, #"["TestKey=TestValue"]"#)
+        #expect(environment.description == #"["TestKey=TestValue"]"#)
     }
 
-    func test_encodable() throws {
+    @Test
+    func encodable() throws {
         var environment = Environment()
         environment["TestKey"] = "TestValue"
         let data = try JSONEncoder().encode(environment)
         let jsonString = String(data: data, encoding: .utf8)
-        XCTAssertEqual(jsonString, #"{"TestKey":"TestValue"}"#)
+        #expect(jsonString == #"{"TestKey":"TestValue"}"#)
     }
 
-    func test_equatable() {
+    @Test
+    func equatable() {
         let environment0: Environment = ["TestKey": "TestValue"]
         let environment1: Environment = ["TestKey": "TestValue"]
-        XCTAssertEqual(environment0, environment1)
+        #expect(environment0 == environment1)
 
 #if os(Windows)
         // Test case insensitivity on windows
         let environment2: Environment = ["testKey": "TestValue"]
-        XCTAssertEqual(environment0, environment2)
+        #expect(environment0 == environment2)
 #endif
     }
 
-    func test_expressibleByDictionaryLiteral() {
+    @Test
+    func expressibleByDictionaryLiteral() {
         let environment: Environment = ["TestKey": "TestValue"]
-        XCTAssertEqual(environment["TestKey"], "TestValue")
+        #expect(environment["TestKey"] == "TestValue")
     }
 
 
-    func test_decodable() throws {
+    @Test
+    func decodable() throws {
         let jsonString = #"{"TestKey":"TestValue"}"#
         let data = jsonString.data(using: .utf8)!
         let environment = try JSONDecoder().decode(Environment.self, from: data)
-        XCTAssertEqual(environment[EnvironmentKey("TestKey")], "TestValue")
+        #expect(environment[EnvironmentKey("TestKey")] == "TestValue")
     }
 }

--- a/Tests/BasicsTests/FileSystem/FileSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/FileSystemTests.swift
@@ -9,13 +9,15 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @testable import Basics
 import TSCTestSupport
-import XCTest
+import Testing
 
-final class FileSystemTests: XCTestCase {
-    func testStripFirstLevelComponent() throws {
+struct FileSystemTests {
+    @Test
+    func stripFirstLevelComponent() throws {
         let fileSystem = InMemoryFileSystem()
 
         let rootPath = AbsolutePath("/root")
@@ -35,29 +37,31 @@ final class FileSystemTests: XCTestCase {
 
         do {
             let contents = try fileSystem.getDirectoryContents(.root)
-            XCTAssertEqual(contents.count, 1)
+            #expect(contents.count == 1)
         }
 
         try fileSystem.stripFirstLevel(of: .root)
 
         do {
             let contents = Set(try fileSystem.getDirectoryContents(.root))
-            XCTAssertEqual(contents.count, totalDirectories + totalFiles)
+            #expect(contents.count == totalDirectories + totalFiles)
 
             for index in 0 ..< totalDirectories {
-                XCTAssertTrue(contents.contains("dir\(index)"))
+                #expect(contents.contains("dir\(index)"))
             }
             for index in 0 ..< totalFiles {
-                XCTAssertTrue(contents.contains("file\(index)"))
+                #expect(contents.contains("file\(index)"))
             }
         }
     }
 
-    func testStripFirstLevelComponentErrors() throws {
+    @Test
+    func stripFirstLevelComponentErrors() throws {
+        let functionUnderTest = "stripFirstLevel"
         do {
             let fileSystem = InMemoryFileSystem()
-            XCTAssertThrowsError(try fileSystem.stripFirstLevel(of: .root), "expected error") { error in
-                XCTAssertMatch((error as? StringError)?.description, .contains("requires single top level directory"))
+            #expect(throws: StringError("\(functionUnderTest) requires single top level directory")) {
+                try fileSystem.stripFirstLevel(of: .root)
             }
         }
 
@@ -67,8 +71,8 @@ final class FileSystemTests: XCTestCase {
                 let path = AbsolutePath.root.appending("dir\(index)")
                 try fileSystem.createDirectory(path, recursive: false)
             }
-            XCTAssertThrowsError(try fileSystem.stripFirstLevel(of: .root), "expected error") { error in
-                XCTAssertMatch((error as? StringError)?.description, .contains("requires single top level directory"))
+            #expect(throws: StringError("\(functionUnderTest) requires single top level directory")) {
+                try fileSystem.stripFirstLevel(of: .root)
             }
         }
 
@@ -78,8 +82,8 @@ final class FileSystemTests: XCTestCase {
                 let path = AbsolutePath.root.appending("file\(index)")
                 try fileSystem.writeFileContents(path, string: "\(index)")
             }
-            XCTAssertThrowsError(try fileSystem.stripFirstLevel(of: .root), "expected error") { error in
-                XCTAssertMatch((error as? StringError)?.description, .contains("requires single top level directory"))
+            #expect(throws: StringError("\(functionUnderTest) requires single top level directory")) {
+                try fileSystem.stripFirstLevel(of: .root)
             }
         }
 
@@ -87,8 +91,8 @@ final class FileSystemTests: XCTestCase {
             let fileSystem = InMemoryFileSystem()
             let path = AbsolutePath.root.appending("file")
             try fileSystem.writeFileContents(path, string: "")
-            XCTAssertThrowsError(try fileSystem.stripFirstLevel(of: .root), "expected error") { error in
-                XCTAssertMatch((error as? StringError)?.description, .contains("requires single top level directory"))
+            #expect(throws: StringError("\(functionUnderTest) requires single top level directory")) {
+                try fileSystem.stripFirstLevel(of: .root)
             }
         }
     }

--- a/Tests/BasicsTests/FileSystem/PathShimTests.swift
+++ b/Tests/BasicsTests/FileSystem/PathShimTests.swift
@@ -12,64 +12,65 @@
 
 import Basics
 import Foundation
-import XCTest
+import Testing
 
-class PathShimTests: XCTestCase {
-    func testRescursiveDirectoryCreation() {
-        // For the tests we'll need a temporary directory.
-        try! withTemporaryDirectory(removeTreeOnDeinit: true) { path in
+struct PathShimTests {
+    @Test
+    func rescursiveDirectoryCreation() throws {
+        try withTemporaryDirectory(removeTreeOnDeinit: true) { path in
             // Create a directory under several ancestor directories.
             let dirPath = path.appending(components: "abc", "def", "ghi", "mno", "pqr")
             try! makeDirectories(dirPath)
 
             // Check that we were able to actually create the directory.
-            XCTAssertTrue(localFileSystem.isDirectory(dirPath))
+            #expect(localFileSystem.isDirectory(dirPath))
 
             // Check that there's no error if we try to create the directory again.
-            try! makeDirectories(dirPath)
+            #expect(throws: Never.self) {
+                try makeDirectories(dirPath)
+            }
         }
     }
 }
 
-class WalkTests: XCTestCase {
-    func testNonRecursive() throws {
-        #if os(Android)
+struct WalkTests {
+    @Test
+    func nonRecursive() throws {
+#if os(Android)
         let root = "/system"
         var expected: [AbsolutePath] = [
             "\(root)/usr",
             "\(root)/bin",
             "\(root)/etc",
         ]
-        #elseif os(Windows)
+        let expectedCount = 3
+#elseif os(Windows)
         let root = ProcessInfo.processInfo.environment["SystemRoot"]!
         var expected: [AbsolutePath] = [
             "\(root)/System32",
             "\(root)/SysWOW64",
         ]
-        #else
+        let expectedCount = (root as NSString).pathComponents.count
+#else
         let root = ""
         var expected: [AbsolutePath] = [
             "/usr",
             "/bin",
             "/sbin",
         ]
-        #endif
+        let expectedCount = 2
+#endif
         for x in try walk(AbsolutePath(validating: "\(root)/"), recursively: false) {
             if let i = expected.firstIndex(of: x) {
                 expected.remove(at: i)
             }
-            #if os(Android)
-            XCTAssertEqual(3, x.components.count)
-            #elseif os(Windows)
-            XCTAssertEqual((root as NSString).pathComponents.count + 2, x.components.count)
-            #else
-            XCTAssertEqual(2, x.components.count)
-            #endif
+            #expect(expectedCount == x.components.count)
         }
-        XCTAssertEqual(expected.count, 0)
+        #expect(expected.count == 0)
     }
 
-    func testRecursive() {
+    @Test
+    func recursive() {
         let root = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory.parentDirectory
             .appending(component: "Sources")
         var expected = [
@@ -82,6 +83,6 @@ class WalkTests: XCTestCase {
                 expected.remove(at: i)
             }
         }
-        XCTAssertEqual(expected, [])
+        #expect(expected == [])
     }
 }

--- a/Tests/BasicsTests/FileSystem/TemporaryFileTests.swift
+++ b/Tests/BasicsTests/FileSystem/TemporaryFileTests.swift
@@ -9,83 +9,84 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
-import XCTest
+import Testing
 
 import Basics
 
-class TemporaryAsyncFileTests: XCTestCase {
-    func testBasicTemporaryDirectory() async throws {
-        // Test can create and remove temp directory.
+struct TemporaryAsyncFileTests {
+    @Test
+    func basicTemporaryDirectory() async throws {
         let path1: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
             // Do some async task
             try await Task.sleep(nanoseconds: 1_000)
-            
-            XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
+
+            #expect(localFileSystem.isDirectory(tempDirPath))
             return tempDirPath
         }.value
-        XCTAssertFalse(localFileSystem.isDirectory(path1))
-        
+        #expect(!localFileSystem.isDirectory(path1))
+
         // Test temp directory is not removed when its not empty.
         let path2: AbsolutePath = try await withTemporaryDirectory { tempDirPath in
-            XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
+            #expect(localFileSystem.isDirectory(tempDirPath))
             // Create a file inside the temp directory.
             let filePath = tempDirPath.appending("somefile")
             // Do some async task
             try await Task.sleep(nanoseconds: 1_000)
-            
+
             try localFileSystem.writeFileContents(filePath, bytes: [])
             return tempDirPath
         }.value
-        XCTAssertTrue(localFileSystem.isDirectory(path2))
+        #expect(localFileSystem.isDirectory(path2))
         // Cleanup.
         try localFileSystem.removeFileTree(path2)
-        XCTAssertFalse(localFileSystem.isDirectory(path2))
-        
+        #expect(!localFileSystem.isDirectory(path2))
+
         // Test temp directory is removed when its not empty and removeTreeOnDeinit is enabled.
         let path3: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
-            XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
+            #expect(localFileSystem.isDirectory(tempDirPath))
             let filePath = tempDirPath.appending("somefile")
             // Do some async task
             try await Task.sleep(nanoseconds: 1_000)
-            
+
             try localFileSystem.writeFileContents(filePath, bytes: [])
             return tempDirPath
         }.value
-        XCTAssertFalse(localFileSystem.isDirectory(path3))
+        #expect(!localFileSystem.isDirectory(path3))
     }
-    
-    func testCanCreateUniqueTempDirectories() async throws {
+
+    @Test
+    func canCreateUniqueTempDirectories() async throws {
         let (pathOne, pathTwo): (AbsolutePath, AbsolutePath) = try await withTemporaryDirectory(removeTreeOnDeinit: true) { pathOne in
             let pathTwo: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { pathTwo in
                 // Do some async task
                 try await Task.sleep(nanoseconds: 1_000)
-                
-                XCTAssertTrue(localFileSystem.isDirectory(pathOne))
-                XCTAssertTrue(localFileSystem.isDirectory(pathTwo))
+
+                #expect(localFileSystem.isDirectory(pathOne))
+                #expect(localFileSystem.isDirectory(pathTwo))
                 // Their paths should be different.
-                XCTAssertTrue(pathOne != pathTwo)
+                #expect(pathOne != pathTwo)
                 return pathTwo
             }.value
             return (pathOne, pathTwo)
         }.value
-        XCTAssertFalse(localFileSystem.isDirectory(pathOne))
-        XCTAssertFalse(localFileSystem.isDirectory(pathTwo))
+        #expect(!localFileSystem.isDirectory(pathOne))
+        #expect(!localFileSystem.isDirectory(pathTwo))
     }
-    
-    func testCancelOfTask() async throws {
+
+    @Test
+    func cancelOfTask() async throws {
         let task: Task<AbsolutePath, Error> = try withTemporaryDirectory { path in
-            
+
             try await Task.sleep(nanoseconds: 1_000_000_000)
-            XCTAssertTrue(Task.isCancelled)
-            XCTAssertFalse(localFileSystem.isDirectory(path))
+            #expect(Task.isCancelled)
+            #expect(!localFileSystem.isDirectory(path))
             return path
         }
         task.cancel()
-        do {
-            // The correct path is to throw an error here
-            let _ = try await task.value
-            XCTFail("The correct path here is to throw an error")
-        } catch {}
+        await #expect(throws: (any Error).self, "Error did not error when accessing `task.value`") {
+            try await task.value
+        }
     }
 }

--- a/Tests/BasicsTests/FileSystem/VFSTests.swift
+++ b/Tests/BasicsTests/FileSystem/VFSTests.swift
@@ -9,10 +9,11 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import Basics
 import func TSCBasic.withTemporaryFile
-import XCTest
+import Testing
 
 import struct TSCBasic.ByteString
 
@@ -34,19 +35,19 @@ func testWithTemporaryDirectory(
     }.value
 }
 
-class VFSTests: XCTestCase {
-    func testLocalBasics() throws {
-        // tiny PE binary from: https://archive.is/w01DO
+struct VFSTests {
+    @Test
+    func localBasics() throws {
         let contents: [UInt8] = [
-          0x4d, 0x5a, 0x00, 0x00, 0x50, 0x45, 0x00, 0x00, 0x4c, 0x01, 0x01, 0x00,
-          0x6a, 0x2a, 0x58, 0xc3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-          0x04, 0x00, 0x03, 0x01, 0x0b, 0x01, 0x08, 0x00, 0x04, 0x00, 0x00, 0x00,
-          0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00,
-          0x04, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
-          0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
-          0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-          0x68, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-          0x02
+            0x4d, 0x5a, 0x00, 0x00, 0x50, 0x45, 0x00, 0x00, 0x4c, 0x01, 0x01, 0x00,
+            0x6a, 0x2a, 0x58, 0xc3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x04, 0x00, 0x03, 0x01, 0x0b, 0x01, 0x08, 0x00, 0x04, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00,
+            0x04, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
+            0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x68, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x02
         ]
 
         let fs = localFileSystem
@@ -76,63 +77,65 @@ class VFSTests: XCTestCase {
             let vfs = try VirtualFileSystem(path: vfsPath.path, fs: fs)
 
             // exists()
-            XCTAssertTrue(vfs.exists(AbsolutePath("/")))
-            XCTAssertFalse(vfs.exists(AbsolutePath("/does-not-exist")))
+            #expect(vfs.exists(AbsolutePath("/")))
+            #expect(!vfs.exists(AbsolutePath("/does-not-exist")))
 
             // isFile()
             let filePath = AbsolutePath("/best")
-            XCTAssertTrue(vfs.exists(filePath))
-            XCTAssertTrue(vfs.isFile(filePath))
-            XCTAssertEqual(try vfs.getFileInfo(filePath).fileType, .typeRegular)
-            XCTAssertFalse(vfs.isDirectory(filePath))
-            XCTAssertFalse(vfs.isFile(AbsolutePath("/does-not-exist")))
-            XCTAssertFalse(vfs.isSymlink(AbsolutePath("/does-not-exist")))
-            XCTAssertThrowsError(try vfs.getFileInfo(AbsolutePath("/does-not-exist")))
+            #expect(vfs.exists(filePath))
+            #expect(vfs.isFile(filePath))
+            #expect(try vfs.getFileInfo(filePath).fileType == .typeRegular)
+            #expect(!vfs.isDirectory(filePath))
+            #expect(!vfs.isFile(AbsolutePath("/does-not-exist")))
+            #expect(!vfs.isSymlink(AbsolutePath("/does-not-exist")))
+            #expect(throws: (any Error).self) {
+                try vfs.getFileInfo(AbsolutePath("/does-not-exist"))
+            }
 
             // isSymlink()
             let symPath = AbsolutePath("/hello")
-            XCTAssertTrue(vfs.isSymlink(symPath))
-            XCTAssertTrue(vfs.isFile(symPath))
-            XCTAssertEqual(try vfs.getFileInfo(symPath).fileType, .typeSymbolicLink)
-            XCTAssertFalse(vfs.isDirectory(symPath))
+            #expect(vfs.isSymlink(symPath))
+            #expect(vfs.isFile(symPath))
+            #expect(try vfs.getFileInfo(symPath).fileType == .typeSymbolicLink)
+            #expect(!vfs.isDirectory(symPath))
 
             // isExecutableFile
             let executablePath = AbsolutePath("/exec-foo")
             let executableSymPath = AbsolutePath("/exec-sym")
-            XCTAssertTrue(vfs.isExecutableFile(executablePath))
-            XCTAssertTrue(vfs.isExecutableFile(executableSymPath))
-            XCTAssertTrue(vfs.isSymlink(executableSymPath))
-            XCTAssertFalse(vfs.isExecutableFile(symPath))
-            XCTAssertFalse(vfs.isExecutableFile(filePath))
-            XCTAssertFalse(vfs.isExecutableFile(AbsolutePath("/does-not-exist")))
-            XCTAssertFalse(vfs.isExecutableFile(AbsolutePath("/")))
+            #expect(vfs.isExecutableFile(executablePath))
+            #expect(vfs.isExecutableFile(executableSymPath))
+            #expect(vfs.isSymlink(executableSymPath))
+            #expect(!vfs.isExecutableFile(symPath))
+            #expect(!vfs.isExecutableFile(filePath))
+            #expect(!vfs.isExecutableFile(AbsolutePath("/does-not-exist")))
+            #expect(!vfs.isExecutableFile(AbsolutePath("/")))
 
             // readFileContents
             let execFileContents = try vfs.readFileContents(executablePath)
-            XCTAssertEqual(execFileContents, ByteString(contents))
+            #expect(execFileContents == ByteString(contents))
 
             // isDirectory()
-            XCTAssertTrue(vfs.isDirectory(AbsolutePath("/")))
-            XCTAssertFalse(vfs.isDirectory(AbsolutePath("/does-not-exist")))
+            #expect(vfs.isDirectory(AbsolutePath("/")))
+            #expect(!vfs.isDirectory(AbsolutePath("/does-not-exist")))
 
             // getDirectoryContents()
-            do {
-                _ = try vfs.getDirectoryContents(AbsolutePath("/does-not-exist"))
-                XCTFail("Unexpected success")
-            } catch {
-                XCTAssertEqual(error.localizedDescription, "no such file or directory: \(AbsolutePath("/does-not-exist"))")
+            let dirContents = try vfs.getDirectoryContents(AbsolutePath("/"))
+            #expect(dirContents.sorted() == ["best", "dir", "exec-foo", "exec-sym", "hello"])
+            #expect {try vfs.getDirectoryContents(AbsolutePath("/does-not-exist"))} throws: { error in
+                (error.localizedDescription == "no such file or directory: \(AbsolutePath("/does-not-exist"))")
             }
 
+
             let thisDirectoryContents = try vfs.getDirectoryContents(AbsolutePath("/"))
-            XCTAssertFalse(thisDirectoryContents.contains(where: { $0 == "." }))
-            XCTAssertFalse(thisDirectoryContents.contains(where: { $0 == ".." }))
-            XCTAssertEqual(thisDirectoryContents.sorted(), ["best", "dir", "exec-foo", "exec-sym", "hello"])
+            #expect(!thisDirectoryContents.contains(where: { $0 == "." }))
+            #expect(!thisDirectoryContents.contains(where: { $0 == ".." }))
+            #expect(thisDirectoryContents.sorted() == ["best", "dir", "exec-foo", "exec-sym", "hello"])
 
             let contents = try vfs.getDirectoryContents(AbsolutePath("/dir"))
-            XCTAssertEqual(contents, ["file"])
+            #expect(contents == ["file"])
 
             let fileContents = try vfs.readFileContents(AbsolutePath("/dir/file"))
-            XCTAssertEqual(fileContents, "")
+            #expect(fileContents == "")
         }
     }
 }

--- a/Tests/BasicsTests/Graph/AdjacencyMatrixTests.swift
+++ b/Tests/BasicsTests/Graph/AdjacencyMatrixTests.swift
@@ -9,30 +9,33 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @testable import Basics
-import XCTest
+import Testing
 
-final class AdjacencyMatrixTests: XCTestCase {
-    func testEmpty() {
+struct AdjacencyMatrixTests {
+    @Test
+    func empty() {
         var matrix = AdjacencyMatrix(rows: 0, columns: 0)
-        XCTAssertEqual(matrix.bitCount, 0)
+        #expect(matrix.bitCount == 0)
 
         matrix = AdjacencyMatrix(rows: 0, columns: 42)
-        XCTAssertEqual(matrix.bitCount, 0)
+        #expect(matrix.bitCount == 0)
 
         matrix = AdjacencyMatrix(rows: 42, columns: 0)
-        XCTAssertEqual(matrix.bitCount, 0)
+        #expect(matrix.bitCount == 0)
     }
 
-    func testBits() {
+    @Test
+    func bits() {
         for count in 1..<10 {
             var matrix = AdjacencyMatrix(rows: count, columns: count)
             for row in 0..<count {
                 for column in 0..<count {
-                    XCTAssertFalse(matrix[row, column])
+                    #expect(!matrix[row, column])
                     matrix[row, column] = true
-                    XCTAssertTrue(matrix[row, column])
+                    #expect(matrix[row, column])
                 }
             }
         }

--- a/Tests/BasicsTests/Graph/DirectedGraphTests.swift
+++ b/Tests/BasicsTests/Graph/DirectedGraphTests.swift
@@ -9,25 +9,27 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 import Basics
 
-import XCTest
+import Testing
 
-final class DirectedGraphTests: XCTestCase {
-    func testNodesConnection() {
+struct DirectedGraphTests {
+    @Test
+    func nodesConnection() {
         var graph = DirectedGraph(nodes: ["app1", "lib1", "lib2", "app2", "lib3"])
         graph.addEdge(source: 0, destination: 1)
         graph.addEdge(source: 1, destination: 2)
-        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 2))
-        XCTAssertFalse(graph.areNodesConnected(source: 2, destination: 0))
+        #expect(graph.areNodesConnected(source: 0, destination: 2))
+        #expect(!graph.areNodesConnected(source: 2, destination: 0))
 
         graph.addEdge(source: 0, destination: 4)
         graph.addEdge(source: 3, destination: 4)
-        XCTAssertTrue(graph.areNodesConnected(source: 3, destination: 4))
-        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 4))
-        XCTAssertFalse(graph.areNodesConnected(source: 1, destination: 4))
-        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 4))
+        #expect(graph.areNodesConnected(source: 3, destination: 4))
+        #expect(graph.areNodesConnected(source: 0, destination: 4))
+        #expect(!graph.areNodesConnected(source: 1, destination: 4))
+        #expect(graph.areNodesConnected(source: 0, destination: 4))
     }
 }

--- a/Tests/BasicsTests/Graph/UndirectedGraphTests.swift
+++ b/Tests/BasicsTests/Graph/UndirectedGraphTests.swift
@@ -9,32 +9,34 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 import Basics
 
-import XCTest
+import Testing
 
-final class UndirectedGraphTests: XCTestCase {
-    func testNodesConnection() {
+struct UndirectedGraphTests {
+    @Test
+    func nodesConnection() {
         var graph = UndirectedGraph(nodes: ["app1", "lib1", "lib2", "app2", "lib3", "app3"])
         graph.addEdge(source: 0, destination: 1)
         graph.addEdge(source: 1, destination: 2)
-        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 2))
-        XCTAssertTrue(graph.areNodesConnected(source: 2, destination: 0))
+        #expect(graph.areNodesConnected(source: 0, destination: 2))
+        #expect(graph.areNodesConnected(source: 2, destination: 0))
 
         graph.addEdge(source: 0, destination: 4)
         graph.addEdge(source: 3, destination: 4)
-        XCTAssertTrue(graph.areNodesConnected(source: 3, destination: 4))
-        XCTAssertTrue(graph.areNodesConnected(source: 4, destination: 3))
-        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 4))
-        XCTAssertTrue(graph.areNodesConnected(source: 4, destination: 0))
-        XCTAssertTrue(graph.areNodesConnected(source: 1, destination: 4))
-        XCTAssertTrue(graph.areNodesConnected(source: 4, destination: 1))
+        #expect(graph.areNodesConnected(source: 3, destination: 4))
+        #expect(graph.areNodesConnected(source: 4, destination: 3))
+        #expect(graph.areNodesConnected(source: 0, destination: 4))
+        #expect(graph.areNodesConnected(source: 4, destination: 0))
+        #expect(graph.areNodesConnected(source: 1, destination: 4))
+        #expect(graph.areNodesConnected(source: 4, destination: 1))
 
         for i in 0...4 {
-            XCTAssertFalse(graph.areNodesConnected(source: i, destination: 5))
-            XCTAssertFalse(graph.areNodesConnected(source: 5, destination: i))
+            #expect(!graph.areNodesConnected(source: i, destination: 5))
+            #expect(!graph.areNodesConnected(source: 5, destination: i))
         }
     }
 }

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -9,222 +9,19 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @testable import Basics
 import _Concurrency
 import _InternalTestSupport
 import XCTest
+import Testing
 
-final class HTTPClientTests: XCTestCase {
-    func testHead() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseStatus = Int.random(in: 201 ..< 500)
-        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody: Data? = nil
+final class HTTPClientsXCTests: XCTestCase {
 
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertEqual(request.url, url, "url should match")
-            XCTAssertEqual(request.method, .head, "method should match")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
-        }
-
-        let response = try await httpClient.head(url, headers: requestHeaders)
-        XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
-        assertResponseHeaders(response.headers, expected: responseHeaders)
-        XCTAssertEqual(response.body, responseBody, "body should match")
-    }
-
-    func testGet() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseStatus = Int.random(in: 201 ..< 500)
-        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = Data(UUID().uuidString.utf8)
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertEqual(request.url, url, "url should match")
-            XCTAssertEqual(request.method, .get, "method should match")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
-        }
-
-        let response = try await httpClient.get(url, headers: requestHeaders)
-        XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
-        assertResponseHeaders(response.headers, expected: responseHeaders)
-        XCTAssertEqual(response.body, responseBody, "body should match")
-    }
-
-    func testPost() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestBody = Data(UUID().uuidString.utf8)
-        let responseStatus = Int.random(in: 201 ..< 500)
-        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = Data(UUID().uuidString.utf8)
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertEqual(request.url, url, "url should match")
-            XCTAssertEqual(request.method, .post, "method should match")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            XCTAssertEqual(request.body, requestBody, "body should match")
-            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
-        }
-
-        let response = try await httpClient.post(url, body: requestBody, headers: requestHeaders)
-        XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
-        assertResponseHeaders(response.headers, expected: responseHeaders)
-        XCTAssertEqual(response.body, responseBody, "body should match")
-    }
-
-    func testPut() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestBody = Data(UUID().uuidString.utf8)
-        let responseStatus = Int.random(in: 201 ..< 500)
-        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = Data(UUID().uuidString.utf8)
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertEqual(request.url, url, "url should match")
-            XCTAssertEqual(request.method, .put, "method should match")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            XCTAssertEqual(request.body, requestBody, "body should match")
-            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
-        }
-
-        let response = try await httpClient.put(url, body: requestBody, headers: requestHeaders)
-        XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
-        assertResponseHeaders(response.headers, expected: responseHeaders)
-        XCTAssertEqual(response.body, responseBody, "body should match")
-    }
-
-    func testDelete() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseStatus = Int.random(in: 201 ..< 500)
-        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = Data(UUID().uuidString.utf8)
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertEqual(request.url, url, "url should match")
-            XCTAssertEqual(request.method, .delete, "method should match")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
-        }
-
-        let response = try await httpClient.delete(url, headers: requestHeaders)
-        XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
-        assertResponseHeaders(response.headers, expected: responseHeaders)
-        XCTAssertEqual(response.body, responseBody, "body should match")
-    }
-
-    func testExtraHeaders() async throws {
-        let url = URL("http://test")
-        let globalHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-
-        let httpClient = HTTPClient(configuration: .init(requestHeaders: globalHeaders)) { request, _ in
-            var expectedHeaders = globalHeaders
-            expectedHeaders.merge(requestHeaders)
-            assertRequestHeaders(request.headers, expected: expectedHeaders)
-            return .init(statusCode: 200)
-        }
-
-        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
-        request.options.addUserAgent = true
-
-        let response = try await httpClient.execute(request)
-        XCTAssertEqual(response.statusCode, 200, "statusCode should match")
-    }
-
-    func testUserAgent() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertTrue(request.headers.contains("User-Agent"), "expecting User-Agent")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            return .init(statusCode: 200)
-        }
-        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
-        request.options.addUserAgent = true
-
-        let response = try await httpClient.execute(request)
-        XCTAssertEqual(response.statusCode, 200, "statusCode should match")
-    }
-
-    func testNoUserAgent() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertFalse(request.headers.contains("User-Agent"), "expecting User-Agent")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            return .init(statusCode: 200)
-        }
-
-        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
-        request.options.addUserAgent = false
-
-        let response = try await httpClient.execute(request)
-        XCTAssertEqual(response.statusCode, 200, "statusCode should match")
-    }
-
-    func testAuthorization() async throws {
-        let url = URL("http://test")
-
-        do {
-            let authorization = UUID().uuidString
-
-            let httpClient = HTTPClient { request, _ in
-                XCTAssertTrue(request.headers.contains("Authorization"), "expecting Authorization")
-                XCTAssertEqual(request.headers.get("Authorization").first, authorization, "expecting Authorization to match")
-                return .init(statusCode: 200)
-            }
-
-            var request = HTTPClient.Request(method: .get, url: url)
-            request.options.authorizationProvider = { requestUrl in
-                requestUrl == url ? authorization : nil
-            }
-
-            let response = try await httpClient.execute(request)
-            XCTAssertEqual(response.statusCode, 200, "statusCode should match")
-        }
-
-        do {
-            let httpClient = HTTPClient { request, _ in
-                XCTAssertFalse(request.headers.contains("Authorization"), "not expecting Authorization")
-                return .init(statusCode: 200)
-            }
-
-            var request = HTTPClient.Request(method: .get, url: url)
-            request.options.authorizationProvider = { _ in "" }
-
-            let response = try await httpClient.execute(request)
-            XCTAssertEqual(response.statusCode, 200, "statusCode should match")
-        }
-    }
-
-    func testValidResponseCodes() async throws {
-        let statusCode = Int.random(in: 201 ..< 500)
-
-        let httpClient = HTTPClient { _, _ in
-            throw HTTPClientError.badResponseStatusCode(statusCode)
-        }
-
-        var request = HTTPClient.Request(method: .get, url: "http://test")
-        request.options.validResponseCodes = [200]
-
-        do {
-            let response = try await httpClient.execute(request)
-            XCTFail("unexpected success \(response)")
-        } catch {
-            XCTAssertEqual(error as? HTTPClientError, .badResponseStatusCode(statusCode), "expected error to match")
-        }
-    }
-
+    // When converting this test to Swift Testing, it was failing in linux
+    //   The XCTAssertEqual( : :  accurary) was converted to use the isApproximatelyEqual
+    //   from swift-numerics.
     func testExponentialBackoff() async throws {
         let counter = SendableBox(0)
         let lastCall = SendableBox<Date>()
@@ -250,8 +47,227 @@ final class HTTPClientTests: XCTestCase {
         let count = await counter.value
         XCTAssertEqual(count, maxAttempts, "retries should match")
     }
+}
 
-    func testHostCircuitBreaker() async throws {
+struct HTTPClientTests {
+    @Test
+    func head() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody: Data? = nil
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(request.url == url, "url should match")
+            #expect(request.method == .head, "method should match")
+            assertRequestHeaders(request.headers, expected: requestHeaders)
+            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let response = try await httpClient.head(url, headers: requestHeaders)
+        #expect(response.statusCode == responseStatus, "statusCode should match")
+        assertResponseHeaders(response.headers, expected: responseHeaders)
+        #expect(response.body == responseBody, "body should match")
+    }
+
+    @Test
+    func testGet() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody = Data(UUID().uuidString.utf8)
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(request.url == url, "url should match")
+            #expect(request.method == .get, "method should match")
+            assertRequestHeaders(request.headers, expected: requestHeaders)
+            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let response = try await httpClient.get(url, headers: requestHeaders)
+        #expect(response.statusCode == responseStatus, "statusCode should match")
+        assertResponseHeaders(response.headers, expected: responseHeaders)
+        #expect(response.body == responseBody, "body should match")
+    }
+
+    @Test
+    func post() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let requestBody = Data(UUID().uuidString.utf8)
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody = Data(UUID().uuidString.utf8)
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(request.url == url, "url should match")
+            #expect(request.method == .post, "method should match")
+            assertRequestHeaders(request.headers, expected: requestHeaders)
+            #expect(request.body == requestBody, "body should match")
+            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let response = try await httpClient.post(url, body: requestBody, headers: requestHeaders)
+        #expect(response.statusCode == responseStatus, "statusCode should match")
+        assertResponseHeaders(response.headers, expected: responseHeaders)
+        #expect(response.body == responseBody, "body should match")
+    }
+
+    @Test
+    func put() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let requestBody = Data(UUID().uuidString.utf8)
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody = Data(UUID().uuidString.utf8)
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(request.url == url, "url should match")
+            #expect(request.method == .put, "method should match")
+            assertRequestHeaders(request.headers, expected: requestHeaders)
+            #expect(request.body == requestBody, "body should match")
+            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let response = try await httpClient.put(url, body: requestBody, headers: requestHeaders)
+        #expect(response.statusCode == responseStatus, "statusCode should match")
+        assertResponseHeaders(response.headers, expected: responseHeaders)
+        #expect(response.body == responseBody, "body should match")
+    }
+
+    @Test
+    func delete() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody = Data(UUID().uuidString.utf8)
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(request.url == url, "url should match")
+            #expect(request.method == .delete, "method should match")
+            assertRequestHeaders(request.headers, expected: requestHeaders)
+            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let response = try await httpClient.delete(url, headers: requestHeaders)
+        #expect(response.statusCode == responseStatus, "statusCode should match")
+        assertResponseHeaders(response.headers, expected: responseHeaders)
+        #expect(response.body == responseBody, "body should match")
+    }
+
+    @Test
+    func extraHeaders() async throws {
+        let url = URL("http://test")
+        let globalHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+
+        let httpClient = HTTPClient(configuration: .init(requestHeaders: globalHeaders)) { request, _ in
+            var expectedHeaders = globalHeaders
+            expectedHeaders.merge(requestHeaders)
+            assertRequestHeaders(request.headers, expected: expectedHeaders)
+            return .init(statusCode: 200)
+        }
+
+        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
+        request.options.addUserAgent = true
+
+        let response = try await httpClient.execute(request)
+        #expect(response.statusCode == 200, "statusCode should match")
+    }
+
+    @Test
+    func userAgent() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(request.headers.contains("User-Agent"), "expecting User-Agent")
+            assertRequestHeaders(request.headers, expected: requestHeaders)
+            return .init(statusCode: 200)
+        }
+        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
+        request.options.addUserAgent = true
+
+        let response = try await httpClient.execute(request)
+        #expect(response.statusCode == 200, "statusCode should match")
+    }
+
+    @Test
+    func noUserAgent() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(!request.headers.contains("User-Agent"), "expecting User-Agent")
+            assertRequestHeaders(request.headers, expected: requestHeaders)
+            return .init(statusCode: 200)
+        }
+
+        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
+        request.options.addUserAgent = false
+
+        let response = try await httpClient.execute(request)
+        #expect(response.statusCode == 200, "statusCode should match")
+    }
+
+    @Test
+    func authorization() async throws {
+        let url = URL("http://test")
+
+        do {
+            let authorization = UUID().uuidString
+
+            let httpClient = HTTPClient { request, _ in
+                #expect(request.headers.contains("Authorization"), "expecting Authorization")
+                #expect(request.headers.get("Authorization").first == authorization, "expecting Authorization to match")
+                return .init(statusCode: 200)
+            }
+
+            var request = HTTPClient.Request(method: .get, url: url)
+            request.options.authorizationProvider = { requestUrl in
+                requestUrl == url ? authorization : nil
+            }
+
+            let response = try await httpClient.execute(request)
+            #expect(response.statusCode == 200, "statusCode should match")
+        }
+
+        do {
+            let httpClient = HTTPClient { request, _ in
+                #expect(!request.headers.contains("Authorization"), "not expecting Authorization")
+                return .init(statusCode: 200)
+            }
+
+            var request = HTTPClient.Request(method: .get, url: url)
+            request.options.authorizationProvider = { _ in "" }
+
+            let response = try await httpClient.execute(request)
+            #expect(response.statusCode == 200, "statusCode should match")
+        }
+    }
+
+    @Test
+    func validResponseCodes() async throws {
+        let statusCode = Int.random(in: 201 ..< 500)
+
+        let httpClient = HTTPClient { _, _ in
+            throw HTTPClientError.badResponseStatusCode(statusCode)
+        }
+
+        var request = HTTPClient.Request(method: .get, url: "http://test")
+        request.options.validResponseCodes = [200]
+
+        await #expect(throws: HTTPClientError.badResponseStatusCode(statusCode)) {
+            let _ = try await httpClient.execute(request)
+        }
+    }
+
+    @Test
+    func hostCircuitBreaker() async throws {
         let maxErrors = 5
         let errorCode = Int.random(in: 500 ..< 600)
         let age = SendableTimeInterval.seconds(5)
@@ -268,31 +284,29 @@ final class HTTPClientTests: XCTestCase {
             for index in (0 ..< maxErrors) {
                 let response = try await httpClient.get(URL("\(host)/\(index)/foo"))
                 await counter.increment()
-                XCTAssertEqual(response.statusCode, errorCode)
+                #expect(response.statusCode == errorCode)
             }
             let count = await counter.value
-            XCTAssertEqual(count, maxErrors, "expected results count to match")
+            #expect(count == maxErrors, "expected results count to match")
         }
 
         // these should all circuit break
         let counter = SendableBox(0)
         let total = Int.random(in: 10 ..< 20)
         for index in (0 ..< total) {
-            do {
-                let response = try await httpClient.get(URL("\(host)/\(index)/foo"))
-                XCTFail("unexpected success \(response)")
-            } catch {
-                XCTAssertEqual(error as? HTTPClientError, .circuitBreakerTriggered, "expected error to match")
+            await #expect(throws: HTTPClientError.circuitBreakerTriggered) {
+                let _ = try await httpClient.get(URL("\(host)/\(index)/foo"))
             }
 
             await counter.increment()
         }
 
         let count = await counter.value
-        XCTAssertEqual(count, total, "expected results count to match")
+        #expect(count == total, "expected results count to match")
     }
 
-    func testHostCircuitBreakerAging() async throws {
+    @Test
+    func hostCircuitBreakerAging() async throws {
         let maxErrors = 5
         let errorCode = Int.random(in: 500 ..< 600)
         let ageInMilliseconds = 100
@@ -320,10 +334,10 @@ final class HTTPClientTests: XCTestCase {
             for index in (0 ..< maxErrors) {
                 let response = try await httpClient.get(URL("\(host)/\(index)/error"))
                 await counter.increment()
-                XCTAssertEqual(response.statusCode, errorCode)
+                #expect(response.statusCode == errorCode)
             }
             let count = await counter.value
-            XCTAssertEqual(count, maxErrors, "expected results count to match")
+            #expect(count == maxErrors, "expected results count to match")
         }
 
         // these should not circuit break since they are deliberately aged
@@ -336,49 +350,51 @@ final class HTTPClientTests: XCTestCase {
             try await Task.sleep(nanoseconds: UInt64(sleepInterval.nanoseconds()!))
             let response = try await httpClient.get("\(host)/\(index)/okay")
             count.increment()
-            XCTAssertEqual(response.statusCode, 200, "expected status code to match")
+            #expect(response.statusCode == 200, "expected status code to match")
         }
 
-        XCTAssertEqual(count.get(), total, "expected results count to match")
+        #expect(count.get() == total, "expected status code to match")
     }
 
-    func testHTTPClientHeaders() async throws {
+    @Test
+    func hTTPClientHeaders() async throws {
         var headers = HTTPClientHeaders()
 
         let items = (1 ... Int.random(in: 10 ... 20)).map { index in HTTPClientHeaders.Item(name: "header-\(index)", value: UUID().uuidString) }
         headers.add(items)
 
-        XCTAssertEqual(headers.count, items.count, "headers count should match")
+        #expect(headers.count == items.count, "headers count should match")
         items.forEach { item in
-            XCTAssertEqual(headers.get(item.name).first, item.value, "headers value should match")
+            #expect(headers.get(item.name).first == item.value, "headers value should match")
         }
 
         headers.add(items.first!)
-        XCTAssertEqual(headers.count, items.count, "headers count should match (no duplicates)")
+        #expect(headers.count == items.count, "headers count should match (no duplicates)")
 
         let name = UUID().uuidString
         let values = (1 ... Int.random(in: 10 ... 20)).map { "value-\($0)" }
         values.forEach { value in
             headers.add(name: name, value: value)
         }
-        XCTAssertEqual(headers.count, items.count + 1, "headers count should match (no duplicates)")
-        XCTAssertEqual(values, headers.get(name), "multiple headers value should match")
+        #expect(headers.count == items.count + 1, "headers count should match (no duplicates)")
+        #expect(values == headers.get(name), "multiple headers value should match")
     }
 
-    func testExceedsDownloadSizeLimitProgress() async throws {
+    @Test
+    func exceedsDownloadSizeLimitProgress() async throws {
         let maxSize: Int64 = 50
 
         let httpClient = HTTPClient { request, progress in
             switch request.method {
-            case .head:
-                return .init(
-                    statusCode: 200,
-                    headers: .init([.init(name: "Content-Length", value: "0")])
-                )
-            case .get:
-                try progress?(Int64(maxSize * 2), 0)
-            default:
-                XCTFail("method should match")
+                case .head:
+                    return .init(
+                        statusCode: 200,
+                        headers: .init([.init(name: "Content-Length", value: "0")])
+                    )
+                case .get:
+                    try progress?(Int64(maxSize * 2), 0)
+                default:
+                    Issue.record("method should match. Received: \(request.method)")
             }
 
             fatalError("unreachable")
@@ -387,15 +403,13 @@ final class HTTPClientTests: XCTestCase {
         var request = HTTPClient.Request(url: "http://test")
         request.options.maximumResponseSizeInBytes = 10
 
-        do {
-            let response = try await httpClient.execute(request)
-            XCTFail("unexpected success \(response)")
-        } catch {
-            XCTAssertEqual(error as? HTTPClientError, .responseTooLarge(maxSize * 2), "expected error to match")
+        await #expect(throws: HTTPClientError.responseTooLarge(maxSize * 2)) {
+            let _ = try await httpClient.execute(request)
         }
     }
 
-    func testMaxConcurrency() async throws {
+    @Test
+    func maxConcurrency() async throws {
         let maxConcurrentRequests = 2
         let concurrentRequests = SendableBox(0)
 
@@ -404,8 +418,9 @@ final class HTTPClientTests: XCTestCase {
         let httpClient = HTTPClient(configuration: configuration) { request, _ in
             await concurrentRequests.increment()
 
-            if await concurrentRequests.value! > maxConcurrentRequests {
-                XCTFail("too many concurrent requests \(concurrentRequests), expected \(maxConcurrentRequests)")
+            let concurrentRequestsCounts = await concurrentRequests.value!
+            if concurrentRequestsCounts > maxConcurrentRequests {
+                Issue.record("too many concurrent requests \(concurrentRequestsCounts), expected \(maxConcurrentRequests)")
             }
 
             await concurrentRequests.decrement()
@@ -426,10 +441,10 @@ final class HTTPClientTests: XCTestCase {
                 results.append(result)
             }
 
-            XCTAssertEqual(results.count, total, "expected number of results to match")
+            #expect(results.count == total, "expected number of results to match")
 
             for result in results {
-                XCTAssertEqual(result.statusCode, 200, "expected '200 okay' response")
+                #expect(result.statusCode == 200, "expected '200 okay' response")
             }
         }
     }
@@ -437,9 +452,9 @@ final class HTTPClientTests: XCTestCase {
 
 private func assertRequestHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {
     let noAgent = HTTPClientHeaders(headers.filter { $0.name != "User-Agent" })
-    XCTAssertEqual(noAgent, expected, "expected headers to match")
+    #expect(noAgent == expected, "expected headers to match")
 }
 
 private func assertResponseHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {
-    XCTAssertEqual(headers, expected, "expected headers to match")
+    #expect(headers == expected, "expected headers to match")
 }

--- a/Tests/BasicsTests/NetrcTests.swift
+++ b/Tests/BasicsTests/NetrcTests.swift
@@ -11,30 +11,32 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-import XCTest
+import Testing
 
-class NetrcTests: XCTestCase {
+struct NetrcTests {
     /// should load machines for a given inline format
-    func testLoadMachinesInline() throws {
+    @Test
+    func loadMachinesInline() throws {
         let content = "machine example.com login anonymous password qwerty"
 
         let netrc = try NetrcParser.parse(content)
-        XCTAssertEqual(netrc.machines.count, 1)
+        #expect(netrc.machines.count == 1)
 
         let machine = netrc.machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qwerty")
+        #expect(machine?.name == "example.com")
+        #expect(machine?.login == "anonymous")
+        #expect(machine?.password == "qwerty")
 
         let authorization = netrc.authorization(for: "http://example.com/resource.zip")
-        XCTAssertEqual(authorization, Netrc.Authorization(login: "anonymous", password: "qwerty"))
+        #expect(authorization == Netrc.Authorization(login: "anonymous", password: "qwerty"))
 
-        XCTAssertNil(netrc.authorization(for: "http://example2.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "http://www.example2.com/resource.zip"))
+        #expect(netrc.authorization(for: "http://example2.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "http://www.example2.com/resource.zip") == nil)
     }
 
     /// should load machines for a given multi-line format
-    func testLoadMachinesMultiLine() throws {
+    @Test
+    func loadMachinesMultiLine() throws {
         let content = """
                     machine example.com
                     login anonymous
@@ -42,22 +44,23 @@ class NetrcTests: XCTestCase {
                     """
 
         let netrc = try NetrcParser.parse(content)
-        XCTAssertEqual(netrc.machines.count, 1)
+        #expect(netrc.machines.count == 1)
 
         let machine = netrc.machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qwerty")
+        #expect(machine?.name == "example.com")
+        #expect(machine?.login == "anonymous")
+        #expect(machine?.password == "qwerty")
 
         let authorization = netrc.authorization(for: "http://example.com/resource.zip")
-        XCTAssertEqual(authorization, Netrc.Authorization(login: "anonymous", password: "qwerty"))
+        #expect(authorization == Netrc.Authorization(login: "anonymous", password: "qwerty"))
 
-        XCTAssertNil(netrc.authorization(for: "http://example2.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "http://www.example2.com/resource.zip"))
+        #expect(netrc.authorization(for: "http://example2.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "http://www.example2.com/resource.zip") == nil)
     }
 
     /// Should fall back to default machine when not matching host
-    func testLoadDefaultMachine() throws {
+    @Test
+    func loadDefaultMachine() throws {
         let content = """
                     machine example.com
                     login anonymous
@@ -69,23 +72,24 @@ class NetrcTests: XCTestCase {
                     """
 
         let netrc = try NetrcParser.parse(content)
-        XCTAssertEqual(netrc.machines.count, 2)
+        #expect(netrc.machines.count == 2)
 
         let machine = netrc.machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qwerty")
+        #expect(machine?.name == "example.com")
+        #expect(machine?.login == "anonymous")
+        #expect(machine?.password == "qwerty")
 
         let machine2 = netrc.machines.last
-        XCTAssertEqual(machine2?.name, "default")
-        XCTAssertEqual(machine2?.login, "id")
-        XCTAssertEqual(machine2?.password, "secret")
+        #expect(machine2?.name == "default")
+        #expect(machine2?.login == "id")
+        #expect(machine2?.password == "secret")
 
         let authorization = netrc.authorization(for: "http://example2.com/resource.zip")
-        XCTAssertEqual(authorization, Netrc.Authorization(login: "id", password: "secret"))
+        #expect(authorization == Netrc.Authorization(login: "id", password: "secret"))
     }
 
-    func testRegexParsing() throws {
+    @Test
+    func regexParsing() throws {
         let content = """
                     machine machine
                     login login
@@ -109,25 +113,26 @@ class NetrcTests: XCTestCase {
                     """
 
         let netrc = try NetrcParser.parse(content)
-        XCTAssertEqual(netrc.machines.count, 3)
+        #expect(netrc.machines.count == 3)
 
-        XCTAssertEqual(netrc.machines[0].name, "machine")
-        XCTAssertEqual(netrc.machines[0].login, "login")
-        XCTAssertEqual(netrc.machines[0].password, "password")
+        #expect(netrc.machines[0].name == "machine")
+        #expect(netrc.machines[0].login == "login")
+        #expect(netrc.machines[0].password == "password")
 
-        XCTAssertEqual(netrc.machines[1].name, "login")
-        XCTAssertEqual(netrc.machines[1].login, "password")
-        XCTAssertEqual(netrc.machines[1].password, "machine")
+        #expect(netrc.machines[1].name == "login")
+        #expect(netrc.machines[1].login == "password")
+        #expect(netrc.machines[1].password == "machine")
 
-        XCTAssertEqual(netrc.machines[2].name, "default")
-        XCTAssertEqual(netrc.machines[2].login, "id")
-        XCTAssertEqual(netrc.machines[2].password, "secret")
+        #expect(netrc.machines[2].name == "default")
+        #expect(netrc.machines[2].login == "id")
+        #expect(netrc.machines[2].password == "secret")
 
         let authorization = netrc.authorization(for: "http://example2.com/resource.zip")
-        XCTAssertEqual(authorization, Netrc.Authorization(login: "id", password: "secret"))
+        #expect(authorization == Netrc.Authorization(login: "id", password: "secret"))
     }
 
-    func testOutOfOrderDefault() {
+    @Test
+    func outOfOrderDefault() {
         let content = """
                     machine machine
                     login login
@@ -146,12 +151,13 @@ class NetrcTests: XCTestCase {
                     password secret
                     """
 
-        XCTAssertThrowsError(try NetrcParser.parse(content)) { error in
-            XCTAssertEqual(error as? NetrcError, .invalidDefaultMachinePosition)
+        #expect(throws: NetrcError.invalidDefaultMachinePosition) {
+            try NetrcParser.parse(content)
         }
     }
 
-    func testErrorOnMultipleDefault() {
+    @Test
+    func errorOnMultipleDefault() {
         let content = """
                     machine machine
                     login login
@@ -174,13 +180,14 @@ class NetrcTests: XCTestCase {
                     password terces
                     """
 
-        XCTAssertThrowsError(try NetrcParser.parse(content)) { error in
-            XCTAssertEqual(error as? NetrcError, .invalidDefaultMachinePosition)
+        #expect(throws: NetrcError.invalidDefaultMachinePosition) {
+            try NetrcParser.parse(content)
         }
     }
 
     /// should load machines for a given multi-line format with comments
-    func testLoadMachinesMultilineComments() throws {
+    @Test
+    func loadMachinesMultilineComments() throws {
         let content = """
                     ## This is a comment
                     # This is another comment
@@ -190,48 +197,51 @@ class NetrcTests: XCTestCase {
                     """
 
         let machines = try NetrcParser.parse(content).machines
-        XCTAssertEqual(machines.count, 1)
+        #expect(machines.count == 1)
 
         let machine = machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qwerty")
+        #expect(machine?.name == "example.com")
+        #expect(machine?.login == "anonymous")
+        #expect(machine?.password == "qwerty")
     }
 
     /// should load machines for a given multi-line + whitespaces format
-    func testLoadMachinesMultilineWhitespaces() throws {
+    @Test
+    func loadMachinesMultilineWhitespaces() throws {
         let content = """
                     machine  example.com login     anonymous
                     password                  qwerty
                     """
 
         let machines = try NetrcParser.parse(content).machines
-        XCTAssertEqual(machines.count, 1)
+        #expect(machines.count == 1)
 
         let machine = machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qwerty")
+        #expect(machine?.name == "example.com")
+        #expect(machine?.login == "anonymous")
+        #expect(machine?.password == "qwerty")
     }
 
     /// should load multiple machines for a given inline format
-    func testLoadMultipleMachinesInline() throws {
+    @Test
+    func loadMultipleMachinesInline() throws {
         let content = "machine example.com login anonymous password qwerty machine example2.com login anonymous2 password qwerty2"
 
         let netrc = try NetrcParser.parse(content)
-        XCTAssertEqual(netrc.machines.count, 2)
+        #expect(netrc.machines.count == 2)
 
-        XCTAssertEqual(netrc.machines[0].name, "example.com")
-        XCTAssertEqual(netrc.machines[0].login, "anonymous")
-        XCTAssertEqual(netrc.machines[0].password, "qwerty")
+        #expect(netrc.machines[0].name == "example.com")
+        #expect(netrc.machines[0].login == "anonymous")
+        #expect(netrc.machines[0].password == "qwerty")
 
-        XCTAssertEqual(netrc.machines[1].name, "example2.com")
-        XCTAssertEqual(netrc.machines[1].login, "anonymous2")
-        XCTAssertEqual(netrc.machines[1].password, "qwerty2")
+        #expect(netrc.machines[1].name == "example2.com")
+        #expect(netrc.machines[1].login == "anonymous2")
+        #expect(netrc.machines[1].password == "qwerty2")
     }
 
     /// should load multiple machines for a given multi-line format
-    func testLoadMultipleMachinesMultiline() throws {
+    @Test
+    func loadMultipleMachinesMultiline() throws {
         let content = """
                     machine  example.com login     anonymous
                     password                  qwerty
@@ -241,90 +251,98 @@ class NetrcTests: XCTestCase {
                     """
 
         let machines = try NetrcParser.parse(content).machines
-        XCTAssertEqual(machines.count, 2)
+        #expect(machines.count == 2)
 
         var machine = machines[0]
-        XCTAssertEqual(machine.name, "example.com")
-        XCTAssertEqual(machine.login, "anonymous")
-        XCTAssertEqual(machine.password, "qwerty")
+        #expect(machine.name == "example.com")
+        #expect(machine.login == "anonymous")
+        #expect(machine.password == "qwerty")
 
         machine = machines[1]
-        XCTAssertEqual(machine.name, "example2.com")
-        XCTAssertEqual(machine.login, "anonymous2")
-        XCTAssertEqual(machine.password, "qwerty2")
+        #expect(machine.name == "example2.com")
+        #expect(machine.login == "anonymous2")
+        #expect(machine.password == "qwerty2")
     }
 
     /// should throw error when machine parameter is missing
-    func testErrorMachineParameterMissing() throws {
+    @Test
+    func errorMachineParameterMissing() throws {
         let content = "login anonymous password qwerty"
 
-        XCTAssertThrowsError(try NetrcParser.parse(content)) { error in
-            XCTAssertEqual(error as? NetrcError, .machineNotFound)
+        #expect(throws: NetrcError.machineNotFound) {
+            try NetrcParser.parse(content)
         }
     }
 
     /// should throw error for an empty machine values
-    func testErrorEmptyMachineValue() throws {
+    @Test
+    func errorEmptyMachineValue() throws {
         let content = "machine"
 
-        XCTAssertThrowsError(try NetrcParser.parse(content)) { error in
-            XCTAssertEqual(error as? NetrcError, .machineNotFound)
+        #expect(throws: NetrcError.machineNotFound) {
+            try NetrcParser.parse(content)
         }
     }
 
     /// should throw error for an empty machine values
-    func testEmptyMachineValueFollowedByDefaultNoError() throws {
+    @Test
+    func emptyMachineValueFollowedByDefaultNoError() throws {
         let content = "machine default login id password secret"
         let netrc = try NetrcParser.parse(content)
         let authorization = netrc.authorization(for: "http://example.com/resource.zip")
-        XCTAssertEqual(authorization, Netrc.Authorization(login: "id", password: "secret"))
+        #expect(authorization == Netrc.Authorization(login: "id", password: "secret"))
     }
 
     /// should return authorization when config contains a given machine
-    func testReturnAuthorizationForMachineMatch() throws {
+    @Test
+    func returnAuthorizationForMachineMatch() throws {
         let content = "machine example.com login anonymous password qwerty"
 
         let netrc = try NetrcParser.parse(content)
         let authorization = netrc.authorization(for: "http://example.com/resource.zip")
-        XCTAssertEqual(authorization, Netrc.Authorization(login: "anonymous", password: "qwerty"))
+        #expect(authorization == Netrc.Authorization(login: "anonymous", password: "qwerty"))
     }
 
-    func testReturnNoAuthorizationForUnmatched() throws {
+    @Test
+    func returnNoAuthorizationForUnmatched() throws {
         let content = "machine example.com login anonymous password qwerty"
         let netrc = try NetrcParser.parse(content)
-        XCTAssertNil(netrc.authorization(for: "http://www.example.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "ftp.example.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "http://example2.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "http://www.example2.com/resource.zip"))
+        #expect(netrc.authorization(for: "http://www.example.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "ftp.example.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "http://example2.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "http://www.example2.com/resource.zip") == nil)
     }
 
     /// should not return authorization when config does not contain a given machine
-    func testNoReturnAuthorizationForNoMachineMatch() throws {
+    @Test
+    func noReturnAuthorizationForNoMachineMatch() throws {
         let content = "machine example.com login anonymous password qwerty"
 
         let netrc = try NetrcParser.parse(content)
-        XCTAssertNil(netrc.authorization(for: "https://example99.com"))
-        XCTAssertNil(netrc.authorization(for: "http://www.example.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "ftp.example.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "http://example2.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "http://www.example2.com/resource.zip"))
+        #expect(netrc.authorization(for: "https://example99.com") == nil)
+        #expect(netrc.authorization(for: "http://www.example.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "ftp.example.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "http://example2.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "http://www.example2.com/resource.zip") == nil)
     }
 
     /// Test case: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/filesreference/netrc.html
-    func testIBMDocumentation() throws {
+    @Test
+    func iBMDocumentation() throws {
         let content = "machine host1.austin.century.com login fred password bluebonnet"
 
         let netrc = try NetrcParser.parse(content)
 
         let machine = netrc.machines.first
-        XCTAssertEqual(machine?.name, "host1.austin.century.com")
-        XCTAssertEqual(machine?.login, "fred")
-        XCTAssertEqual(machine?.password, "bluebonnet")
+        #expect(machine?.name == "host1.austin.century.com")
+        #expect(machine?.login == "fred")
+        #expect(machine?.password == "bluebonnet")
     }
 
     /// Should not fail on presence of `account`, `macdef`, `default`
     /// test case: https://gist.github.com/tpope/4247721
-    func testNoErrorTrailingAccountMacdefDefault() throws {
+    @Test
+    func noErrorTrailingAccountMacdefDefault() throws {
         let content = """
             machine api.heroku.com
               login my@email.com
@@ -341,28 +359,29 @@ class NetrcTests: XCTestCase {
 
         let netrc = try NetrcParser.parse(content)
 
-        XCTAssertEqual(netrc.machines.count, 4)
+        #expect(netrc.machines.count == 4)
 
-        XCTAssertEqual(netrc.machines[0].name, "api.heroku.com")
-        XCTAssertEqual(netrc.machines[0].login, "my@email.com")
-        XCTAssertEqual(netrc.machines[0].password, "01230123012301230123012301230123")
+        #expect(netrc.machines[0].name == "api.heroku.com")
+        #expect(netrc.machines[0].login == "my@email.com")
+        #expect(netrc.machines[0].password == "01230123012301230123012301230123")
 
-        XCTAssertEqual(netrc.machines[1].name, "api.github.com")
-        XCTAssertEqual(netrc.machines[1].login, "somebody")
-        XCTAssertEqual(netrc.machines[1].password, "something")
+        #expect(netrc.machines[1].name == "api.github.com")
+        #expect(netrc.machines[1].login == "somebody")
+        #expect(netrc.machines[1].password == "something")
 
-        XCTAssertEqual(netrc.machines[2].name, "ftp.server")
-        XCTAssertEqual(netrc.machines[2].login, "abc")
-        XCTAssertEqual(netrc.machines[2].password, "def")
+        #expect(netrc.machines[2].name == "ftp.server")
+        #expect(netrc.machines[2].login == "abc")
+        #expect(netrc.machines[2].password == "def")
 
-        XCTAssertEqual(netrc.machines[3].name, "default")
-        XCTAssertEqual(netrc.machines[3].login, "anonymous")
-        XCTAssertEqual(netrc.machines[3].password, "my@email.com")
+        #expect(netrc.machines[3].name == "default")
+        #expect(netrc.machines[3].login == "anonymous")
+        #expect(netrc.machines[3].password == "my@email.com")
     }
 
     /// Should not fail on presence of `account`, `macdef`, `default`
     /// test case: https://gist.github.com/tpope/4247721
-    func testNoErrorMixedAccount() throws {
+    @Test
+    func noErrorMixedAccount() throws {
         let content = """
             machine api.heroku.com
               login my@email.com
@@ -379,28 +398,29 @@ class NetrcTests: XCTestCase {
 
         let netrc = try NetrcParser.parse(content)
 
-        XCTAssertEqual(netrc.machines.count, 4)
+        #expect(netrc.machines.count == 4)
 
-        XCTAssertEqual(netrc.machines[0].name, "api.heroku.com")
-        XCTAssertEqual(netrc.machines[0].login, "my@email.com")
-        XCTAssertEqual(netrc.machines[0].password, "01230123012301230123012301230123")
+        #expect(netrc.machines[0].name == "api.heroku.com")
+        #expect(netrc.machines[0].login == "my@email.com")
+        #expect(netrc.machines[0].password == "01230123012301230123012301230123")
 
-        XCTAssertEqual(netrc.machines[1].name, "api.github.com")
-        XCTAssertEqual(netrc.machines[1].login, "somebody")
-        XCTAssertEqual(netrc.machines[1].password, "something")
+        #expect(netrc.machines[1].name == "api.github.com")
+        #expect(netrc.machines[1].login == "somebody")
+        #expect(netrc.machines[1].password == "something")
 
-        XCTAssertEqual(netrc.machines[2].name, "ftp.server")
-        XCTAssertEqual(netrc.machines[2].login, "abc")
-        XCTAssertEqual(netrc.machines[2].password, "def")
+        #expect(netrc.machines[2].name == "ftp.server")
+        #expect(netrc.machines[2].login == "abc")
+        #expect(netrc.machines[2].password == "def")
 
-        XCTAssertEqual(netrc.machines[3].name, "default")
-        XCTAssertEqual(netrc.machines[3].login, "anonymous")
-        XCTAssertEqual(netrc.machines[3].password, "my@email.com")
+        #expect(netrc.machines[3].name == "default")
+        #expect(netrc.machines[3].login == "anonymous")
+        #expect(netrc.machines[3].password == "my@email.com")
     }
 
     /// Should not fail on presence of `account`, `macdef`, `default`
     /// test case: https://renenyffenegger.ch/notes/Linux/fhs/home/username/_netrc
-    func testNoErrorMultipleMacdefAndComments() throws {
+    @Test
+    func noErrorMultipleMacdefAndComments() throws {
         let content = """
             machine  ftp.foobar.baz
             login    john
@@ -421,18 +441,19 @@ class NetrcTests: XCTestCase {
 
         let netrc = try NetrcParser.parse(content)
 
-        XCTAssertEqual(netrc.machines.count, 2)
+        #expect(netrc.machines.count == 2)
 
-        XCTAssertEqual(netrc.machines[0].name, "ftp.foobar.baz")
-        XCTAssertEqual(netrc.machines[0].login, "john")
-        XCTAssertEqual(netrc.machines[0].password, "5ecr3t")
+        #expect(netrc.machines[0].name == "ftp.foobar.baz")
+        #expect(netrc.machines[0].login == "john")
+        #expect(netrc.machines[0].password == "5ecr3t")
 
-        XCTAssertEqual(netrc.machines[1].name, "other.server.org")
-        XCTAssertEqual(netrc.machines[1].login, "fred")
-        XCTAssertEqual(netrc.machines[1].password, "sunshine4ever")
+        #expect(netrc.machines[1].name == "other.server.org")
+        #expect(netrc.machines[1].login == "fred")
+        #expect(netrc.machines[1].password == "sunshine4ever")
     }
 
-    func testComments() throws {
+    @Test
+    func comments() throws {
         let content = """
             # A comment at the beginning of the line
             machine example.com # Another comment
@@ -442,73 +463,55 @@ class NetrcTests: XCTestCase {
 
         let netrc = try NetrcParser.parse(content)
 
-        let machine = netrc.machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qw#erty")
+        let machine = try #require(netrc.machines.first)
+        #expect(machine.name == "example.com")
+        #expect(machine.login == "anonymous")
+        #expect(machine.password == "qw#erty")
     }
 
-    // TODO: These permutation tests would be excellent swift-testing parameterized tests.
-    func testAllHashQuotingPermutations() throws {
-        let cases = [
-            ("qwerty", "qwerty"),
-            ("qwe#rty", "qwe#rty"),
-            ("\"qwe#rty\"", "qwe#rty"),
-            ("\"qwe #rty\"", "qwe #rty"),
-            ("\"qwe# rty\"", "qwe# rty"),
+    @Test(
+        arguments: [
+            (testCase: "qwerty", expected: "qwerty"),
+            (testCase: "qwe#rty", expected: "qwe#rty"),
+            (testCase: "\"qwe#rty\"", expected: "qwe#rty"),
+            (testCase: "\"qwe #rty\"", expected: "qwe #rty"),
+            (testCase: "\"qwe# rty\"", expected: "qwe# rty"),
+            // Comments permutations
+            (testCase: "qwerty   # a comment", expected: "qwerty"),
+            (testCase: "qwe#rty   # a comment", expected: "qwe#rty"),
+            (testCase: "\"qwe#rty\"   # a comment", expected: "qwe#rty"),
+            (testCase: "\"qwe #rty\"   # a comment", expected: "qwe #rty"),
+            (testCase: "\"qwe# rty\"   # a comment", expected: "qwe# rty"),
         ]
+    )
+    func allHashQuotingPermutations(testCase: String, expected: String) throws {
 
-        for (testCase, expected) in cases {
-            let content = """
-                machine example.com
-                login \(testCase)
-                password \(testCase)
-                """
-            let netrc = try NetrcParser.parse(content)
+        let content = """
+            machine example.com
+            login \(testCase)
+            password \(testCase)
+            """
+        let netrc = try NetrcParser.parse(content)
 
-            let machine = netrc.machines.first
-            XCTAssertEqual(machine?.name, "example.com")
-            XCTAssertEqual(machine?.login, expected, "Expected login \(testCase) to parse as \(expected)")
-            XCTAssertEqual(machine?.password, expected, "Expected \(testCase) to parse as \(expected)")
-        }
+        let machine = try #require(netrc.machines.first)
+        #expect(machine.name == "example.com")
+        #expect(machine.login == expected, "Expected login \(testCase) to parse as \(expected)")
+        #expect(machine.password == expected, "Expected \(testCase) to parse as \(expected)")
     }
 
-    func testAllCommentPermutations() throws {
-        let cases = [
-            ("qwerty   # a comment", "qwerty"),
-            ("qwe#rty   # a comment", "qwe#rty"),
-            ("\"qwe#rty\"   # a comment", "qwe#rty"),
-            ("\"qwe #rty\"   # a comment", "qwe #rty"),
-            ("\"qwe# rty\"   # a comment", "qwe# rty"),
-        ]
-
-        for (testCase, expected) in cases {
-            let content = """
-                machine example.com
-                login \(testCase)
-                password \(testCase)
-                """
-            let netrc = try NetrcParser.parse(content)
-
-            let machine = netrc.machines.first
-            XCTAssertEqual(machine?.name, "example.com")
-            XCTAssertEqual(machine?.login, expected, "Expected login \(testCase) to parse as \(expected)")
-            XCTAssertEqual(machine?.password, expected, "Expected password \(testCase) to parse as \(expected)")
-        }
-    }
-
-    func testQuotedMachine() throws {
+    @Test
+    func quotedMachine() throws {
         let content = """
             machine "example.com"
             login anonymous
             password qwerty
             """
-
         let netrc = try NetrcParser.parse(content)
 
-        let machine = netrc.machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qwerty")
+        let machine = try #require(netrc.machines.first)
+
+        #expect(machine.name == "example.com")
+        #expect(machine.login == "anonymous")
+        #expect(machine.password == "qwerty")
     }
 }

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -9,16 +9,18 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @testable import Basics
 import _InternalTestSupport
-import XCTest
+import Testing
 
 // TODO: remove when transition to new diagnostics system is complete
 typealias Diagnostic = Basics.Diagnostic
 
-final class ObservabilitySystemTest: XCTestCase {
-    func testScopes() throws {
+struct ObservabilitySystemTest {
+    @Test
+    func scopes() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)
 
@@ -33,16 +35,16 @@ final class ObservabilitySystemTest: XCTestCase {
         let emitter1 = childScope1.makeDiagnosticsEmitter()
         emitter1.emit(error: "error 1.5")
 
-        testDiagnostics(collector.diagnostics) { result in
-            let diagnostic1 = result.check(diagnostic: "error 1", severity: .error)
-            XCTAssertEqual(diagnostic1?.metadata?.testKey1, metadata1.testKey1)
-            XCTAssertEqual(diagnostic1?.metadata?.testKey2, metadata1.testKey2)
-            XCTAssertEqual(diagnostic1?.metadata?.testKey3, metadata1.testKey3)
+        try expectDiagnostics(collector.diagnostics) { result in
+            let diagnostic1 = try #require(result.check(diagnostic: "error 1", severity: .error))
+            #expect(diagnostic1.metadata?.testKey1 == metadata1.testKey1)
+            #expect(diagnostic1.metadata?.testKey2 == metadata1.testKey2)
+            #expect(diagnostic1.metadata?.testKey3 == metadata1.testKey3)
 
-            let diagnostic1_5 = result.check(diagnostic: "error 1.5", severity: .error)
-            XCTAssertEqual(diagnostic1_5?.metadata?.testKey1, metadata1.testKey1)
-            XCTAssertEqual(diagnostic1_5?.metadata?.testKey2, metadata1.testKey2)
-            XCTAssertEqual(diagnostic1_5?.metadata?.testKey3, metadata1.testKey3)
+            let diagnostic1_5 = try #require(result.check(diagnostic: "error 1.5", severity: .error))
+            #expect(diagnostic1_5.metadata?.testKey1 == metadata1.testKey1)
+            #expect(diagnostic1_5.metadata?.testKey2 == metadata1.testKey2)
+            #expect(diagnostic1_5.metadata?.testKey3 == metadata1.testKey3)
         }
 
         collector.clear()
@@ -52,9 +54,9 @@ final class ObservabilitySystemTest: XCTestCase {
         metadata2.testKey2 = Int.random(in: Int.min..<Int.max)
 
         let mergedMetadata2 = metadata1.merging(metadata2)
-        XCTAssertEqual(mergedMetadata2.testKey1, metadata2.testKey1)
-        XCTAssertEqual(mergedMetadata2.testKey2, metadata2.testKey2)
-        XCTAssertEqual(mergedMetadata2.testKey3, metadata1.testKey3)
+        #expect(mergedMetadata2.testKey1 == metadata2.testKey1)
+        #expect(mergedMetadata2.testKey2 == metadata2.testKey2)
+        #expect(mergedMetadata2.testKey3 == metadata1.testKey3)
 
         let childScope2 = childScope1.makeChildScope(description: "child 2", metadata: metadata2)
         childScope2.emit(error: "error 2")
@@ -62,16 +64,16 @@ final class ObservabilitySystemTest: XCTestCase {
         let emitter2 = childScope2.makeDiagnosticsEmitter()
         emitter2.emit(error: "error 2.5")
 
-        testDiagnostics(collector.diagnostics) { result in
-            let diagnostic2 = result.check(diagnostic: "error 2", severity: .error)!
-            XCTAssertEqual(diagnostic2.metadata?.testKey1, mergedMetadata2.testKey1)
-            XCTAssertEqual(diagnostic2.metadata?.testKey2, mergedMetadata2.testKey2)
-            XCTAssertEqual(diagnostic2.metadata?.testKey3, mergedMetadata2.testKey3)
+        try expectDiagnostics(collector.diagnostics) { result in
+            let diagnostic2 = try #require(result.check(diagnostic: "error 2", severity: .error)!)
+            #expect(diagnostic2.metadata?.testKey1 == mergedMetadata2.testKey1)
+            #expect(diagnostic2.metadata?.testKey2 == mergedMetadata2.testKey2)
+            #expect(diagnostic2.metadata?.testKey3 == mergedMetadata2.testKey3)
 
-            let diagnostic2_5 = result.check(diagnostic: "error 2.5", severity: .error)
-            XCTAssertEqual(diagnostic2_5?.metadata?.testKey1, mergedMetadata2.testKey1)
-            XCTAssertEqual(diagnostic2_5?.metadata?.testKey2, mergedMetadata2.testKey2)
-            XCTAssertEqual(diagnostic2_5?.metadata?.testKey3, mergedMetadata2.testKey3)
+            let diagnostic2_5 = try #require(result.check(diagnostic: "error 2.5", severity: .error))
+            #expect(diagnostic2_5.metadata?.testKey1 == mergedMetadata2.testKey1)
+            #expect(diagnostic2_5.metadata?.testKey2 == mergedMetadata2.testKey2)
+            #expect(diagnostic2_5.metadata?.testKey3 == mergedMetadata2.testKey3)
         }
 
         collector.clear()
@@ -80,9 +82,9 @@ final class ObservabilitySystemTest: XCTestCase {
         metadata3.testKey1 = UUID().uuidString
 
         let mergedMetadata3 = metadata1.merging(metadata2).merging(metadata3)
-        XCTAssertEqual(mergedMetadata3.testKey1, metadata3.testKey1)
-        XCTAssertEqual(mergedMetadata3.testKey2, metadata2.testKey2)
-        XCTAssertEqual(mergedMetadata3.testKey3, metadata1.testKey3)
+        #expect(mergedMetadata3.testKey1 == metadata3.testKey1)
+        #expect(mergedMetadata3.testKey2 == metadata2.testKey2)
+        #expect(mergedMetadata3.testKey3 == metadata1.testKey3)
 
         let childScope3 = childScope2.makeChildScope(description: "child 3", metadata: metadata3)
         childScope3.emit(error: "error 3")
@@ -91,27 +93,28 @@ final class ObservabilitySystemTest: XCTestCase {
         metadata3_5.testKey1 = UUID().uuidString
 
         let mergedMetadata3_5 = metadata1.merging(metadata2).merging(metadata3).merging(metadata3_5)
-        XCTAssertEqual(mergedMetadata3_5.testKey1, metadata3_5.testKey1)
-        XCTAssertEqual(mergedMetadata3_5.testKey2, metadata2.testKey2)
-        XCTAssertEqual(mergedMetadata3_5.testKey3, metadata1.testKey3)
+        #expect(mergedMetadata3_5.testKey1 == metadata3_5.testKey1)
+        #expect(mergedMetadata3_5.testKey2 == metadata2.testKey2)
+        #expect(mergedMetadata3_5.testKey3 == metadata1.testKey3)
 
         let emitter3 = childScope3.makeDiagnosticsEmitter(metadata: metadata3_5)
         emitter3.emit(error: "error 3.5")
 
-        testDiagnostics(collector.diagnostics) { result in
-            let diagnostic3 = result.check(diagnostic: "error 3", severity: .error)
-            XCTAssertEqual(diagnostic3?.metadata?.testKey1, mergedMetadata3.testKey1)
-            XCTAssertEqual(diagnostic3?.metadata?.testKey2, mergedMetadata3.testKey2)
-            XCTAssertEqual(diagnostic3?.metadata?.testKey3, mergedMetadata3.testKey3)
+        try expectDiagnostics(collector.diagnostics) { result in
+            let diagnostic3 = try #require(result.check(diagnostic: "error 3", severity: .error))
+            #expect(diagnostic3.metadata?.testKey1 == mergedMetadata3.testKey1)
+            #expect(diagnostic3.metadata?.testKey2 == mergedMetadata3.testKey2)
+            #expect(diagnostic3.metadata?.testKey3 == mergedMetadata3.testKey3)
 
-            let diagnostic3_5 = result.check(diagnostic: "error 3.5", severity: .error)
-            XCTAssertEqual(diagnostic3_5?.metadata?.testKey1, mergedMetadata3_5.testKey1)
-            XCTAssertEqual(diagnostic3_5?.metadata?.testKey2, mergedMetadata3_5.testKey2)
-            XCTAssertEqual(diagnostic3_5?.metadata?.testKey3, mergedMetadata3_5.testKey3)
+            let diagnostic3_5 = try #require(result.check(diagnostic: "error 3.5", severity: .error))
+            #expect(diagnostic3_5.metadata?.testKey1 == mergedMetadata3_5.testKey1)
+            #expect(diagnostic3_5.metadata?.testKey2 == mergedMetadata3_5.testKey2)
+            #expect(diagnostic3_5.metadata?.testKey3 == mergedMetadata3_5.testKey3)
         }
     }
 
-    func testBasicDiagnostics() throws {
+    @Test
+    func basicDiagnostics() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)
 
@@ -130,48 +133,49 @@ final class ObservabilitySystemTest: XCTestCase {
         emitter.emit(debug: "debug")
         emitter.emit(.debug("debug 2"))
 
-        testDiagnostics(collector.diagnostics, problemsOnly: false) { result in
+        try expectDiagnostics(collector.diagnostics, problemsOnly: false) { result in
             do {
-                let diagnostic = result.check(diagnostic: "error", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "error", severity: .error))
+                #expect(diagnostic.metadata?.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "error 2", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "error 2", severity: .error))
+                #expect(diagnostic.metadata?.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "error 3", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
-                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? StringError, StringError("error 3"))
+                let diagnostic = try #require(result.check(diagnostic: "error 3", severity: .error))
+                #expect(diagnostic.metadata?.testKey1 == metadata.testKey1)
+                #expect(diagnostic.metadata?.underlyingError as? StringError == StringError("error 3"))
             }
             do {
-                let diagnostic = result.check(diagnostic: "warning", severity: .warning)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "warning", severity: .warning))
+                #expect(diagnostic.metadata?.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "warning 2", severity: .warning)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "warning 2", severity: .warning))
+                #expect(diagnostic.metadata?.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "info", severity: .info)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "info", severity: .info))
+                #expect(diagnostic.metadata?.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "info 2", severity: .info)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "info 2", severity: .info))
+                #expect(diagnostic.metadata?.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "debug", severity: .debug)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "debug", severity: .debug))
+                #expect(diagnostic.metadata?.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "debug 2", severity: .debug)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "debug 2", severity: .debug))
+                #expect(diagnostic.metadata?.testKey1 == metadata.testKey1)
             }
         }
     }
 
-    func testDiagnosticsErrorDescription() throws {
+    @Test
+    func diagnosticsErrorDescription() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)
 
@@ -181,26 +185,26 @@ final class ObservabilitySystemTest: XCTestCase {
         observabilitySystem.topScope.emit(MyDescribedError(description: "error 4"))
         observabilitySystem.topScope.emit(MyLocalizedError(errorDescription: "error 5"))
 
-        testDiagnostics(collector.diagnostics, problemsOnly: false) { result in
+        try expectDiagnostics(collector.diagnostics, problemsOnly: false) { result in
             do {
-                let diagnostic = result.check(diagnostic: "error", severity: .error)
-                XCTAssertNil(diagnostic?.metadata?.underlyingError)
+                let diagnostic = try #require(result.check(diagnostic: "error", severity: .error))
+                #expect(diagnostic.metadata?.underlyingError == nil)
             }
             do {
-                let diagnostic = result.check(diagnostic: "error 2", severity: .error)
-                XCTAssertNil(diagnostic?.metadata?.underlyingError)
+                let diagnostic = try #require(result.check(diagnostic: "error 2", severity: .error))
+                #expect(diagnostic.metadata?.underlyingError == nil)
             }
             do {
-                let diagnostic = result.check(diagnostic: "MyError(description: \"error 3\")", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? MyError, MyError(description: "error 3"))
+                let diagnostic = try #require(result.check(diagnostic: "MyError(description: \"error 3\")", severity: .error))
+                #expect(diagnostic.metadata?.underlyingError as? MyError == MyError(description: "error 3"))
             }
             do {
-                let diagnostic = result.check(diagnostic: "error 4", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? MyDescribedError, MyDescribedError(description: "error 4"))
+                let diagnostic = try #require(result.check(diagnostic: "error 4", severity: .error))
+                #expect(diagnostic.metadata?.underlyingError as? MyDescribedError == MyDescribedError(description: "error 4"))
             }
             do {
-                let diagnostic = result.check(diagnostic: "error 5", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? MyLocalizedError, MyLocalizedError(errorDescription: "error 5"))
+                let diagnostic = try #require(result.check(diagnostic: "error 5", severity: .error))
+                #expect(diagnostic.metadata?.underlyingError as? MyLocalizedError == MyLocalizedError(errorDescription: "error 5"))
             }
         }
 
@@ -218,7 +222,8 @@ final class ObservabilitySystemTest: XCTestCase {
         }
     }
 
-    func testDiagnosticsMetadataMerge() throws {
+    @Test
+    func diagnosticsMetadataMerge() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)
 
@@ -234,9 +239,9 @@ final class ObservabilitySystemTest: XCTestCase {
         emitterMetadata.testKey2 = Int.random(in: Int.min..<Int.max)
 
         let emitterMergedMetadata = scopeMetadata.merging(emitterMetadata)
-        XCTAssertEqual(emitterMergedMetadata.testKey1, emitterMetadata.testKey1)
-        XCTAssertEqual(emitterMergedMetadata.testKey2, emitterMetadata.testKey2)
-        XCTAssertEqual(emitterMergedMetadata.testKey3, scopeMetadata.testKey3)
+        #expect(emitterMergedMetadata.testKey1 == emitterMetadata.testKey1)
+        #expect(emitterMergedMetadata.testKey2 == emitterMetadata.testKey2)
+        #expect(emitterMergedMetadata.testKey3 == scopeMetadata.testKey3)
 
         let emitter = scope.makeDiagnosticsEmitter(metadata: emitterMetadata)
         emitter.emit(error: "error")
@@ -245,24 +250,24 @@ final class ObservabilitySystemTest: XCTestCase {
         diagnosticMetadata.testKey1 = UUID().uuidString
 
         let diagnosticMergedMetadata = scopeMetadata.merging(emitterMetadata).merging(diagnosticMetadata)
-        XCTAssertEqual(diagnosticMergedMetadata.testKey1, diagnosticMetadata.testKey1)
-        XCTAssertEqual(diagnosticMergedMetadata.testKey2, emitterMetadata.testKey2)
-        XCTAssertEqual(diagnosticMergedMetadata.testKey3, scopeMetadata.testKey3)
+        #expect(diagnosticMergedMetadata.testKey1 == diagnosticMetadata.testKey1)
+        #expect(diagnosticMergedMetadata.testKey2 == emitterMetadata.testKey2)
+        #expect(diagnosticMergedMetadata.testKey3 == scopeMetadata.testKey3)
 
         emitter.emit(warning: "warning", metadata: diagnosticMetadata)
 
-        testDiagnostics(collector.diagnostics) { result in
+        try expectDiagnostics(collector.diagnostics) { result in
             do {
-                let diagnostic = result.check(diagnostic: "error", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, emitterMergedMetadata.testKey1)
-                XCTAssertEqual(diagnostic?.metadata?.testKey2, emitterMergedMetadata.testKey2)
-                XCTAssertEqual(diagnostic?.metadata?.testKey3, emitterMergedMetadata.testKey3)
+                let diagnostic = try #require(result.check(diagnostic: "error", severity: .error))
+                #expect(diagnostic.metadata?.testKey1 == emitterMergedMetadata.testKey1)
+                #expect(diagnostic.metadata?.testKey2 == emitterMergedMetadata.testKey2)
+                #expect(diagnostic.metadata?.testKey3 == emitterMergedMetadata.testKey3)
             }
             do {
-                let diagnostic = result.check(diagnostic: "warning", severity: .warning)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, diagnosticMergedMetadata.testKey1)
-                XCTAssertEqual(diagnostic?.metadata?.testKey2, diagnosticMergedMetadata.testKey2)
-                XCTAssertEqual(diagnostic?.metadata?.testKey3, diagnosticMergedMetadata.testKey3)
+                let diagnostic = try #require(result.check(diagnostic: "warning", severity: .warning))
+                #expect(diagnostic.metadata?.testKey1 == diagnosticMergedMetadata.testKey1)
+                #expect(diagnostic.metadata?.testKey2 == diagnosticMergedMetadata.testKey2)
+                #expect(diagnostic.metadata?.testKey3 == diagnosticMergedMetadata.testKey3)
             }
         }
     }

--- a/Tests/BasicsTests/ProgressAnimationTests.swift
+++ b/Tests/BasicsTests/ProgressAnimationTests.swift
@@ -9,16 +9,17 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import _Concurrency
-import XCTest
+import Testing
 
 @_spi(SwiftPMInternal)
 @testable
 import Basics
 import TSCBasic
 
-final class ProgressAnimationTests: XCTestCase {
+struct ProgressAnimationTests {
     class TrackingProgressAnimation: ProgressAnimationProtocol {
         var steps: [Int] = []
 
@@ -30,7 +31,8 @@ final class ProgressAnimationTests: XCTestCase {
         func clear() {}
     }
 
-    func testThrottledPercentProgressAnimation() {
+    @Test
+    func throttledPercentProgressAnimation() {
         do {
             let tracking = TrackingProgressAnimation()
             var now = ContinuousClock().now
@@ -46,7 +48,7 @@ final class ProgressAnimationTests: XCTestCase {
                 now += .milliseconds(50)
             }
             animation.complete(success: true)
-            XCTAssertEqual(tracking.steps, [0, 2, 4, 6, 8, 10])
+            #expect(tracking.steps == [0, 2, 4, 6, 8, 10])
         }
 
         do {
@@ -67,10 +69,10 @@ final class ProgressAnimationTests: XCTestCase {
             }
             // The next update is at 1000ms, but we are at 950ms,
             // so "step 9" is not sent yet.
-            XCTAssertEqual(tracking.steps, [0, 2, 4, 6, 8])
+            #expect(tracking.steps == [0, 2, 4, 6, 8])
             // After explicit "completion", the last step is flushed out.
             animation.complete(success: true)
-            XCTAssertEqual(tracking.steps, [0, 2, 4, 6, 8, 9])
+            #expect(tracking.steps == [0, 2, 4, 6, 8, 9])
         }
     }
 }

--- a/Tests/BasicsTests/Serialization/SerializedJSONTests.swift
+++ b/Tests/BasicsTests/Serialization/SerializedJSONTests.swift
@@ -9,36 +9,39 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @testable import Basics
-import XCTest
+import Testing
 
-final class SerializedJSONTests: XCTestCase {
-    func testPathInterpolation() throws {
+struct SerializedJSONTests {
+    @Test
+    func pathInterpolation() throws {
         var path = try AbsolutePath(validating: #"/test\backslashes"#)
         var json: SerializedJSON = "\(path)"
 
 #if os(Windows)
-        XCTAssertEqual(json.underlying, #"\\test\\backslashes"#)
+        let expected = #"\\test\\backslashes"#
 #else
-        XCTAssertEqual(json.underlying, #"/test\\backslashes"#)
+        let expected = #"/test\\backslashes"#
 #endif
+        #expect(json.underlying == expected)
 
-        #if os(Windows)
+#if os(Windows)
         path = try AbsolutePath(validating: #"\\?\C:\Users"#)
         json = "\(path)"
 
-        XCTAssertEqual(json.underlying, #"C:\\Users"#)
+        #expect(json.underlying == #"C:\\Users"#)
 
         path = try AbsolutePath(validating: #"\\.\UNC\server\share\"#)
         json = "\(path)"
 
-        XCTAssertEqual(json.underlying, #"\\.\\UNC\\server\\share"#)
+        #expect(json.underlying == #"\\.\\UNC\\server\\share"#)
 
         path = try AbsolutePath(validating: #"\??\Volumes{b79de17a-a1ed-4c58-a353-731b7c4885a6}\\"#)
         json = "\(path)"
 
-        XCTAssertEqual(json.underlying, #"\\??\\Volumes{b79de17a-a1ed-4c58-a353-731b7c4885a6}"#)
-        #endif
+        #expect(json.underlying == #"\\??\\Volumes{b79de17a-a1ed-4c58-a353-731b7c4885a6}"#)
+#endif
     }
 }

--- a/Tests/BasicsTests/StringExtensionsTests.swift
+++ b/Tests/BasicsTests/StringExtensionsTests.swift
@@ -9,27 +9,30 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import Basics
-import XCTest
+import Testing
 
-final class StringExtensionsTests: XCTestCase {
-    func testSHA256Checksum() {
+struct StringExtensionsTests {
+    @Test
+    func sHA256Checksum() {
         let string = "abc"
-        XCTAssertEqual(Array(string.utf8), [0x61, 0x62, 0x63])
+        #expect(Array(string.utf8) == [0x61, 0x62, 0x63])
 
         // See https://csrc.nist.gov/csrc/media/projects/cryptographic-standards-and-guidelines/documents/examples/sha_all.pdf
-        XCTAssertEqual(string.sha256Checksum, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+        #expect(string.sha256Checksum == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
     }
 
-    func testDropPrefix() {
+    @Test
+    func dropPrefix() {
         do {
             let string = "prefixSuffix"
-            XCTAssertEqual(string.spm_dropPrefix("prefix"), "Suffix")
+            #expect(string.spm_dropPrefix("prefix") == "Suffix")
         }
         do {
             let string = "prefixSuffix"
-            XCTAssertEqual(string.spm_dropPrefix("notMyPrefix"), string)
+            #expect(string.spm_dropPrefix("notMyPrefix") == string)
         }
     }
 }

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -9,204 +9,235 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import Basics
-import XCTest
+import Testing
 
-final class TripleTests: XCTestCase {
-    func testIsAppleIsDarwin() {
-        func XCTAssertTriple(
-            _ triple: String,
-            isApple: Bool,
-            isDarwin: Bool,
-            file: StaticString = #filePath,
-            line: UInt = #line
-        ) {
-            guard let triple = try? Triple(triple) else {
-                XCTFail(
-                    "Unknown triple '\(triple)'.",
-                    file: file,
-                    line: line)
-                return
-            }
-            XCTAssert(
-                isApple == triple.isApple(),
-                """
-                Expected triple '\(triple.tripleString)' \
-                \(isApple ? "" : " not") to be an Apple triple.
-                """,
-                file: file,
-                line: line)
-            XCTAssert(
-                isDarwin == triple.isDarwin(),
-                """
-                Expected triple '\(triple.tripleString)' \
-                \(isDarwin ? "" : " not") to be a Darwin triple.
-                """,
-                file: file,
-                line: line)
-        }
 
-        XCTAssertTriple("x86_64-pc-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("x86_64-pc-linux-musl", isApple: false, isDarwin: false)
-        XCTAssertTriple("powerpc-bgp-linux", isApple: false, isDarwin: false)
-        XCTAssertTriple("arm-none-none-eabi", isApple: false, isDarwin: false)
-        XCTAssertTriple("arm-none-linux-musleabi", isApple: false, isDarwin: false)
-        XCTAssertTriple("wasm32-unknown-wasi", isApple: false, isDarwin: false)
-        XCTAssertTriple("riscv64-unknown-linux", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips-mti-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("mipsel-img-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips64-mti-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips64el-img-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips64el-img-linux-gnuabin32", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips64-unknown-linux-gnuabi64", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips64-unknown-linux-gnuabin32", isApple: false, isDarwin: false)
-        XCTAssertTriple("mipsel-unknown-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips-unknown-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("arm-oe-linux-gnueabi", isApple: false, isDarwin: false)
-        XCTAssertTriple("aarch64-oe-linux", isApple: false, isDarwin: false)
-        XCTAssertTriple("armv7em-unknown-none-macho", isApple: false, isDarwin: false)
-        XCTAssertTriple("armv7em-apple-none-macho", isApple: true, isDarwin: false)
-        XCTAssertTriple("armv7em-apple-none", isApple: true, isDarwin: false)
-        XCTAssertTriple("aarch64-apple-macosx", isApple: true, isDarwin: true)
-        XCTAssertTriple("x86_64-apple-macosx", isApple: true, isDarwin: true)
-        XCTAssertTriple("x86_64-apple-macosx10.15", isApple: true, isDarwin: true)
-        XCTAssertTriple("x86_64h-apple-darwin", isApple: true, isDarwin: true)
-        XCTAssertTriple("i686-pc-windows-msvc", isApple: false, isDarwin: false)
-        XCTAssertTriple("i686-pc-windows-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("i686-pc-windows-cygnus", isApple: false, isDarwin: false)
+
+struct TripleTests {
+    @Test(
+        "Triple is Apple and is Darwin",
+        arguments: [
+            (tripleName:"x86_64-pc-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName:"x86_64-pc-linux-musl", isApple: false, isDarwin: false),
+            (tripleName:"powerpc-bgp-linux", isApple: false, isDarwin: false),
+            (tripleName:"arm-none-none-eabi", isApple: false, isDarwin: false),
+            (tripleName:"arm-none-linux-musleabi", isApple: false, isDarwin: false),
+            (tripleName:"wasm32-unknown-wasi", isApple: false, isDarwin: false),
+            (tripleName:"riscv64-unknown-linux", isApple: false, isDarwin: false),
+            (tripleName:"mips-mti-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName:"mipsel-img-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName:"mips64-mti-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName:"mips64el-img-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName:"mips64el-img-linux-gnuabin32", isApple: false, isDarwin: false),
+            (tripleName:"mips64-unknown-linux-gnuabi64", isApple: false, isDarwin: false),
+            (tripleName:"mips64-unknown-linux-gnuabin32", isApple: false, isDarwin: false),
+            (tripleName:"mipsel-unknown-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName:"mips-unknown-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName:"arm-oe-linux-gnueabi", isApple: false, isDarwin: false),
+            (tripleName:"aarch64-oe-linux", isApple: false, isDarwin: false),
+            (tripleName:"armv7em-unknown-none-macho", isApple: false, isDarwin: false),
+            (tripleName:"armv7em-apple-none-macho", isApple: true, isDarwin: false),
+            (tripleName:"armv7em-apple-none", isApple: true, isDarwin: false),
+            (tripleName:"aarch64-apple-macosx", isApple: true, isDarwin: true),
+            (tripleName:"x86_64-apple-macosx", isApple: true, isDarwin: true),
+            (tripleName:"x86_64-apple-macosx10.15", isApple: true, isDarwin: true),
+            (tripleName:"x86_64h-apple-darwin", isApple: true, isDarwin: true),
+            (tripleName:"i686-pc-windows-msvc", isApple: false, isDarwin: false),
+            (tripleName:"i686-pc-windows-gnu", isApple: false, isDarwin: false),
+            (tripleName:"i686-pc-windows-cygnus", isApple: false, isDarwin: false)
+        ]
+    )
+    func isAppleIsDarwin(_ tripleName: String, _ isApple: Bool, _ isDarwin: Bool) throws {
+        let triple = try #require(try Triple(tripleName), "Unknown triple '\(tripleName)'.")
+        #expect(
+            isApple == triple.isApple(),
+            """
+            Expected triple '\(triple.tripleString)' \
+            \(isApple ? "" : " not") to be an Apple triple.
+            """
+        )
+        #expect(
+            isDarwin == triple.isDarwin(),
+            """
+            Expected triple '\(triple.tripleString)' \
+            \(isDarwin ? "" : " not") to be a Darwin triple.
+            """
+        )
     }
 
-    func testDescription() throws {
+    @Test
+    func description() throws {
         let triple = try Triple("x86_64-pc-linux-gnu")
-        XCTAssertEqual("foo \(triple) bar", "foo x86_64-pc-linux-gnu bar")
+        #expect("foo \(triple) bar" == "foo x86_64-pc-linux-gnu bar")
     }
 
-    func testTripleStringForPlatformVersion() throws {
-        func XCTAssertTriple(
-            _ triple: String,
-            forPlatformVersion version: String,
-            is expectedTriple: String,
-            file: StaticString = #filePath,
-            line: UInt = #line
-        ) {
-            guard let triple = try? Triple(triple) else {
-                XCTFail("Unknown triple '\(triple)'.", file: file, line: line)
-                return
-            }
-            let actualTriple = triple.tripleString(forPlatformVersion: version)
-            XCTAssert(
-                actualTriple == expectedTriple,
-                """
-                Actual triple '\(actualTriple)' did not match expected triple \
-                '\(expectedTriple)' for platform version '\(version)'.
-                """,
-                file: file,
-                line: line)
-        }
+    @Test(
+        "Triple String for Platform Version",
+        arguments: [
+            (tripleName: "x86_64-apple-macosx", version: "", expectedTriple: "x86_64-apple-macosx"),
+            (tripleName: "x86_64-apple-macosx", version: "13.0", expectedTriple: "x86_64-apple-macosx13.0"),
+            (tripleName: "armv7em-apple-macosx10.12", version: "", expectedTriple: "armv7em-apple-macosx"),
+            (tripleName: "armv7em-apple-macosx10.12", version: "13.0", expectedTriple: "armv7em-apple-macosx13.0"),
+            (tripleName: "powerpc-apple-macos", version: "", expectedTriple: "powerpc-apple-macos"),
+            (tripleName: "powerpc-apple-macos", version: "13.0", expectedTriple: "powerpc-apple-macos13.0"),
+            (tripleName: "i686-apple-macos10.12.0", version: "", expectedTriple: "i686-apple-macos"),
+            (tripleName: "i686-apple-macos10.12.0", version: "13.0", expectedTriple: "i686-apple-macos13.0"),
+            (tripleName: "riscv64-apple-darwin", version: "", expectedTriple: "riscv64-apple-darwin"),
+            (tripleName: "riscv64-apple-darwin", version: "22", expectedTriple: "riscv64-apple-darwin22"),
+            (tripleName: "mips-apple-darwin19", version: "", expectedTriple: "mips-apple-darwin"),
+            (tripleName: "mips-apple-darwin19", version: "22", expectedTriple: "mips-apple-darwin22"),
+            (tripleName: "arm64-apple-ios-simulator", version: "", expectedTriple: "arm64-apple-ios-simulator"),
+            (tripleName: "arm64-apple-ios-simulator", version: "13.0", expectedTriple: "arm64-apple-ios13.0-simulator"),
+            (tripleName: "arm64-apple-ios12-simulator", version: "", expectedTriple: "arm64-apple-ios-simulator"),
+            (tripleName: "arm64-apple-ios12-simulator", version: "13.0", expectedTriple: "arm64-apple-ios13.0-simulator")
+        ]
+    )
+    func tripleStringForPlatformVersion(tripleName: String, version: String, expectedTriple: String) throws {
+        let triple = try #require(try Triple(tripleName), "Unknown triple '\(tripleName)'.")
+        let actualTriple = triple.tripleString(forPlatformVersion: version)
+        #expect(
+            actualTriple == expectedTriple,
+            """
+            Actual triple '\(actualTriple)' did not match expected triple \
+            '\(expectedTriple)' for platform version '\(version)'.
+            """
+        )
+   }
 
-        XCTAssertTriple("x86_64-apple-macosx", forPlatformVersion: "", is: "x86_64-apple-macosx")
-        XCTAssertTriple("x86_64-apple-macosx", forPlatformVersion: "13.0", is: "x86_64-apple-macosx13.0")
-
-        XCTAssertTriple("armv7em-apple-macosx10.12", forPlatformVersion: "", is: "armv7em-apple-macosx")
-        XCTAssertTriple("armv7em-apple-macosx10.12", forPlatformVersion: "13.0", is: "armv7em-apple-macosx13.0")
-
-        XCTAssertTriple("powerpc-apple-macos", forPlatformVersion: "", is: "powerpc-apple-macos")
-        XCTAssertTriple("powerpc-apple-macos", forPlatformVersion: "13.0", is: "powerpc-apple-macos13.0")
-
-        XCTAssertTriple("i686-apple-macos10.12.0", forPlatformVersion: "", is: "i686-apple-macos")
-        XCTAssertTriple("i686-apple-macos10.12.0", forPlatformVersion: "13.0", is: "i686-apple-macos13.0")
-
-        XCTAssertTriple("riscv64-apple-darwin", forPlatformVersion: "", is: "riscv64-apple-darwin")
-        XCTAssertTriple("riscv64-apple-darwin", forPlatformVersion: "22", is: "riscv64-apple-darwin22")
-
-        XCTAssertTriple("mips-apple-darwin19", forPlatformVersion: "", is: "mips-apple-darwin")
-        XCTAssertTriple("mips-apple-darwin19", forPlatformVersion: "22", is: "mips-apple-darwin22")
-
-        XCTAssertTriple("arm64-apple-ios-simulator", forPlatformVersion: "", is: "arm64-apple-ios-simulator")
-        XCTAssertTriple("arm64-apple-ios-simulator", forPlatformVersion: "13.0", is: "arm64-apple-ios13.0-simulator")
-
-        XCTAssertTriple("arm64-apple-ios12-simulator", forPlatformVersion: "", is: "arm64-apple-ios-simulator")
-        XCTAssertTriple("arm64-apple-ios12-simulator", forPlatformVersion: "13.0", is: "arm64-apple-ios13.0-simulator")
+    struct DataKnownTripleParsing {
+        var tripleName: String
+        var expectedArch: Triple.Arch?
+        var expectedSubArch: Triple.SubArch?
+        var expectedVendor: Triple.Vendor?
+        var expectedOs: Triple.OS?
+        var expectedEnvironment: Triple.Environment?
+        var expectedObjectFormat: Triple.ObjectFormat?
     }
+    @Test(
+        "Known Triple Parsing",
+        arguments: [
+            DataKnownTripleParsing(
+                tripleName: "armv7em-apple-none-eabihf-macho",
+                expectedArch: .arm,
+                expectedSubArch : .arm(.v7em),
+                expectedVendor: .apple,
+                expectedOs: .noneOS,
+                expectedEnvironment: .eabihf,
+                expectedObjectFormat: .macho
+            ),
+            DataKnownTripleParsing(
+                tripleName: "x86_64-apple-macosx",
+                expectedArch: .x86_64,
+                expectedSubArch: nil,
+                expectedVendor: .apple,
+                expectedOs: .macosx,
+                expectedEnvironment: nil,
+                expectedObjectFormat: .macho
+            ),
+            DataKnownTripleParsing(
+                tripleName: "x86_64-unknown-linux-gnu",
+                expectedArch: .x86_64,
+                expectedSubArch: nil,
+                expectedVendor: nil,
+                expectedOs: .linux,
+                expectedEnvironment: .gnu,
+                expectedObjectFormat: .elf
+            ),
+            DataKnownTripleParsing(
+                tripleName: "aarch64-unknown-linux-gnu",
+                expectedArch: .aarch64,
+                expectedSubArch: nil,
+                expectedVendor: nil,
+                expectedOs: .linux,
+                expectedEnvironment: .gnu,
+                expectedObjectFormat: .elf
+            ),
+            DataKnownTripleParsing(
+                tripleName: "aarch64-unknown-linux-android",
+                expectedArch: .aarch64,
+                expectedSubArch: nil,
+                expectedVendor: nil,
+                expectedOs: .linux,
+                expectedEnvironment: .android,
+                expectedObjectFormat: .elf
+            ),
+            DataKnownTripleParsing(
+                tripleName: "x86_64-unknown-windows-msvc",
+                expectedArch: .x86_64,
+                expectedSubArch: nil,
+                expectedVendor: nil,
+                expectedOs: .win32,
+                expectedEnvironment: .msvc,
+                expectedObjectFormat: .coff
+            ),
+            DataKnownTripleParsing(
+                tripleName: "wasm32-unknown-wasi",
+                expectedArch: .wasm32,
+                expectedSubArch: nil,
+                expectedVendor: nil,
+                expectedOs: .wasi,
+                expectedEnvironment: nil,
+                expectedObjectFormat: .wasm
+            )
+        ]
+    )
+   func knownTripleParsing(data: DataKnownTripleParsing) throws {
+        let triple = try #require(try Triple(data.tripleName), "Unknown triple '\(data.tripleName)'.")
+        #expect(triple.arch == data.expectedArch)
+        #expect(triple.subArch == data.expectedSubArch)
+        #expect(triple.vendor == data.expectedVendor)
+        #expect(triple.os == data.expectedOs)
+        #expect(triple.environment == data.expectedEnvironment)
+        #expect(triple.objectFormat == data.expectedObjectFormat)
+   }
 
-    func testKnownTripleParsing() {
-        func XCTAssertTriple(
-            _ triple: String,
-            matches components: (
-                arch: Triple.Arch?,
-                subArch: Triple.SubArch?,
-                vendor: Triple.Vendor?,
-                os: Triple.OS?,
-                environment: Triple.Environment?,
-                objectFormat: Triple.ObjectFormat?),
-            file: StaticString = #filePath,
-            line: UInt = #line
-        ) {
-            guard let triple = try? Triple(triple) else {
-                XCTFail(
-                    "Unknown triple '\(triple)'.",
-                    file: file,
-                    line: line)
-                return
-            }
-            XCTAssertEqual(triple.arch, components.arch, file: file, line: line)
-            XCTAssertEqual(triple.subArch, components.subArch, file: file, line: line)
-            XCTAssertEqual(triple.vendor, components.vendor, file: file, line: line)
-            XCTAssertEqual(triple.os, components.os, file: file, line: line)
-            XCTAssertEqual(triple.environment, components.environment, file: file, line: line)
-            XCTAssertEqual(triple.objectFormat, components.objectFormat, file: file, line: line)
-        }
-        XCTAssertTriple("armv7em-apple-none-eabihf-macho", matches: (.arm, .arm(.v7em), .apple, .noneOS, .eabihf, .macho))
-        XCTAssertTriple("x86_64-apple-macosx", matches: (.x86_64, nil, .apple, .macosx, nil, .macho))
-        XCTAssertTriple("x86_64-unknown-linux-gnu", matches: (.x86_64, nil, nil, .linux, .gnu, .elf))
-        XCTAssertTriple("aarch64-unknown-linux-gnu", matches: (.aarch64, nil, nil, .linux, .gnu, .elf))
-        XCTAssertTriple("aarch64-unknown-linux-android", matches: (.aarch64, nil, nil, .linux, .android, .elf))
-        XCTAssertTriple("x86_64-unknown-windows-msvc", matches: (.x86_64, nil, nil, .win32, .msvc, .coff))
-        XCTAssertTriple("wasm32-unknown-wasi", matches: (.wasm32, nil, nil, .wasi, nil, .wasm))
-    }    
+    @Test
+    func tripleValidation() throws {
+        let linux = try Triple("x86_64-unknown-linux-gnu")
+        #expect(linux != nil)
+        #expect(linux.os == .linux)
+        #expect(linux.osVersion == Triple.Version.zero)
+        #expect(linux.environment == .gnu)
 
-    func testTriple() {
-        let linux = try? Triple("x86_64-unknown-linux-gnu")
-        XCTAssertNotNil(linux)
-        XCTAssertEqual(linux!.os, .linux)
-        XCTAssertEqual(linux!.osVersion, Triple.Version.zero)
-        XCTAssertEqual(linux!.environment, .gnu)
-
-        let macos = try? Triple("x86_64-apple-macosx10.15")
-        XCTAssertNotNil(macos!)
-        XCTAssertEqual(macos!.osVersion, .init(parse: "10.15"))
+        let macos = try Triple("x86_64-apple-macosx10.15")
+        #expect(macos != nil)
+        #expect(macos.osVersion == .init(parse: "10.15"))
         let newVersion = "10.12"
-        let tripleString = macos!.tripleString(forPlatformVersion: newVersion)
-        XCTAssertEqual(tripleString, "x86_64-apple-macosx10.12")
-        let macosNoX = try? Triple("x86_64-apple-macos12.2")
-        XCTAssertNotNil(macosNoX!)
-        XCTAssertEqual(macosNoX!.os, .macosx)
-        XCTAssertEqual(macosNoX!.osVersion, .init(parse: "12.2"))
+        let tripleString = macos.tripleString(forPlatformVersion: newVersion)
+        #expect(tripleString == "x86_64-apple-macosx10.12")
+        let macosNoX = try Triple("x86_64-apple-macos12.2")
+        #expect(macosNoX != nil)
+        #expect(macosNoX.os == .macosx)
+        #expect(macosNoX.osVersion == .init(parse: "12.2"))
 
-        let android = try? Triple("aarch64-unknown-linux-android24")
-        XCTAssertNotNil(android)
-        XCTAssertEqual(android!.os, .linux)
-        XCTAssertEqual(android!.environment, .android)
+        let android = try Triple("aarch64-unknown-linux-android24")
+        #expect(android != nil)
+        #expect(android.os == .linux)
+        #expect(android.environment == .android)
 
-        let linuxWithABIVersion = try? Triple("x86_64-unknown-linux-gnu42")
-        XCTAssertEqual(linuxWithABIVersion!.environment, .gnu)
+        let linuxWithABIVersion = try Triple("x86_64-unknown-linux-gnu42")
+        #expect(linuxWithABIVersion.environment == .gnu)
     }
 
-    func testEquality() throws {
-        let macOSTriple = try Triple("arm64-apple-macos")
-        let macOSXTriple = try Triple("arm64-apple-macosx")
-        XCTAssertEqual(macOSTriple, macOSXTriple)
+    @Test
+   func equalityOperator() throws {
+       let macOSTriple = try Triple("arm64-apple-macos")
+       let macOSXTriple = try Triple("arm64-apple-macosx")
+        #expect(macOSTriple == macOSXTriple)
 
-        let intelMacOSTriple = try Triple("x86_64-apple-macos")
-        XCTAssertNotEqual(macOSTriple, intelMacOSTriple)
+       let intelMacOSTriple = try Triple("x86_64-apple-macos")
+        #expect(macOSTriple != intelMacOSTriple)
 
-        let linuxWithoutGNUABI = try Triple("x86_64-unknown-linux")
-        let linuxWithGNUABI = try Triple("x86_64-unknown-linux-gnu")
-        XCTAssertNotEqual(linuxWithoutGNUABI, linuxWithGNUABI)
-    }
+       let linuxWithoutGNUABI = try Triple("x86_64-unknown-linux")
+       let linuxWithGNUABI = try Triple("x86_64-unknown-linux-gnu")
+        #expect(linuxWithoutGNUABI != linuxWithGNUABI)
+   }
 
-    func testWASI() throws {
+    @Test
+    func WASI() throws {
         let wasi = try Triple("wasm32-unknown-wasi")
 
 
@@ -216,30 +247,36 @@ final class TripleTests: XCTestCase {
         _ = wasi.dynamicLibraryExtension
     }
 
-    func testNoneOSDynamicLibrary() throws {
-      // Dynamic libraries aren't actually supported for OS none, but swiftpm
-      // wants an extension to avoid crashing during build planning.
-      try XCTAssertEqual(
-          Triple("armv7em-unknown-none-coff").dynamicLibraryExtension,
-          ".coff")
-      try XCTAssertEqual(
-          Triple("armv7em-unknown-none-elf").dynamicLibraryExtension,
-          ".elf")
-      try XCTAssertEqual(
-          Triple("armv7em-unknown-none-macho").dynamicLibraryExtension,
-          ".macho")
-      try XCTAssertEqual(
-          Triple("armv7em-unknown-none-wasm").dynamicLibraryExtension,
-          ".wasm")
-      try XCTAssertEqual(
-          Triple("armv7em-unknown-none-xcoff").dynamicLibraryExtension,
-          ".xcoff")
+    @Test(
+        "Test dynamicLibraryExtesion attribute on Triple returns expected value",
+        arguments: [
+            (tripleName: "armv7em-unknown-none-coff", expected: ".coff"),
+            (tripleName: "armv7em-unknown-none-elf", expected: ".elf"),
+            (tripleName: "armv7em-unknown-none-macho", expected: ".macho"),
+            (tripleName: "armv7em-unknown-none-wasm", expected: ".wasm"),
+            (tripleName: "armv7em-unknown-none-xcoff", expected: ".xcoff"),
+            (tripleName: "wasm32-unknown-wasi", expected: ".wasm"), // Added by bkhouri
+        ]
+    )
+    func noneOSDynamicLibrary(tripleName: String, expected: String) throws {
+        // Dynamic libraries aren't actually supported for OS none, but swiftpm
+        // wants an extension to avoid crashing during build planning.
+        let triple = try Triple(tripleName)
+        #expect(triple.dynamicLibraryExtension == expected)
     }
 
-    func testIsRuntimeCompatibleWith() throws {
-        try XCTAssertTrue(Triple("x86_64-apple-macosx").isRuntimeCompatible(with: Triple("x86_64-apple-macosx")))
-        try XCTAssertTrue(Triple("x86_64-unknown-linux").isRuntimeCompatible(with: Triple("x86_64-unknown-linux")))
-        try XCTAssertFalse(Triple("x86_64-apple-macosx").isRuntimeCompatible(with: Triple("x86_64-apple-linux")))
-        try XCTAssertTrue(Triple("x86_64-apple-macosx14.0").isRuntimeCompatible(with: Triple("x86_64-apple-macosx13.0")))
-    }
+    @Test(
+        "isRuntimeCompatibleWith returns expected value",
+        arguments:[
+            (firstTripleName: "x86_64-apple-macosx", secondTripleName: "x86_64-apple-macosx", isCompatible: true),
+            (firstTripleName: "x86_64-unknown-linux", secondTripleName: "x86_64-unknown-linux", isCompatible: true),
+            (firstTripleName: "x86_64-apple-macosx", secondTripleName: "x86_64-apple-linux", isCompatible: false),
+            (firstTripleName: "x86_64-apple-macosx14.0", secondTripleName: "x86_64-apple-macosx13.0", isCompatible: true),
+        ]
+    )
+    func isRuntimeCompatibleWith(firstTripleName: String, secondTripleName: String, isCompatible: Bool) throws {
+        let triple = try Triple(firstTripleName)
+        let other = try Triple(secondTripleName)
+        #expect(triple.isRuntimeCompatible(with: other ) == isCompatible)
+   }
 }


### PR DESCRIPTION
Convert some BasicsTests from XCTest to Swift Testing to make use of parallelism and, in some cases, test parameterization

### Motivation:

The XCTest run, by default, sequentially. Convert most of the WorkspaceTests from XCTests to Swift Testing to make use of parallelism, and in some cases, parameterized test cases.

Not all Test Suites in BasicsTests have been converted as some use helpers in swift-tools-core-support, which don't have a matching swift testing helper.

### Modifications:

Convert XCTests to Swift Testing

### Result:

Ran the equivalent of
```
for _ in $(seq 0 100); 
do
    swift test --enable-swift-testing --disable-xctest
done
```
and ensured there were no test-related  failures.

Blocked by #8137 
Requires https://github.com/swiftlang/swift/pull/78300
Might conflict with #8210