### PR TITLE
Fix resolve failing when package from registry is referenced by name

### DIFF
--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -257,11 +257,11 @@ extension Workspace {
                     var modifiedDependencies = [TargetDescription.Dependency]()
                     for dependency in target.dependencies {
                         var modifiedDependency = dependency
-                        if case .product(let name, let packageName, let moduleAliases, let condition) = dependency,
-                           let packageName
-                        {
-                            // makes sure we use the updated package name for target based dependencies
-                            if let modifiedPackageName = targetDependencyPackageNameTransformations[packageName] {
+                        switch dependency {
+                        case let .product(name: name, package: packageName, moduleAliases: moduleAliases, condition: condition):
+                            if let packageName,
+                               // makes sure we use the updated package name for target based dependencies
+                               let modifiedPackageName = targetDependencyPackageNameTransformations[packageName] {
                                 modifiedDependency = .product(
                                     name: name,
                                     package: modifiedPackageName,
@@ -269,6 +269,17 @@ extension Workspace {
                                     condition: condition
                                 )
                             }
+                        case let .byName(name: name, condition: condition):
+                            if let modifiedPackageName = targetDependencyPackageNameTransformations[name] {
+                                modifiedDependency = .product(
+                                    name: name,
+                                    package: modifiedPackageName,
+                                    moduleAliases: [:],
+                                    condition: condition
+                                )
+                            }
+                        case .target:
+                            break
                         }
                         modifiedDependencies.append(modifiedDependency)
                     }

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -269,10 +269,10 @@ extension Workspace {
                                     condition: condition
                                 )
                             }
-                        case let .byName(name: name, condition: condition):
-                            if let modifiedPackageName = targetDependencyPackageNameTransformations[name] {
+                        case let .byName(name: packageName, condition: condition):
+                            if let modifiedPackageName = targetDependencyPackageNameTransformations[packageName] {
                                 modifiedDependency = .product(
-                                    name: name,
+                                    name: packageName,
                                     package: modifiedPackageName,
                                     moduleAliases: [:],
                                     condition: condition

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -258,10 +258,16 @@ extension Workspace {
                     for dependency in target.dependencies {
                         var modifiedDependency = dependency
                         switch dependency {
-                        case let .product(name: name, package: packageName, moduleAliases: moduleAliases, condition: condition):
+                        case .product(
+                            name: let name,
+                            package: let packageName,
+                            moduleAliases: let moduleAliases,
+                            condition: let condition
+                        ):
                             if let packageName,
                                // makes sure we use the updated package name for target based dependencies
-                               let modifiedPackageName = targetDependencyPackageNameTransformations[packageName] {
+                               let modifiedPackageName = targetDependencyPackageNameTransformations[packageName]
+                            {
                                 modifiedDependency = .product(
                                     name: name,
                                     package: modifiedPackageName,
@@ -269,7 +275,7 @@ extension Workspace {
                                     condition: condition
                                 )
                             }
-                        case let .byName(name: packageName, condition: condition):
+                        case .byName(name: let packageName, condition: let condition):
                             if let modifiedPackageName = targetDependencyPackageNameTransformations[packageName] {
                                 modifiedDependency = .product(
                                     name: packageName,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -12814,7 +12814,7 @@ final class WorkspaceTests: XCTestCase {
         )
     }
     
-    func testTransitiveResolutionFromRegistryWithByNameReferencesWhenSourceControlToRegistryDependencyTransformationIsSwizzle() async throws {
+    func testTransitiveResolutionFromRegistryWithByNameDependencies() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -12878,10 +12878,12 @@ final class WorkspaceTests: XCTestCase {
                 result.check(roots: "Root")
                 result.check(packages: "org.bar", "org.foo", "Root")
                 result.check(modules: "FooTarget", "BarTarget", "RootTarget")
-                result
-                    .checkTarget("RootTarget") { result in result.check(dependencies: "FooProduct") }
-                result
-                    .checkTarget("FooTarget") { result in result.check(dependencies: "Bar") }
+                result.checkTarget("RootTarget") { result in 
+                    result.check(dependencies: "FooProduct")
+                }
+                result.checkTarget("FooTarget") { result in
+                    result.check(dependencies: "Bar")
+                }
             }
         }
         

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -12856,7 +12856,7 @@ final class WorkspaceTests: XCTestCase {
                     alternativeURLs: ["https://git/org/foo"],
                     targets: [
                         MockTarget(name: "FooTarget", dependencies: [
-                            "Bar"
+                            "Bar",
                         ]),
                     ],
                     products: [
@@ -12871,14 +12871,14 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.sourceControlToRegistryDependencyTransformation = .swizzle
-        
+
         try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "org.bar", "org.foo", "Root")
                 result.check(modules: "FooTarget", "BarTarget", "RootTarget")
-                result.checkTarget("RootTarget") { result in 
+                result.checkTarget("RootTarget") { result in
                     result.check(dependencies: "FooProduct")
                 }
                 result.checkTarget("FooTarget") { result in
@@ -12886,7 +12886,7 @@ final class WorkspaceTests: XCTestCase {
                 }
             }
         }
-        
+
         workspace.checkManagedDependencies { result in
             result.check(dependency: "org.foo", at: .registryDownload("1.2.0"))
             result.check(dependency: "org.bar", at: .registryDownload("1.1.0"))


### PR DESCRIPTION
Fix resolve failing when package from registry is referenced by name

### Motivation:

When running `swift package --replace-scm-with-registry --default-registry-url {our-registry-url} resolve`, the command fails when depending on packages that reference their transitive dependencies by name.

I created a [demo](https://github.com/fortmarek/spm-registry-by-name-references) where you can reproduce the issue by running `swift package --replace-scm-with-registry --default-registry-url {our-registry-url} resolve`. You should see the following error:
```
error: 'cpisciotta.xcbeautify': unknown dependency 'Colorizer' in target 'XcbeautifyLib'; valid dependencies are: 'swift-argument-parser' (from 'https://github.com/apple/swift-argument-parser.git'), 'getGuaka.Colorizer', 'MaxDesiatov.XMLCoder'
error: 'cpisciotta.xcbeautify': unknown dependency 'XMLCoder' in target 'XcbeautifyLib'; valid dependencies are: 'swift-argument-parser' (from 'https://github.com/apple/swift-argument-parser.git'), 'getGuaka.Colorizer', 'MaxDesiatov.XMLCoder'
```

The issue boils down to:
```swift
// Root Package.swift
import PackageDescription

let package = Package(
    name: "package-test",
    dependencies: [
        // We're depending on `xcbeautify` from our root `Package.swift`
        .package(url: "https://github.com/cpisciotta/xcbeautify", exact: "2.13.0")
    ],
    targets: [
        .target(name: "package-test"),
    ]
)

// Package.swift at https://github.com/cpisciotta/xcbeautify/blob/main/Package.swift
import PackageDescription

let package = Package(
    name: "xcbeautify",
    products: [
        .library(name: "XcbeautifyLib", targets: ["XcbeautifyLib"]),
    ],
    dependencies: [
        .package(
            url: "https://github.com/getGuaka/Colorizer.git",
            .upToNextMinor(from: "0.2.1")
        ),
        .package(
            url: "https://github.com/MaxDesiatov/XMLCoder.git",
            .upToNextMinor(from: "0.17.1")
        ),
    ],
    targets: [
        .target(
            name: "XcbeautifyLib",
            dependencies: [
                // Transitive package products referenced by name
                "Colorizer",
                "XMLCoder",
            ]
        ),
    ]
)
```

The issue is that when swizzling the package product names to their identity counterparts, only dependencies referenced via `.product(...)` are swizzled. Indeed, when we change the `XcbeautifyLib`'s dependencies to:
```swift
.product(name: "Colorizer", package: "Colorizer"),
.product(name: "XMLCoder", package: "XMLCoder"),
```

the resolution succeeds.

### Modifications:

To fix the above issue, we swizzle also dependencies referenced by name _iff_ the product name is the same as the package name the root depends on. This aligns with how `byName` is treated in other parts of the codebase, such as [here](https://github.com/swiftlang/swift-package-manager/blob/main/Sources/PackageModel/Manifest/Manifest.swift#L407).

### Result:

`swift package --replace-scm-with-registry --default-registry-url {our-registry-url} resolve` succeeds when run in the [repro sample](https://github.com/fortmarek/spm-registry-by-name-references).
