### PR TITLE
Package plugins don't work on Windows if the PATH environment variable isn't accessed with the right case

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -1062,7 +1062,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                         var environment = Environment.current
                         #if os(Windows)
                         let windowsPathComponent = runtimePath.pathString.replacingOccurrences(of: "/", with: "\\")
-                        environment["Path"] = "\(windowsPathComponent);\(environment["Path"] ?? "")"
+                        environment.prependPath(key: .path, value: windowsPathComponent)
                         #endif
 
                         let cleanupAfterRunning = cleanupIfError.delay()

--- a/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
@@ -466,13 +466,9 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         process.environment = ProcessInfo.processInfo.environment
 #if os(Windows)
         let pluginLibraryPath = self.toolchain.swiftPMLibrariesLocation.pluginLibraryPath.pathString
-        var env = ProcessInfo.processInfo.environment
-        if let Path = env["Path"] {
-            env["Path"] = "\(pluginLibraryPath);\(Path)"
-        } else {
-            env["Path"] = pluginLibraryPath
-        }
-        process.environment = env
+        var env = Environment.current
+        env.prependPath(key: .path, value: pluginLibraryPath)
+        process.environment = .init(env)
 #endif
         process.currentDirectoryURL = workingDirectory.asURL
         


### PR DESCRIPTION
Builds of packages using package plugins may fail on Windows with the following error:

```
error: plugin process ended by an uncaught signal: 309 <command: C:\foo\.build\plugins\cache\myplugin.exe>, <output:
>
```

309 translates to 0x135, which maps to 0xc0000135 aka STATUS_DLL_NOT_FOUND.

This is due to the following code in DefaultPluginScriptRunner.swift:

```swift
#if os(Windows)
        let pluginLibraryPath = self.toolchain.swiftPMLibrariesLocation.pluginLibraryPath.pathString
        var env = ProcessInfo.processInfo.environment
        if let Path = env["Path"] {
            env["Path"] = "\(pluginLibraryPath);\(Path)"
        } else {
            env["Path"] = pluginLibraryPath
        }
        process.environment = env
#endif
```

Environment variable names are case-insensitive on Windows. On a real Windows host, it tends to be spelled "Path". In a Windows Container (Docker), it tends to be spelled "PATH".

The code will end up clearing out the other paths from the PATH environment variable in the else case because Path != PATH.

We need to access the path here in a case-insensitive manner -- use the existing Environment abstraction for this, which handles Windows case sensitivity concerns.

Closes #8125

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
