### PR TITLE
Expose all target files to SourceKit-LSP

### DIFF
--- a/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
@@ -57,6 +57,16 @@ public final class ClangModuleBuildDescription {
         self.target.underlying.resources + self.pluginDerivedResources
     }
 
+    /// The list of files in the target that were marked as ignored.
+    public var ignored: [AbsolutePath] {
+        self.target.underlying.ignored
+    }
+
+    /// The list of other kinds of files in the target.
+    public var others: [AbsolutePath] {
+        self.target.underlying.others
+    }
+
     /// Path to the bundle generated for this module (if any).
     var bundlePath: AbsolutePath? {
         guard !self.resources.isEmpty else {

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -108,6 +108,16 @@ public final class SwiftModuleBuildDescription {
         self.target.underlying.resources + self.pluginDerivedResources
     }
 
+    /// The list of files in the target that were marked as ignored.
+    public var ignored: [AbsolutePath] {
+        self.target.underlying.ignored
+    }
+
+    /// The list of other kinds of files in the target.
+    public var others: [AbsolutePath] {
+        self.target.underlying.others
+    }
+
     /// The objects in this target, containing either machine code or bitcode
     /// depending on the build parameters used.
     public var objects: [AbsolutePath] {

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -43,7 +43,7 @@ public protocol BuildTarget {
     /// Files in the target that were marked as ignored.
     var ignored: [URL] { get }
 
-    /// Other kinds of files in the module.
+    /// Other kinds of files in the target.
     var others: [URL] { get }
 
     /// The name of the target. It should be possible to build a target by passing this name to `swift build --target`
@@ -86,11 +86,11 @@ private struct WrappedClangTargetBuildDescription: BuildTarget {
     }
 
     var ignored: [URL] {
-        return description.ignored.map { URL(fileURLWithPath: $0.pathString)}
+        return description.ignored.map { URL(fileURLWithPath: $0.pathString) }
     }
 
     var others: [URL] {
-        return description.others.map { URL(fileURLWithPath: $0.pathString)}
+        return description.others.map { URL(fileURLWithPath: $0.pathString) }
     }
 
     public var name: String {

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -139,11 +139,11 @@ private struct WrappedSwiftTargetBuildDescription: BuildTarget {
     }
 
     var ignored: [URL] {
-        return description.ignored.map { URL(fileURLWithPath: $0.pathString)}
+        return description.ignored.map { URL(fileURLWithPath: $0.pathString) }
     }
 
     var others: [URL] {
-        return description.others.map { URL(fileURLWithPath: $0.pathString)}
+        return description.others.map { URL(fileURLWithPath: $0.pathString) }
     }
 
     func compileArguments(for fileURL: URL) throws -> [String] {

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -37,6 +37,15 @@ public protocol BuildTarget {
     /// Header files in the target
     var headers: [URL] { get }
 
+    /// The resource files in the target.
+    var resources: [URL] { get }
+
+    /// Files in the target that were marked as ignored.
+    var ignored: [URL] { get }
+
+    /// Other kinds of files in the module.
+    var others: [URL] { get }
+
     /// The name of the target. It should be possible to build a target by passing this name to `swift build --target`
     var name: String { get }
 
@@ -70,6 +79,18 @@ private struct WrappedClangTargetBuildDescription: BuildTarget {
 
     public var headers: [URL] {
         return description.clangTarget.headers.map(\.asURL)
+    }
+
+    var resources: [URL] {
+        return description.resources.map { URL(fileURLWithPath: $0.path.pathString) }
+    }
+
+    var ignored: [URL] {
+        return description.ignored.map { URL(fileURLWithPath: $0.pathString)}
+    }
+
+    var others: [URL] {
+        return description.others.map { URL(fileURLWithPath: $0.pathString)}
     }
 
     public var name: String {
@@ -112,6 +133,18 @@ private struct WrappedSwiftTargetBuildDescription: BuildTarget {
     }
 
     var headers: [URL] { [] }
+
+    var resources: [URL] {
+        return description.resources.map { URL(fileURLWithPath: $0.path.pathString) }
+    }
+
+    var ignored: [URL] {
+        return description.ignored.map { URL(fileURLWithPath: $0.pathString)}
+    }
+
+    var others: [URL] {
+        return description.others.map { URL(fileURLWithPath: $0.pathString)}
+    }
 
     func compileArguments(for fileURL: URL) throws -> [String] {
         // Note: we ignore the `fileURL` here as the expectation is that we get a command line for the entire target

--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -41,6 +41,18 @@ struct PluginTargetBuildDescription: BuildTarget {
 
     var headers: [URL] { [] }
 
+    var resources: [URL] {
+        return target.underlying.resources.map { URL(fileURLWithPath: $0.path.pathString) }
+    }
+
+    var ignored: [URL] {
+        return target.underlying.ignored.map { URL(fileURLWithPath: $0.pathString)}
+    }
+
+    var others: [URL] {
+        return target.underlying.others.map { URL(fileURLWithPath: $0.pathString)}
+    }
+
     var name: String {
         return target.name
     }

--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -46,11 +46,11 @@ struct PluginTargetBuildDescription: BuildTarget {
     }
 
     var ignored: [URL] {
-        return target.underlying.ignored.map { URL(fileURLWithPath: $0.pathString)}
+        return target.underlying.ignored.map { URL(fileURLWithPath: $0.pathString) }
     }
 
     var others: [URL] {
-        return target.underlying.others.map { URL(fileURLWithPath: $0.pathString)}
+        return target.underlying.others.map { URL(fileURLWithPath: $0.pathString) }
     }
 
     var name: String {

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -33,7 +33,7 @@ final class SourceKitLSPAPITests: XCTestCase {
             "/Pkg/Sources/lib/README.md",
             "/Pkg/Sources/lib/lib.docc/GettingStarted.md",
             "/Pkg/Sources/lib/Resources/some_file.txt",
-            "/Pkg/Plugins/plugin/plugin.swift",
+            "/Pkg/Plugins/plugin/plugin.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()


### PR DESCRIPTION
Add `resources`, `ignored`, and `other` files to `BuildTarget` for use by SourceKit-LSP.

This is tracked by rdar://139431738 as part of swiftlang/vscode-swift#562

### Motivation:

SourceKit-LSP needs to be able to determine which target contains a given DocC catalog in order to fulfill documentation related requests. However, the catalog is not listed as one of the `sources` or `headers`. Rather, it is part of `other` files in most cases. Expose all file types to SourceKit-LSP so that it can properly determine which target a given file belongs to.

### Modifications:

Added three new properties to `BuildTarget`: `resources`, `ignored`, and `other` which are arrays of `URL` pointing to the given file types in the target.

### Result:

SourceKit-LSP will be able to see all files contained within a given target.
