### PR TITLE
Revert "Retrieve resolved package versions in parallel"

### DIFF
--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -426,31 +426,26 @@ extension Workspace {
         }
 
         // Retrieve the required resolved packages.
-        await withThrowingTaskGroup(of: Void.self) { taskGroup in
-            for resolvedPackage in requiredResolvedPackages {
-                let observabilityScope = observabilityScope.makeChildScope(
-                    description: "retrieving resolved package versions for dependencies",
-                    metadata: resolvedPackage.packageRef.diagnosticsMetadata
-                )
-                taskGroup.addTask {
-                    await observabilityScope.trap {
-                        switch resolvedPackage.packageRef.kind {
-                        case .localSourceControl, .remoteSourceControl:
-                            _ = try await self.checkoutRepository(
-                                package: resolvedPackage.packageRef,
-                                at: resolvedPackage.state,
-                                observabilityScope: observabilityScope
-                            )
-                        case .registry:
-                            _ = try await self.downloadRegistryArchive(
-                                package: resolvedPackage.packageRef,
-                                at: resolvedPackage.state,
-                                observabilityScope: observabilityScope
-                            )
-                        default:
-                            throw InternalError("invalid resolved package type \(resolvedPackage.packageRef.kind)")
-                        }
-                    }
+        for resolvedPackage in requiredResolvedPackages {
+            await observabilityScope.makeChildScope(
+                description: "retrieving resolved package versions for dependencies",
+                metadata: resolvedPackage.packageRef.diagnosticsMetadata
+            ).trap {
+                switch resolvedPackage.packageRef.kind {
+                case .localSourceControl, .remoteSourceControl:
+                    _ = try await self.checkoutRepository(
+                        package: resolvedPackage.packageRef,
+                        at: resolvedPackage.state,
+                        observabilityScope: observabilityScope
+                    )
+                case .registry:
+                    _ = try await self.downloadRegistryArchive(
+                        package: resolvedPackage.packageRef,
+                        at: resolvedPackage.state,
+                        observabilityScope: observabilityScope
+                    )
+                default:
+                    throw InternalError("invalid resolved package type \(resolvedPackage.packageRef.kind)")
                 }
             }
         }


### PR DESCRIPTION
Reverts swiftlang/swift-package-manager#8203

This is causing crashes in SwiftPM during the parallelized checkout. The checkouts update the workspace state and then save it. The workspace save data is not protected against multi-thread access while the save is walking the data which is causing the crash.