### PR TITLE
Workspace/InitPackage: Add `.vscode` to `.gitignore`

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -439,6 +439,7 @@ public final class InitPackage {
                 .swiftpm/configuration/registries.json
                 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
                 .netrc
+                .vscode
 
                 """
             )


### PR DESCRIPTION
### Motivation:

When using VS Code, this directory gets created, but generally isn't meant to be checked in, similar to Xcode' xcuserdata.

### Modifications:

Added .vscode to the generated .gitignore for new packages.

### Result:

When creating a new package, when an adopter uses VS Code, they won't have to add this entry into their .gitignore by hand.