### PR TITLE
Show human-readable git errors

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -1168,7 +1168,8 @@ public struct GitShellError: Error, CustomStringConvertible {
         let stdout = (try? self.result.utf8Output()) ?? ""
         let stderr = (try? self.result.utf8stderrOutput()) ?? ""
         let output = (stdout + stderr).spm_chomp()
-        return output
+        let command = result.arguments.joined(separator: " ")
+        return "Git command '\(command)' failed: \(output)"
     }
 }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -204,21 +204,13 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
     }
 
     public func isValidDirectory(_ directory: Basics.AbsolutePath) throws -> Bool {
-        do {
-            let result = try self.git.run(["-C", directory.pathString, "rev-parse", "--git-dir"])
-            return result == ".git" || result == "." || result == directory.pathString
-        } catch _ as GitShellError {
-            return false
-        }
+        let result = try self.git.run(["-C", directory.pathString, "rev-parse", "--git-dir"])
+        return result == ".git" || result == "." || result == directory.pathString
     }
 
     public func isValidDirectory(_ directory: Basics.AbsolutePath, for repository: RepositorySpecifier) throws -> Bool {
-        do {
-            let remoteURL = try self.git.run(["-C", directory.pathString, "config", "--get", "remote.origin.url"])
-            return CanonicalPackageURL(remoteURL) == CanonicalPackageURL(repository.url)
-        } catch _ as GitShellError {
-            return false
-        }
+        let remoteURL = try self.git.run(["-C", directory.pathString, "config", "--get", "remote.origin.url"])
+        return CanonicalPackageURL(remoteURL) == CanonicalPackageURL(repository.url)
     }
 
     public func copy(from sourcePath: Basics.AbsolutePath, to destinationPath: Basics.AbsolutePath) throws {

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -1161,8 +1161,15 @@ extension GitFileSystemView: @unchecked Sendable {}
 
 // MARK: - Errors
 
-private struct GitShellError: Error {
+private struct GitShellError: Error, CustomStringConvertible {
     let result: AsyncProcessResult
+
+    public var description: String {
+        let stdout = (try? self.result.utf8Output()) ?? ""
+        let stderr = (try? self.result.utf8stderrOutput()) ?? ""
+        let output = (stdout + stderr).spm_chomp()
+        return output
+    }
 }
 
 private enum GitInterfaceError: Swift.Error {

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -1161,7 +1161,7 @@ extension GitFileSystemView: @unchecked Sendable {}
 
 // MARK: - Errors
 
-public struct GitShellError: Error, CustomStringConvertible {
+package struct GitShellError: Error, CustomStringConvertible {
     let result: AsyncProcessResult
 
     public var description: String {

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -1161,7 +1161,7 @@ extension GitFileSystemView: @unchecked Sendable {}
 
 // MARK: - Errors
 
-private struct GitShellError: Error, CustomStringConvertible {
+public struct GitShellError: Error, CustomStringConvertible {
     let result: AsyncProcessResult
 
     public var description: String {

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -204,13 +204,21 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
     }
 
     public func isValidDirectory(_ directory: Basics.AbsolutePath) throws -> Bool {
-        let result = try self.git.run(["-C", directory.pathString, "rev-parse", "--git-dir"])
-        return result == ".git" || result == "." || result == directory.pathString
+        do {
+            let result = try self.git.run(["-C", directory.pathString, "rev-parse", "--git-dir"])
+            return result == ".git" || result == "." || result == directory.pathString
+        } catch _ as GitShellError {
+            return false
+        }
     }
 
     public func isValidDirectory(_ directory: Basics.AbsolutePath, for repository: RepositorySpecifier) throws -> Bool {
-        let remoteURL = try self.git.run(["-C", directory.pathString, "config", "--get", "remote.origin.url"])
-        return CanonicalPackageURL(remoteURL) == CanonicalPackageURL(repository.url)
+        do {
+            let remoteURL = try self.git.run(["-C", directory.pathString, "config", "--get", "remote.origin.url"])
+            return CanonicalPackageURL(remoteURL) == CanonicalPackageURL(repository.url)
+        } catch _ as GitShellError {
+            return false
+        }
     }
 
     public func copy(from sourcePath: Basics.AbsolutePath, to destinationPath: Basics.AbsolutePath) throws {

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -1168,7 +1168,7 @@ package struct GitShellError: Error, CustomStringConvertible {
         let stdout = (try? self.result.utf8Output()) ?? ""
         let stderr = (try? self.result.utf8stderrOutput()) ?? ""
         let output = (stdout + stderr).spm_chomp()
-        let command = result.arguments.joined(separator: " ")
+        let command = self.result.arguments.joined(separator: " ")
         return "Git command '\(command)' failed: \(output)"
     }
 }

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -57,23 +57,59 @@ class GitRepositoryProviderTests: XCTestCase {
     }
 
     func testGitShelErrorIsPrintable() throws {
-        let output = "An error from Git"
+        let stdOut = "An error from Git - stdout"
+        let stdErr = "An error from Git - stderr"
         let arguments = ["git", "error"]
         let command = "git error"
         let result = AsyncProcessResult(
             arguments: arguments,
             environment: [:],
             exitStatus: .terminated(code: 1),
-            output: .success(Array(output.utf8)),
-            stderrOutput: .success(Array(output.utf8))
+            output: .success(Array(stdOut.utf8)),
+            stderrOutput: .success(Array(stdErr.utf8))
         )
         let error = GitShellError(result: result)
         let errorString = "\(error)"
         XCTAssertTrue(
-            errorString.contains(output),
-            "Error string '\(errorString)' should contain '\(output)'")
+            errorString.contains(stdOut),
+            "Error string '\(errorString)' should contain '\(stdOut)'")
+        XCTAssertTrue(
+            errorString.contains(stdErr),
+            "Error string '\(errorString)' should contain '\(stdErr)'")
         XCTAssertTrue(
             errorString.contains(command),
             "Error string '\(errorString)' should contain '\(command)'")
+        }
+
+    func testGitShelErrorEmptyStdOut() throws {
+        let stdErr = "An error from Git - stderr"
+        let result = AsyncProcessResult(
+            arguments: ["git", "error"],
+            environment: [:],
+            exitStatus: .terminated(code: 1),
+            output: .success([]),
+            stderrOutput: .success(Array(stdErr.utf8))
+        )
+        let error = GitShellError(result: result)
+        let errorString = "\(error)"
+        XCTAssertTrue(
+            errorString.contains(stdErr),
+            "Error string '\(errorString)' should contain '\(stdErr)'")
+        }
+
+    func testGitShelErrorEmptyStdErr() throws {
+        let stdOut = "An error from Git - stdout"
+        let result = AsyncProcessResult(
+            arguments: ["git", "error"],
+            environment: [:],
+            exitStatus: .terminated(code: 1),
+            output: .success(Array(stdOut.utf8)),
+            stderrOutput: .success([])
+        )
+        let error = GitShellError(result: result)
+        let errorString = "\(error)"
+        XCTAssertTrue(
+            errorString.contains(stdOut),
+            "Error string '\(errorString)' should contain '\(stdOut)'")
         }
 }

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -33,11 +33,27 @@ class GitRepositoryProviderTests: XCTestCase {
 
             // non-git directory
             let notGitPath = sandbox.appending("test-not-git")
-            XCTAssertFalse(try provider.isValidDirectory(notGitPath))
+            XCTAssertThrowsError(try provider.isValidDirectory(notGitPath))
 
             // non-git child directory of a git directory
             let notGitChildPath = repositoryPath.appending("test-not-git")
-            XCTAssertFalse(try provider.isValidDirectory(notGitChildPath))
+            XCTAssertThrowsError(try provider.isValidDirectory(notGitChildPath))
         }
     }
+
+    func testIsValidDirectoryThrowsPrintableError() throws {
+        try testWithTemporaryDirectory { temp in
+            let provider = GitRepositoryProvider()
+            let expectedErrorMessage = "not a git repository"
+            do {
+                try _ = provider.isValidDirectory(temp)
+            } catch let error {
+                let errorString = String(describing: error)
+                XCTAssertTrue(
+                    errorString.contains(expectedErrorMessage),
+                    "Error string '\(errorString)' should contain '\(expectedErrorMessage)'")
+            }
+        }
+    }
+
 }

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -58,8 +58,10 @@ class GitRepositoryProviderTests: XCTestCase {
 
     func testGitShelErrorIsPrintable() throws {
         let output = "An error from Git"
+        let arguments = ["git", "error"]
+        let command = "git error"
         let result = AsyncProcessResult(
-            arguments: [],
+            arguments: arguments,
             environment: [:],
             exitStatus: .terminated(code: 1),
             output: .success(Array(output.utf8)),
@@ -70,5 +72,8 @@ class GitRepositoryProviderTests: XCTestCase {
         XCTAssertTrue(
             errorString.contains(output),
             "Error string '\(errorString)' should contain '\(output)'")
+        XCTAssertTrue(
+            errorString.contains(command),
+            "Error string '\(errorString)' should contain '\(command)'")
         }
 }

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -56,4 +56,19 @@ class GitRepositoryProviderTests: XCTestCase {
         }
     }
 
+    func testGitShelErrorIsPrintable() throws {
+        let output = "An error from Git"
+        let result = AsyncProcessResult(
+            arguments: [],
+            environment: [:],
+            exitStatus: .terminated(code: 1),
+            output: .success(Array(output.utf8)),
+            stderrOutput: .success(Array(output.utf8))
+        )
+        let error = GitShellError(result: result)
+        let errorString = "\(error)"
+        XCTAssertTrue(
+            errorString.contains(output),
+            "Error string '\(errorString)' should contain '\(output)'")
+        }
 }

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -33,27 +33,11 @@ class GitRepositoryProviderTests: XCTestCase {
 
             // non-git directory
             let notGitPath = sandbox.appending("test-not-git")
-            XCTAssertThrowsError(try provider.isValidDirectory(notGitPath))
+            XCTAssertFalse(try provider.isValidDirectory(notGitPath))
 
             // non-git child directory of a git directory
             let notGitChildPath = repositoryPath.appending("test-not-git")
-            XCTAssertThrowsError(try provider.isValidDirectory(notGitChildPath))
+            XCTAssertFalse(try provider.isValidDirectory(notGitChildPath))
         }
     }
-
-    func testIsValidDirectoryThrowsPrintableError() throws {
-        try testWithTemporaryDirectory { temp in
-            let provider = GitRepositoryProvider()
-            let expectedErrorMessage = "not a git repository"
-            do {
-                try _ = provider.isValidDirectory(temp)
-            } catch let error {
-                let errorString = String(describing: error)
-                XCTAssertTrue(
-                    errorString.contains(expectedErrorMessage),
-                    "Error string '\(errorString)' should contain '\(expectedErrorMessage)'")
-            }
-        }
-    }
-
 }

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -45,9 +45,7 @@ class GitRepositoryProviderTests: XCTestCase {
         try testWithTemporaryDirectory { temp in
             let provider = GitRepositoryProvider()
             let expectedErrorMessage = "not a git repository"
-            do {
-                try _ = provider.isValidDirectory(temp)
-            } catch let error {
+            XCTAssertThrowsError(try provider.isValidDirectory(temp)) {error in
                 let errorString = String(describing: error)
                 XCTAssertTrue(
                     errorString.contains(expectedErrorMessage),

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -40,4 +40,20 @@ class GitRepositoryProviderTests: XCTestCase {
             XCTAssertThrowsError(try provider.isValidDirectory(notGitChildPath))
         }
     }
+
+    func testIsValidDirectoryThrowsPrintableError() throws {
+        try testWithTemporaryDirectory { temp in
+            let provider = GitRepositoryProvider()
+            let expectedErrorMessage = "not a git repository"
+            do {
+                try _ = provider.isValidDirectory(temp)
+            } catch let error {
+                let errorString = String(describing: error)
+                XCTAssertTrue(
+                    errorString.contains(expectedErrorMessage),
+                    "Error string '\(errorString)' should contain '\(expectedErrorMessage)'")
+            }
+        }
+    }
+
 }

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -56,7 +56,7 @@ class GitRepositoryProviderTests: XCTestCase {
         }
     }
 
-    func testGitShelErrorIsPrintable() throws {
+    func testGitShellErrorIsPrintable() throws {
         let stdOut = "An error from Git - stdout"
         let stdErr = "An error from Git - stderr"
         let arguments = ["git", "error"]
@@ -81,7 +81,7 @@ class GitRepositoryProviderTests: XCTestCase {
             "Error string '\(errorString)' should contain '\(command)'")
         }
 
-    func testGitShelErrorEmptyStdOut() throws {
+    func testGitShellErrorEmptyStdOut() throws {
         let stdErr = "An error from Git - stderr"
         let result = AsyncProcessResult(
             arguments: ["git", "error"],
@@ -97,7 +97,7 @@ class GitRepositoryProviderTests: XCTestCase {
             "Error string '\(errorString)' should contain '\(stdErr)'")
         }
 
-    func testGitShelErrorEmptyStdErr() throws {
+    func testGitShellErrorEmptyStdErr() throws {
         let stdOut = "An error from Git - stdout"
         let result = AsyncProcessResult(
             arguments: ["git", "error"],

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -45,11 +45,12 @@ class GitRepositoryProviderTests: XCTestCase {
         try testWithTemporaryDirectory { temp in
             let provider = GitRepositoryProvider()
             let expectedErrorMessage = "not a git repository"
-            XCTAssertThrowsError(try provider.isValidDirectory(temp)) {error in
+            XCTAssertThrowsError(try provider.isValidDirectory(temp)) { error in
                 let errorString = String(describing: error)
                 XCTAssertTrue(
                     errorString.contains(expectedErrorMessage),
-                    "Error string '\(errorString)' should contain '\(expectedErrorMessage)'")
+                    "Error string '\(errorString)' should contain '\(expectedErrorMessage)'"
+                )
             }
         }
     }
@@ -70,14 +71,17 @@ class GitRepositoryProviderTests: XCTestCase {
         let errorString = "\(error)"
         XCTAssertTrue(
             errorString.contains(stdOut),
-            "Error string '\(errorString)' should contain '\(stdOut)'")
+            "Error string '\(errorString)' should contain '\(stdOut)'"
+        )
         XCTAssertTrue(
             errorString.contains(stdErr),
-            "Error string '\(errorString)' should contain '\(stdErr)'")
+            "Error string '\(errorString)' should contain '\(stdErr)'"
+        )
         XCTAssertTrue(
             errorString.contains(command),
-            "Error string '\(errorString)' should contain '\(command)'")
-        }
+            "Error string '\(errorString)' should contain '\(command)'"
+        )
+    }
 
     func testGitShellErrorEmptyStdOut() throws {
         let stdErr = "An error from Git - stderr"
@@ -92,8 +96,9 @@ class GitRepositoryProviderTests: XCTestCase {
         let errorString = "\(error)"
         XCTAssertTrue(
             errorString.contains(stdErr),
-            "Error string '\(errorString)' should contain '\(stdErr)'")
-        }
+            "Error string '\(errorString)' should contain '\(stdErr)'"
+        )
+    }
 
     func testGitShellErrorEmptyStdErr() throws {
         let stdOut = "An error from Git - stdout"
@@ -108,6 +113,7 @@ class GitRepositoryProviderTests: XCTestCase {
         let errorString = "\(error)"
         XCTAssertTrue(
             errorString.contains(stdOut),
-            "Error string '\(errorString)' should contain '\(stdOut)'")
-        }
+            "Error string '\(errorString)' should contain '\(stdOut)'"
+        )
+    }
 }

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -787,9 +787,9 @@ class GitRepositoryTests: XCTestCase {
             let customRemote = "../OriginOfSomePackage.git"
             
             // Before initializing the directory with a git repo, it is never valid.
-            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir))
-            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(packageDir.pathString))))
-            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(customRemote))))
+            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir))
+            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(packageDir.pathString))))
+            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(customRemote))))
             
             initGitRepo(packageDir)
             // Set the remote.
