### PR TITLE
PackageDescription.Target.Dependency type have been changed to conform to Sendable

### DIFF
--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -42,7 +42,7 @@ public final class Target {
     }
 
     /// The different types of a target's dependency on another entity.
-    public enum Dependency {
+    public enum Dependency: Sendable {
         /// A dependency on a target.
         ///
         ///  - Parameters:
@@ -1357,7 +1357,7 @@ extension Target.Dependency {
 }
 
 /// A condition that limits the application of a target's dependency.
-public struct TargetDependencyCondition {
+public struct TargetDependencyCondition: Sendable {
     let platforms: [Platform]?
     let traits: Set<String>?
 


### PR DESCRIPTION
PackageDescription.Target.Dependency type have been changed to conform to Sendable.

### Motivation:

Since PackageDescription.Target.Dependency type does not conform to Sendable, we need to add `@preconcurrency` to ignore the warning from the dependency.

The following is an example where `@preconcurrency` is required.

```swift
// swift-tools-version: 6.0
@preconcurrency import PackageDescription

// ...

private extension PackageDescription.Target.Dependency {
    static let collections: Self = .product(name: "Collections", package: "swift-collections")
    static let asyncAlgorithms: Self = .product(name: "AsyncAlgorithms", package: "swift-async-algorithms")
}
```

### Modifications:

PackageDescription.Target.Dependency type and TargetDependencyCondition type have been changed to conform to Sendable.

### Result:

In the example above, `@preconcurrency` is not required.
