### PR TITLE
Remove `/.index-build` from the `.gitignore` generated by `swift package init`

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -433,7 +433,6 @@ public final class InitPackage {
                 """
                 .DS_Store
                 /.build
-                /.index-build
                 /Packages
                 xcuserdata/
                 DerivedData/


### PR DESCRIPTION
https://github.com/swiftlang/sourcekit-lsp/pull/1803 is moving `.index-build` to be a subdirectory of `.build`.