@@ -833,9 +833,9 @@ class GitRepositoryTests: XCTestCase {
             let customRemote = tmpDir.appending("OriginOfSomePackage.git")
             
             // Before initializing the directory with a git repo, it is never valid.
-            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir))
-            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(packageDir.pathString))))
-            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(customRemote.pathString))))
+            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir))
+            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(packageDir.pathString))))
+            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(customRemote.pathString))))
             
             initGitRepo(packageDir)
             // Set the remote.
@@ -883,8 +883,8 @@ class GitRepositoryTests: XCTestCase {
             let customRemote = try XCTUnwrap(URL(string: "https://mycustomdomain/some-package.git"))
             
             // Before initializing the directory with a git repo, it is never valid.
-            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir))
-            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(customRemote))))
+            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir))
+            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(customRemote))))
             
             initGitRepo(packageDir)
             // Set the remote.

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -787,9 +787,9 @@ class GitRepositoryTests: XCTestCase {
             let customRemote = "../OriginOfSomePackage.git"
             
             // Before initializing the directory with a git repo, it is never valid.
-            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir))
-            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(packageDir.pathString))))
-            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(customRemote))))
+            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir))
+            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(packageDir.pathString))))
+            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(customRemote))))
             
             initGitRepo(packageDir)
             // Set the remote.
