### PR TITLE
[6.1] Include the path to the platform's PrivateFrameworks directory in DYLD_FRAMEWORK_PATH when launching test runners

### DIFF
--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -219,8 +219,12 @@ enum TestingSupport {
         // Since XCTestHelper targets macOS, we need the macOS platform paths here.
         if let sdkPlatformPaths = try? SwiftSDK.sdkPlatformPaths(for: .macOS) {
             // appending since we prefer the user setting (if set) to the one we inject
-            env.appendPath(key: "DYLD_FRAMEWORK_PATH", value: sdkPlatformPaths.frameworks.pathString)
-            env.appendPath(key: "DYLD_LIBRARY_PATH", value: sdkPlatformPaths.libraries.pathString)
+            for frameworkPath in sdkPlatformPaths.frameworks {
+                env.appendPath(key: "DYLD_FRAMEWORK_PATH", value: frameworkPath.pathString)
+            }
+            for libraryPath in sdkPlatformPaths.libraries {
+                env.appendPath(key: "DYLD_LIBRARY_PATH", value: libraryPath.pathString)
+            }
         }
 
         // We aren't using XCTest's harness logic to run Swift Testing tests.


### PR DESCRIPTION
  - **Explanation**: This modifies the logic which sets the value of the `DYLD_FRAMEWORK_PATH` environment variable when launching test runners on Darwin when Xcode is installed: currently it includes the path to the platform's developer "Frameworks" directory, and this change adds the sibling "PrivateFrameworks" directory as well.
  - **Scope**: Affects tests run on Darwin only, when Xcode is installed.
  - **Issues**: n/a
  - **Original PRs**: https://github.com/swiftlang/swift-package-manager/pull/8199
  - **Risk**: Low. Including this runtime framework search path should have no effect when running tests for any supported version of Xcode.
  - **Testing**: I validated this works as expected using a local build.
  - **Reviewers**: @briancroom, @grynspan, @plemarquand, @jakepetroules 

Resolves rdar://142522110

