### PR TITLE
Add `import _Concurrency` to `Workspace+BinaryArtifacts.swift`

### DIFF
--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import Basics
 import Foundation
 import PackageLoading


### PR DESCRIPTION
This fixes the build in certain configurations where this module is not auto-imported.
