### PR TITLE
Add include dir from a clang module into the build args in `diagnose-api-breaking-changes` command.

### DIFF
--- a/Fixtures/Miscellaneous/APIDiff/CIncludePath/Package.swift
+++ b/Fixtures/Miscellaneous/APIDiff/CIncludePath/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Sample",
+    products: [
+        .library(
+            name: "Sample",
+            targets: ["Sample"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CSample",
+            sources: ["./vendorsrc/src"],
+            cSettings: [
+                .headerSearchPath("./vendorsrc/include"),
+            ]
+        ),
+        .target(
+            name: "Sample",
+            dependencies: ["CSample"]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/include/CSample.h
+++ b/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/include/CSample.h
@@ -1,0 +1,3 @@
+
+#include "config.h"
+#include "../vendorsrc/include/vendor.h"

--- a/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/include/config.h
+++ b/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/include/config.h
@@ -1,0 +1,1 @@
+#define HAVE_VENDOR_CONFIG

--- a/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/vendorsrc/include/vendor.h
+++ b/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/vendorsrc/include/vendor.h
@@ -1,0 +1,2 @@
+
+#include "config.h"

--- a/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/vendorsrc/src/vendor.c
+++ b/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/vendorsrc/src/vendor.c
@@ -1,0 +1,6 @@
+#include "vendor.h"
+
+int vendor__func(int n)
+{
+  return 0;
+}

--- a/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/Sample/Sample.swift
+++ b/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/Sample/Sample.swift
@@ -1,0 +1,1 @@
+import CSample

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -593,6 +593,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 if let includeDir = targetDescription.moduleMap?.parentDirectory {
                     arguments += ["-I", includeDir.pathString]
                 }
+                arguments += ["-I", targetDescription.clangTarget.includeDir.pathString]
             }
         }
 

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -263,6 +263,16 @@ final class APIDiffTests: CommandsTestCase {
         }
     }
 
+    func testAPIDiffOfVendoredCDependency() async throws {
+        try skipIfApiDigesterUnsupportedOrUnset()
+        try await fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending("CIncludePath")
+            let (output, _) = try await execute(["diagnose-api-breaking-changes", "main"], packagePath: packageRoot)
+
+            XCTAssertMatch(output, .contains("No breaking changes detected in Sample"))
+        }
+    }
+
     func testNoBreakingChanges() async throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try await fixture(name: "Miscellaneous/APIDiff/") { fixturePath in


### PR DESCRIPTION
Fixes #8073: Update include paths for clang module in `diagnose-api-breaking-changes` command.

### Motivation:

Swift package manager's command `diagnose-api-breaking-changes` is a wrapper on top of `swift-api-digester`. Purpose of `swift-api-digester` is to detect API incompatible changes between two revisions of code. `diagnose-api-breaking-changes` makes it more convenient to use with packages and does a few things under the hood:
 - it copies git repo into temp dir and checks out its working dir to "baseline" commit
 - it calls `swift-api-digester` to compare current package to the baseline commit
 - it calls `swift-api-digester` with necessary build flags determined by toolchain, configuration and environment 

@PeterAdams-A reported in #8073 that `swift-api-digester` failed to build a baseline commit for a specific package with vendored C library. This PR resolves the issue.

### Modifications:

Turns out, `diagnose-api-breaking-changes` was missing some include paths which were necessary for the package to be built. The PR corrects that and adds a new include path for CLang targets. The build arguments are used only by `swift-api-digester` and do not impact other commands. I distilled the failing scenario to a test case and added it to `APIDiff` tests.

Modifications:
 - Each clang module has public `include` dir. When building current module then it typically works as-is, but when a module has non-standard source location, then explicit include of `include` is necessary.
 - A new test to make sure `diagnose-api-breaking-changes` can check API compatibility for a package with non-default source location and include files.

### Result:

 - `diagnose-api-breaking-changes` doesn't error out on such packages
 - #8073 is resolved