### PR TITLE
[Traits] Only allow valid Swift identifiers

### DIFF
--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -107,18 +107,9 @@ public struct ManifestValidator {
                 continue
             }
 
-            for (index, unicodeScalar) in traitName.unicodeScalars.enumerated() {
-                let properties = unicodeScalar.properties
-
-                if index == 0 {
-                    if !(properties.isIDStart || properties.isASCIIHexDigit || unicodeScalar == "_") {
-                        diagnostics.append(.invalidFirstCharacterInTrait(firstCharater: unicodeScalar, trait: trait.name))
-                    }
-                } else {
-                    if !(properties.isXIDContinue || unicodeScalar == "_" || unicodeScalar == "+") {
-                        diagnostics.append(.invalidCharacterInTrait(character: unicodeScalar, trait: trait.name))
-                    }
-                }
+            guard traitName.isValidIdentifier else {
+                diagnostics.append(.invalidTraitName(trait: traitName))
+                continue
             }
         }
 
@@ -365,12 +356,8 @@ extension Basics.Diagnostic {
         .error("Empty strings are not allowed as trait names")
     }
 
-    static func invalidFirstCharacterInTrait(firstCharater: UnicodeScalar, trait: String) -> Self {
-        .error("Invalid first character (\(firstCharater)) in trait \(trait). The first character must be a Unicode XID start character (most letters), a digit, or _.")
-    }
-
-    static func invalidCharacterInTrait(character: UnicodeScalar, trait: String) -> Self {
-        .error("Invalid character \(character) in trait \(trait). Characters must be a Unicode XID continue character (a digit, _, or most letters), -, or +")
+    static func invalidTraitName(trait: String) -> Self {
+        .error("Invalid trait name \(trait). Trait names must be valid Swift identifiers")
     }
 
     static func invalidEnabledTrait(trait: String, enabledBy enablerTrait: String) -> Self {

--- a/Tests/PackageLoadingTests/TraitLoadingTests.swift
+++ b/Tests/PackageLoadingTests/TraitLoadingTests.swift
@@ -95,7 +95,6 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
             ".",
             "?",
             ",",
-            "ⒶⒷⒸ",
         ]
 
         for traitName in invalidTraitNames {
@@ -114,7 +113,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
             XCTAssertNoDiagnostics(observability.diagnostics)
             let firstDiagnostic = try XCTUnwrap(validationDiagnostics.first)
             XCTAssertEqual(firstDiagnostic.severity, .error)
-            XCTAssertEqual(firstDiagnostic.message, "Invalid first character (\(traitName.first!)) in trait \(traitName). The first character must be a Unicode XID start character (most letters), a digit, or _.")
+            XCTAssertEqual(firstDiagnostic.message, "Invalid trait name \(traitName). Trait names must be valid Swift identifiers")
         }
     }
 
@@ -129,7 +128,6 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
             "foo,",
             "foo:bar",
             "foo?",
-            "a¼",
         ]
 
         for traitName in invalidTraitNames {


### PR DESCRIPTION
# Motivation

During the proposal review it was brought up that the rules around trait names wasn't inline with Swift identifiers. Neither was the implementation which was inline with the proposal.

# Modification

This PR changes our validation logic to only allow valid Swift identifiers.

# Result

Only allows trait names that can be used as Swift identifiers.
