### PR TITLE
Add `--experimental-attachments-path` to `swift test`.

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -119,6 +119,11 @@ struct TestEventStreamOptions: ParsableArguments {
     @Option(name: .customLong("event-stream-version"),
             help: .hidden)
     var eventStreamVersion: Int?
+
+  /// Experimental path for writing attachments (Swift Testing only.)
+  @Option(name: .customLong("experimental-attachments-path"),
+          help: .private)
+  var experimentalAttachmentsPath: AbsolutePath?
 }
 
 struct TestCommandOptions: ParsableArguments {


### PR DESCRIPTION
This PR adds the given experimental command-line argument to `swift test` to allow writing attachments to a user-supplied directory when using Swift Testing. In the future, we will formally propose this flag as part of the attachments feature.

XCTest on Darwin would need separate changes to support this argument and they are beyond the scope of this PR. XCTest on non-Darwin platforms (corelibs-xctest) does not support attachments.

Resolves rdar://141225464.