### PR TITLE
version: set the version back to 6.1.0

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -58,7 +58,7 @@ public struct SwiftVersion: Sendable {
 extension SwiftVersion {
     /// The current version of the package manager.
     public static let current = SwiftVersion(
-        version: (6, 2, 0),
+        version: (6, 1, 0),
         isDevelopment: true,
         buildIdentifier: getBuildIdentifier()
     )


### PR DESCRIPTION
Update the branch to accurately reflect the version.

### Motivation:

Need to accurately display the version

### Modifications:

Reverted https://github.com/swiftlang/swift-package-manager/pull/8135 

### Result:

N/A