### PR TITLE
Tool version updates

### DIFF
--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -32,6 +32,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
     public static let v5_9 = ToolsVersion(version: "5.9.0")
     public static let v5_10 = ToolsVersion(version: "5.10.0")
     public static let v6_0 = ToolsVersion(version: "6.0.0")
+    public static let v6_1 = ToolsVersion(version: "6.1.0")
     public static let vNext = ToolsVersion(version: "999.0.0")
 
     /// The current tools version in use.

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -218,10 +218,24 @@ final class WorkspaceTests: XCTestCase {
             }
 
             do {
+                let ws = try createWorkspace(
+                    """
+                    // swift-tools-version:5.9.2
+                    import PackageDescription
+                    let package = Package(
+                        name: "foo"
+                    )
+                    """
+                )
+
+                XCTAssertMatch(try ws.interpreterFlags(for: packageManifest), [.equal("-swift-version"), .equal("5")])
+            }
+
+            do {
                 // Invalid package manifest should still produce build settings.
                 let ws = try createWorkspace(
                     """
-                    // swift-tools-version:999.0
+                    // swift-tools-version:5.9.2
                     import PackageDescription
                     """
                 )
@@ -4122,7 +4136,7 @@ final class WorkspaceTests: XCTestCase {
                         .sourceControl(url: "https://localhost/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
                         .sourceControl(url: "https://localhost/org/bar", requirement: .upToNextMinor(from: "1.1.0"))
                     ],
-                    toolsVersion: .vNext // change to the one after 5.9
+                    toolsVersion: .v5_10
                 ),
             ],
             packages: [

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -32,6 +32,9 @@ set -x
 
 env | sort
 
+# Display toolchain version
+swift --version
+
 # Perform package update in order to get the latest commits for the dependencies.
 swift package update
 swift build -c $CONFIGURATION


### PR DESCRIPTION
Update the `ToolsVersion` data structure to include the 6.1.0 release, and update some references to ToolsVersion.vNext and 999.0 to non-development releases.


References:
- https://github.com/swiftlang/swift-package-manager/pull/8139
- https://github.com/swiftlang/swift-package-manager/pull/8074