### PR TITLE
Update xUnit to display output on failures

### DIFF
--- a/Fixtures/Miscellaneous/TestMultipleFailureSwiftTesting/Package.swift
+++ b/Fixtures/Miscellaneous/TestMultipleFailureSwiftTesting/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TestMultipleFailureSwiftTesting",
+    targets: [
+        .testTarget(
+            name: "TestMultipleFailureSwiftTestingTests"
+        )
+    ]
+)

--- a/Fixtures/Miscellaneous/TestMultipleFailureSwiftTesting/Tests/TestMultipleFailureSwiftTestingTests/TestMultipleFailureSwiftTestingTests.swift
+++ b/Fixtures/Miscellaneous/TestMultipleFailureSwiftTesting/Tests/TestMultipleFailureSwiftTestingTests/TestMultipleFailureSwiftTestingTests.swift
@@ -1,0 +1,41 @@
+import Testing
+
+@Test func testFailure1() async throws {
+    #expect(Bool(false), "ST Test failure 1")
+}
+
+@Test func testFailure2() async throws {
+    #expect(Bool(false), "ST Test failure 2")
+}
+
+@Test func testFailure3() async throws {
+    #expect(Bool(false), "ST Test failure 3")
+}
+
+@Test func testFailure4() async throws {
+    #expect(Bool(false), "ST Test failure 4")
+}
+
+@Test func testFailure5() async throws {
+    #expect(Bool(false), "ST Test failure 5")
+}
+
+@Test func testFailure6() async throws {
+    #expect(Bool(false), "ST Test failure 6")
+}
+
+@Test func testFailure7() async throws {
+    #expect(Bool(false), "ST Test failure 7")
+}
+
+@Test func testFailure8() async throws {
+    #expect(Bool(false), "ST Test failure 8")
+}
+
+@Test func testFailure9() async throws {
+    #expect(Bool(false), "ST Test failure 9")
+}
+
+@Test func testFailure10() async throws {
+    #expect(Bool(false), "ST Test failure 10")
+}

--- a/Fixtures/Miscellaneous/TestMultipleFailureXCTest/Package.swift
+++ b/Fixtures/Miscellaneous/TestMultipleFailureXCTest/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TestMultipleFailureXCTest",
+    targets: [
+        .testTarget(
+            name: "TestMultipleFailureXCTestTests"
+        )
+    ]
+)

--- a/Fixtures/Miscellaneous/TestMultipleFailureXCTest/Tests/TestMultipleFailureXCTestTests/TestMultipleFailureXCTestTests.swift
+++ b/Fixtures/Miscellaneous/TestMultipleFailureXCTest/Tests/TestMultipleFailureXCTestTests/TestMultipleFailureXCTestTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+final class TestMultipleFailureXCTestTests: XCTestCase {
+    func testFailure1() throws {
+        XCTAssertFalse(true, "Test failure 1")
+    }
+
+    func testFailure2() throws {
+        XCTAssertFalse(true, "Test failure 2")
+    }
+
+    func testFailure3() throws {
+        XCTAssertFalse(true, "Test failure 3")
+    }
+
+    func testFailure4() throws {
+        XCTAssertFalse(true, "Test failure 4")
+    }
+
+    func testFailure5() throws {
+        XCTAssertFalse(true, "Test failure 5")
+    }
+
+    func testFailure6() throws {
+        XCTAssertFalse(true, "Test failure 6")
+    }
+
+    func testFailure7() throws {
+        XCTAssertFalse(true, "Test failure 7")
+    }
+
+    func testFailure8() throws {
+        XCTAssertFalse(true, "Test failure 8")
+    }
+
+    func testFailure9() throws {
+        XCTAssertFalse(true, "Test failure 9")
+    }
+
+    func testFailure10() throws {
+        XCTAssertFalse(true, "Test failure 10")
+    }
+
+}

