### PR TITLE
Fix registry package swizzling when package name casing differs

### DIFF
--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -152,7 +152,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
                 return settings.nameForTargetDependencyResolutionOnly ?? PackageIdentityParser.computeDefaultName(fromURL: url)
             }
         case .registry:
-            return self.identity.description
+            return self.identity.description.lowercased()
         }
     }
 

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -220,7 +220,7 @@ extension Workspace {
                                     info: "swizzling '\(dependency.locationString)' with registry dependency '\(registryIdentity)'."
                                 )
                             targetDependencyPackageNameTransformations[dependency
-                                .nameForModuleDependencyResolutionOnly] = registryIdentity.description
+                                .nameForModuleDependencyResolutionOnly.lowercased()] = registryIdentity.description
                             modifiedDependency = .registry(
                                 identity: registryIdentity,
                                 requirement: requirement,
@@ -261,7 +261,7 @@ extension Workspace {
                            let packageName
                         {
                             // makes sure we use the updated package name for target based dependencies
-                            if let modifiedPackageName = targetDependencyPackageNameTransformations[packageName] {
+                            if let modifiedPackageName = targetDependencyPackageNameTransformations[packageName.lowercased()] {
                                 modifiedDependency = .product(
                                     name: name,
                                     package: modifiedPackageName,


### PR DESCRIPTION
Fix registry package swizzling when package name casing differs

### Motivation:

When swizzling dependencies when running `swift package --replace-scm-with-registry resolve`, package references that have different casing don't get swizzled.

You can find an example of this scenario in the [Firebase SDK](https://github.com/firebase/firebase-ios-sdk/blob/main/Package.swift) that boils down to:
```swift
import PackageDescription


let package = Package(
  name: "Firebase",
  dependencies: [
    .package(
      url: "https://github.com/google/promises.git", // lowercase
      "2.4.0" ..< "3.0.0"
    ),
  ],
  targets: [
    .target(
      name: "FirebaseCrashlytics",
      dependencies: [
        .product(name: "FBLPromises", package: "Promises"), // uppercase
      ]
    )
  ]
)
```

The `.product(name: "FBLPromises", package: "Promises")`should be swizzled to use the `google.promises` identifier, but because of the different casing, it's not.

### Modifications:

When creating the map for packages to be swizzled, make the key lowercase. When we access the map, we again use a lowercase variant of the package name, so we don't unexpectedly miss an entry because of a different casing.

### Result:

Packages with different casing are swizzled when using the `swift package --replace-scm-with-registry resolve` command.
