### PR TITLE
Use Windows-style paths with backslashes in SourceKit-LSP compiler arguments for plugins

### DIFF
--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -54,7 +54,43 @@ struct PluginTargetBuildDescription: BuildTarget {
         // FIXME: This is very odd and we should clean this up by merging `ManifestLoader` and `DefaultPluginScriptRunner` again.
         var args = ManifestLoader.interpreterFlags(for: self.toolsVersion, toolchain: toolchain)
         // Note: we ignore the `fileURL` here as the expectation is that we get a commandline for the entire target in case of Swift. Plugins are always assumed to only consist of Swift files.
-        args += sources.map { $0.path }
+        args += try sources.map { try $0.filePath }
         return args
     }
+}
+
+fileprivate enum FilePathError: Error, CustomStringConvertible {
+  case noFileSystemRepresentation(URL)
+  case noFileURL(URL)
+
+  var description: String {
+    switch self {
+    case .noFileSystemRepresentation(let url):
+      return "\(url.description) cannot be represented as a file system path"
+    case .noFileURL(let url):
+      return "\(url.description) is not a file URL"
+    }
+  }
+}
+
+fileprivate extension URL {
+  /// Assuming that this is a file URL, the path with which the file system refers to the file. This is similar to
+  /// `path` but has two differences:
+  /// - It uses backslashes as the path separator on Windows instead of forward slashes
+  /// - It throws an error when called on a non-file URL.
+  ///
+  /// `filePath` should generally be preferred over `path` when dealing with file URLs.
+  var filePath: String {
+    get throws {
+      guard self.isFileURL else {
+        throw FilePathError.noFileURL(self)
+      }
+      return try self.withUnsafeFileSystemRepresentation { buffer in
+        guard let buffer else {
+          throw FilePathError.noFileSystemRepresentation(self)
+        }
+        return String(cString: buffer)
+      }
+    }
+  }
 }


### PR DESCRIPTION
`URL.path` returns a URL path with forward slashes. We need to go through `withUnsafeFileSystemRepresentation` to get a Windows file system path with backslashes.

Fixes https://github.com/swiftlang/sourcekit-lsp/issues/1775
