### PR TITLE
Test: Convert more tests to Swift Testing

### DIFF
--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -42,6 +42,17 @@ import enum TSCUtility.Git
 public let isInCiEnvironment = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] != nil
 public let isSelfHostedCiEnvironment = ProcessInfo.processInfo.environment["SWIFTCI_IS_SELF_HOSTED"] != nil
 
+public let isRealSigningIdentyEcLabelEnvVarSet =
+    ProcessInfo.processInfo.environment["REAL_SIGNING_IDENTITY_EC_LABEL"] != nil
+
+public let isRealSigningIdentitTestDefined = {
+    #if ENABLE_REAL_SIGNING_IDENTITY_TEST
+        return true
+    #else
+        return false
+    #endif
+}()
+
 /// Test helper utility for executing a block with a temporary directory.
 public func testWithTemporaryDirectory(
     function: StaticString = #function,

--- a/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
+++ b/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
@@ -135,17 +135,6 @@ struct FilePackageSigningEntityStorageTests {
             }
             return true
         }
-        // await XCTAssertAsyncThrowsError(try storage.put(
-        //     package: package,
-        //     version: version,
-        //     signingEntity: appleseed,
-        //     origin: .registry(URL("http://foo.com"))
-        // )) { error in
-        //     guard case PackageSigningEntityStorageError.conflict = error else {
-        //         Issue.record("Expected PackageSigningEntityStorageError.conflict, got \(error)")
-        //         return
-        //     }
-        // }
     }
 
     @Test
@@ -208,17 +197,6 @@ struct FilePackageSigningEntityStorageTests {
             }
             return true
         }
-        // await XCTAssertAsyncThrowsError(try storage.put(
-        //     package: package,
-        //     version: version,
-        //     signingEntity: appleseed,
-        //     origin: .registry(URL("http://bar.com")) // origin is different and should be added
-        // )) { error in
-        //     guard case PackageSigningEntityStorageError.unrecognizedSigningEntity = error else {
-        //         Issue.record("Expected PackageSigningEntityStorageError.unrecognizedSigningEntity but got \(error)")
-        //         return
-        //     }
-        // }
     }
 
     @Test
@@ -302,17 +280,6 @@ struct FilePackageSigningEntityStorageTests {
             }
             return true
         }
-        // await XCTAssertAsyncThrowsError(try storage.add(
-        //     package: package,
-        //     version: version,
-        //     signingEntity: appleseed,
-        //     origin: .registry(URL("http://bar.com"))
-        // )) { error in
-        //     guard case PackageSigningEntityStorageError.unrecognizedSigningEntity = error else {
-        //         Issue.record("Expected PackageSigningEntityStorageError.unrecognizedSigningEntity but got \(error)")
-        //         return
-        //     }
-        // }
     }
 
     @Test
@@ -479,17 +446,6 @@ struct FilePackageSigningEntityStorageTests {
             }
             return true
         }
-        // await XCTAsserttAsyncThrowsError(try storage.changeSigningEntityForAllVersions(
-        //     package: package,
-        //     version: Version("1.5.0"),
-        //     signingEntity: appleseed,
-        //     origin: .registry(URL("http://bar.com"))
-        // )) { error in
-        //     guard case PackageSigningEntityStorageError.unrecognizedSigningEntity = error else {
-        //         Issue.record("Expected PackageSigningEntityStorageError.unrecognizedSigningEntity but got \(error)")
-        //         return
-        //     }
-        // }
     }
 }
 

--- a/Tests/PackageSigningTests/SigningEntityTests.swift
+++ b/Tests/PackageSigningTests/SigningEntityTests.swift
@@ -9,7 +9,8 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-
+import Foundation
+import Testing
 import XCTest
 
 import Basics
@@ -17,8 +18,9 @@ import Basics
 import _InternalTestSupport
 import X509
 
