### PR TITLE
Test: Add platform helpers

### DIFF
--- a/Sources/_InternalTestSupport/PlatformHelpers.swift
+++ b/Sources/_InternalTestSupport/PlatformHelpers.swift
@@ -1,0 +1,53 @@
+
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import Basics
+
+import Testing
+
+public func isWindows() -> Bool {
+    #if os(Windows)
+    return true
+    #else
+    return false
+    #endif
+}
+
+public func isLinux() -> Bool {
+    #if os(Linux)
+    return true
+    #else
+    return false
+    #endif
+}
+
+public func isMacOS() -> Bool {
+    #if os(macOS)
+    return true
+    #else
+    return false
+    #endif
+}
+
+public func isRealSigningIdentityTestEnabled() -> Bool {
+    #if ENABLE_REAL_SIGNING_IDENTITY_TEST
+    return true
+    #else
+    return false
+    #endif
+}
+
+public func isEnvironmentVariableSet(_ variableName: EnvironmentKey) -> Bool {
+    guard let value = Environment.current[variableName] else { return false }
+    return !value.isEmpty
+}

--- a/Tests/_InternalTestSupportTests/PlatformHelpersTests.swift
+++ b/Tests/_InternalTestSupportTests/PlatformHelpersTests.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import _InternalTestSupport
+import Basics
+import Testing
+
+struct testisEnvironmentVariableSet {
+    @Test(
+        arguments: [
+            (name: "", expected: false),
+            (name: "DOES_NOT_EXIST", expected: false),
+            (name: "HOME", expected: true)
+        ]
+    )
+    func testisEnvironmentVariableSetReturnsExpectedValue(name: String, expected: Bool) {
+        // GIVEN we have an environment variable name
+        let variableName = EnvironmentKey(name)
+
+        // WHEN we call isEnvironmentVariableSet(varaiblename)
+        let actual = isEnvironmentVariableSet(variableName)
+
+        // THEN we expect to return true
+        #expect(actual == expected, "Actual is not as expected")
+    }
+}


### PR DESCRIPTION
Add helpers related to the current platform to assist with conditionally running test cases.

### Motivation:

Some XCTests have the following implementation, or a variation thereof

```
#if os(macOS)
    func testLibraryEnvironmentVariable() async throws {
       //test implementation
    }
#endif
```

The idiomatic Swift Testing is to use the `enabled`/`disabled` traits, thus allowing the test to be compiled.  As such, create some helpers function. that will allow enabling/disabling a test using these helper functions.

### Modifications:

Add helper functions and add some Swift Testing tests.

### Result:

Ran the equivalent of the following and ensured there were no test-related failures 

```
for _ in $(seq 0 100);
do
    swift test --enable-swift-testing --disable-xctest
done
```


Blocked by #8137 
Requires https://github.com/swiftlang/swift/pull/78300