### PR TITLE
[cxx-interop] Do not pass `-lc++`/`-lstdc++` flags to the compiler

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -54,27 +54,6 @@ extension BuildPlan {
             }
         }
 
-        // Don't link libc++ or libstd++ when building for Embedded Swift.
-        // Users can still link it manually for embedded platforms when needed,
-        // by providing `-Xlinker -lc++` options via CLI or `Package.swift`.
-        if !buildProduct.product.modules.contains(where: \.underlying.isEmbeddedSwiftTarget) {
-            // Link C++ if needed.
-            // Note: This will come from build settings in future.
-            for description in dependencies.staticTargets {
-                if case let target as ClangModule = description.module.underlying, target.isCXX {
-                    let triple = buildProduct.buildParameters.triple
-                    if triple.isDarwin() {
-                        buildProduct.additionalFlags += ["-lc++"]
-                    } else if triple.isWindows() {
-                        // Don't link any C++ library.
-                    } else {
-                        buildProduct.additionalFlags += ["-lstdc++"]
-                    }
-                    break
-                }
-            }
-        }
-
         for description in dependencies.staticTargets {
             switch description.module.underlying {
             case is SwiftModule:

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1657,7 +1657,6 @@ final class BuildPlanTests: XCTestCase {
         #if os(macOS)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
-            "-lc++",
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -1684,7 +1683,6 @@ final class BuildPlanTests: XCTestCase {
         #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
-            "-lstdc++",
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -2900,15 +2898,7 @@ final class BuildPlanTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(2)
-        var linkArgs = try result.buildProduct(for: "exe").linkArguments()
 
-        #if os(macOS)
-        XCTAssertMatch(linkArgs, ["-lc++"])
-        #elseif !os(Windows)
-        XCTAssertMatch(linkArgs, ["-lstdc++"])
-        #endif
-
-        // Verify that `-lstdc++` is passed instead of `-lc++` when cross-compiling to Linux.
         result = try await BuildPlanResult(plan: mockBuildPlan(
             triple: .arm64Linux,
             graph: graph,
@@ -2917,9 +2907,6 @@ final class BuildPlanTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(2)
-        linkArgs = try result.buildProduct(for: "exe").linkArguments()
-
-        XCTAssertMatch(linkArgs, ["-lstdc++"])
     }
 
     func testDynamicProducts() async throws {
@@ -3282,7 +3269,6 @@ final class BuildPlanTests: XCTestCase {
         #if os(macOS)
         XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), [
             result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
-            "-lc++",
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "liblib.dylib").pathString,
             "-module-name", "lib",
@@ -3336,7 +3322,6 @@ final class BuildPlanTests: XCTestCase {
         #else
         XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), [
             result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
-            "-lstdc++",
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "liblib.so").pathString,
             "-module-name", "lib",


### PR DESCRIPTION
### Motivation:

The Swift compiler has recently introduced support for building with C++ stdlibs which aren't the default on the target platform, specifically libc++ on Linux. The Swift Driver has logic to determine which C++ stdlib should be used, depending on the target and explicit `-Xcc -stdlib=xyz` flags, and link against the requested standard library. Similar functionality exists in Clang Driver. We should defer the C++ stdlib selection to the compiler driver, it shouldn't be necessary to duplicate it in the build system.

### Modifications:

This makes sure that SwiftPM does not explicitly ask the compiler to link against a particular C++ stdlib.

### Result:

Projects that use libc++ on Linux build correctly with SwiftPM.

rdar://141047307