--- a/Fixtures/Miscellaneous/TestSingleFailureSwiftTesting/Package.swift
+++ b/Fixtures/Miscellaneous/TestSingleFailureSwiftTesting/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TestFailuresSwiftTesting",
+    targets: [
+        .testTarget(
+            name: "TestFailuresSwiftTestingTests"
+        )
+    ]
+)

--- a/Fixtures/Miscellaneous/TestSingleFailureSwiftTesting/Tests/TestFailuresSwiftTestingTests/TestFailuresSwiftTestingTests.swift
+++ b/Fixtures/Miscellaneous/TestSingleFailureSwiftTesting/Tests/TestFailuresSwiftTestingTests/TestFailuresSwiftTestingTests.swift
@@ -1,0 +1,5 @@
+import Testing
+
+@Test func example() async throws {
+    #expect(Bool(false), "Purposely failing & validating XML espace \"'<>")
+}

--- a/Fixtures/Miscellaneous/TestSingleFailureXCTest/Package.swift
+++ b/Fixtures/Miscellaneous/TestSingleFailureXCTest/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TestFailures",
+    targets: [
+        .testTarget(
+            name: "TestFailuresTests"
+        )
+    ]
+)

--- a/Fixtures/Miscellaneous/TestSingleFailureXCTest/Tests/TestFailuresTests/TestFailuresTests.swift
+++ b/Fixtures/Miscellaneous/TestSingleFailureXCTest/Tests/TestFailuresTests/TestFailuresTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+final class TestFailuresTests: XCTestCase {
+    func testExample() throws {
+        XCTAssertFalse(true, "Purposely failing & validating XML espace \"'<>")
+    }
+}
+

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -339,10 +339,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                     result = runner.ranSuccessfully ? .success : .failure
                 }
 
-                try generateXUnitOutputIfRequested(
-                    for: testResults,
-                    swiftCommandState: swiftCommandState,
-                )
+                try generateXUnitOutputIfRequested(for: testResults, swiftCommandState: swiftCommandState)
                 results.append(result)
             }
         }
