### PR TITLE
Use `AbsolutePath.asURL` instead of creating a new URL from the path string

### DIFF
--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -82,15 +82,15 @@ private struct WrappedClangTargetBuildDescription: BuildTarget {
     }
 
     var resources: [URL] {
-        return description.resources.map { URL(fileURLWithPath: $0.path.pathString) }
+        return description.resources.map(\.path.asURL)
     }
 
     var ignored: [URL] {
-        return description.ignored.map { URL(fileURLWithPath: $0.pathString) }
+        return description.ignored.map(\.asURL)
     }
 
     var others: [URL] {
-        return description.others.map { URL(fileURLWithPath: $0.pathString) }
+        return description.others.map(\.asURL)
     }
 
     public var name: String {

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -129,21 +129,21 @@ private struct WrappedSwiftTargetBuildDescription: BuildTarget {
     }
 
     var sources: [URL] {
-        return description.sources.map { URL(fileURLWithPath: $0.pathString) }
+        return description.sources.map(\.asURL)
     }
 
     var headers: [URL] { [] }
 
     var resources: [URL] {
-        return description.resources.map { URL(fileURLWithPath: $0.path.pathString) }
+        return description.resources.map(\.path.asURL)
     }
 
     var ignored: [URL] {
-        return description.ignored.map { URL(fileURLWithPath: $0.pathString) }
+        return description.ignored.map(\.asURL)
     }
 
     var others: [URL] {
-        return description.others.map { URL(fileURLWithPath: $0.pathString) }
+        return description.others.map(\.asURL)
     }
 
     func compileArguments(for fileURL: URL) throws -> [String] {

--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -36,21 +36,21 @@ struct PluginTargetBuildDescription: BuildTarget {
     }
 
     var sources: [URL] {
-        return target.sources.paths.map { URL(fileURLWithPath: $0.pathString) }
+        return target.sources.paths.map(\.asURL)
     }
 
     var headers: [URL] { [] }
 
     var resources: [URL] {
-        return target.underlying.resources.map { URL(fileURLWithPath: $0.path.pathString) }
+        return target.underlying.resources.map(\.path.asURL)
     }
 
     var ignored: [URL] {
-        return target.underlying.ignored.map { URL(fileURLWithPath: $0.pathString) }
+        return target.underlying.ignored.map(\.asURL)
     }
 
     var others: [URL] {
-        return target.underlying.others.map { URL(fileURLWithPath: $0.pathString) }
+        return target.underlying.others.map(\.asURL)
     }
 
     var name: String {


### PR DESCRIPTION
Use `AbsolutePath.asURL` instead of creating a new URL from the path string.

### Motivation:

The original PR that added `resources`, `ignored`, and `other` files to `BuildTarget` should have used `AbsolutePath.asURL` instead of creating a new URL from the path string. This PR fixes that in order to maintain a single location where absolute paths can be converted to URLs.

### Modifications:

I've replaced the `AbsolutePath` to `URL` mappings in `SourceKitLSPAPI` with calls to `AbsolutePath.asURL`.

### Result:

This PR does not have an affect on the functionality of Swift Package Manager.
