### PR TITLE
Mark all test classes fileprivate

### DIFF
--- a/Tests/BasicsTests/Archiver/TarArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/TarArchiverTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 import struct TSCBasic.FileSystemError
 
-final class TarArchiverTests: XCTestCase {
+fileprivate final class TarArchiverTests: XCTestCase {
     func testSuccess() async throws {
         try await testWithTemporaryDirectory { tmpdir in
             let archiver = TarArchiver(fileSystem: localFileSystem)

--- a/Tests/BasicsTests/Archiver/UniversalArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/UniversalArchiverTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 import struct TSCBasic.FileSystemError
 
-final class UniversalArchiverTests: XCTestCase {
+fileprivate final class UniversalArchiverTests: XCTestCase {
     func testSuccess() async throws {
         try await testWithTemporaryDirectory { tmpdir in
             let archiver = UniversalArchiver(localFileSystem)

--- a/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
@@ -17,7 +17,7 @@ import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported
 
 import struct TSCBasic.FileSystemError
 
-final class ZipArchiverTests: XCTestCase {
+fileprivate final class ZipArchiverTests: XCTestCase {
     func testZipArchiverSuccess() async throws {
         try await testWithTemporaryDirectory { tmpdir in
             let archiver = ZipArchiver(fileSystem: localFileSystem)

--- a/Tests/BasicsTests/AsyncProcessTests.swift
+++ b/Tests/BasicsTests/AsyncProcessTests.swift
@@ -22,7 +22,7 @@ import class TSCBasic.Thread
 import func TSCBasic.withTemporaryFile
 import func TSCTestSupport.withCustomEnv
 
-final class AsyncProcessTests: XCTestCase {
+fileprivate final class AsyncProcessTests: XCTestCase {
     func testBasics() throws {
         do {
             let process = AsyncProcess(args: "echo", "hello")

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -14,7 +14,7 @@
 import _InternalTestSupport
 import XCTest
 
-final class AuthorizationProviderTests: XCTestCase {
+fileprivate final class AuthorizationProviderTests: XCTestCase {
     func testBasicAPIs() {
         let url = URL("http://\(UUID().uuidString)")
         let user = UUID().uuidString

--- a/Tests/BasicsTests/ByteStringExtensionsTests.swift
+++ b/Tests/BasicsTests/ByteStringExtensionsTests.swift
@@ -15,7 +15,7 @@ import XCTest
 
 import struct TSCBasic.ByteString
 
-final class ByteStringExtensionsTests: XCTestCase {
+fileprivate final class ByteStringExtensionsTests: XCTestCase {
     func testSHA256Checksum() {
         let byteString = ByteString(encodingAsUTF8: "abc")
         XCTAssertEqual(byteString.contents, [0x61, 0x62, 0x63])

--- a/Tests/BasicsTests/CancellatorTests.swift
+++ b/Tests/BasicsTests/CancellatorTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 import class Basics.AsyncProcess
 
-final class CancellatorTests: XCTestCase {
+fileprivate final class CancellatorTests: XCTestCase {
     func testHappyCase() throws {
         let observability = ObservabilitySystem.makeForTesting()
         let cancellator = Cancellator(observabilityScope: observability.topScope)
@@ -399,7 +399,7 @@ fileprivate struct Worker {
     }
 }
 
-class ProcessStartedSemaphore {
+fileprivate final class ProcessStartedSemaphore {
     let term: String
     let underlying = DispatchSemaphore(value: 0)
     let lock = NSLock()

--- a/Tests/BasicsTests/ConcurrencyHelpersTests.swift
+++ b/Tests/BasicsTests/ConcurrencyHelpersTests.swift
@@ -14,7 +14,7 @@
 import TSCTestSupport
 import XCTest
 
-final class ConcurrencyHelpersTest: XCTestCase {
+fileprivate final class ConcurrencyHelpersTest: XCTestCase {
     let queue = DispatchQueue(label: "ConcurrencyHelpersTest", attributes: .concurrent)
 
     func testThreadSafeKeyValueStore() {

--- a/Tests/BasicsTests/DictionaryTest.swift
+++ b/Tests/BasicsTests/DictionaryTest.swift
@@ -13,7 +13,7 @@
 @testable import Basics
 import XCTest
 
-final class DictionaryTests: XCTestCase {
+fileprivate final class DictionaryTests: XCTestCase {
     func testThrowingUniqueKeysWithValues() throws {
         do {
             let keysWithValues = [("key1", "value1"), ("key2", "value2")]

--- a/Tests/BasicsTests/DispatchTimeTests.swift
+++ b/Tests/BasicsTests/DispatchTimeTests.swift
@@ -13,7 +13,7 @@
 import Basics
 import XCTest
 
-final class DispatchTimeTests: XCTestCase {
+fileprivate final class DispatchTimeTests: XCTestCase {
     func testDifferencePositive() {
         let point: DispatchTime = .now()
         let future: DispatchTime = point + .seconds(10)

--- a/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
@@ -13,7 +13,7 @@
 @testable import Basics
 import XCTest
 
-final class EnvironmentKeyTests: XCTestCase {
+fileprivate final class EnvironmentKeyTests: XCTestCase {
     func test_comparable() {
         let key0 = EnvironmentKey("Test")
         let key1 = EnvironmentKey("Test1")

--- a/Tests/BasicsTests/Environment/EnvironmentTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentTests.swift
@@ -16,7 +16,7 @@ import Basics
 
 import XCTest
 
-final class EnvironmentTests: XCTestCase {
+fileprivate final class EnvironmentTests: XCTestCase {
     func test_init() {
         let environment = Environment()
         XCTAssertTrue(environment.isEmpty)

--- a/Tests/BasicsTests/FileSystem/FileSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/FileSystemTests.swift
@@ -14,7 +14,7 @@
 import TSCTestSupport
 import XCTest
 
-final class FileSystemTests: XCTestCase {
+fileprivate final class FileSystemTests: XCTestCase {
     func testStripFirstLevelComponent() throws {
         let fileSystem = InMemoryFileSystem()
 

--- a/Tests/BasicsTests/FileSystem/PathShimTests.swift
+++ b/Tests/BasicsTests/FileSystem/PathShimTests.swift
@@ -14,7 +14,7 @@ import Basics
 import Foundation
 import XCTest
 
-class PathShimTests: XCTestCase {
+fileprivate final class PathShimTests: XCTestCase {
     func testRescursiveDirectoryCreation() {
         // For the tests we'll need a temporary directory.
         try! withTemporaryDirectory(removeTreeOnDeinit: true) { path in
@@ -31,7 +31,7 @@ class PathShimTests: XCTestCase {
     }
 }
 
-class WalkTests: XCTestCase {
+fileprivate final class WalkTests: XCTestCase {
     func testNonRecursive() throws {
         #if os(Android)
         let root = "/system"

--- a/Tests/BasicsTests/FileSystem/PathTests.swift
+++ b/Tests/BasicsTests/FileSystem/PathTests.swift
@@ -18,7 +18,7 @@ private var windows: Bool { true }
 private var windows: Bool { false }
 #endif
 
-class PathTests: XCTestCase {
+fileprivate final class PathTests: XCTestCase {
     func testBasics() {
         XCTAssertEqual(AbsolutePath("/").pathString, windows ? #"\"# : "/")
         XCTAssertEqual(AbsolutePath("/a").pathString, windows ? #"\a"# : "/a")

--- a/Tests/BasicsTests/FileSystem/TemporaryFileTests.swift
+++ b/Tests/BasicsTests/FileSystem/TemporaryFileTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 import Basics
 
-class TemporaryAsyncFileTests: XCTestCase {
+fileprivate final class TemporaryAsyncFileTests: XCTestCase {
     func testBasicTemporaryDirectory() async throws {
         // Test can create and remove temp directory.
         let path1: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in

--- a/Tests/BasicsTests/FileSystem/VFSTests.swift
+++ b/Tests/BasicsTests/FileSystem/VFSTests.swift
@@ -34,7 +34,7 @@ func testWithTemporaryDirectory(
     }.value
 }
 
-class VFSTests: XCTestCase {
+fileprivate final class VFSTests: XCTestCase {
     func testLocalBasics() throws {
         // tiny PE binary from: https://archive.is/w01DO
         let contents: [UInt8] = [

--- a/Tests/BasicsTests/Graph/AdjacencyMatrixTests.swift
+++ b/Tests/BasicsTests/Graph/AdjacencyMatrixTests.swift
@@ -13,7 +13,7 @@
 @testable import Basics
 import XCTest
 
-final class AdjacencyMatrixTests: XCTestCase {
+fileprivate final class AdjacencyMatrixTests: XCTestCase {
     func testEmpty() {
         var matrix = AdjacencyMatrix(rows: 0, columns: 0)
         XCTAssertEqual(matrix.bitCount, 0)

--- a/Tests/BasicsTests/Graph/DirectedGraphTests.swift
+++ b/Tests/BasicsTests/Graph/DirectedGraphTests.swift
@@ -15,7 +15,7 @@ import Basics
 
 import XCTest
 
-final class DirectedGraphTests: XCTestCase {
+fileprivate final class DirectedGraphTests: XCTestCase {
     func testNodesConnection() {
         var graph = DirectedGraph(nodes: ["app1", "lib1", "lib2", "app2", "lib3"])
         graph.addEdge(source: 0, destination: 1)

--- a/Tests/BasicsTests/Graph/UndirectedGraphTests.swift
+++ b/Tests/BasicsTests/Graph/UndirectedGraphTests.swift
@@ -15,7 +15,7 @@ import Basics
 
 import XCTest
 
-final class UndirectedGraphTests: XCTestCase {
+fileprivate final class UndirectedGraphTests: XCTestCase {
     func testNodesConnection() {
         var graph = UndirectedGraph(nodes: ["app1", "lib1", "lib2", "app2", "lib3", "app3"])
         graph.addEdge(source: 0, destination: 1)

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -15,7 +15,7 @@ import _Concurrency
 import _InternalTestSupport
 import XCTest
 
-final class HTTPClientTests: XCTestCase {
+fileprivate final class HTTPClientTests: XCTestCase {
     func testHead() async throws {
         let url = URL("http://test")
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])

--- a/Tests/BasicsTests/LegacyHTTPClientTests.swift
+++ b/Tests/BasicsTests/LegacyHTTPClientTests.swift
@@ -14,7 +14,7 @@
 import _InternalTestSupport
 import XCTest
 
-final class LegacyHTTPClientTests: XCTestCase {
+fileprivate final class LegacyHTTPClientTests: XCTestCase {
     func testHead() {
         let url = URL("http://test")
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])

--- a/Tests/BasicsTests/NetrcTests.swift
+++ b/Tests/BasicsTests/NetrcTests.swift
@@ -13,7 +13,7 @@
 import Basics
 import XCTest
 
-class NetrcTests: XCTestCase {
+fileprivate final class NetrcTests: XCTestCase {
     /// should load machines for a given inline format
     func testLoadMachinesInline() throws {
         let content = "machine example.com login anonymous password qwerty"

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -17,7 +17,7 @@ import XCTest
 // TODO: remove when transition to new diagnostics system is complete
 typealias Diagnostic = Basics.Diagnostic
 
-final class ObservabilitySystemTest: XCTestCase {
+fileprivate final class ObservabilitySystemTest: XCTestCase {
     func testScopes() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)

--- a/Tests/BasicsTests/ProgressAnimationTests.swift
+++ b/Tests/BasicsTests/ProgressAnimationTests.swift
@@ -17,7 +17,7 @@ import XCTest
 @testable
 import Basics
 
-final class ProgressAnimationTests: XCTestCase {
+fileprivate final class ProgressAnimationTests: XCTestCase {
     class TrackingProgressAnimation: ProgressAnimationProtocol {
         var steps: [Int] = []
 

--- a/Tests/BasicsTests/SQLiteBackedCacheTests.swift
+++ b/Tests/BasicsTests/SQLiteBackedCacheTests.swift
@@ -15,7 +15,7 @@ import _InternalTestSupport
 import tsan_utils
 import XCTest
 
-final class SQLiteBackedCacheTests: XCTestCase {
+fileprivate final class SQLiteBackedCacheTests: XCTestCase {
     func testHappyCase() throws {
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending("test.db")

--- a/Tests/BasicsTests/SandboxTests.swift
+++ b/Tests/BasicsTests/SandboxTests.swift
@@ -18,7 +18,7 @@ import XCTest
 import Darwin
 #endif
 
-final class SandboxTest: XCTestCase {
+fileprivate final class SandboxTest: XCTestCase {
     func testSandboxOnAllPlatforms() throws {
         try withTemporaryDirectory { path in
 #if os(Windows)

--- a/Tests/BasicsTests/Serialization/SerializedJSONTests.swift
+++ b/Tests/BasicsTests/Serialization/SerializedJSONTests.swift
@@ -13,7 +13,7 @@
 @testable import Basics
 import XCTest
 
-final class SerializedJSONTests: XCTestCase {
+fileprivate final class SerializedJSONTests: XCTestCase {
     func testPathInterpolation() throws {
         var path = try AbsolutePath(validating: #"/test\backslashes"#)
         var json: SerializedJSON = "\(path)"

--- a/Tests/BasicsTests/StringExtensionsTests.swift
+++ b/Tests/BasicsTests/StringExtensionsTests.swift
@@ -13,7 +13,7 @@
 import Basics
 import XCTest
 
-final class StringExtensionsTests: XCTestCase {
+fileprivate final class StringExtensionsTests: XCTestCase {
     func testSHA256Checksum() {
         let string = "abc"
         XCTAssertEqual(Array(string.utf8), [0x61, 0x62, 0x63])

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -13,7 +13,7 @@
 import Basics
 import XCTest
 
-final class TripleTests: XCTestCase {
+fileprivate final class TripleTests: XCTestCase {
     func testIsAppleIsDarwin() {
         func XCTAssertTriple(
             _ triple: String,

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -24,7 +24,7 @@ import struct TSCBasic.ByteString
 import enum TSCBasic.FileMode
 import struct TSCBasic.FileSystemError
 
-final class URLSessionHTTPClientTest: XCTestCase {
+fileprivate final class URLSessionHTTPClientTest: XCTestCase {
     func testHead() {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockURLProtocol.self]
@@ -1119,7 +1119,7 @@ private class MockURLProtocol: URLProtocol {
     }
 }
 
-final class FailingFileSystem: FileSystem {
+fileprivate final class FailingFileSystem: FileSystem {
     var currentWorkingDirectory: TSCAbsolutePath? {
         fatalError("unexpected call")
     }

--- a/Tests/BuildTests/BuildOperationTests.swift
+++ b/Tests/BuildTests/BuildOperationTests.swift
@@ -48,7 +48,7 @@ private func mockBuildOperation(
     )
 }
 
-final class BuildOperationTests: XCTestCase {
+fileprivate final class BuildOperationTests: XCTestCase {
     func testDetectProductTripleChange() async throws {
         let observability = ObservabilitySystem.makeForTesting()
         let fs = InMemoryFileSystem(

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -44,7 +44,7 @@ extension Build.BuildPlan {
     }
 }
 
-final class BuildPlanTests: XCTestCase {
+fileprivate final class BuildPlanTests: XCTestCase {
     let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
 
     /// The j argument.

--- a/Tests/BuildTests/BuildPlanTraversalTests.swift
+++ b/Tests/BuildTests/BuildPlanTraversalTests.swift
@@ -20,7 +20,7 @@ import PackageGraph
 import _InternalTestSupport
 import SPMBuildCore
 
-final class BuildPlanTraversalTests: XCTestCase {
+fileprivate final class BuildPlanTraversalTests: XCTestCase {
     typealias Dest = BuildParameters.Destination
 
     struct Result {

--- a/Tests/BuildTests/BuildSystemDelegateTests.swift
+++ b/Tests/BuildTests/BuildSystemDelegateTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 import var TSCBasic.localFileSystem
 
-final class BuildSystemDelegateTests: XCTestCase {
+fileprivate final class BuildSystemDelegateTests: XCTestCase {
     func testDoNotFilterLinkerDiagnostics() async throws {
         try UserToolchain.default.skipUnlessAtLeastSwift6()
         try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")

--- a/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
@@ -18,7 +18,7 @@ import SPMBuildCore
 import _InternalTestSupport
 import XCTest
 
-final class ClangTargetBuildDescriptionTests: XCTestCase {
+fileprivate final class ClangTargetBuildDescriptionTests: XCTestCase {
     func testClangIndexStorePath() throws {
         let targetDescription = try makeTargetBuildDescription("test")
         XCTAssertTrue(try targetDescription.basicArguments().contains("-index-store-path"))

--- a/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
+++ b/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
@@ -38,7 +38,7 @@ import func _InternalTestSupport.XCTAssertNoDiagnostics
 
 import XCTest
 
-final class CrossCompilationBuildPlanTests: XCTestCase {
+fileprivate final class CrossCompilationBuildPlanTests: XCTestCase {
     func testEmbeddedWasmTarget() async throws {
         var (graph, fs, observabilityScope) = try trivialPackageGraph()
 

--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -36,7 +36,7 @@ import typealias TSCBasic.ProcessEnvironmentBlock
 ///    could be determined without running any of the commands (i.e. it would
 ///    assume that there's no feedback during the build)
 ///
-final class IncrementalBuildTests: XCTestCase {
+fileprivate final class IncrementalBuildTests: XCTestCase {
 
     func testIncrementalSingleModuleCLibraryInSources() async throws {
         try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")

--- a/Tests/BuildTests/LLBuildManifestBuilderTests.swift
+++ b/Tests/BuildTests/LLBuildManifestBuilderTests.swift
@@ -25,7 +25,7 @@ import _InternalTestSupport
 
 import XCTest
 
-final class LLBuildManifestBuilderTests: XCTestCase {
+fileprivate final class LLBuildManifestBuilderTests: XCTestCase {
     func testCreateProductCommand() async throws {
         let pkg = AbsolutePath("/pkg")
         let fs = InMemoryFileSystem(

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -24,7 +24,7 @@ import SwiftDriver
 import Workspace
 import XCTest
 
-final class ModuleAliasingBuildTests: XCTestCase {
+fileprivate final class ModuleAliasingBuildTests: XCTestCase {
     func testModuleAliasingEmptyAlias() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:

--- a/Tests/BuildTests/PluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/PluginsBuildPlanTests.swift
@@ -16,7 +16,7 @@ import _InternalTestSupport
 import XCTest
 import PackageModel
 
-final class PluginsBuildPlanTests: XCTestCase {
+fileprivate final class PluginsBuildPlanTests: XCTestCase {
     func testBuildToolsDatabasePath() async throws {
         try await fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath)

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -24,7 +24,7 @@ import func PackageGraph.loadModulesGraph
 import class PackageModel.Manifest
 import struct PackageModel.TargetDescription
 
-class PrepareForIndexTests: XCTestCase {
+fileprivate final class PrepareForIndexTests: XCTestCase {
     func testPrepare() async throws {
         let (graph, fs, scope) = try macrosPackageGraph()
 

--- a/Tests/BuildTests/ProductBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ProductBuildDescriptionTests.swift
@@ -29,7 +29,7 @@ import func _InternalTestSupport.mockBuildParameters
 import func _InternalTestSupport.XCTAssertNoDiagnostics
 import XCTest
 
-final class ProductBuildDescriptionTests: XCTestCase {
+fileprivate final class ProductBuildDescriptionTests: XCTestCase {
     func testEmbeddedProducts() throws {
         let fs = InMemoryFileSystem(
             emptyFiles:

--- a/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
+++ b/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
@@ -13,7 +13,7 @@
 import XCTest
 import Build
 
-class SwiftCompilerOutputParserTests: XCTestCase {
+fileprivate final class SwiftCompilerOutputParserTests: XCTestCase {
     func testParse() throws {
         let delegate = MockSwiftCompilerOutputParserDelegate()
         let parser = SwiftCompilerOutputParser(targetName: "dummy", delegate: delegate)
@@ -207,7 +207,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
     }
 }
 
-class MockSwiftCompilerOutputParserDelegate: SwiftCompilerOutputParserDelegate {
+fileprivate final class MockSwiftCompilerOutputParserDelegate: SwiftCompilerOutputParserDelegate {
     private var messages: [SwiftCompilerMessage] = []
     private var error: Error?
 

--- a/Tests/BuildTests/WindowsBuildPlanTests.swift
+++ b/Tests/BuildTests/WindowsBuildPlanTests.swift
@@ -20,7 +20,7 @@ import _InternalTestSupport
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 import PackageGraph
 
-final class WindowsBuildPlanTests: XCTestCase {
+fileprivate final class WindowsBuildPlanTests: XCTestCase {
     // Tests that our build plan is build correctly to handle separation
     // of object files that export symbols and ones that don't and to ensure
     // DLL products pick up the right ones.

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -24,7 +24,7 @@ import _InternalTestSupport
 import Workspace
 import XCTest
 
-final class APIDiffTests: CommandsTestCase {
+fileprivate final class APIDiffTests: CommandsTestCase {
     @discardableResult
     private func execute(
         _ args: [String],

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -22,7 +22,7 @@ import _InternalTestSupport
 import Workspace
 import XCTest
 
-struct BuildResult {
+fileprivate struct BuildResult {
     let binPath: AbsolutePath
     let stdout: String
     let stderr: String
@@ -30,7 +30,7 @@ struct BuildResult {
     let moduleContents: [String]
 }
 
-final class BuildCommandTests: CommandsTestCase {
+fileprivate final class BuildCommandTests: CommandsTestCase {
     @discardableResult
     private func execute(
         _ args: [String] = [],

--- a/Tests/CommandsTests/MermaidPackageSerializerTests.swift
+++ b/Tests/CommandsTests/MermaidPackageSerializerTests.swift
@@ -26,7 +26,7 @@ import Commands
 
 import XCTest
 
-final class MermaidPackageSerializerTests: XCTestCase {
+fileprivate final class MermaidPackageSerializerTests: XCTestCase {
     func testSimplePackage() throws {
         let observability = ObservabilitySystem.makeForTesting()
         let fileSystem = InMemoryFileSystem(

--- a/Tests/CommandsTests/MultiRootSupportTests.swift
+++ b/Tests/CommandsTests/MultiRootSupportTests.swift
@@ -16,7 +16,7 @@ import _InternalTestSupport
 import Workspace
 import XCTest
 
-final class MultiRootSupportTests: CommandsTestCase {
+fileprivate final class MultiRootSupportTests: CommandsTestCase {
     func testWorkspaceLoader() throws {
         let fs = InMemoryFileSystem(emptyFiles: [
             "/tmp/test/dep/Package.swift",

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -30,7 +30,7 @@ import class TSCBasic.BufferedOutputByteStream
 import enum TSCBasic.JSON
 import class Basics.AsyncProcess
 
-final class PackageCommandTests: CommandsTestCase {
+fileprivate final class PackageCommandTests: CommandsTestCase {
     @discardableResult
     private func execute(
         _ args: [String] = [],

--- a/Tests/CommandsTests/PackageRegistryCommandTests.swift
+++ b/Tests/CommandsTests/PackageRegistryCommandTests.swift
@@ -29,7 +29,7 @@ import struct Basics.AsyncProcessResult
 let defaultRegistryBaseURL = URL("https://packages.example.com")
 let customRegistryBaseURL = URL("https://custom.packages.example.com")
 
-final class PackageRegistryCommandTests: CommandsTestCase {
+fileprivate final class PackageRegistryCommandTests: CommandsTestCase {
     @discardableResult
     private func execute(
         _ args: [String],

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 import class Basics.AsyncProcess
 
-final class RunCommandTests: CommandsTestCase {
+fileprivate final class RunCommandTests: CommandsTestCase {
     private func execute(
         _ args: [String] = [],
         packagePath: AbsolutePath? = nil

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -26,7 +26,7 @@ import class TSCBasic.BufferedOutputByteStream
 import protocol TSCBasic.OutputByteStream
 import var TSCBasic.stderrStream
 
-final class SwiftCommandStateTests: CommandsTestCase {
+fileprivate final class SwiftCommandStateTests: CommandsTestCase {
     func testVerbosityLogLevel() async throws {
         try fixture(name: "Miscellaneous/Simple") { fixturePath in
             do {

--- a/Tests/CommandsTests/SwiftSDKCommandTests.swift
+++ b/Tests/CommandsTests/SwiftSDKCommandTests.swift
@@ -24,7 +24,7 @@ private let sdkCommandDeprecationWarning = """
     """
 
 
-final class SwiftSDKCommandTests: CommandsTestCase {
+fileprivate final class SwiftSDKCommandTests: CommandsTestCase {
     func testUsage() async throws {
         for command in [SwiftPM.sdk, SwiftPM.experimentalSDK] {
             let stdout = try await command.execute(["-help"]).stdout

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-final class TestCommandTests: CommandsTestCase {
+fileprivate final class TestCommandTests: CommandsTestCase {
     private func execute(_ args: [String], packagePath: AbsolutePath? = nil) async throws -> (stdout: String, stderr: String) {
         try await SwiftPM.Test.execute(args, packagePath: packagePath)
     }

--- a/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
+++ b/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
@@ -20,7 +20,7 @@
 //
 //import class TSCTestSupport.XCTestCasePerf
 //
-//final class BuildPerfTests: XCTestCasePerf {
+//fileprivate final class BuildPerfTests: XCTestCasePerf {
 //    @discardableResult
 //    func execute(args: [String] = [], packagePath: AbsolutePath) async throws -> (stdout: String, stderr: String) {
 //        // FIXME: We should pass the SWIFT_EXEC at lower level.

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -34,7 +34,7 @@ private func XCTAssertDirectoryContainsFile(dir: AbsolutePath, filename: String,
     XCTFail("Directory \(dir) does not contain \(file)", file: file, line: line)
 }
 
-final class CFamilyTargetTestCase: XCTestCase {
+fileprivate final class CFamilyTargetTestCase: XCTestCase {
     func testCLibraryWithSpaces() async throws {
         try await fixture(name: "CFamilyTargets/CLibraryWithSpaces") { fixturePath in
             await XCTAssertBuilds(fixturePath)

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -18,7 +18,7 @@ import _InternalTestSupport
 import Workspace
 import XCTest
 
-class DependencyResolutionTests: XCTestCase {
+fileprivate final class DependencyResolutionTests: XCTestCase {
     func testInternalSimple() async throws {
         try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             await XCTAssertBuilds(fixturePath)

--- a/Tests/FunctionalTests/MacroTests.swift
+++ b/Tests/FunctionalTests/MacroTests.swift
@@ -15,7 +15,7 @@ import _InternalTestSupport
 import PackageModel
 import XCTest
 
-class MacroTests: XCTestCase {
+fileprivate final class MacroTests: XCTestCase {
     func testMacrosBasic() throws {
         #if BUILD_MACROS_AS_DYLIBS
         // Check for required compiler support.

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -21,7 +21,7 @@ import class Basics.AsyncProcess
 
 typealias ProcessID = AsyncProcess.ProcessID
 
-final class MiscellaneousTestCase: XCTestCase {
+fileprivate final class MiscellaneousTestCase: XCTestCase {
     func testPrintsSelectedDependencyVersion() async throws {
         // verifies the stdout contains information about
         // the selected version of the package

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -17,7 +17,7 @@ import _InternalTestSupport
 import Workspace
 import XCTest
  
-final class ModuleAliasingFixtureTests: XCTestCase {
+fileprivate final class ModuleAliasingFixtureTests: XCTestCase {
     func testModuleDirectDeps1() async throws {
         try await fixture(name: "ModuleAliasing/DirectDeps1") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -17,7 +17,7 @@ import _InternalTestSupport
 import Workspace
 import XCTest
 
-final class ModuleMapsTestCase: XCTestCase {
+fileprivate final class ModuleMapsTestCase: XCTestCase {
     private func fixture(
         name: String,
         cModuleName: String,

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -22,7 +22,7 @@ import _InternalTestSupport
 import Workspace
 import XCTest
 
-final class PluginTests: XCTestCase {
+fileprivate final class PluginTests: XCTestCase {
     func testUseOfBuildToolPluginTargetByExecutableInSamePackage() async throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -15,7 +15,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-final class ResourcesTests: XCTestCase {
+fileprivate final class ResourcesTests: XCTestCase {
     func testSimpleResources() async throws {
         try await fixture(name: "Resources/Simple") { fixturePath in
             var executables = ["SwiftyResource"]

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -15,7 +15,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-final class TestDiscoveryTests: XCTestCase {
+fileprivate final class TestDiscoveryTests: XCTestCase {
     func testBuild() async throws {
         try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath)

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -18,7 +18,7 @@ import _InternalTestSupport
 import Workspace
 import XCTest
 
-final class ToolsVersionTests: XCTestCase {
+fileprivate final class ToolsVersionTests: XCTestCase {
     func testToolsVersion() async throws {
         try await testWithTemporaryDirectory{ path in
             let fs = localFileSystem

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import TSCBasic
 import XCTest
 
-final class TraitTests: XCTestCase {
+fileprivate final class TraitTests: XCTestCase {
     func testTraits_whenNoFlagPassed() async throws {
         try await fixture(name: "Traits") { fixturePath in
             let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example")

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -15,7 +15,7 @@ import SourceControl
 import _InternalTestSupport
 import XCTest
 
-final class VersionSpecificTests: XCTestCase {
+fileprivate final class VersionSpecificTests: XCTestCase {
     /// Functional tests of end-to-end support for version specific dependency resolution.
     func testEndToEndResolution() async throws {
         try await testWithTemporaryDirectory{ path in

--- a/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
+++ b/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 private let testEntitlement = "test-entitlement"
 
-final class LLBuildManifestTests: XCTestCase {
+fileprivate final class LLBuildManifestTests: XCTestCase {
     func testEntitlementsPlist() throws {
         let FileType = WriteAuxiliary.EntitlementPlist.self
         let inputs = FileType.computeInputs(entitlement: testEntitlement)

--- a/Tests/PackageCollectionsModelTests/PackageCollectionModelTests.swift
+++ b/Tests/PackageCollectionsModelTests/PackageCollectionModelTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @testable import PackageCollectionsModel
 
-class PackageCollectionModelTests: XCTestCase {
+fileprivate final class PackageCollectionModelTests: XCTestCase {
     typealias Model = PackageCollectionModel.V1
 
     func testCollectionCodable() throws {

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -18,7 +18,7 @@ import SwiftASN1
 import X509
 import XCTest
 
-class CertificatePolicyTests: XCTestCase {
+fileprivate final class CertificatePolicyTests: XCTestCase {
     func test_RSA_validate_happyCase() async throws {
         let certChain = try await self.readTestRSACertChain()
         let policy = TestCertificatePolicy(trustedRoots: certChain.suffix(1))

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTests.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTests.swift
@@ -19,7 +19,7 @@ import _InternalTestSupport
 import X509
 import XCTest
 
-class PackageCollectionSigningTests: XCTestCase {
+fileprivate final class PackageCollectionSigningTests: XCTestCase {
     func test_RSA_signAndValidate_happyCase() async throws {
         try await withTemporaryDirectory { tmp in
             let collection = try await self.readTestPackageCollection()

--- a/Tests/PackageCollectionsSigningTests/SignatureTests.swift
+++ b/Tests/PackageCollectionsSigningTests/SignatureTests.swift
@@ -20,7 +20,7 @@ import _InternalTestSupport
 import X509
 import XCTest
 
-class SignatureTests: XCTestCase {
+fileprivate final class SignatureTests: XCTestCase {
     func test_RS256_generateAndValidate_happyCase() async throws {
         let jsonEncoder = JSONEncoder.makeWithDefaults()
         let jsonDecoder = JSONDecoder.makeWithDefaults()

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -21,7 +21,7 @@ import _InternalTestSupport
 
 import struct TSCUtility.Version
 
-class GitHubPackageMetadataProviderTests: XCTestCase {
+fileprivate final class GitHubPackageMetadataProviderTests: XCTestCase {
     func testBaseURL() throws {
         let apiURL = URL("https://api.github.com/repos/octocat/Hello-World")
 

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -20,7 +20,7 @@ import PackageModel
 import SourceControl
 import _InternalTestSupport
 
-class JSONPackageCollectionProviderTests: XCTestCase {
+fileprivate final class JSONPackageCollectionProviderTests: XCTestCase {
     func testGood() async throws {
         try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "JSON", "good.json")

--- a/Tests/PackageCollectionsTests/PackageCollectionSourceCertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionSourceCertificatePolicyTests.swift
@@ -16,7 +16,7 @@ import XCTest
 @testable import PackageCollections
 import PackageCollectionsSigning
 
-final class PackageCollectionSourceCertificatePolicyTests: XCTestCase {
+fileprivate final class PackageCollectionSourceCertificatePolicyTests: XCTestCase {
     func testCustomData() {
         let sourceCertPolicy = PackageCollectionSourceCertificatePolicy(sourceCertPolicies: [
             "package-collection-1": [

--- a/Tests/PackageCollectionsTests/PackageCollectionValidationTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionValidationTests.swift
@@ -17,7 +17,7 @@ import XCTest
 @testable import PackageCollectionsModel
 import PackageModel
 
-class PackageCollectionValidationTests: XCTestCase {
+fileprivate final class PackageCollectionValidationTests: XCTestCase {
     typealias Model = PackageCollectionModel.V1
 
     func test_validationOK() throws {

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -16,7 +16,7 @@ import Basics
 import _InternalTestSupport
 import XCTest
 
-final class PackageCollectionsModelTests: XCTestCase {
+fileprivate final class PackageCollectionsModelTests: XCTestCase {
     func testLatestVersions() {
         let targets = [PackageCollectionsModel.Target(name: "Foo", moduleName: "Foo")]
         let products = [PackageCollectionsModel.Product(name: "Foo", type: .library(.automatic), targets: targets)]

--- a/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
@@ -15,7 +15,7 @@ import Basics
 import _InternalTestSupport
 import XCTest
 
-final class PackageCollectionsSourcesStorageTest: XCTestCase {
+fileprivate final class PackageCollectionsSourcesStorageTest: XCTestCase {
     func testHappyCase() async throws {
         let mockFileSystem = InMemoryFileSystem()
         let storage = FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem)

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -16,7 +16,7 @@ import _InternalTestSupport
 import tsan_utils
 import XCTest
 
-class PackageCollectionsStorageTests: XCTestCase {
+fileprivate final class PackageCollectionsStorageTests: XCTestCase {
     func testHappyCase() async throws {
         try await testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending("test.db")

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -21,7 +21,7 @@ import SourceControl
 
 import struct TSCUtility.Version
 
-final class PackageCollectionsTests: XCTestCase {
+fileprivate final class PackageCollectionsTests: XCTestCase {
     func testUpdateAuthTokens() async throws {
         let authTokens = ThreadSafeKeyValueStore<AuthTokenType, String>()
         let configuration = PackageCollections.Configuration(authTokens: { authTokens.get() })

--- a/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 import struct TSCUtility.Version
 
-class PackageIndexAndCollectionsTests: XCTestCase {
+fileprivate final class PackageIndexAndCollectionsTests: XCTestCase {
     func testCollectionAddRemoveGetList() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
         

--- a/Tests/PackageCollectionsTests/PackageIndexConfigurationTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexConfigurationTests.swift
@@ -14,7 +14,7 @@ import class Basics.InMemoryFileSystem
 import PackageCollections
 import XCTest
 
-final class PackageIndexConfigurationTests: XCTestCase {
+fileprivate final class PackageIndexConfigurationTests: XCTestCase {
     func testSaveAndLoad() throws {
         let url = URL("https://package-index.test")
         let configuration = PackageIndexConfiguration(url: url)

--- a/Tests/PackageCollectionsTests/PackageIndexTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexTests.swift
@@ -17,7 +17,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-class PackageIndexTests: XCTestCase {
+fileprivate final class PackageIndexTests: XCTestCase {
     func testGetPackageMetadata() async throws {
         let url = URL("https://package-index.test")
         var configuration = PackageIndexConfiguration(url: url, disableCache: true)

--- a/Tests/PackageCollectionsTests/TrieTests.swift
+++ b/Tests/PackageCollectionsTests/TrieTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 @testable import PackageCollections
 
-class TrieTests: XCTestCase {
+fileprivate final class TrieTests: XCTestCase {
     func testContains() {
         let trie = Trie<Int>()
 

--- a/Tests/PackageCollectionsTests/ValidationMessageTests.swift
+++ b/Tests/PackageCollectionsTests/ValidationMessageTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 @testable import PackageCollections
 
-class ValidationMessageTests: XCTestCase {
+fileprivate final class ValidationMessageTests: XCTestCase {
     func testMessageToError() {
         let warningWithProperty = ValidationMessage.warning("warning with property", property: "foo")
         let warning = ValidationMessage.warning("warning")

--- a/Tests/PackageDescriptionTests/VersionTests.swift
+++ b/Tests/PackageDescriptionTests/VersionTests.swift
@@ -13,7 +13,7 @@
 import PackageDescription
 import XCTest
 
-class VersionTests: XCTestCase {
+fileprivate final class VersionTests: XCTestCase {
     
     func testVersionInitialization() {
         let v0 = Version(0, 0, 0, prereleaseIdentifiers: [], buildMetadataIdentifiers: [])

--- a/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
+++ b/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 import struct TSCUtility.Version
 
-final class FilePackageFingerprintStorageTests: XCTestCase {
+fileprivate final class FilePackageFingerprintStorageTests: XCTestCase {
     func testHappyCase() async throws {
         let mockFileSystem = InMemoryFileSystem()
         let directoryPath = AbsolutePath("/fingerprints")

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -31,7 +31,7 @@ import class TSCTestSupport.XCTestCasePerf
 private let v1: Version = "1.0.0"
 private let v1Range: VersionSetSpecifier = .range("1.0.0" ..< "2.0.0")
 
-class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
+fileprivate final class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
     func testKituraPubGrub_X100() async throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -23,7 +23,7 @@ import XCTest
 
 import class TSCTestSupport.XCTestCasePerf
 
-final class PackageGraphPerfTests: XCTestCasePerf {
+fileprivate final class PackageGraphPerfTests: XCTestCasePerf {
     func testLoading100Packages() throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")

--- a/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
+++ b/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
@@ -19,7 +19,7 @@ import PackageGraph
 
 import XCTest
 
-final class CrossCompilationPackageGraphTests: XCTestCase {
+fileprivate final class CrossCompilationPackageGraphTests: XCTestCase {
     func testTrivialPackage() throws {
         let graph = try trivialPackageGraph().graph
         PackageGraphTester(graph) { result in

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -42,7 +42,7 @@ private let v1_1Range: VersionSetSpecifier = .range("1.1.0" ..< "1.2.0")
 private let v1_1_0Range: VersionSetSpecifier = .range("1.1.0" ..< "1.1.1")
 private let v2_0_0Range: VersionSetSpecifier = .range("2.0.0" ..< "2.0.1")
 
-class DependencyResolverTests: XCTestCase {
+fileprivate final class DependencyResolverTests: XCTestCase {
     func testVersionSetSpecifier() {
         // Check `contains`.
         XCTAssert(v1Range.contains("1.1.0"))

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 import struct TSCBasic.ByteString
 
-final class ModulesGraphTests: XCTestCase {
+fileprivate final class ModulesGraphTests: XCTestCase {
     func testBasic() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Foo/Sources/Foo/source.swift",

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -68,7 +68,7 @@ let rootNode = DependencyResolutionNode.root(package: rootRef)
 let rootCause = try! Incompatibility(Term(rootNode, .exact(v1)), root: rootNode)
 let _cause = try! Incompatibility("cause@0.0.0", root: rootNode)
 
-final class PubGrubTests: XCTestCase {
+fileprivate final class PubGrubTests: XCTestCase {
     func testTermInverse() {
         let a = Term("a@1.0.0")
         XCTAssertFalse(a.inverse.isPositive)

--- a/Tests/PackageGraphTests/ResolvedTargetTests.swift
+++ b/Tests/PackageGraphTests/ResolvedTargetTests.swift
@@ -25,7 +25,7 @@ private func XCTAssertEqualTargetIDs(
     XCTAssertEqual(lhs.map(\.id), rhs.map(\.id), file: file, line: line)
 }
 
-final class ResolvedModuleDependencyTests: XCTestCase {
+fileprivate final class ResolvedModuleDependencyTests: XCTestCase {
     func test1() throws {
         let t1 = ResolvedModule.mock(packageIdentity: "pkg", name: "t1")
         let t2 = ResolvedModule.mock(packageIdentity: "pkg", name: "t2", deps: t1)

--- a/Tests/PackageGraphTests/TopologicalSortTests.swift
+++ b/Tests/PackageGraphTests/TopologicalSortTests.swift
@@ -47,7 +47,7 @@ private func topologicalSort(_ node: Int, _ successors: [Int: [Int]]) throws -> 
     return try topologicalSort([node], successors)
 }
 
-final class TopologicalSortTests: XCTestCase {
+fileprivate final class TopologicalSortTests: XCTestCase {
     func testTopologicalSort() throws {
         // A trivial graph.
         XCTAssertEqual([1, 2], try topologicalSort(1, [1: [2]]))

--- a/Tests/PackageGraphTests/VersionSetSpecifierTests.swift
+++ b/Tests/PackageGraphTests/VersionSetSpecifierTests.swift
@@ -15,7 +15,7 @@ import XCTest
 
 import PackageGraph
 
-final class VersionSetSpecifierTests: XCTestCase {
+fileprivate final class VersionSetSpecifierTests: XCTestCase {
     func testUnion() {
         XCTAssertEqual(VersionSetSpecifier.union(from: ["1.0.0"..<"1.0.1"]), .exact("1.0.0"))
         XCTAssertEqual(VersionSetSpecifier.union(from: ["1.0.0"..<"1.0.5"]), .range("1.0.0"..<"1.0.5"))

--- a/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
@@ -17,7 +17,7 @@ import _InternalTestSupport
 import XCTest
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-final class ManifestLoaderCacheTests: XCTestCase {
+fileprivate final class ManifestLoaderCacheTests: XCTestCase {
 
     func testDBCaching() async throws {
         try UserToolchain.default.skipUnlessAtLeastSwift6()

--- a/Tests/PackageLoadingTests/ManifestSignatureParserTests.swift
+++ b/Tests/PackageLoadingTests/ManifestSignatureParserTests.swift
@@ -16,7 +16,7 @@ import PackageLoading
 import _InternalTestSupport
 import XCTest
 
-class ManifestSignatureParserTests: XCTestCase {
+fileprivate final class ManifestSignatureParserTests: XCTestCase {
     func testSignedManifest() throws {
         try testWithTemporaryDirectory { tmpPath in
             let manifestPath = tmpPath.appending("Package.swift")

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-final class ModuleMapGeneration: XCTestCase {
+fileprivate final class ModuleMapGeneration: XCTestCase {
     func testModuleNameHeaderInInclude() throws {
         let root: AbsolutePath = .root
 
@@ -177,7 +177,7 @@ final class ModuleMapGeneration: XCTestCase {
 }
 
 /// Helper function to test module map generation.  Given a target name and optionally the name of a public-headers directory, this function determines the module map type of the public-headers directory by examining the contents of a file system and invokes a given block to check the module result (including any diagnostics).
-func ModuleMapTester(_ targetName: String, includeDir: String = "include", in fileSystem: FileSystem, _ body: (ModuleMapResult) -> Void) {
+fileprivate func ModuleMapTester(_ targetName: String, includeDir: String = "include", in fileSystem: FileSystem, _ body: (ModuleMapResult) -> Void) {
     let observability = ObservabilitySystem.makeForTesting()
     // Create a module map generator, and determine the type of module map to use for the header directory.  This may emit diagnostics.
     let moduleMapGenerator = ModuleMapGenerator(targetName: targetName, moduleName: targetName.spm_mangledToC99ExtendedIdentifier(), publicHeadersDir: AbsolutePath.root.appending(component: includeDir), fileSystem: fileSystem)
@@ -199,7 +199,7 @@ func ModuleMapTester(_ targetName: String, includeDir: String = "include", in fi
     result.validateDiagnostics()
 }
 
-final class ModuleMapResult {
+fileprivate final class ModuleMapResult {
     private var diagnostics: [Basics.Diagnostic]
     private var diagsChecked: Bool
     private let path: AbsolutePath

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v4
     }

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -22,7 +22,7 @@ import enum TSCBasic.PathValidationError
 import struct TSCUtility.Version
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
-final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v4_2
     }

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 import struct TSCBasic.ByteString
 
-final class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v5
     }

--- a/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v5_2
     }

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 import enum TSCBasic.PathValidationError
 
-final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v5_3
     }

--- a/Tests/PackageLoadingTests/PD_5_4_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_4_LoadingTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-class PackageDescription5_4LoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class PackageDescription5_4LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v5_4
     }

--- a/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
@@ -17,7 +17,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-class PackageDescription5_5LoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class PackageDescription5_5LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v5_5
     }

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-final class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v5_6
     }

--- a/Tests/PackageLoadingTests/PD_5_7_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_7_LoadingTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-final class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v5_7
     }

--- a/Tests/PackageLoadingTests/PD_5_9_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_9_LoadingTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-final class PackageDescription5_9LoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class PackageDescription5_9LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v5_9
     }

--- a/Tests/PackageLoadingTests/PD_6_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_6_0_LoadingTests.swift
@@ -16,7 +16,7 @@ import SourceControl
 import _InternalTestSupport
 import XCTest
 
-final class PackageDescription6_0LoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class PackageDescription6_0LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v6_0
     }

--- a/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import _InternalTestSupport
 import XCTest
 
-class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .vNext
     }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -17,7 +17,7 @@ import _InternalTestSupport
 import XCTest
 
 /// Tests for the handling of source layout conventions.
-final class PackageBuilderTests: XCTestCase {
+fileprivate final class PackageBuilderTests: XCTestCase {
     func testDotFilesAreIgnored() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/foo/.Bar.swift",
@@ -3184,7 +3184,7 @@ final class PackageBuilderTests: XCTestCase {
     }
 }
 
-final class PackageBuilderTester {
+fileprivate final class PackageBuilderTester {
     private enum Result {
         case package(PackageModel.Package)
         case error(String)

--- a/Tests/PackageLoadingTests/PkgConfigAllowlistTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigAllowlistTests.swift
@@ -14,7 +14,7 @@ import Basics
 import PackageLoading
 import XCTest
 
-final class PkgConfigAllowlistTests: XCTestCase {
+fileprivate final class PkgConfigAllowlistTests: XCTestCase {
     func testSimpleFlags() throws {
         let cFlags = ["-I/usr/local/Cellar/gtk+3/3.18.9/include/gtk-3.0"]
         let libs = ["-L/usr/local/Cellar/gtk+3/3.18.9/lib", "-lgtk-3", "-w"]

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 import struct TSCBasic.ByteString
 
-final class PkgConfigParserTests: XCTestCase {
+fileprivate final class PkgConfigParserTests: XCTestCase {
     func testCircularPCFile() throws {
         let observability = ObservabilitySystem.makeForTesting()
 

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -26,7 +26,7 @@ extension SystemLibraryModule {
     }
 }
 
-class PkgConfigTests: XCTestCase {
+fileprivate final class PkgConfigTests: XCTestCase {
     let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
     let observability = ObservabilitySystem.makeForTesting()
     let fs = localFileSystem

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -17,7 +17,7 @@ import PackageLoading
 import _InternalTestSupport
 import XCTest
 
-final class TargetSourcesBuilderTests: XCTestCase {
+fileprivate final class TargetSourcesBuilderTests: XCTestCase {
     func testBasicFileContentsComputation() throws {
         let target = try TargetDescription(
             name: "Foo",

--- a/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
@@ -16,7 +16,7 @@ import PackageLoading
 import _InternalTestSupport
 import XCTest
 
-final class ToolsVersionParserTests: XCTestCase {
+fileprivate final class ToolsVersionParserTests: XCTestCase {
     func parse(_ content: String, _ body: ((ToolsVersion) -> Void)? = nil) throws {
         let toolsVersion = try ToolsVersionParser.parse(utf8String: content)
         body?(toolsVersion)

--- a/Tests/PackageLoadingTests/TraitLoadingTests.swift
+++ b/Tests/PackageLoadingTests/TraitLoadingTests.swift
@@ -17,7 +17,7 @@ import SourceControl
 import _InternalTestSupport
 import XCTest
 
-final class TraitLoadingTests: PackageDescriptionLoadingTests {
+fileprivate final class TraitLoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .vNext
     }

--- a/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
+++ b/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
@@ -66,7 +66,7 @@ func assertManifestRefactor(
     )
 }
 
-class ManifestEditTests: XCTestCase {
+fileprivate final class ManifestEditTests: XCTestCase {
     static let swiftSystemURL: SourceControlURL = "https://github.com/apple/swift-system.git"
     static let swiftSystemPackageDependency = PackageDependency.remoteSourceControl(
             identity: PackageIdentity(url: swiftSystemURL),

--- a/Tests/PackageModelTests/CanonicalPackageLocationTests.swift
+++ b/Tests/PackageModelTests/CanonicalPackageLocationTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 @testable import PackageModel
 
-final class CanonicalPackageLocationTests: XCTestCase {
+fileprivate final class CanonicalPackageLocationTests: XCTestCase {
     func testCaseInsensitivity() {
         XCTAssertEqual(
             CanonicalPackageLocation("MONA/LINKEDLIST").description,

--- a/Tests/PackageModelTests/InstalledSwiftPMConfigurationTests.swift
+++ b/Tests/PackageModelTests/InstalledSwiftPMConfigurationTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 @testable import PackageModel
 
-final class InstalledSwiftPMConfigurationTests: XCTestCase {
+fileprivate final class InstalledSwiftPMConfigurationTests: XCTestCase {
     func testVersionDescription() {
         do {
             let version = InstalledSwiftPMConfiguration.Version(major: 509, minor: 0, patch: 0)

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -14,7 +14,7 @@ import XCTest
 import PackageModel
 import _InternalTestSupport
 
-class ManifestTests: XCTestCase {
+fileprivate final class ManifestTests: XCTestCase {
     func testRequiredTargets() throws {
         let products = [
             try ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),

--- a/Tests/PackageModelTests/MinimumDeploymentTargetTests.swift
+++ b/Tests/PackageModelTests/MinimumDeploymentTargetTests.swift
@@ -15,7 +15,7 @@ import XCTest
 
 import struct Basics.AsyncProcessResult
 
-final class MinimumDeploymentTargetTests: XCTestCase {
+fileprivate final class MinimumDeploymentTargetTests: XCTestCase {
     func testDoesNotAssertWithNoOutput() throws {
         #if !os(macOS)
         // these tests eventually call `xcrun`.

--- a/Tests/PackageModelTests/PackageIdentityNameTests.swift
+++ b/Tests/PackageModelTests/PackageIdentityNameTests.swift
@@ -14,7 +14,7 @@ import XCTest
 import Basics
 import PackageModel
 
-class PackageIdentityNameTests: XCTestCase {
+fileprivate final class PackageIdentityNameTests: XCTestCase {
     func testValidNames() throws {
         XCTAssertNoThrow(try PackageIdentity.Name(validating: "LinkedList"))
         XCTAssertNoThrow(try PackageIdentity.Name(validating: "Linked-List"))

--- a/Tests/PackageModelTests/PackageIdentityParser.swift
+++ b/Tests/PackageModelTests/PackageIdentityParser.swift
@@ -14,7 +14,7 @@ import XCTest
 
 @testable import PackageModel
 
-final class PackageIdentityParserTests: XCTestCase {
+fileprivate final class PackageIdentityParserTests: XCTestCase {
     func testPackageIdentityDescriptions() {
         XCTAssertEqual(PackageIdentityParser("foo").description, "foo")
         XCTAssertEqual(PackageIdentityParser("/foo").description, "foo")

--- a/Tests/PackageModelTests/PackageIdentityScopeTests.swift
+++ b/Tests/PackageModelTests/PackageIdentityScopeTests.swift
@@ -14,7 +14,7 @@ import XCTest
 import Basics
 import PackageModel
 
-class PackageIdentityScopeTests: XCTestCase {
+fileprivate final class PackageIdentityScopeTests: XCTestCase {
     func testValidScopes() throws {
         XCTAssertNoThrow(try PackageIdentity.Scope(validating: "mona"))
         XCTAssertNoThrow(try PackageIdentity.Scope(validating: "m-o-n-a"))

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 import struct TSCBasic.ByteString
 
-final class PackageModelTests: XCTestCase {
+fileprivate final class PackageModelTests: XCTestCase {
     func testProductTypeCodable() throws {
         struct Foo: Codable, Equatable {
             var type: ProductType

--- a/Tests/PackageModelTests/SnippetTests.swift
+++ b/Tests/PackageModelTests/SnippetTests.swift
@@ -14,7 +14,7 @@ import Basics
 @testable import PackageModel
 import XCTest
 
-class SnippetTests: XCTestCase {
+fileprivate final class SnippetTests: XCTestCase {
     let fakeSourceFilePath = AbsolutePath("/fake/path/to/test.swift")
 
     /// Test the contents of the ``Snippet`` model when parsing an empty file.

--- a/Tests/PackageModelTests/SwiftLanguageVersionTests.swift
+++ b/Tests/PackageModelTests/SwiftLanguageVersionTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 import PackageModel
 
-class SwiftLanguageVersionTests: XCTestCase {
+fileprivate final class SwiftLanguageVersionTests: XCTestCase {
 
     func testBasics() throws {
 

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -135,7 +135,7 @@ private let fixtureSDKsPath = try! AbsolutePath(validating: #file)
     .parentDirectory
     .appending(components: ["Fixtures", "SwiftSDKs"])
 
-final class SwiftSDKBundleTests: XCTestCase {
+fileprivate final class SwiftSDKBundleTests: XCTestCase {
     func testInstallRemote() async throws {
         #if canImport(Darwin) && !os(macOS)
         try XCTSkipIf(true, "skipping test because process launching is not available")

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -352,7 +352,7 @@ private let testFiles: [(path: AbsolutePath, json: SerializedJSON)] = [
     invalidToolset,
 ]
 
-final class DestinationTests: XCTestCase {
+fileprivate final class DestinationTests: XCTestCase {
     func testDestinationCodable() throws {
         let fs = InMemoryFileSystem()
         try fs.createDirectory(AbsolutePath(validating: "/tools"))

--- a/Tests/PackageModelTests/ToolsVersionTests.swift
+++ b/Tests/PackageModelTests/ToolsVersionTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 import PackageModel
 
-class ToolsVersionTests: XCTestCase {
+fileprivate final class ToolsVersionTests: XCTestCase {
 
     func testBasics() throws {
 

--- a/Tests/PackageModelTests/ToolsetTests.swift
+++ b/Tests/PackageModelTests/ToolsetTests.swift
@@ -93,7 +93,7 @@ private let someToolsWithRelativeRoot = (
     """# as SerializedJSON
 )
 
-final class ToolsetTests: XCTestCase {
+fileprivate final class ToolsetTests: XCTestCase {
     func testToolset() throws {
         let fileSystem = InMemoryFileSystem()
         try fileSystem.createDirectory(AbsolutePath(validating: "/tools"))

--- a/Tests/PackagePluginAPITests/ArgumentExtractorTests.swift
+++ b/Tests/PackagePluginAPITests/ArgumentExtractorTests.swift
@@ -13,7 +13,7 @@
 import PackagePlugin
 import XCTest
 
-class ArgumentExtractorAPITests: XCTestCase {
+fileprivate final class ArgumentExtractorAPITests: XCTestCase {
 
     func testBasics() throws {
         var extractor = ArgumentExtractor(["--verbose", "--target", "Target1", "Positional1", "--flag", "--verbose", "--target", "Target2", "Positional2"])

--- a/Tests/PackagePluginAPITests/PathTests.swift
+++ b/Tests/PackagePluginAPITests/PathTests.swift
@@ -13,7 +13,7 @@
 import PackagePlugin
 import XCTest
 
-class PathAPITests: XCTestCase {
+fileprivate final class PathAPITests: XCTestCase {
 
     func testBasics() throws {
         let path = Path("/tmp/file.foo")

--- a/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 import struct TSCUtility.Version
 
-final class PackageSigningEntityTOFUTests: XCTestCase {
+fileprivate final class PackageSigningEntityTOFUTests: XCTestCase {
     func testSigningEntitySeenForTheFirstTime() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!

--- a/Tests/PackageRegistryTests/PackageVersionChecksumTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageVersionChecksumTOFUTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 import struct TSCUtility.Version
 
-final class PackageVersionChecksumTOFUTests: XCTestCase {
+fileprivate final class PackageVersionChecksumTOFUTests: XCTestCase {
     func testSourceArchiveChecksumSeenForTheFirstTime() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -24,7 +24,7 @@ import XCTest
 import protocol TSCBasic.HashAlgorithm
 import struct TSCUtility.Version
 
-final class RegistryClientTests: XCTestCase {
+fileprivate final class RegistryClientTests: XCTestCase {
     func testGetPackageMetadata() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")

--- a/Tests/PackageRegistryTests/RegistryConfigurationTests.swift
+++ b/Tests/PackageRegistryTests/RegistryConfigurationTests.swift
@@ -19,7 +19,7 @@ import XCTest
 private let defaultRegistryBaseURL = URL("https://packages.example.com/")
 private let customRegistryBaseURL = URL("https://custom.packages.example.com/")
 
-final class RegistryConfigurationTests: XCTestCase {
+fileprivate final class RegistryConfigurationTests: XCTestCase {
     let encoder = JSONEncoder()
     let decoder = JSONDecoder()
 

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 import struct TSCUtility.Version
 
-final class RegistryDownloadsManagerTests: XCTestCase {
+fileprivate final class RegistryDownloadsManagerTests: XCTestCase {
     func testNoCache() async throws {
         let observability = ObservabilitySystem.makeForTesting()
         let fs = InMemoryFileSystem()

--- a/Tests/PackageRegistryTests/SignatureValidationTests.swift
+++ b/Tests/PackageRegistryTests/SignatureValidationTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 import struct TSCUtility.Version
 
-final class SignatureValidationTests: XCTestCase {
+fileprivate final class SignatureValidationTests: XCTestCase {
     private static let unsignedManifest = """
     // swift-tools-version: 5.7
 

--- a/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
+++ b/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 import struct TSCUtility.Version
 
-final class FilePackageSigningEntityStorageTests: XCTestCase {
+fileprivate final class FilePackageSigningEntityStorageTests: XCTestCase {
     func testHappyCase() async throws {
         let mockFileSystem = InMemoryFileSystem()
         let directoryPath = AbsolutePath("/signing")

--- a/Tests/PackageSigningTests/SigningEntityTests.swift
+++ b/Tests/PackageSigningTests/SigningEntityTests.swift
@@ -17,7 +17,7 @@ import Basics
 import _InternalTestSupport
 import X509
 
-final class SigningEntityTests: XCTestCase {
+fileprivate final class SigningEntityTests: XCTestCase {
     func testTwoADPSigningEntitiesAreEqualIfTeamIDEqual() {
         let adp1 = SigningEntity.recognized(
             type: .adp,

--- a/Tests/PackageSigningTests/SigningIdentityTests.swift
+++ b/Tests/PackageSigningTests/SigningIdentityTests.swift
@@ -19,7 +19,7 @@ import Crypto
 import _InternalTestSupport
 import X509
 
-final class SigningIdentityTests: XCTestCase {
+fileprivate final class SigningIdentityTests: XCTestCase {
     func testSwiftSigningIdentityWithECKey() throws {
         try fixture(name: "Signing", createGitRepo: false) { fixturePath in
             let certificateBytes = try readFileContents(

--- a/Tests/PackageSigningTests/SigningTests.swift
+++ b/Tests/PackageSigningTests/SigningTests.swift
@@ -20,7 +20,7 @@ import SwiftASN1
 @testable import X509 // need internal APIs for OCSP testing
 import XCTest
 
-final class SigningTests: XCTestCase {
+fileprivate final class SigningTests: XCTestCase {
     func testCMS1_0_0EndToEnd() async throws {
         let keyAndCertChain = try self.ecTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(

--- a/Tests/QueryEngineTests/QueryEngineTests.swift
+++ b/Tests/QueryEngineTests/QueryEngineTests.swift
@@ -98,7 +98,7 @@ private struct Expression: CachingQuery {
   }
 }
 
-final class QueryEngineTests: XCTestCase {
+fileprivate final class QueryEngineTests: XCTestCase {
   func testFilePathHashing() throws {
     let path = "/root"
 

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -14,7 +14,7 @@ import Basics
 import PackageModel
 import XCTest
 
-final class ArtifactsArchiveMetadataTests: XCTestCase {
+fileprivate final class ArtifactsArchiveMetadataTests: XCTestCase {
     func testParseMetadata() throws {
         let fileSystem = InMemoryFileSystem()
         try fileSystem.writeFileContents(

--- a/Tests/SPMBuildCoreTests/BuildParametersTests.swift
+++ b/Tests/SPMBuildCoreTests/BuildParametersTests.swift
@@ -16,7 +16,7 @@ import struct PackageModel.BuildEnvironment
 import _InternalTestSupport
 import XCTest
 
-final class BuildParametersTests: XCTestCase {
+fileprivate final class BuildParametersTests: XCTestCase {
     func testConfigurationDependentProperties() throws {
         // Ensure that properties that depend on the "configuration" property are
         // correctly updated after modifying the configuration.

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -31,7 +31,7 @@ import struct Build.PluginConfiguration
 
 import struct TSCUtility.SerializedDiagnostics
 
-final class PluginInvocationTests: XCTestCase {
+fileprivate final class PluginInvocationTests: XCTestCase {
     func testBasics() async throws {
         // Construct a canned file system and package graph with a single package and a library that uses a build tool plugin that invokes a tool.
         let fileSystem = InMemoryFileSystem(emptyFiles:

--- a/Tests/SPMBuildCoreTests/XCFrameworkMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/XCFrameworkMetadataTests.swift
@@ -14,7 +14,7 @@ import class Basics.InMemoryFileSystem
 import SPMBuildCore
 import XCTest
 
-final class XCFrameworkMetadataTests: XCTestCase {
+fileprivate final class XCFrameworkMetadataTests: XCTestCase {
     func testParseFramework() throws {
         let fileSystem = InMemoryFileSystem(files: [
             "/Info.plist":  """

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -15,7 +15,7 @@ import _InternalTestSupport
 @testable import SourceControl
 import XCTest
 
-class GitRepositoryProviderTests: XCTestCase {
+fileprivate final class GitRepositoryProviderTests: XCTestCase {
     func testIsValidDirectory() throws {
         try testWithTemporaryDirectory { sandbox in
             let provider = GitRepositoryProvider()

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -22,7 +22,7 @@ import class Basics.AsyncProcess
 
 import enum TSCUtility.Git
 
-class GitRepositoryTests: XCTestCase {
+fileprivate final class GitRepositoryTests: XCTestCase {
 
     override func setUp() {
         // needed for submodule tests

--- a/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
+++ b/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
@@ -15,7 +15,7 @@ import SourceControl
 import _InternalTestSupport
 import XCTest
 
-final class InMemoryGitRepositoryTests: XCTestCase {
+fileprivate final class InMemoryGitRepositoryTests: XCTestCase {
     func testBasics() throws {
         let fs = InMemoryFileSystem()
         let repo = InMemoryGitRepository(path: .root, fs: fs)

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -17,7 +17,7 @@ import _InternalTestSupport
 @testable import SourceControl
 import XCTest
 
-final class RepositoryManagerTests: XCTestCase {
+fileprivate final class RepositoryManagerTests: XCTestCase {
     func testBasics() async throws {
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -22,7 +22,7 @@ import struct SPMBuildCore.BuildParameters
 import _InternalTestSupport
 import XCTest
 
-final class SourceKitLSPAPITests: XCTestCase {
+fileprivate final class SourceKitLSPAPITests: XCTestCase {
     func testBasicSwiftPackage() async throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/exe/main.swift",

--- a/Tests/WorkspaceTests/AuthorizationProviderTests.swift
+++ b/Tests/WorkspaceTests/AuthorizationProviderTests.swift
@@ -15,7 +15,7 @@ import _InternalTestSupport
 import Workspace
 import XCTest
 
-final class AuthorizationProviderTests: XCTestCase {
+fileprivate final class AuthorizationProviderTests: XCTestCase {
     func testNetrcAuthorizationProviders() throws {
         let observability = ObservabilitySystem.makeForTesting()
 

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import Workspace
 import XCTest
 
-final class InitTests: XCTestCase {
+fileprivate final class InitTests: XCTestCase {
 
     // MARK: TSCBasic package creation for each package type.
     

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -33,7 +33,7 @@ extension String {
     }
 }
 
-final class ManifestSourceGenerationTests: XCTestCase {
+fileprivate final class ManifestSourceGenerationTests: XCTestCase {
     /// Private function that writes the contents of a package manifest to a temporary package directory and then loads it, then serializes the loaded manifest back out again and loads it once again, after which it compares that no information was lost. Return the source of the newly generated manifest.
     @discardableResult
     private func testManifestWritingRoundTrip(

--- a/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
+++ b/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
@@ -15,7 +15,7 @@ import _InternalTestSupport
 import Workspace
 import XCTest
 
-final class MirrorsConfigurationTests: XCTestCase {
+fileprivate final class MirrorsConfigurationTests: XCTestCase {
     func testLoadingSchema1() throws {
         let fs = InMemoryFileSystem()
         let configFile = AbsolutePath("/config/mirrors.json")

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -23,7 +23,7 @@ import XCTest
 
 import struct TSCUtility.Version
 
-final class RegistryPackageContainerTests: XCTestCase {
+fileprivate final class RegistryPackageContainerTests: XCTestCase {
     func testToolsVersionCompatibleVersions() async throws {
         let fs = InMemoryFileSystem()
         try fs.createMockToolchain()

--- a/Tests/WorkspaceTests/ResolvedPackagesStoreTests.swift
+++ b/Tests/WorkspaceTests/ResolvedPackagesStoreTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 import struct TSCUtility.Version
 
-final class ResolvedPackagesStoreTests: XCTestCase {
+fileprivate final class ResolvedPackagesStoreTests: XCTestCase {
 
     let v1: Version = "1.0.0"
 

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -123,7 +123,7 @@ private let v1: Version = "1.0.0"
 private let v2: Version = "2.0.0"
 private let v1Range: VersionSetSpecifier = .range("1.0.0" ..< "2.0.0")
 
-final class SourceControlPackageContainerTests: XCTestCase {
+fileprivate final class SourceControlPackageContainerTests: XCTestCase {
     func testVprefixVersions() async throws {
         let fs = InMemoryFileSystem()
         try fs.createMockToolchain()

--- a/Tests/WorkspaceTests/ToolsVersionSpecificationGenerationTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionSpecificationGenerationTests.swift
@@ -20,7 +20,7 @@ import PackageModel
 import struct TSCUtility.Version
 
 /// Test cases for the generation of Swift tools version specifications.
-class ToolsVersionSpecificationGenerationTests: XCTestCase {
+fileprivate final class ToolsVersionSpecificationGenerationTests: XCTestCase {
     /// Tests the generation of Swift tools version specifications.
     func testToolsVersionSpecificationGeneration() throws {
         let versionWithNonZeroPatch = ToolsVersion(version: Version(4, 3, 2))

--- a/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
@@ -20,7 +20,7 @@ import PackageModel
 import XCTest
 
 /// Test cases for `rewriteToolsVersionSpecification(toDefaultManifestIn:specifying:fileSystem:)`
-final class ToolsVersionSpecificationRewriterTests: XCTestCase {
+fileprivate final class ToolsVersionSpecificationRewriterTests: XCTestCase {
     
     /// Tests `rewriteToolsVersionSpecification(toDefaultManifestIn:specifying:fileSystem:)`.
     func testNonVersionSpecificManifests() throws {

--- a/Tests/WorkspaceTests/WorkspaceStateTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceStateTests.swift
@@ -14,7 +14,7 @@ import Basics
 @testable import Workspace
 import XCTest
 
-final class WorkspaceStateTests: XCTestCase {
+fileprivate final class WorkspaceStateTests: XCTestCase {
     func testV4Format() throws {
         let fs = InMemoryFileSystem()
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -27,7 +27,7 @@ import struct TSCBasic.ByteString
 
 import struct TSCUtility.Version
 
-final class WorkspaceTests: XCTestCase {
+fileprivate final class WorkspaceTests: XCTestCase {
     func testBasics() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -23,7 +23,7 @@ import _InternalTestSupport
 @testable import XCBuildSupport
 import XCTest
 
-final class PIFBuilderTests: XCTestCase {
+fileprivate final class PIFBuilderTests: XCTestCase {
     let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
 
     func testOrdering() throws {

--- a/Tests/XCBuildSupportTests/PIFTests.swift
+++ b/Tests/XCBuildSupportTests/PIFTests.swift
@@ -19,7 +19,7 @@ import _InternalTestSupport
 
 import enum TSCBasic.JSON
 
-class PIFTests: XCTestCase {
+fileprivate final class PIFTests: XCTestCase {
     let topLevelObject = PIF.TopLevelObject(workspace:
         PIF.Workspace(
             guid: "workspace",

--- a/Tests/_AsyncFileSystemTests/AsyncFileSystemTests.swift
+++ b/Tests/_AsyncFileSystemTests/AsyncFileSystemTests.swift
@@ -13,7 +13,7 @@ import _InternalTestSupport
 import XCTest
 import struct SystemPackage.FilePath
 
-final class AsyncFileSystemTests: XCTestCase {
+fileprivate final class AsyncFileSystemTests: XCTestCase {
     func testMockFileSystem() async throws {
         let fs = MockFileSystem()
 

--- a/Tests/_InternalTestSupportTests/Misc.swift
+++ b/Tests/_InternalTestSupportTests/Misc.swift
@@ -1,7 +1,7 @@
 import _InternalTestSupport
 import XCTest
 
-final class TestGetNumberOfMatches: XCTestCase {
+fileprivate final class TestGetNumberOfMatches: XCTestCase {
     func testEmptyStringMatchesOnEmptyStringZeroTimes() {
         let matchOn = ""
         let value = ""


### PR DESCRIPTION
This reduces the number of unnecessary exported symbols.