### PR TITLE
Disable development mode

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -59,7 +59,7 @@ extension SwiftVersion {
     /// The current version of the package manager.
     public static let current = SwiftVersion(
         version: (6, 1, 0),
-        isDevelopment: true,
+        isDevelopment: false,
         buildIdentifier: getBuildIdentifier()
     )
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -206,7 +206,7 @@ final class WorkspaceTests: XCTestCase {
             do {
                 let ws = try createWorkspace(
                     """
-                    // swift-tools-version:999.0
+                    // swift-tools-version:5.9.2
                     import PackageDescription
                     let package = Package(
                         name: "foo"
@@ -214,7 +214,7 @@ final class WorkspaceTests: XCTestCase {
                     """
                 )
 
-                XCTAssertMatch(try ws.interpreterFlags(for: packageManifest), [.equal("-swift-version"), .equal("6")])
+                XCTAssertMatch(try ws.interpreterFlags(for: packageManifest), [.equal("-swift-version"), .equal("5")])
             }
 
             do {


### PR DESCRIPTION
Disable development mode in the release 6.1 branch.

### Motivation:

We should never release Swift Package Manager in development mode. So this disables dev mode and brings in the functionality of `999.0` over being introduced specific swift tool version (primarily in tests)

### Modifications:

Modify `SwiftVersion` `isDevelopment` to `false` and update references to swift tool version `999.0` to  a specific version.

### Result:

`swift test`