### PR TITLE
Android: switch to the new swift-toolchain-sqlite package instead of requiring an external dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -76,7 +76,10 @@ let includeDynamicLibrary: Bool = false
 let systemSQLitePkgConfig: String? = nil
 #else
 let includeDynamicLibrary: Bool = true
-let systemSQLitePkgConfig: String? = "sqlite3"
+var systemSQLitePkgConfig: String? = "sqlite3"
+if ProcessInfo.processInfo.environment["SWIFTCI_INSTALL_RPATH_OS"] == "android" {
+    systemSQLitePkgConfig = nil
+}
 #endif
 
 /** An array of products which have two versions listed: one dynamically linked, the other with the
@@ -199,7 +202,7 @@ let package = Package(
             dependencies: [
                 "_AsyncFileSystem",
                 .target(name: "SPMSQLite3", condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .visionOS, .macCatalyst, .linux])),
-                .product(name: "SwiftToolchainCSQLite", package: "swift-toolchain-sqlite", condition: .when(platforms: [.windows])),
+                .product(name: "SwiftToolchainCSQLite", package: "swift-toolchain-sqlite", condition: .when(platforms: [.windows, .android])),
                 .product(name: "DequeModule", package: "swift-collections"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),

--- a/Sources/Basics/SQLite.swift
+++ b/Sources/Basics/SQLite.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if SWIFT_PACKAGE && os(Windows)
+#if SWIFT_PACKAGE && (os(Windows) || os(Android))
 #if USE_IMPL_ONLY_IMPORTS
 @_implementationOnly import SwiftToolchainCSQLite
 #else


### PR DESCRIPTION
I've been building with this patch both natively on Android and [on my Android CI](https://github.com/finagolfin/swift-android-sdk/blob/3493a85cd1ae767792ba01c8634e3d9456d19901/swift-android-ci-except-release.patch#L34), confirming that it [got rid of the external dependency on `libsqlite3.so`](https://github.com/finagolfin/swift-android-sdk/actions/runs/12095721068/job/33729218006#step:8:20591) and works well.

@jakepetroules, along with your recent llbuild pull, this gets rid of the external SQLite3 dependency for the Android toolchain except for one llbuild executable, `swift-build-tool`, whose build is configured by CMake and appears to be unused, so we can clean that up last.