### PR TITLE
Return compiler arguments for invalid package manifests

### DIFF
--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -384,33 +384,23 @@ extension Workspace {
     }
 
     /// Returns manifest interpreter flags for a package.
-    // TODO: should this be throwing instead?
-    public func interpreterFlags(for packagePath: AbsolutePath) -> [String] {
-        do {
-            guard let manifestLoader = self.manifestLoader as? ManifestLoader else {
-                throw StringError("unexpected manifest loader kind")
-            }
-
-            let manifestPath = try ManifestLoader.findManifest(
-                packagePath: packagePath,
-                fileSystem: self.fileSystem,
-                currentToolsVersion: self.currentToolsVersion
-            )
-            let manifestToolsVersion = try ToolsVersionParser.parse(
-                manifestPath: manifestPath,
-                fileSystem: self.fileSystem
-            )
-
-            guard self.currentToolsVersion >= manifestToolsVersion || SwiftVersion.current.isDevelopment,
-                  manifestToolsVersion >= ToolsVersion.minimumRequired
-            else {
-                throw StringError("invalid tools version")
-            }
-            return manifestLoader.interpreterFlags(for: manifestToolsVersion)
-        } catch {
-            // We ignore all failures here and return empty array.
-            return []
+    public func interpreterFlags(for manifestPath: AbsolutePath) throws -> [String] {
+        guard let manifestLoader = self.manifestLoader as? ManifestLoader else {
+            throw StringError("unexpected manifest loader kind")
         }
+
+        let manifestToolsVersion = (try? ToolsVersionParser.parse(
+            manifestPath: manifestPath,
+            fileSystem: self.fileSystem
+        )) ?? self.currentToolsVersion
+
+
+        guard self.currentToolsVersion >= manifestToolsVersion || SwiftVersion.current.isDevelopment,
+                manifestToolsVersion >= ToolsVersion.minimumRequired
+        else {
+            throw StringError("invalid tools version")
+        }
+        return manifestLoader.interpreterFlags(for: manifestToolsVersion)
     }
 
     /// Load the manifests for the current dependency tree.


### PR DESCRIPTION
Currently, when there‘s a syntax error in a package manifest, we don’t get any build settings from it in SourceKit-LSP and thus loose almost all semantic functionality. If we can’t parse the package manifest, fall back to providing build settings by assuming it has the current Swift tools version.

Fixes swiftlang/sourcekit-lsp#1704
rdar://136423767