@@ -833,9 +833,9 @@ class GitRepositoryTests: XCTestCase {
             let customRemote = tmpDir.appending("OriginOfSomePackage.git")
             
             // Before initializing the directory with a git repo, it is never valid.
-            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir))
-            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(packageDir.pathString))))
-            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(customRemote.pathString))))
+            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir))
+            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(packageDir.pathString))))
+            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(customRemote.pathString))))
             
             initGitRepo(packageDir)
             // Set the remote.
@@ -883,8 +883,8 @@ class GitRepositoryTests: XCTestCase {
             let customRemote = try XCTUnwrap(URL(string: "https://mycustomdomain/some-package.git"))
             
             // Before initializing the directory with a git repo, it is never valid.
-            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir))
-            XCTAssertFalse(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(customRemote))))
+            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir))
+            XCTAssertThrowsError(try repositoryManager.isValidDirectory(packageDir, for: RepositorySpecifier(url: SourceControlURL(customRemote))))
             
             initGitRepo(packageDir)
             // Set the remote.

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
Show human-readable git errors

### Motivation:

I noticed that when swiftpm cache is empty and there's a network issue, then `swift build` throws an error which is not helpful, something like this:

```
error: GitShellError(result: <AsyncProcessResult: exit: terminated(code: 128), output:
 
>)
```

where it does say "output" but doesn't actually include output or show any details about what dependency caused the error.

### Modifications:

 - `GitShellError` now conforms to CustomStringConvertible protocol, so that when it is thrown then it will print what was the git error
 - `GitShelError` has now package access to allow catching it explicitly.

### Result:

Errors now tell details of the failure: 

```
error: Git command 'git -C /Users/yy/Library/Caches/org.swift.swiftpm/repositories/postgres-kit-e4358808 config --get remote.origin.url' failed: fatal: cannot change to '/Users/yy/Library/Caches/org.swift.swiftpm/repositories/postgres-kit-e4358808': No such file or directory
```