### PR TITLE
Fix comment typo in `SwiftCommandState.swift`

### DIFF
--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -238,8 +238,8 @@ public final class SwiftCommandState {
 
     /// Holds the currently active workspace.
     ///
-    /// It is not initialized in init() because for some of the commands like package `init`, usage etc,
-    /// workspace is not needed, in-fact it would be an error to ask for the workspace object
+    /// It is not initialized in init() because for some of the commands like `package init`, usage etc,
+    /// a workspace is not needed. In fact it would be an error to ask for the workspace object
     /// for `package init` because the manifest file should *not* be present.
     private var _workspace: Workspace?
     private var _workspaceDelegate: WorkspaceDelegate?

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -238,9 +238,9 @@ public final class SwiftCommandState {
 
     /// Holds the currently active workspace.
     ///
-    /// It is not initialized in init() because for some of the commands like package init , usage etc,
+    /// It is not initialized in init() because for some of the commands like package `init`, usage etc,
     /// workspace is not needed, in-fact it would be an error to ask for the workspace object
-    /// for package init because the Manifest file should *not* present.
+    /// for `package init` because the manifest file should *not* be present.
     private var _workspace: Workspace?
     private var _workspaceDelegate: WorkspaceDelegate?
 


### PR DESCRIPTION
`the manifest file should *not* present` -> `the manifest file should *not* be present`