@@ -418,7 +415,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     /// Generate xUnit file if requested.
     private func generateXUnitOutputIfRequested(
         for testResults: [ParallelTestRunner.TestResult],
-        swiftCommandState: SwiftCommandState,
+        swiftCommandState: SwiftCommandState
     ) throws {
         guard let xUnitOutput = options.xUnitOutput else {
             return

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -191,7 +191,7 @@ struct TestCommandOptions: ParsableArguments {
     @Flag(
         name: .customLong("experimental-xunit-message-failure"),
         help: ArgumentHelp(
-            "When Set, enabled an experimental message failure content (XCTest only).",
+            "When set, include the content of stdout/stderr in failure messages (XCTest only, experimental).",
             visibility: .hidden
         )
     )

--- a/Sources/_InternalTestSupport/SwiftPMProduct.swift
+++ b/Sources/_InternalTestSupport/SwiftPMProduct.swift
@@ -76,6 +76,7 @@ extension SwiftPM {
     ///         - args: The arguments to pass.
     ///         - env: Additional environment variables to pass. The values here are merged with default env.
     ///         - packagePath: Adds argument `--package-path <path>` if not nil.
+    ///         - throwIfCommandFails: If set, will throw an error if the command does not have a 0 return code.
     ///
     /// - Returns: The output of the process.
     @discardableResult
@@ -83,7 +84,7 @@ extension SwiftPM {
         _ args: [String] = [],
         packagePath: AbsolutePath? = nil,
         env: Environment? = nil,
-        errorIfCommandUnsuccessful: Bool = true
+        throwIfCommandFails: Bool = true
     ) async throws -> (stdout: String, stderr: String) {
         let result = try await executeProcess(
             args,
@@ -95,7 +96,7 @@ extension SwiftPM {
         let stderr = try result.utf8stderrOutput()
         
         let returnValue = (stdout: stdout, stderr: stderr)
-        if (!errorIfCommandUnsuccessful) { return returnValue }
+        if (!throwIfCommandFails) { return returnValue }
 
         if result.exitStatus == .terminated(code: 0) {
             return returnValue

--- a/Sources/_InternalTestSupport/SwiftPMProduct.swift
+++ b/Sources/_InternalTestSupport/SwiftPMProduct.swift
@@ -82,7 +82,8 @@ extension SwiftPM {
     public func execute(
         _ args: [String] = [],
         packagePath: AbsolutePath? = nil,
-        env: Environment? = nil
+        env: Environment? = nil,
+        errorIfCommandUnsuccessful: Bool = true
     ) async throws -> (stdout: String, stderr: String) {
         let result = try await executeProcess(
             args,
@@ -93,8 +94,11 @@ extension SwiftPM {
         let stdout = try result.utf8Output()
         let stderr = try result.utf8stderrOutput()
         
+        let returnValue = (stdout: stdout, stderr: stderr)
+        if (!errorIfCommandUnsuccessful) { return returnValue }
+
         if result.exitStatus == .terminated(code: 0) {
-            return (stdout: stdout, stderr: stderr)
+            return returnValue
         }
         throw SwiftPMError.executionFailure(
             underlying: AsyncProcessResult.Error.nonZeroExit(result),

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -14,16 +14,33 @@ import Basics
 import Commands
 import PackageModel
 import _InternalTestSupport
+import TSCTestSupport
 import XCTest
 
 final class TestCommandTests: CommandsTestCase {
-    private func execute(_ args: [String], packagePath: AbsolutePath? = nil) async throws -> (stdout: String, stderr: String) {
-        try await SwiftPM.Test.execute(args, packagePath: packagePath)
+    private func execute(
+        _ args: [String],
+        packagePath: AbsolutePath? = nil,
+        errorIfCommandUnsuccessful: Bool = true
+    ) async throws -> (stdout: String, stderr: String) {
+        try await SwiftPM.Test.execute(args, packagePath: packagePath, errorIfCommandUnsuccessful: errorIfCommandUnsuccessful)
     }
 
     func testUsage() async throws {
         let stdout = try await execute(["-help"]).stdout
         XCTAssert(stdout.contains("USAGE: swift test"), "got stdout:\n" + stdout)
+    }
+
+    func testExperimentalXunitMessageFailureArgumentIsHidden() async throws {
+        let stdout = try await execute(["--help"]).stdout
+        XCTAssertFalse(
+            stdout.contains("--experimental-xunit-message-failure"),
+            "got stdout:\n" + stdout
+        )
+        XCTAssertFalse(
+            stdout.contains("When Set, enabled an experimental message failure content (XCTest only)."),
+            "got stdout:\n" + stdout
+        )
     }
 
     func testSeeAlso() async throws {
@@ -155,6 +172,184 @@ final class TestCommandTests: CommandsTestCase {
             let contents: String = try localFileSystem.readFileContents(xUnitOutput)
             XCTAssertMatch(contents, .contains("tests=\"0\" failures=\"0\""))
         }
+    }
+
+    enum TestRunner {
+        case XCTest
+        case SwiftTesting
+
+        var fileSuffix: String {
+            switch self {
+                case .XCTest: return ""
+                case .SwiftTesting: return "-swift-testing"
+            }
+        }
+    }
+    func _testSwiftTestXMLOutputFailureMessage(
+        fixtureName: String,
+        testRunner: TestRunner,
+        enableExperimentalFlag: Bool,
+        matchesPattern: [StringPattern]
+    ) async throws {
+        try await fixture(name: fixtureName) { fixturePath in
+            // GIVEN we have a Package with a failing \(testRunner) test cases
+            let xUnitOutput = fixturePath.appending("result.xml")
+            let xUnitUnderTest = fixturePath.appending("result\(testRunner.fileSuffix).xml")
+
+            // WHEN we execute swift-test in parallel while specifying xUnit generation
+            let extraCommandArgs = enableExperimentalFlag ? ["--experimental-xunit-message-failure"]: [],
+            _ = try await execute(
+                [
+                    "--parallel",
+                    "--verbose",
+                    "--enable-swift-testing",
+                    "--enable-xctest",
+                    "--xunit-output",
+                    xUnitOutput.pathString
+                ] + extraCommandArgs,
+                packagePath: fixturePath,
+                errorIfCommandUnsuccessful: false
+            )
+
+            // THEN we expect \(xUnitUnderTest) to exists
+            XCTAssertFileExists(xUnitUnderTest)
+            let contents: String = try localFileSystem.readFileContents(xUnitUnderTest)
+            // AND that the xUnit file has the expected contents
+            for match in matchesPattern {
+                XCTAssertMatch(contents, match)
+            }
+        }
+    }
+
+    func testSwiftTestXMLOutputVerifySingleTestFailureMessageWithFlagEnabledXCTest() async throws {
+        try await self._testSwiftTestXMLOutputFailureMessage(
+            fixtureName: "Miscellaneous/TestSingleFailureXCTest",
+            testRunner: .XCTest,
+            enableExperimentalFlag: true,
+            matchesPattern: [.contains("Purposely failing &amp; validating XML espace &quot;'&lt;&gt;")]
+        )
+    }
+
+    func testSwiftTestXMLOutputVerifySingleTestFailureMessageWithFlagEnabledSwiftTesting() async throws {
+        #if compiler(<6)
+        _ = XCTSkip("Swift Testing is not available by default in this Swift compiler version")
+        #else
+        try await self._testSwiftTestXMLOutputFailureMessage(
+            fixtureName: "Miscellaneous/TestSingleFailureSwiftTesting",
+            testRunner: .SwiftTesting,
+            enableExperimentalFlag: true,
+            matchesPattern: [.contains("Purposely failing &amp; validating XML espace &quot;'&lt;&gt;")]
+        )
+        #endif
+    }
+    func testSwiftTestXMLOutputVerifySingleTestFailureMessageWithFlagDisabledXCTest() async throws {
+        try await self._testSwiftTestXMLOutputFailureMessage(
+            fixtureName: "Miscellaneous/TestSingleFailureXCTest",
+            testRunner: .XCTest,
+            enableExperimentalFlag: false,
+            matchesPattern: [.contains("failure")]
+        )
+    }
+
+    func testSwiftTestXMLOutputVerifySingleTestFailureMessageWithFlagDisabledSwiftTesting() async throws {
+        #if compiler(<6)
+        _ = XCTSkip("Swift Testing is not available by default in this Swift compiler version")
+        #else
+        try await self._testSwiftTestXMLOutputFailureMessage(
+            fixtureName: "Miscellaneous/TestSingleFailureSwiftTesting",
+            testRunner: .SwiftTesting,
+            enableExperimentalFlag: false,
+            matchesPattern: [.contains("Purposely failing &amp; validating XML espace &quot;'&lt;&gt;")]
+        )
+        #endif
+    }
+
+    func testSwiftTestXMLOutputVerifyMultipleTestFailureMessageWithFlagEnabledXCTest() async throws {
+        try await self._testSwiftTestXMLOutputFailureMessage(
+            fixtureName: "Miscellaneous/TestMultipleFailureXCTest",
+            testRunner: .XCTest,
+            enableExperimentalFlag: true,
+            matchesPattern: [
+                .contains("Test failure 1"),
+                .contains("Test failure 2"),
+                .contains("Test failure 3"),
+                .contains("Test failure 4"),
+                .contains("Test failure 5"),
+                .contains("Test failure 6"),
+                .contains("Test failure 7"),
+                .contains("Test failure 8"),
+                .contains("Test failure 9"),
+                .contains("Test failure 10")
+            ]
+        )
+    }
+
+    func testSwiftTestXMLOutputVerifyMultipleTestFailureMessageWithFlagEnabledSwiftTesting() async throws {
+        #if compiler(<6)
+        _ = XCTSkip("Swift Testing is not available by default in this Swift compiler version")
+        #else
+        try await self._testSwiftTestXMLOutputFailureMessage(
+            fixtureName: "Miscellaneous/TestMultipleFailureSwiftTesting",
+            testRunner: .SwiftTesting,
+            enableExperimentalFlag: true,
+            matchesPattern: [
+                .contains("ST Test failure 1"),
+                .contains("ST Test failure 2"),
+                .contains("ST Test failure 3"),
+                .contains("ST Test failure 4"),
+                .contains("ST Test failure 5"),
+                .contains("ST Test failure 6"),
+                .contains("ST Test failure 7"),
+                .contains("ST Test failure 8"),
+                .contains("ST Test failure 9"),
+                .contains("ST Test failure 10")
+            ]
+        )
+        #endif
+    }
+
+    func testSwiftTestXMLOutputVerifyMultipleTestFailureMessageWithFlagDisabledXCTest() async throws {
+        try await self._testSwiftTestXMLOutputFailureMessage(
+            fixtureName: "Miscellaneous/TestMultipleFailureXCTest",
+            testRunner: .XCTest,
+            enableExperimentalFlag: false,
+            matchesPattern: [
+                .contains("failure"),
+                .contains("failure"),
+                .contains("failure"),
+                .contains("failure"),
+                .contains("failure"),
+                .contains("failure"),
+                .contains("failure"),
+                .contains("failure"),
+                .contains("failure"),
+                .contains("failure")
+            ]
+        )
+    }
+
+    func testSwiftTestXMLOutputVerifyMultipleTestFailureMessageWithFlagDisabledSwiftTesting() async throws {
+        #if compiler(<6)
+        _ = XCTSkip("Swift Testing is not available by default in this Swift compiler version")
+        #else
+        try await self._testSwiftTestXMLOutputFailureMessage(
+            fixtureName: "Miscellaneous/TestMultipleFailureSwiftTesting",
+            testRunner: .SwiftTesting,
+            enableExperimentalFlag: false,
+            matchesPattern: [
+                .contains("ST Test failure 1"),
+                .contains("ST Test failure 2"),
+                .contains("ST Test failure 3"),
+                .contains("ST Test failure 4"),
+                .contains("ST Test failure 5"),
+                .contains("ST Test failure 6"),
+                .contains("ST Test failure 7"),
+                .contains("ST Test failure 8"),
+                .contains("ST Test failure 9"),
+                .contains("ST Test failure 10")
+            ]
+        )
+        #endif
     }
 
     func testSwiftTestFilter() async throws {

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -21,9 +21,9 @@ final class TestCommandTests: CommandsTestCase {
     private func execute(
         _ args: [String],
         packagePath: AbsolutePath? = nil,
-        errorIfCommandUnsuccessful: Bool = true
+        throwIfCommandFails: Bool = true
     ) async throws -> (stdout: String, stderr: String) {
-        try await SwiftPM.Test.execute(args, packagePath: packagePath, errorIfCommandUnsuccessful: errorIfCommandUnsuccessful)
+        try await SwiftPM.Test.execute(args, packagePath: packagePath, throwIfCommandFails: throwIfCommandFails)
     }
 
     func testUsage() async throws {
@@ -208,7 +208,7 @@ final class TestCommandTests: CommandsTestCase {
                     xUnitOutput.pathString
                 ] + extraCommandArgs,
                 packagePath: fixturePath,
-                errorIfCommandUnsuccessful: false
+                throwIfCommandFails: false
             )
 
             // THEN we expect \(xUnitUnderTest) to exists


### PR DESCRIPTION
Modify the XCTest xUnit failure message to display the test result.

### Motivation:

The generated xUnit XML file is not helpful when tests fail as it contains the message "failure", which is redundant with the test results.

### Modifications:

Update the XML output to display the result output instead of static "failure" message.  The failure message may contain irrelevant output, but it's better than the current message of `failure`.

### Result:

```
swift test 
```

Requires: https://github.com/swiftlang/swift/pull/78300
