### PR TITLE
Add Package edit support for packages with unsafe flags

### DIFF
--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -147,9 +147,9 @@ extension Workspace {
                       result.insert(packageRef)
                     }
 
-                case .registryDownload, .edited, .custom:
+                case .registryDownload, .custom:
                     continue
-                case .fileSystem:
+                case .fileSystem, .edited:
                     result.insert(dependency.packageRef)
                 }
             }


### PR DESCRIPTION
Fixes #8079

Allows unsafe flags for edited packages


### Motivation:

Edited packages in SwiftPM should be allowed to use unsafe flags.


### Modifications:

Adjusted logic in `unsafeAllowedPackages` to add `.edited` packages to the allowed list, alongside the root package and `.fileSystem` packages


### Result:

After this change, edited packages will be permitted to use unsafe flags.

