### PR TITLE
Removed unused dependency 'DriverSupport' from 'XCBuildSupport'.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -435,7 +435,7 @@ let package = Package(
         .target(
             /** Support for building using Xcode's build system */
             name: "XCBuildSupport",
-            dependencies: ["DriverSupport", "SPMBuildCore", "PackageGraph"],
+            dependencies: ["SPMBuildCore", "PackageGraph"],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
                 .unsafeFlags(["-static"]),


### PR DESCRIPTION
Clean up the dependency list because 'DriverSupport' is not used by 'XCBuildSupport'. 