### PR TITLE
Fix typo in `Package.swift` comment

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -841,7 +841,7 @@ package.targets.append(contentsOf: [
 ])
 #endif
 
-// Workaround SPM's attempt to link in executables which does not work on all
+// Workaround SwiftPM's attempt to link in executables which does not work on all
 // platforms.
 #if !os(Windows)
 package.targets.append(contentsOf: [


### PR DESCRIPTION
There's no such product or entity as "SPM", this contraction is just as invalid as "MOS" would be for macOS, or "SNIO" for SwiftNIO. All marketing and documentation materials consistently refer to it as "SwiftPM", and we should stay consistent in our codebase too. This also simplifies code search, as anything named as "SPM" almost never shows up in results when searching globally for "SwiftPM".