-final class SigningEntityTests: XCTestCase {
-    func testTwoADPSigningEntitiesAreEqualIfTeamIDEqual() {
+struct SigningEntityTests {
+    @Test
+    func twoADPSigningEntitiesAreEqualIfTeamIDEqual() {
         let adp1 = SigningEntity.recognized(
             type: .adp,
             name: "A. Appleseed",
@@ -37,48 +39,39 @@ final class SigningEntityTests: XCTestCase {
             organizationalUnit: "SwiftPM Test Unit Y",
             organization: "C"
         )
-        XCTAssertEqual(adp1, adp2) // Only team ID (org unit) needs to match
-        XCTAssertNotEqual(adp1, adp3)
+        #expect(adp1 == adp2) // Only team ID (org unit) needs to match
+        #expect(adp1 != adp3)
     }
 
-    func testFromECKeyCertificate() throws {
+    @Test(
+        "From certificate key",
+        arguments: [
+            (certificateFilename: "Test_ec.cer", id: "EC Key"),
+            (certificateFilename: "Test_rsa.cer", id: "RSA Key")
+        ]
+    )
+    func fromCertificate(certificateFilename: String, id: String) throws {
         try fixture(name: "Signing", createGitRepo: false) { fixturePath in
             let certificateBytes = try readFileContents(
                 in: fixturePath,
                 pathComponents: "Certificates",
-                "Test_ec.cer"
+                certificateFilename
             )
             let certificate = try Certificate(certificateBytes)
 
             let signingEntity = SigningEntity.from(certificate: certificate)
             guard case .unrecognized(let name, let organizationalUnit, let organization) = signingEntity else {
-                return XCTFail("Expected SigningEntity.unrecognized but got \(signingEntity)")
+                Issue.record("Expected SigningEntity.unrecognized but got \(signingEntity)")
+                return
             }
-            XCTAssertEqual(name, certificate.subject.commonName)
-            XCTAssertEqual(organizationalUnit, certificate.subject.organizationalUnitName)
-            XCTAssertEqual(organization, certificate.subject.organizationName)
+            #expect(name == certificate.subject.commonName)
+            #expect(organizationalUnit == certificate.subject.organizationalUnitName)
+            #expect(organization == certificate.subject.organizationName)
         }
     }
+}
 
-    func testFromRSAKeyCertificate() throws {
-        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-            let certificateBytes = try readFileContents(
-                in: fixturePath,
-                pathComponents: "Certificates",
-                "Test_rsa.cer"
-            )
-            let certificate = try Certificate(certificateBytes)
-
-            let signingEntity = SigningEntity.from(certificate: certificate)
-            guard case .unrecognized(let name, let organizationalUnit, let organization) = signingEntity else {
-                return XCTFail("Expected SigningEntity.unrecognized but got \(signingEntity)")
-            }
-            XCTAssertEqual(name, certificate.subject.commonName)
-            XCTAssertEqual(organizationalUnit, certificate.subject.organizationalUnitName)
-            XCTAssertEqual(organization, certificate.subject.organizationName)
-        }
-    }
-
+final class SigningEntityXCTests: XCTestCase {
     #if os(macOS)
     func testFromKeychainCertificate() async throws {
         #if ENABLE_REAL_SIGNING_IDENTITY_TEST

--- a/Tests/PackageSigningTests/SigningIdentityTests.swift
+++ b/Tests/PackageSigningTests/SigningIdentityTests.swift
@@ -9,7 +9,9 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
+import Testing
 import XCTest
 
 import _CryptoExtras // For RSA
@@ -19,8 +21,9 @@ import Crypto
 import _InternalTestSupport
 import X509
 
-final class SigningIdentityTests: XCTestCase {
-    func testSwiftSigningIdentityWithECKey() throws {
+struct SigningIdentityTests {
+    @Test
+    func swiftSigningIdentityWithECKey() throws {
         try fixture(name: "Signing", createGitRepo: false) { fixturePath in
             let certificateBytes = try readFileContents(
                 in: fixturePath,
@@ -30,9 +33,9 @@ final class SigningIdentityTests: XCTestCase {
             let certificate = try Certificate(certificateBytes)
 
             let subject = certificate.subject
-            XCTAssertEqual("Test (EC) leaf", subject.commonName)
-            XCTAssertEqual("Test (EC) org unit", subject.organizationalUnitName)
-            XCTAssertEqual("Test (EC) org", subject.organizationName)
+            #expect("Test (EC) leaf" == subject.commonName)
+            #expect("Test (EC) org unit" == subject.organizationalUnitName)
+            #expect("Test (EC) org" == subject.organizationName)
 
             let privateKeyBytes = try readFileContents(
                 in: fixturePath,
@@ -43,17 +46,19 @@ final class SigningIdentityTests: XCTestCase {
             _ = SwiftSigningIdentity(certificate: certificate, privateKey: Certificate.PrivateKey(privateKey))
 
             // Test public API
-            XCTAssertNoThrow(
+            #expect(throws: Never.self) {
+
                 try SwiftSigningIdentity(
                     derEncodedCertificate: certificateBytes,
                     derEncodedPrivateKey: privateKeyBytes,
                     privateKeyType: .p256
                 )
-            )
+            }
         }
     }
 
-    func testSwiftSigningIdentityWithRSAKey() throws {
+    @Test
+    func swiftSigningIdentityWithRSAKey() throws {
         try fixture(name: "Signing", createGitRepo: false) { fixturePath in
             let certificateBytes = try readFileContents(
                 in: fixturePath,
@@ -63,9 +68,9 @@ final class SigningIdentityTests: XCTestCase {
             let certificate = try Certificate(certificateBytes)
 
             let subject = certificate.subject
-            XCTAssertEqual("Test (RSA) leaf", subject.commonName)
-            XCTAssertEqual("Test (RSA) org unit", subject.organizationalUnitName)
-            XCTAssertEqual("Test (RSA) org", subject.organizationName)
+            #expect("Test (RSA) leaf" == subject.commonName)
+            #expect("Test (RSA) org unit" == subject.organizationalUnitName)
+            #expect("Test (RSA) org" == subject.organizationName)
 
             let privateKeyBytes = try readFileContents(
                 in: fixturePath,
@@ -76,6 +81,8 @@ final class SigningIdentityTests: XCTestCase {
             _ = SwiftSigningIdentity(certificate: certificate, privateKey: Certificate.PrivateKey(privateKey))
         }
     }
+}
+final class SigningIdentityXCTests: XCTestCase {
 
     #if os(macOS)
     func testSigningIdentityFromKeychain() async throws {

--- a/Tests/QueryEngineTests/QueryEngineTests.swift
+++ b/Tests/QueryEngineTests/QueryEngineTests.swift
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import _AsyncFileSystem
 import Basics
@@ -17,154 +18,157 @@ import struct Foundation.Data
 @testable import QueryEngine
 import struct SystemPackage.FilePath
 import _InternalTestSupport
-import XCTest
+import Testing
 
 private let encoder = JSONEncoder()
 private let decoder = JSONDecoder()
 
 private extension AsyncFileSystem {
-  func read<V: Decodable>(_ path: FilePath, bufferLimit: Int = 10 * 1024 * 1024, as: V.Type) async throws -> V {
-    let data = try await self.withOpenReadableFile(path) {
-      var data = Data()
-      for try await chunk in try await $0.read() {
-        data.append(contentsOf: chunk)
+    func read<V: Decodable>(_ path: FilePath, bufferLimit: Int = 10 * 1024 * 1024, as: V.Type) async throws -> V {
+        let data = try await self.withOpenReadableFile(path) {
+            var data = Data()
+            for try await chunk in try await $0.read() {
+                data.append(contentsOf: chunk)
 
-        assert(data.count < bufferLimit)
-      }
-      return data
+                assert(data.count < bufferLimit)
+            }
+            return data
+        }
+
+        return try decoder.decode(V.self, from: data)
     }
 
-    return try decoder.decode(V.self, from: data)
-  }
-
-  func write(_ path: FilePath, _ value: some Encodable) async throws {
-    let data = try encoder.encode(value)
-    try await self.withOpenWritableFile(path) { fileHandle in
-      try await fileHandle.write(data)
+    func write(_ path: FilePath, _ value: some Encodable) async throws {
+        let data = try encoder.encode(value)
+        try await self.withOpenWritableFile(path) { fileHandle in
+            try await fileHandle.write(data)
+        }
     }
-  }
 }
 
 private struct Const: CachingQuery {
-  let x: Int
+    let x: Int
 
-  func run(engine: QueryEngine) async throws -> FilePath {
-    let resultPath = FilePath("/Const-\(x)")
-    try await engine.fileSystem.write(resultPath, self.x)
-    return resultPath
-  }
+    func run(engine: QueryEngine) async throws -> FilePath {
+        let resultPath = FilePath("/Const-\(x)")
+        try await engine.fileSystem.write(resultPath, self.x)
+        return resultPath
+    }
 }
 
 private struct MultiplyByTwo: CachingQuery {
-  let x: Int
+    let x: Int
 
-  func run(engine: QueryEngine) async throws -> FilePath {
-    let constPath = try await engine[Const(x: self.x)].path
-    let constResult = try await engine.fileSystem.read(constPath, as: Int.self)
+    func run(engine: QueryEngine) async throws -> FilePath {
+        let constPath = try await engine[Const(x: self.x)].path
+        let constResult = try await engine.fileSystem.read(constPath, as: Int.self)
 
-    let resultPath = FilePath("/MultiplyByTwo-\(constResult)")
-    try await engine.fileSystem.write(resultPath, constResult * 2)
-    return resultPath
-  }
+        let resultPath = FilePath("/MultiplyByTwo-\(constResult)")
+        try await engine.fileSystem.write(resultPath, constResult * 2)
+        return resultPath
+    }
 }
 
 private struct AddThirty: CachingQuery {
-  let x: Int
+    let x: Int
 
-  func run(engine: QueryEngine) async throws -> FilePath {
-    let constPath = try await engine[Const(x: self.x)].path
-    let constResult = try await engine.fileSystem.read(constPath, as: Int.self)
+    func run(engine: QueryEngine) async throws -> FilePath {
+        let constPath = try await engine[Const(x: self.x)].path
+        let constResult = try await engine.fileSystem.read(constPath, as: Int.self)
 
-    let resultPath = FilePath("/AddThirty-\(constResult)")
-    try await engine.fileSystem.write(resultPath, constResult + 30)
-    return resultPath
-  }
+        let resultPath = FilePath("/AddThirty-\(constResult)")
+        try await engine.fileSystem.write(resultPath, constResult + 30)
+        return resultPath
+    }
 }
 
 private struct Expression: CachingQuery {
-  let x: Int
-  let y: Int
+    let x: Int
+    let y: Int
 
-  func run(engine: QueryEngine) async throws -> FilePath {
-    let multiplyPath = try await engine[MultiplyByTwo(x: self.x)].path
-    let addThirtyPath = try await engine[AddThirty(x: self.y)].path
+    func run(engine: QueryEngine) async throws -> FilePath {
+        let multiplyPath = try await engine[MultiplyByTwo(x: self.x)].path
+        let addThirtyPath = try await engine[AddThirty(x: self.y)].path
 
-    let multiplyResult = try await engine.fileSystem.read(multiplyPath, as: Int.self)
-    let addThirtyResult = try await engine.fileSystem.read(addThirtyPath, as: Int.self)
+        let multiplyResult = try await engine.fileSystem.read(multiplyPath, as: Int.self)
+        let addThirtyResult = try await engine.fileSystem.read(addThirtyPath, as: Int.self)
 
-    let resultPath = FilePath("/Expression-\(multiplyResult)-\(addThirtyResult)")
-    try await engine.fileSystem.write(resultPath, multiplyResult + addThirtyResult)
-    return resultPath
-  }
+        let resultPath = FilePath("/Expression-\(multiplyResult)-\(addThirtyResult)")
+        try await engine.fileSystem.write(resultPath, multiplyResult + addThirtyResult)
+        return resultPath
+    }
 }
 
-final class QueryEngineTests: XCTestCase {
-  func testFilePathHashing() throws {
-    try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8541")
-
-    let path = "/root"
-
-    let hashEncoder1 = HashEncoder<SHA256>()
-    try hashEncoder1.encode(FilePath(path))
-    let digest1 = hashEncoder1.finalize()
-
-    let hashEncoder2 = HashEncoder<SHA256>()
-    try hashEncoder2.encode(String(reflecting: FilePath.self))
-    try hashEncoder2.encode(path)
-    let digest2 = hashEncoder2.finalize()
-
-    XCTAssertEqual(digest1, digest2)
-  }
-
-  func testSimpleCaching() async throws {
-    let observabilitySystem = ObservabilitySystem.makeForTesting()
-    let engine = QueryEngine(
-      MockFileSystem(),
-      observabilitySystem.topScope,
-      cacheLocation: .memory
+struct QueryEngineTests {
+    @Test(
+        .bug("https://github.com/swiftlang/swift-package-manager/issues/8541"),
+        .disabled(if: ProcessInfo.hostOperatingSystem == .windows),
     )
+    func filePathHashing() throws {
+        let path = "/root"
 
-    var resultPath = try await engine[Expression(x: 1, y: 2)].path
-    var result = try await engine.fileSystem.read(resultPath, as: Int.self)
+        let hashEncoder1 = HashEncoder<SHA256>()
+        try hashEncoder1.encode(FilePath(path))
+        let digest1 = hashEncoder1.finalize()
 
-    XCTAssertEqual(result, 34)
+        let hashEncoder2 = HashEncoder<SHA256>()
+        try hashEncoder2.encode(String(reflecting: FilePath.self))
+        try hashEncoder2.encode(path)
+        let digest2 = hashEncoder2.finalize()
 
-    var cacheMisses = await engine.cacheMisses
-    XCTAssertEqual(cacheMisses, 5)
+        #expect(digest1 == digest2)
+    }
 
-    var cacheHits = await engine.cacheHits
-    XCTAssertEqual(cacheHits, 0)
+    @Test
+    func simpleCaching() async throws {
+        let observabilitySystem = ObservabilitySystem.makeForTesting()
+        let engine = QueryEngine(
+            MockFileSystem(),
+            observabilitySystem.topScope,
+            cacheLocation: .memory
+        )
 
-    resultPath = try await engine[Expression(x: 1, y: 2)].path
-    result = try await engine.fileSystem.read(resultPath, as: Int.self)
-    XCTAssertEqual(result, 34)
+        var resultPath = try await engine[Expression(x: 1, y: 2)].path
+        var result = try await engine.fileSystem.read(resultPath, as: Int.self)
 
-    cacheMisses = await engine.cacheMisses
-    XCTAssertEqual(cacheMisses, 5)
+        #expect(result == 34)
 
-    cacheHits = await engine.cacheHits
-    XCTAssertEqual(cacheHits, 1)
+        var cacheMisses = await engine.cacheMisses
+        #expect(cacheMisses == 5)
 
-    resultPath = try await engine[Expression(x: 2, y: 1)].path
-    result = try await engine.fileSystem.read(resultPath, as: Int.self)
-    XCTAssertEqual(result, 35)
+        var cacheHits = await engine.cacheHits
+        #expect(cacheHits == 0)
 
-    cacheMisses = await engine.cacheMisses
-    XCTAssertEqual(cacheMisses, 8)
+        resultPath = try await engine[Expression(x: 1, y: 2)].path
+        result = try await engine.fileSystem.read(resultPath, as: Int.self)
+        #expect(result == 34)
 
-    cacheHits = await engine.cacheHits
-    XCTAssertEqual(cacheHits, 3)
+        cacheMisses = await engine.cacheMisses
+        #expect(cacheMisses == 5)
 
-    resultPath = try await engine[Expression(x: 2, y: 1)].path
-    result = try await engine.fileSystem.read(resultPath, as: Int.self)
-    XCTAssertEqual(result, 35)
+        cacheHits = await engine.cacheHits
+        #expect(cacheHits == 1)
 
-    cacheMisses = await engine.cacheMisses
-    XCTAssertEqual(cacheMisses, 8)
+        resultPath = try await engine[Expression(x: 2, y: 1)].path
+        result = try await engine.fileSystem.read(resultPath, as: Int.self)
+        #expect(result == 35)
 
-    cacheHits = await engine.cacheHits
-    XCTAssertEqual(cacheHits, 4)
+        cacheMisses = await engine.cacheMisses
+        #expect(cacheMisses == 8)
 
-    try await engine.shutDown()
-  }
+        cacheHits = await engine.cacheHits
+        #expect(cacheHits == 3)
+
+        resultPath = try await engine[Expression(x: 2, y: 1)].path
+        result = try await engine.fileSystem.read(resultPath, as: Int.self)
+        #expect(result == 35)
+
+        cacheMisses = await engine.cacheMisses
+        #expect(cacheMisses == 8)
+
+        cacheHits = await engine.cacheHits
+        #expect(cacheHits == 4)
+
+        try await engine.shutDown()
+    }
 }

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -9,17 +9,19 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import Basics
 import _InternalTestSupport
 @testable import SourceControl
-import XCTest
+import Testing
 
-class GitRepositoryProviderTests: XCTestCase {
-    func testIsValidDirectory() throws {
-        // Skipping all tests that call git on Windows.
-        // We have a hang in CI when running in parallel.
-        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
+struct GitRepositoryProviderTests {
+    @Test(
+        .bug("https://github.com/swiftlang/swift-package-manager/issues/8564"),
+        .disabled(if: isSelfHostedCiEnvironment && ProcessInfo.hostOperatingSystem == .windows),
+    )
+    func isValidDirectory() throws {
         try testWithTemporaryDirectory { sandbox in
             let provider = GitRepositoryProvider()
 
@@ -27,40 +29,50 @@ class GitRepositoryProviderTests: XCTestCase {
             let repositoryPath = sandbox.appending("test")
             try localFileSystem.createDirectory(repositoryPath)
             initGitRepo(repositoryPath)
-            XCTAssertTrue(try provider.isValidDirectory(repositoryPath))
+            #expect(try provider.isValidDirectory(repositoryPath))
 
             // no-checkout bare repository
             let noCheckoutRepositoryPath = sandbox.appending("test-no-checkout")
             try localFileSystem.copy(from: repositoryPath.appending(".git"), to: noCheckoutRepositoryPath)
-            XCTAssertTrue(try provider.isValidDirectory(noCheckoutRepositoryPath))
+            #expect(try provider.isValidDirectory(noCheckoutRepositoryPath))
 
             // non-git directory
             let notGitPath = sandbox.appending("test-not-git")
-            XCTAssertThrowsError(try provider.isValidDirectory(notGitPath))
+            #expect(throws: (any Error).self) {
+                try provider.isValidDirectory(notGitPath)
+            }
 
             // non-git child directory of a git directory
             let notGitChildPath = repositoryPath.appending("test-not-git")
-            XCTAssertThrowsError(try provider.isValidDirectory(notGitChildPath))
-        }
-    }
-
-    func testIsValidDirectoryThrowsPrintableError() throws {
-        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
-        try testWithTemporaryDirectory { temp in
-            let provider = GitRepositoryProvider()
-            let expectedErrorMessage = "not a git repository"
-            XCTAssertThrowsError(try provider.isValidDirectory(temp)) { error in
-                let errorString = String(describing: error)
-                XCTAssertTrue(
-                    errorString.contains(expectedErrorMessage),
-                    "Error string '\(errorString)' should contain '\(expectedErrorMessage)'"
-                )
+            #expect(throws: (any Error).self) {
+                try provider.isValidDirectory(notGitChildPath)
             }
         }
     }
 
-    func testGitShellErrorIsPrintable() throws {
-        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
+    @Test(
+        .bug("https://github.com/swiftlang/swift-package-manager/issues/8564"),
+        .disabled(if: isSelfHostedCiEnvironment && ProcessInfo.hostOperatingSystem == .windows),
+    )
+    func isValidDirectoryThrowsPrintableError() throws {
+        try testWithTemporaryDirectory { temp in
+            let provider = GitRepositoryProvider()
+            let expectedErrorMessage = "not a git repository"
+            #expect {
+                try provider.isValidDirectory(temp)
+            } throws: { error in
+                let errorString = String(describing: error)
+                let matched = errorString.contains(expectedErrorMessage)
+                return matched
+            }
+        }
+    }
+
+    @Test(
+        .bug("https://github.com/swiftlang/swift-package-manager/issues/8564"),
+        .disabled(if: isSelfHostedCiEnvironment && ProcessInfo.hostOperatingSystem == .windows),
+    )
+    func gitShellErrorIsPrintable() throws {
         let stdOut = "An error from Git - stdout"
         let stdErr = "An error from Git - stderr"
         let arguments = ["git", "error"]
@@ -74,22 +86,22 @@ class GitRepositoryProviderTests: XCTestCase {
         )
         let error = GitShellError(result: result)
         let errorString = "\(error)"
-        XCTAssertTrue(
+        #expect(
             errorString.contains(stdOut),
-            "Error string '\(errorString)' should contain '\(stdOut)'"
-        )
-        XCTAssertTrue(
+            "Error string '\(errorString)' should contain '\(stdOut)'")
+        #expect(
             errorString.contains(stdErr),
-            "Error string '\(errorString)' should contain '\(stdErr)'"
-        )
-        XCTAssertTrue(
+            "Error string '\(errorString)' should contain '\(stdErr)'")
+        #expect(
             errorString.contains(command),
-            "Error string '\(errorString)' should contain '\(command)'"
-        )
+            "Error string '\(errorString)' should contain '\(command)'")
     }
 
-    func testGitShellErrorEmptyStdOut() throws {
-        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
+    @Test(
+        .bug("https://github.com/swiftlang/swift-package-manager/issues/8564"),
+        .disabled(if: isSelfHostedCiEnvironment && ProcessInfo.hostOperatingSystem == .windows),
+    )
+    func gitShellErrorEmptyStdOut() throws {
         let stdErr = "An error from Git - stderr"
         let result = AsyncProcessResult(
             arguments: ["git", "error"],
@@ -100,14 +112,16 @@ class GitRepositoryProviderTests: XCTestCase {
         )
         let error = GitShellError(result: result)
         let errorString = "\(error)"
-        XCTAssertTrue(
+        #expect(
             errorString.contains(stdErr),
-            "Error string '\(errorString)' should contain '\(stdErr)'"
-        )
+            "Error string '\(errorString)' should contain '\(stdErr)'")
     }
 
-    func testGitShellErrorEmptyStdErr() throws {
-        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
+    @Test(
+        .bug("https://github.com/swiftlang/swift-package-manager/issues/8564"),
+        .disabled(if: isSelfHostedCiEnvironment && ProcessInfo.hostOperatingSystem == .windows),
+    )
+    func gitShellErrorEmptyStdErr() throws {
         let stdOut = "An error from Git - stdout"
         let result = AsyncProcessResult(
             arguments: ["git", "error"],
@@ -118,7 +132,7 @@ class GitRepositoryProviderTests: XCTestCase {
         )
         let error = GitShellError(result: result)
         let errorString = "\(error)"
-        XCTAssertTrue(
+        #expect(
             errorString.contains(stdOut),
             "Error string '\(errorString)' should contain '\(stdOut)'"
         )

--- a/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
+++ b/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
@@ -9,69 +9,72 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import Basics
 import SourceControl
 import _InternalTestSupport
-import XCTest
+import Testing
 
-final class InMemoryGitRepositoryTests: XCTestCase {
-    func testBasics() throws {
+struct InMemoryGitRepositoryTests {
+    @Test
+    func basics() throws {
         let fs = InMemoryFileSystem()
         let repo = InMemoryGitRepository(path: .root, fs: fs)
 
         try repo.createDirectory("/new-dir/subdir", recursive: true)
-        XCTAssertTrue(!repo.hasUncommittedChanges())
+        #expect(!repo.hasUncommittedChanges())
         let filePath = AbsolutePath("/new-dir/subdir").appending("new-file.txt")
 
         try repo.writeFileContents(filePath, bytes: "one")
-        XCTAssertEqual(try repo.readFileContents(filePath), "one")
-        XCTAssertTrue(repo.hasUncommittedChanges())
+        #expect(try repo.readFileContents(filePath) == "one")
+        #expect(repo.hasUncommittedChanges())
 
         let firstCommit = try repo.commit()
-        XCTAssertTrue(!repo.hasUncommittedChanges())
+        #expect(!repo.hasUncommittedChanges())
 
-        XCTAssertEqual(try repo.readFileContents(filePath), "one")
-        XCTAssertEqual(try fs.readFileContents(filePath), "one")
+        #expect(try repo.readFileContents(filePath) == "one")
+        #expect(try fs.readFileContents(filePath) == "one")
 
         try repo.writeFileContents(filePath, bytes: "two")
-        XCTAssertEqual(try repo.readFileContents(filePath), "two")
-        XCTAssertTrue(repo.hasUncommittedChanges())
+        #expect(try repo.readFileContents(filePath) == "two")
+        #expect(repo.hasUncommittedChanges())
 
         let secondCommit = try repo.commit()
-        XCTAssertTrue(!repo.hasUncommittedChanges())
-        XCTAssertEqual(try repo.readFileContents(filePath), "two")
+        #expect(!repo.hasUncommittedChanges())
+        #expect(try repo.readFileContents(filePath) == "two")
 
         try repo.writeFileContents(filePath, bytes: "three")
-        XCTAssertTrue(repo.hasUncommittedChanges())
-        XCTAssertEqual(try repo.readFileContents(filePath), "three")
+        #expect(repo.hasUncommittedChanges())
+        #expect(try repo.readFileContents(filePath) == "three")
 
         try repo.checkout(revision: firstCommit)
-        XCTAssertTrue(!repo.hasUncommittedChanges())
-        XCTAssertEqual(try repo.readFileContents(filePath), "one")
-        XCTAssertEqual(try fs.readFileContents(filePath), "one")
+        #expect(!repo.hasUncommittedChanges())
+        #expect(try repo.readFileContents(filePath) == "one")
+        #expect(try fs.readFileContents(filePath) == "one")
 
         try repo.checkout(revision: secondCommit)
-        XCTAssertTrue(!repo.hasUncommittedChanges())
-        XCTAssertEqual(try repo.readFileContents(filePath), "two")
+        #expect(!repo.hasUncommittedChanges())
+        #expect(try repo.readFileContents(filePath) == "two")
 
-        XCTAssert(try repo.getTags().isEmpty)
+        #expect(try repo.getTags().isEmpty)
         try repo.tag(name: "2.0.0")
-        XCTAssertEqual(try repo.getTags(), ["2.0.0"])
-        XCTAssertTrue(!repo.hasUncommittedChanges())
-        XCTAssertEqual(try repo.readFileContents(filePath), "two")
-        XCTAssertEqual(try fs.readFileContents(filePath), "two")
+        #expect(try repo.getTags() == ["2.0.0"])
+        #expect(!repo.hasUncommittedChanges())
+        #expect(try repo.readFileContents(filePath) == "two")
+        #expect(try fs.readFileContents(filePath) == "two")
 
         try repo.checkout(revision: firstCommit)
-        XCTAssertTrue(!repo.hasUncommittedChanges())
-        XCTAssertEqual(try repo.readFileContents(filePath), "one")
+        #expect(!repo.hasUncommittedChanges())
+        #expect(try repo.readFileContents(filePath) == "one")
 
         try repo.checkout(tag: "2.0.0")
-        XCTAssertTrue(!repo.hasUncommittedChanges())
-        XCTAssertEqual(try repo.readFileContents(filePath), "two")
+        #expect(!repo.hasUncommittedChanges())
+        #expect(try repo.readFileContents(filePath) == "two")
     }
 
-    func testProvider() throws {
+    @Test
+    func provider() throws {
         let v1 = "1.0.0"
         let v2 = "2.0.0"
         let repo = InMemoryGitRepository(path: .root, fs: InMemoryFileSystem())
@@ -95,23 +98,23 @@ final class InMemoryGitRepositoryTests: XCTestCase {
 
         // Adding a new tag in original repo shouldn't show up in fetched repo.
         try repo.tag(name: "random")
-        XCTAssertEqual(try fooRepo.getTags().sorted(), [v1, v2])
-        XCTAssert(fooRepo.exists(revision: try fooRepo.resolveRevision(tag: v1)))
+        #expect(try fooRepo.getTags().sorted() == [v1, v2])
+        #expect(fooRepo.exists(revision: try fooRepo.resolveRevision(tag: v1)))
 
         let fooCheckoutPath = AbsolutePath("/fooCheckout")
-        XCTAssertFalse(try provider.workingCopyExists(at: fooCheckoutPath))
+        #expect(!(try provider.workingCopyExists(at: fooCheckoutPath)))
         _ = try provider.createWorkingCopy(repository: specifier, sourcePath: fooRepoPath, at: fooCheckoutPath, editable: false)
-        XCTAssertTrue(try provider.workingCopyExists(at: fooCheckoutPath))
+        #expect(try provider.workingCopyExists(at: fooCheckoutPath))
         let fooCheckout = try provider.openWorkingCopy(at: fooCheckoutPath)
 
-        XCTAssertEqual(try fooCheckout.getTags().sorted(), [v1, v2])
-        XCTAssert(fooCheckout.exists(revision: try fooCheckout.getCurrentRevision()))
+        #expect(try fooCheckout.getTags().sorted() == [v1, v2])
+        #expect(fooCheckout.exists(revision: try fooCheckout.getCurrentRevision()))
         let checkoutRepo = try provider.openRepo(at: fooCheckoutPath)
 
         try fooCheckout.checkout(tag: v1)
-        XCTAssertEqual(try checkoutRepo.readFileContents(filePath), "one")
+        #expect(try checkoutRepo.readFileContents(filePath) == "one")
 
         try fooCheckout.checkout(tag: v2)
-        XCTAssertEqual(try checkoutRepo.readFileContents(filePath), "two")
+        #expect(try checkoutRepo.readFileContents(filePath) == "two")
     }
 }


### PR DESCRIPTION
Convert additional suites from XCTest to Swift Testing


### Motivation:

The XCTest run, by default, sequentially.  Convert some suites from XCTest to Swift Testing to make use of parallel execution and, in some cases, test parameterization.

Not all Test Suite in the respective folders have been converted as some use helpers in swift-tools-core-support, which don't have a matching  swift testing helper.

### Modifications:

Convert XCTest to Swift Testing

### Result:

Ran the equivalent of the following and ensured there were no test-related failures

```
for _ in $(seq 0 100);
do
    swift test --enable-swift-testing --disable-xctest
done
```

Blocked by #8137 
Blocked by  https://github.com/swiftlang/swift/pull/78300
Blocked by https://github.com/swiftlang/swift/pull/81217