### PR TITLE
Fix registry resolution of major alternate package manifests 

### DIFF
--- a/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
@@ -200,6 +200,8 @@ public class RegistryPackageContainer: PackageContainer {
                                             return true
                                         } else if preferredToolsVersion.patch == 0, file == Manifest.basename + "@swift-\(preferredToolsVersion.major).\(preferredToolsVersion.minor).swift" {
                                             return true
+                                        } else if preferredToolsVersion.patch == 0, preferredToolsVersion.minor == 0, file == Manifest.basename + "@swift-\(preferredToolsVersion.major).swift" {
+                                            return true
                                         } else {
                                             return false
                                         }


### PR DESCRIPTION
### Motivation:

Let's take the following `Package.swift`:
```swift
// swift-tools-version: 5.7

import PackageDescription

let package = Package(
    name: "Library",
    dependencies: [
        .package(id: "AliSoftware.OHHTTPStubs", exact: "9.0.0")
    ]
)
```

You can find the `OHHTTPStubs` dependency at that version [here](https://github.com/AliSoftware/OHHTTPStubs/tree/e92b5a5746ef16add2a1424f1fc19529d9a75cde).

The dependency has two manifests:
- `Package.swift` with `swift-tools-version` at `4.0`
- `Package@swift-5.swift` with `swift-tools-version` at `5.0`

When resolving packages via the registry, SwiftPM should use the `Package@swift-5.swift`. However, instead SwiftPM fails with:
```
Running resolver because the following dependencies were added: 'AliSoftware.OHHTTPStubs' (AliSoftware.OHHTTPStubs)
Computing version for AliSoftware.OHHTTPStubs
info: 'AliSoftware.OHHTTPStubs': retrieving AliSoftware.OHHTTPStubs metadata from http://localhost:8080/api/accounts/tuist/registry/swift/AliSoftware/OHHTTPStubs
info: 'AliSoftware.OHHTTPStubs': retrieving AliSoftware.OHHTTPStubs 9.0.0 metadata from http://localhost:8080/api/accounts/tuist/registry/swift/AliSoftware/OHHTTPStubs/9.0.0
info: 'AliSoftware.OHHTTPStubs': retrieving available manifests for AliSoftware.OHHTTPStubs 9.0.0 from http://localhost:8080/api/accounts/tuist/registry/swift/AliSoftware/OHHTTPStubs/9.0.0/Package.swift
info: 'AliSoftware.OHHTTPStubs': retrieving AliSoftware.OHHTTPStubs 9.0.0 metadata from http://localhost:8080/api/accounts/tuist/registry/swift/AliSoftware/OHHTTPStubs/9.0.0
info: 'AliSoftware.OHHTTPStubs': retrieving AliSoftware.OHHTTPStubs 9.0.0 manifest from http://localhost:8080/api/accounts/tuist/registry/swift/AliSoftware/OHHTTPStubs/9.0.0/Package.swift?swift-version=5.0.0
error: failed locating placeholder manifest for 5.0.0
```

### Modifications:

The reason for the error is because when looking up the alternate package manifests from the downloaded source archive, SwiftPM doesn't try to find `Package@swift-5.swift` – only `Package@swift-5.0.swift` and `Package@swift-5.0.0.swift`.

When both minor and patch versions of the swift tools version are 0, SwiftPM should try to use the `Package@swift-5.swift` alternate manifest.

### Result:

_[After your change, what will change.]_

`swift package resolve` will work for packages in a registry that have alternate manifests in the format of `Package@X-swift.swift`.
