### PR TITLE
Unify env vars for `Utilities/bootstrap` commands

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -359,16 +359,9 @@ def test(args):
     """Builds SwiftPM, then tests itself."""
     build(args)
 
-    if '-macosx' in args.build_target:
-        extra_env = ["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS=YES"]
-    else:
-        extra_env = []
-
     note("Testing")
     parse_test_args(args)
-    cmd = extra_env + [
-        "SWIFT_EXEC=" + args.swiftc_path,
-        "SWIFT_DRIVER_SWIFT_EXEC=" + args.swiftc_path,
+    cmd = [
         os.path.join(args.bin_dir, "swift-test")
     ]
     if args.parallel:
@@ -646,11 +639,7 @@ def build_swiftpm_with_cmake(args):
 def build_swiftpm_with_swiftpm(args, integrated_swift_driver):
     """Builds SwiftPM using the version of SwiftPM built with CMake."""
 
-    swiftpm_args = [
-        "SWIFT_EXEC=" + args.swiftc_path,
-        "SWIFT_DRIVER_SWIFT_EXEC=" + args.swiftc_path,
-        "CC=" + args.clang_path
-    ]
+    swiftpm_args = []
 
     if args.bootstrap:
         note("Building SwiftPM (with a freshly built swift-bootstrap)")
@@ -777,6 +766,14 @@ def get_swiftpm_env_cmd(args):
             libs_joined = ":".join(libs + args.target_info["paths"]["runtimeLibraryPaths"])
             env_cmd.append("LD_LIBRARY_PATH=%s" % libs_joined)
 
+    if '-macosx' in args.build_target:
+        env_cmd.append("SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS=YES")
+
+    env_cmd += [
+        "SWIFT_EXEC=" + args.swiftc_path,
+        "SWIFT_DRIVER_SWIFT_EXEC=" + args.swiftc_path,
+        "CC=" + args.clang_path,
+    ]
     return env_cmd
 
 def get_swiftpm_flags(args):


### PR DESCRIPTION
This is a prerequisite for enabling incremental builds when running `./Utillities/bootstrap build --release` and `./Utilities/bootstrap test --release` in a sequence.

### Motivation:

Environment variables passed to `swift-bootstrap` from `./Utilities/bootstrap build` and `./Utilities/bootstrap test` commands unnecessarily differed slightly, which caused generated build manifests to be different. This precluded incremental builds when running these commands in a sequence one after each other, slowing down our CI jobs.

### Modifications:

Moved env var computation logic to the existing `get_swiftpm_env_cmd` function in `Utilities/bootstrap`.

### Result:

`swift-bootstrap` is consistently called with the same environment variables, ensuring that generated build manifests can be the same, eventually enabling incremental builds.