### PR TITLE
Handle hash characters (#) in netrc fields

### DIFF
--- a/Tests/BasicsTests/NetrcTests.swift
+++ b/Tests/BasicsTests/NetrcTests.swift
@@ -431,5 +431,65 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(netrc.machines[1].login, "fred")
         XCTAssertEqual(netrc.machines[1].password, "sunshine4ever")
     }
-}
 
+    func testComments() throws {
+        let content = """
+            # A comment at the beginning of the line
+            machine example.com # Another comment
+            login anonymous
+            password qw#erty
+            """
+
+        let netrc = try NetrcParser.parse(content)
+
+        let machine = netrc.machines.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qw#erty")
+    }
+
+    func testHashSymbolInPassword() throws {
+        let content = """
+            machine example.com
+            login anonymous
+            password qw#erty
+            """
+
+        let netrc = try NetrcParser.parse(content)
+
+        let machine = netrc.machines.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qw#erty")
+    }
+
+    func testQuotedPasswordWithSpace() throws {
+        let content = """
+            machine example.com
+            login anonymous
+            password "qw erty"
+            """
+
+        let netrc = try NetrcParser.parse(content)
+
+        let machine = netrc.machines.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qw erty")
+    }
+
+    func testQuotedPasswordWithSpaceAndHash() throws {
+        let content = """
+            machine example.com
+            login anonymous
+            password "qw #erty"
+            """
+
+        let netrc = try NetrcParser.parse(content)
+
+        let machine = netrc.machines.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qw #erty")
+    }
+}

--- a/Tests/BasicsTests/NetrcTests.swift
+++ b/Tests/BasicsTests/NetrcTests.swift
@@ -492,4 +492,19 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(machine?.login, "anonymous")
         XCTAssertEqual(machine?.password, "qw #erty")
     }
+
+    func testQuotedPasswordWithSpaceAndHashAndCommentAtEndOfLine() throws {
+        let content = """
+            machine example.com
+            login anonymous
+            password "qw #erty" # A comment
+            """
+
+        let netrc = try NetrcParser.parse(content)
+
+        let machine = netrc.machines.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qw #erty")
+    }
 }


### PR DESCRIPTION
Hash symbols were always treated as the beginning of a comment even if they were in the middle of a username or password. To address this require some whitespace before a hash character before a comment is parsed.

That patch also implements support for quoted fields so that passwords can contain the sequence "foo #bar" without dropping "bar" as a comment.

Issue: #8090
