### PR TITLE
[Traits] Remove experimental and SPI guards

### DIFF
--- a/Fixtures/Traits/Example/Package.swift
+++ b/Fixtures/Traits/Example/Package.swift
@@ -1,6 +1,6 @@
-// swift-tools-version: 999.0.0
+// swift-tools-version: 6.1
 
-@_spi(ExperimentalTraits) import PackageDescription
+import PackageDescription
 
 let package = Package(
     name: "TraitsExample",

--- a/Fixtures/Traits/Package1/Package.swift
+++ b/Fixtures/Traits/Package1/Package.swift
@@ -1,6 +1,6 @@
-// swift-tools-version: 999.0.0
+// swift-tools-version: 6.1
 
-@_spi(ExperimentalTraits) import PackageDescription
+import PackageDescription
 
 let package = Package(
     name: "Package1",

--- a/Fixtures/Traits/Package10/Package.swift
+++ b/Fixtures/Traits/Package10/Package.swift
@@ -1,6 +1,6 @@
-// swift-tools-version: 999.0.0
+// swift-tools-version: 6.1
 
-@_spi(ExperimentalTraits) import PackageDescription
+import PackageDescription
 
 let package = Package(
     name: "Package10",

--- a/Fixtures/Traits/Package2/Package.swift
+++ b/Fixtures/Traits/Package2/Package.swift
@@ -1,6 +1,6 @@
-// swift-tools-version: 999.0.0
+// swift-tools-version: 6.1
 
-@_spi(ExperimentalTraits) import PackageDescription
+import PackageDescription
 
 let package = Package(
     name: "Package2",

--- a/Fixtures/Traits/Package3/Package.swift
+++ b/Fixtures/Traits/Package3/Package.swift
@@ -1,6 +1,6 @@
-// swift-tools-version: 999.0.0
+// swift-tools-version: 6.1
 
-@_spi(ExperimentalTraits) import PackageDescription
+import PackageDescription
 
 let package = Package(
     name: "Package3",

--- a/Fixtures/Traits/Package4/Package.swift
+++ b/Fixtures/Traits/Package4/Package.swift
@@ -1,6 +1,6 @@
-// swift-tools-version: 999.0.0
+// swift-tools-version: 6.1
 
-@_spi(ExperimentalTraits) import PackageDescription
+import PackageDescription
 
 let package = Package(
     name: "Package4",

--- a/Fixtures/Traits/Package5/Package.swift
+++ b/Fixtures/Traits/Package5/Package.swift
@@ -1,6 +1,6 @@
-// swift-tools-version: 999.0.0
+// swift-tools-version: 6.1
 
-@_spi(ExperimentalTraits) import PackageDescription
+import PackageDescription
 
 let package = Package(
     name: "Package5",

--- a/Fixtures/Traits/Package6/Package.swift
+++ b/Fixtures/Traits/Package6/Package.swift
@@ -1,6 +1,6 @@
-// swift-tools-version: 999.0.0
+// swift-tools-version: 6.1
 
-@_spi(ExperimentalTraits) import PackageDescription
+import PackageDescription
 
 let package = Package(
     name: "Package6",

--- a/Fixtures/Traits/Package7/Package.swift
+++ b/Fixtures/Traits/Package7/Package.swift
@@ -1,6 +1,6 @@
-// swift-tools-version: 999.0.0
+// swift-tools-version: 6.1
 
-@_spi(ExperimentalTraits) import PackageDescription
+import PackageDescription
 
 let package = Package(
     name: "Package7",

--- a/Fixtures/Traits/Package8/Package.swift
+++ b/Fixtures/Traits/Package8/Package.swift
@@ -1,6 +1,6 @@
-// swift-tools-version: 999.0.0
+// swift-tools-version: 6.1
 
-@_spi(ExperimentalTraits) import PackageDescription
+import PackageDescription
 
 let package = Package(
     name: "Package8",

--- a/Fixtures/Traits/Package9/Package.swift
+++ b/Fixtures/Traits/Package9/Package.swift
@@ -1,6 +1,6 @@
-// swift-tools-version: 999.0.0
+// swift-tools-version: 6.1
 
-@_spi(ExperimentalTraits) import PackageDescription
+import PackageDescription
 
 let package = Package(
     name: "Package9",

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -647,7 +647,7 @@ package struct TraitOptions: ParsableArguments {
 
     /// The traits to enable for the package.
     @Option(
-        name: .customLong("experimental-traits"),
+        name: .customLong("traits"),
         help: "Enables the passed traits of the package. Multiple traits can be specified by providing a space separated list e.g. `--traits Trait1 Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command."
     )
     package var _enabledTraits: String?
@@ -659,14 +659,14 @@ package struct TraitOptions: ParsableArguments {
 
     /// Enables all traits of the package.
     @Flag(
-        name: .customLong("experimental-enable-all-traits"),
+        name: .customLong("enable-all-traits"),
         help: "Enables all traits of the package."
     )
     package var enableAllTraits: Bool = false
 
     /// Disables all default traits of the package.
     @Flag(
-        name: .customLong("experimental-disable-default-traits"),
+        name: .customLong("disable-default-traits"),
         help: "Disables all default traits of the package."
     )
     public var disableDefaultTraits: Bool = false

--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -83,8 +83,7 @@ public struct BuildSettingCondition: Sendable {
     ///   - platforms: The applicable platforms for this build setting condition.
     ///   - configuration: The applicable build configuration for this build setting condition.
     ///   - traits: The applicable traits for this build setting condition.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func when(
         platforms: [Platform]? = nil,
         configuration: BuildConfiguration? = nil,

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -51,7 +51,6 @@ extension Package {
         public let kind: Kind
 
         /// The dependencies traits configuration.
-        @_spi(ExperimentalTraits)
         @available(_PackageDescription, introduced: 999.0)
         public let traits: Set<Trait>
 
@@ -224,8 +223,7 @@ extension Package.Dependency {
     /// - Parameter traits: The trait configuration of this dependency. Defaults to enabling the default traits.
     ///
     /// - Returns: A package dependency.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func package(
         path: String,
         traits: Set<Trait> = [.defaults]
@@ -266,8 +264,7 @@ extension Package.Dependency {
     ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
     ///
     /// - Returns: A package dependency.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func package(
         name: String,
         path: String,
@@ -332,8 +329,7 @@ extension Package.Dependency {
     ///    - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
     ///
     /// - Returns: A `Package.Dependency` instance.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func package(
         url: String,
         from version: Version,
@@ -408,8 +404,7 @@ extension Package.Dependency {
     ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
     ///
     /// - Returns: A `Package.Dependency` instance.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func package(
         url: String,
         branch: String,
@@ -470,8 +465,7 @@ extension Package.Dependency {
     ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
     ///
     /// - Returns: A `Package.Dependency` instance.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func package(
         url: String,
         revision: String,
@@ -541,8 +535,7 @@ extension Package.Dependency {
     ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
     ///
     /// - Returns: A `Package.Dependency` instance.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func package(
         url: String,
         _ range: Range<Version>,
@@ -616,8 +609,7 @@ extension Package.Dependency {
     ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
     ///
     /// - Returns: A `Package.Dependency` instance.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func package(
         url: String,
         _ range: ClosedRange<Version>,
@@ -779,8 +771,7 @@ extension Package.Dependency {
     ///   - traits: The trait configuration of this dependency.  Defaults to enabling the default traits.
     ///
     /// - Returns: A `Package.Dependency` instance.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func package(
         url: String,
         exact version: Version,
@@ -900,8 +891,7 @@ extension Package.Dependency {
     ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
     ///
     /// - Returns: A `Package.Dependency` instance.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func package(
         id: String,
         from version: Version,
@@ -955,8 +945,7 @@ extension Package.Dependency {
     ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
     ///
     /// - Returns: A `Package.Dependency` instance.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func package(
         id: String,
         exact version: Version,
@@ -1032,8 +1021,7 @@ extension Package.Dependency {
     ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
     ///
     /// - Returns: A `Package.Dependency` instance.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func package(
         id: String,
         _ range: Range<Version>,
@@ -1087,8 +1075,7 @@ extension Package.Dependency {
     ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
     ///
     /// - Returns: A `Package.Dependency` instance.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func package(
         id: String,
         _ range: ClosedRange<Version>,

--- a/Sources/PackageDescription/PackageDependencyTrait.swift
+++ b/Sources/PackageDescription/PackageDependencyTrait.swift
@@ -12,8 +12,7 @@
 
 extension Package.Dependency {
     /// A struct representing an enabled trait of a dependency.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public struct Trait: Hashable, Sendable, ExpressibleByStringLiteral {
         /// Enables all default traits of a package.
         public static let defaults = Self.init(name: "default")

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -101,8 +101,7 @@ public final class Package {
     public var products: [Product]
 
     /// The set of traits of this package.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public var traits: Set<Trait>
 
     /// The list of package dependencies.
@@ -352,8 +351,7 @@ public final class Package {
     ///   - swiftLanguageModes: The list of Swift language modes with which this package is compatible.
     ///   - cLanguageStandard: The C language standard to use for all C targets in this package.
     ///   - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public init(
         name: String,
         defaultLocalization: LanguageTag? = nil,

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -1393,8 +1393,7 @@ public struct TargetDependencyCondition: Sendable {
     ///
     /// - Parameter platforms: The applicable platforms for this target dependency condition.
     /// - Parameter traits: The applicable traits for this target dependency condition.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func when(
         platforms: [Platform],
         traits: Set<String>
@@ -1405,8 +1404,7 @@ public struct TargetDependencyCondition: Sendable {
     /// Creates a target dependency condition.
     ///
     /// - Parameter traits: The applicable traits for this target dependency condition.
-    @_spi(ExperimentalTraits)
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.1)
     public static func when(
         traits: Set<String>
     ) -> TargetDependencyCondition? {

--- a/Sources/PackageDescription/Trait.swift
+++ b/Sources/PackageDescription/Trait.swift
@@ -15,8 +15,7 @@
 /// Traits can be used for expressing conditional compilation and optional dependencies.
 ///
 /// - Important: Traits must be strictly additive and enabling a trait **must not** remove API.
-@_spi(ExperimentalTraits)
-@available(_PackageDescription, introduced: 999.0)
+@available(_PackageDescription, introduced: 6.1)
 public struct Trait: Hashable, ExpressibleByStringLiteral {
     /// Declares the default traits for this package.
     public static func `default`(enabledTraits: Set<String>) -> Self {

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -524,7 +524,7 @@ extension Manifest: Encodable {
     private enum CodingKeys: CodingKey {
         case name, path, url, version, targetMap, toolsVersion,
              pkgConfig, providers, cLanguageStandard, cxxLanguageStandard, swiftLanguageVersions,
-             dependencies, products, targets, experimentalTraits, platforms, packageKind, revision,
+             dependencies, products, targets, traits, platforms, packageKind, revision,
              defaultLocalization
     }
 
@@ -555,7 +555,7 @@ extension Manifest: Encodable {
         try container.encode(self.dependencies, forKey: .dependencies)
         try container.encode(self.products, forKey: .products)
         try container.encode(self.targets, forKey: .targets)
-        try container.encode(self.traits, forKey: .experimentalTraits)
+        try container.encode(self.traits, forKey: .traits)
         try container.encode(self.platforms, forKey: .platforms)
         try container.encode(self.packageKind, forKey: .packageKind)
     }

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -38,7 +38,7 @@ final class TraitTests: XCTestCase {
 
     func testTraits_whenTraitUnification() async throws {
         try await fixture(name: "Traits") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "default,Package9,Package10"])
+            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--traits", "default,Package9,Package10"])
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
             // When fixed, GitHub issue #8131 should re-enable the below assert.
             // XCTAssertFalse(stderr.contains("warning:"))
@@ -61,7 +61,7 @@ final class TraitTests: XCTestCase {
 
     func testTraits_whenTraitUnification_whenSecondTraitNotEnabled() async throws {
         try await fixture(name: "Traits") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "default,Package9"])
+            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--traits", "default,Package9"])
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
             // When fixed, GitHub issue #8131 should re-enable the below assert.
             // XCTAssertFalse(stderr.contains("warning:"))
@@ -82,7 +82,7 @@ final class TraitTests: XCTestCase {
 
     func testTraits_whenIndividualTraitsEnabled_andDefaultTraits() async throws {
         try await fixture(name: "Traits") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "default,Package5,Package7,BuildCondition3"])
+            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--traits", "default,Package5,Package7,BuildCondition3"])
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
             // When fixed, GitHub issue #8131 should re-enable the below assert.
             // XCTAssertFalse(stderr.contains("warning:"))
@@ -104,7 +104,7 @@ final class TraitTests: XCTestCase {
 
     func testTraits_whenDefaultTraitsDisabled() async throws {
         try await fixture(name: "Traits") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-disable-default-traits"])
+            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--disable-default-traits"])
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
             // When fixed, GitHub issue #8131 should re-enable the below assert.
             // XCTAssertFalse(stderr.contains("warning:"))
@@ -119,7 +119,7 @@ final class TraitTests: XCTestCase {
 
     func testTraits_whenIndividualTraitsEnabled_andDefaultTraitsDisabled() async throws {
         try await fixture(name: "Traits") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "Package5,Package7"])
+            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--traits", "Package5,Package7"])
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
             // When fixed, GitHub issue #8131 should re-enable the below assert.
             // XCTAssertFalse(stderr.contains("warning:"))
@@ -137,7 +137,7 @@ final class TraitTests: XCTestCase {
 
     func testTraits_whenAllTraitsEnabled() async throws {
         try await fixture(name: "Traits") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-enable-all-traits"])
+            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--enable-all-traits"])
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
             // GitHub issue #8131
             // XCTAssertFalse(stderr.contains("warning:"))
@@ -163,7 +163,7 @@ final class TraitTests: XCTestCase {
 
     func testTraits_whenAllTraitsEnabled_andDefaultTraitsDisabled() async throws {
         try await fixture(name: "Traits") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-enable-all-traits", "--experimental-disable-default-traits"])
+            let (stdout, stderr) = try await executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--enable-all-traits", "--disable-default-traits"])
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
             // GitHub issue #8131
             // XCTAssertFalse(stderr.contains("warning:"))
@@ -193,7 +193,7 @@ final class TraitTests: XCTestCase {
             let (dumpOutput, _) = try await SwiftPM.Package.execute(["dump-package"], packagePath: packageRoot)
             let json = try JSON(bytes: ByteString(encodingAsUTF8: dumpOutput))
             guard case let .dictionary(contents) = json else { XCTFail("unexpected result"); return }
-            guard case let .array(traits)? = contents["experimentalTraits"] else { XCTFail("unexpected result"); return }
+            guard case let .array(traits)? = contents["traits"] else { XCTFail("unexpected result"); return }
             XCTAssertEqual(traits.count, 12)
         }
     }
@@ -217,7 +217,7 @@ final class TraitTests: XCTestCase {
 
     func testTests_whenAllTraitsEnabled_andDefaultTraitsDisabled() async throws {
         try await fixture(name: "Traits") { fixturePath in
-            let (stdout, _) = try await executeSwiftTest(fixturePath.appending("Example"), extraArgs: ["--experimental-enable-all-traits", "--experimental-disable-default-traits"])
+            let (stdout, _) = try await executeSwiftTest(fixturePath.appending("Example"), extraArgs: ["--enable-all-traits", "--disable-default-traits"])
             let expectedOut = """
             Package1Library1 trait1 enabled
             Package2Library1 trait2 enabled

--- a/Tests/PackageLoadingTests/TraitLoadingTests.swift
+++ b/Tests/PackageLoadingTests/TraitLoadingTests.swift
@@ -24,7 +24,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
 
     func testTraits() async throws {
         let content =  """
-            @_spi(ExperimentalTraits) import PackageDescription
+            import PackageDescription
             let package = Package(
                 name: "Foo",
                 traits: [
@@ -50,7 +50,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
     func testTraits_whenTooMany() async throws {
         let traits = Array(0...300).map { "\"Trait\($0)\"" }.joined(separator: ",")
         let content =  """
-            @_spi(ExperimentalTraits) import PackageDescription
+            import PackageDescription
             let package = Package(
                 name: "Foo",
                 traits: [\(traits)]
@@ -67,7 +67,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
 
     func testTraits_whenUnknownEnabledTrait() async throws {
         let content =  """
-            @_spi(ExperimentalTraits) import PackageDescription
+            import PackageDescription
             let package = Package(
                 name: "Foo",
                 traits: [
@@ -99,7 +99,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
 
         for traitName in invalidTraitNames {
             let content =  """
-            @_spi(ExperimentalTraits) import PackageDescription
+            import PackageDescription
             let package = Package(
                 name: "Foo",
                 traits: [
@@ -132,7 +132,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
 
         for traitName in invalidTraitNames {
             let content =  """
-            @_spi(ExperimentalTraits) import PackageDescription
+            import PackageDescription
             let package = Package(
                 name: "Foo",
                 traits: [
@@ -151,7 +151,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
 
     func testDefaultTraits() async throws {
         let content =  """
-            @_spi(ExperimentalTraits) import PackageDescription
+            import PackageDescription
             let package = Package(
                 name: "Foo",
                 traits: [
@@ -178,7 +178,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
 
     func testDependencies() async throws {
         let content =  """
-            @_spi(ExperimentalTraits) import PackageDescription
+            import PackageDescription
             let package = Package(
                 name: "Foo",
                 traits: [


### PR DESCRIPTION
# Motivation

Traits got oficially accepted https://forums.swift.org/t/accepted-with-modifications-se-0450-package-traits/76705 so we can remove the the SPI and experimental guards now.

# Modification

This PR removes the SPI for traits, makes the availability 6.1, and removes the experimental prefix from all the arguments.

# Result

Traits are becoming an official feature.