### PR TITLE
Update owners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,4 +26,4 @@
 
 Sources/XCBuildSupport/* @jakepetroules
 
-* @bnbarham @MaxDesiatov @jakepetroules @francescomikulis @xedin @dschaefer2 @shawnhyam @bripeticca @plemarquand @owenv
+* @bnbarham @MaxDesiatov @jakepetroules @francescomikulis @xedin @dschaefer2 @shawnhyam @bripeticca @plemarquand @owenv @bkhouri


### PR DESCRIPTION
Although I don't have commit access, yet, I've been working on trying to get the self-hosted macOS pipeline to use the nightly toolchain.  Updating the `CODEOWNERS` file will hopefully allow me to trigger the macOS self-hosted nightly toolchain without depending/waiting on another developer to do it for me.