### PR TITLE
use closefrom(2) on platforms supports it to reduce race condition window

### DIFF
--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -312,16 +312,20 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
         sigfillset(&sig_set_all)
         sigprocmask(SIG_UNBLOCK, &sig_set_all, nil)
 
+        #if os(FreeBSD) || os(OpenBSD)
+        closefrom(3)
+        #else
         #if os(Android)
         let number_fds = Int32(sysconf(_SC_OPEN_MAX))
         #else
         let number_fds = getdtablesize()
-        #endif
+        #endif /* os(Android) */
         
         // 2. close all file descriptors.
         for i in 3..<number_fds {
             close(i)
         }
+        #endif /* os(FreeBSD) || os(OpenBSD) */
         #endif
 
         try TSCBasic.exec(path: path, args: args)


### PR DESCRIPTION
Use `closefrom(2)` instead of `close(2)` in a loop to reduce the window of race condition with other part of the process cloud be polling/processing the file descriptors. 

### Motivation:

Currently, a loop is used to close all possible file descriptors prior to `execve(2)` being called. This has the side effect that file descriptors owned by different components of the same process is being closed unexpectedly, which cause issue #8197.

Use `closefrom(2)` instead of `close` in a loop to significantly reduce the window between closing the file descriptors and calling `execve(2)`, to minimize the impact.

In #8197, linking a debug build of `libdispatch` can randomly crash `swift-run`, due to dispatch catching that the file descriptors it works on no longer being valid, which causes an assertion and crash the process.

### Modifications:

Use `closefrom(2)` instead of `close(2)` in a loop on platforms supports it.

### Result:

Reduce the probability `swift-run` crash due to race conditions.
