### PR TITLE
Use prebuilts for macro tests. Add debug URL for swift-syntax.

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -188,10 +188,19 @@ public struct CachingOptions: ParsableArguments {
     }
 
     /// Whether to use macro prebuilts or not
-    @Flag(name: .customLong("experimental-prebuilts"),
-          inversion: .prefixedEnableDisable,
-          help: "Whether to use prebuilt swift-syntax libraries for macros")
+    @Flag(
+        name: .customLong("experimental-prebuilts"),
+        inversion: .prefixedEnableDisable,
+        help: "Whether to use prebuilt swift-syntax libraries for macros"
+    )
     public var usePrebuilts: Bool = false
+
+    /// Hidden option to override the prebuilts download location for testing
+    @Option(
+        name: .customLong("experimental-prebuilts-download-url"),
+        help: .hidden
+    )
+    public var prebuiltsDownloadURL: String?
 }
 
 public struct LoggingOptions: ParsableArguments {

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -472,7 +472,8 @@ public final class SwiftCommandState {
                     .init(url: $0, supportsAvailability: true)
                 },
                 manifestImportRestrictions: .none,
-                usePrebuilts: options.caching.usePrebuilts
+                usePrebuilts: options.caching.usePrebuilts,
+                prebuiltsDownloadURL: options.caching.prebuiltsDownloadURL
             ),
             cancellator: self.cancellator,
             initializationWarningHandler: { self.observabilityScope.emit(warning: $0) },

--- a/Sources/Workspace/ManagedPrebuilt.swift
+++ b/Sources/Workspace/ManagedPrebuilt.swift
@@ -16,8 +16,8 @@ import PackageModel
 extension Workspace {
     /// A downloaded prebuilt managed by the workspace.
     public struct ManagedPrebuilt {
-        /// The package reference.
-        public let packageRef: PackageReference
+        /// The package identity
+        public let identity: PackageIdentity
 
         /// The name of the binary target the artifact corresponds to.
         public let libraryName: String
@@ -35,7 +35,7 @@ extension Workspace {
 
 extension Workspace.ManagedPrebuilt: CustomStringConvertible {
     public var description: String {
-        return "<ManagedArtifact: \(self.packageRef.identity).\(self.libraryName)>"
+        return "<ManagedArtifact: \(self.identity).\(self.libraryName)>"
     }
 }
 
@@ -56,7 +56,7 @@ extension Workspace {
         }
 
         init(_ artifacts: [ManagedPrebuilt]) throws {
-            let artifactsByPackagePath = Dictionary(grouping: artifacts, by: { $0.packageRef.identity })
+            let artifactsByPackagePath = Dictionary(grouping: artifacts, by: { $0.identity })
             self.artifactMap = try artifactsByPackagePath.mapValues{ artifacts in
                 try Dictionary(artifacts.map { ($0.libraryName, $0) }, uniquingKeysWith: { _, _ in
                     // should be unique
@@ -70,7 +70,7 @@ extension Workspace {
         }
 
         public func add(_ artifact: ManagedPrebuilt) {
-            self.artifactMap[artifact.packageRef.identity, default: [:]][artifact.libraryName] = artifact
+            self.artifactMap[artifact.identity, default: [:]][artifact.libraryName] = artifact
         }
 
         public func remove(packageIdentity: PackageIdentity, targetName: String) {

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -792,6 +792,9 @@ public struct WorkspaceConfiguration {
     /// Whether or not to use prebuilt swift-syntax for macros
     public var usePrebuilts: Bool
 
+    /// String URL to allow override of the prebuilts download location
+    public var prebuiltsDownloadURL: String?
+
     public init(
         skipDependenciesUpdates: Bool,
         prefetchBasedOnResolvedFile: Bool,
@@ -805,7 +808,8 @@ public struct WorkspaceConfiguration {
         sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation,
         defaultRegistry: Registry?,
         manifestImportRestrictions: (startingToolsVersion: ToolsVersion, allowedImports: [String])?,
-        usePrebuilts: Bool
+        usePrebuilts: Bool,
+        prebuiltsDownloadURL: String?
     ) {
         self.skipDependenciesUpdates = skipDependenciesUpdates
         self.prefetchBasedOnResolvedFile = prefetchBasedOnResolvedFile
@@ -820,6 +824,7 @@ public struct WorkspaceConfiguration {
         self.defaultRegistry = defaultRegistry
         self.manifestImportRestrictions = manifestImportRestrictions
         self.usePrebuilts = usePrebuilts
+        self.prebuiltsDownloadURL = prebuiltsDownloadURL
     }
 
     /// Default instance of WorkspaceConfiguration
@@ -837,7 +842,8 @@ public struct WorkspaceConfiguration {
             sourceControlToRegistryDependencyTransformation: .disabled,
             defaultRegistry: .none,
             manifestImportRestrictions: .none,
-            usePrebuilts: false
+            usePrebuilts: false,
+            prebuiltsDownloadURL: nil
         )
     }
 

--- a/Sources/Workspace/Workspace+Prebuilts.swift
+++ b/Sources/Workspace/Workspace+Prebuilts.swift
@@ -177,7 +177,8 @@ extension Workspace {
             cachePath: AbsolutePath?,
             customHTTPClient: HTTPClient?,
             customArchiver: Archiver?,
-            delegate: Delegate?
+            delegate: Delegate?,
+            prebuiltsDownloadURL: String?
         ) {
             self.fileSystem = fileSystem
             self.authorizationProvider = authorizationProvider
@@ -186,33 +187,41 @@ extension Workspace {
             self.scratchPath = scratchPath
             self.cachePath = cachePath
             self.delegate = delegate
+
+            self.prebuiltPackages = [
+                // TODO: we should have this in a manifest somewhere, not hardcoded like this
+                .init(
+                    identity: .plain("swift-syntax"),
+                    packageRefs: [
+                        .init(
+                            identity: .plain("swift-syntax"),
+                            kind: .remoteSourceControl("https://github.com/swiftlang/swift-syntax.git")
+                        ),
+                        .init(
+                            identity: .plain("swift-syntax"),
+                            kind: .remoteSourceControl("git@github.com:swiftlang/swift-syntax.git")
+                        ),
+                    ],
+                    prebuiltsURL: URL(
+                        string: prebuiltsDownloadURL ?? "https://github.com/dschaefer2/swift-syntax/releases/download"
+                    )!
+                ),
+            ]
         }
 
         struct PrebuiltPackage {
-            let packageRef: PackageReference
+            let identity: PackageIdentity
+            let packageRefs: [PackageReference]
             let prebuiltsURL: URL
         }
 
-        private let prebuiltPackages: [PrebuiltPackage] = [
-            .init(
-                packageRef: .init(
-                    identity: .plain("swift-syntax"),
-                    kind: .remoteSourceControl("https://github.com/swiftlang/swift-syntax.git")
-                ),
-                prebuiltsURL: URL(
-                    string:
-                        "https://github.com/dschaefer2/swift-syntax/releases/download"
-                )!
-            ),
-        ]
+        private let prebuiltPackages: [PrebuiltPackage]
 
         // Version of the compiler we're building against
         private let swiftVersion =
             "\(SwiftVersion.current.major).\(SwiftVersion.current.minor)"
 
-        fileprivate func findPrebuilts(packages: [PackageReference])
-            -> [PrebuiltPackage]
-        {
+        fileprivate func findPrebuilts(packages: [PackageReference]) -> [PrebuiltPackage] {
             var prebuilts: [PrebuiltPackage] = []
             for packageRef in packages {
                 guard case let .remoteSourceControl(pkgURL) = packageRef.kind else {
@@ -221,21 +230,23 @@ extension Workspace {
                 }
 
                 if let prebuilt = prebuiltPackages.first(where: {
-                    guard case let .remoteSourceControl(prebuiltURL) = $0.packageRef.kind,
-                        $0.packageRef.identity == packageRef.identity else {
-                        return false
-                    }
+                    $0.packageRefs.contains(where: {
+                        guard case let .remoteSourceControl(prebuiltURL) = $0.kind,
+                              $0.identity == packageRef.identity else {
+                            return false
+                        }
 
-                    if pkgURL == prebuiltURL {
-                        return true
-                    } else if !pkgURL.lastPathComponent.hasSuffix(".git") {
-                        // try with the git extension
-                        // TODO: Does this need to be in the PackageRef Equatable?
-                        let gitURL = SourceControlURL(pkgURL.absoluteString + ".git")
-                        return gitURL == prebuiltURL
-                    } else {
-                        return false
-                    }
+                        if pkgURL == prebuiltURL {
+                            return true
+                        } else if !pkgURL.lastPathComponent.hasSuffix(".git") {
+                            // try with the git extension
+                            // TODO: Does this need to be in the PackageRef Equatable?
+                            let gitURL = SourceControlURL(pkgURL.absoluteString + ".git")
+                            return gitURL == prebuiltURL
+                        } else {
+                            return false
+                        }
+                    })
                 }) {
                     prebuilts.append(prebuilt)
                 }
@@ -251,7 +262,7 @@ extension Workspace {
             let manifestFile = swiftVersion + "-manifest.json"
             let prebuiltsDir = cachePath ?? scratchPath
             let destination = prebuiltsDir.appending(components:
-                package.packageRef.identity.description,
+                package.identity.description,
                 version.description,
                 manifestFile
             )
@@ -279,32 +290,38 @@ extension Workspace {
                 components: version.description,
                 manifestFile
             )
-            var headers = HTTPClientHeaders()
-            headers.add(name: "Accept", value: "application/json")
-            var request = HTTPClient.Request.download(
-                url: manifestURL,
-                headers: headers,
-                fileSystem: self.fileSystem,
-                destination: destination
-            )
-            request.options.authorizationProvider =
-                self.authorizationProvider?.httpAuthorizationHeader(for:)
-            request.options.retryStrategy = .exponentialBackoff(
-                maxAttempts: 3,
-                baseDelay: .milliseconds(50)
-            )
-            request.options.validResponseCodes = [200]
 
-            do {
-                _ = try await self.httpClient.execute(request) { _, _ in
-                    // TODO: send to delegate
-                }
-            } catch {
-                observabilityScope.emit(
-                    info: "Prebuilt \(manifestFile)",
-                    underlyingError: error
+            if manifestURL.scheme == "file" {
+                // simply copy it over
+                try fileSystem.copy(from: AbsolutePath(validating: manifestURL.path), to: destination)
+            } else {
+                var headers = HTTPClientHeaders()
+                headers.add(name: "Accept", value: "application/json")
+                var request = HTTPClient.Request.download(
+                    url: manifestURL,
+                    headers: headers,
+                    fileSystem: self.fileSystem,
+                    destination: destination
                 )
-                return nil
+                request.options.authorizationProvider =
+                self.authorizationProvider?.httpAuthorizationHeader(for:)
+                request.options.retryStrategy = .exponentialBackoff(
+                    maxAttempts: 3,
+                    baseDelay: .milliseconds(50)
+                )
+                request.options.validResponseCodes = [200]
+
+                do {
+                    _ = try await self.httpClient.execute(request) { _, _ in
+                        // TODO: send to delegate
+                    }
+                } catch {
+                    observabilityScope.emit(
+                        info: "Prebuilt \(manifestFile)",
+                        underlyingError: error
+                    )
+                    return nil
+                }
             }
 
             do {
@@ -338,7 +355,7 @@ extension Workspace {
             let artifactName =
                 "\(swiftVersion)-\(library.name)-\(artifact.platform.rawValue)"
             let scratchDir = scratchPath.appending(
-                package.packageRef.identity.description
+                package.identity.description
             )
             let artifactDir = scratchDir.appending(artifactName)
             guard !fileSystem.exists(artifactDir) else {
@@ -348,7 +365,7 @@ extension Workspace {
             let artifactFile = artifactName + ".zip"
             let prebuiltsDir = cachePath ?? scratchPath
             let destination = prebuiltsDir.appending(components:
-                package.packageRef.identity.description,
+                package.identity.description,
                 version.description,
                 artifactFile
             )
@@ -370,48 +387,53 @@ extension Workspace {
                     components: version.description,
                     artifactFile
                 )
-                let fetchStart = DispatchTime.now()
-                var headers = HTTPClientHeaders()
-                headers.add(name: "Accept", value: "application/octet-stream")
-                var request = HTTPClient.Request.download(
-                    url: artifactURL,
-                    headers: headers,
-                    fileSystem: self.fileSystem,
-                    destination: destination
-                )
-                request.options.authorizationProvider =
-                    self.authorizationProvider?.httpAuthorizationHeader(for:)
-                request.options.retryStrategy = .exponentialBackoff(
-                    maxAttempts: 3,
-                    baseDelay: .milliseconds(50)
-                )
-                request.options.validResponseCodes = [200]
 
-                self.delegate?.willDownloadPrebuilt(
-                    from: artifactURL.absoluteString,
-                    fromCache: false
-                )
-                do {
-                    _ = try await self.httpClient.execute(request) {
-                        bytesDownloaded,
-                        totalBytesToDownload in
-                        self.delegate?.downloadingPrebuilt(
-                            from: artifactURL.absoluteString,
-                            bytesDownloaded: bytesDownloaded,
-                            totalBytesToDownload: totalBytesToDownload
-                        )
-                    }
-                } catch {
-                    observabilityScope.emit(
-                        info: "Prebuilt artifact \(artifactFile)",
-                        underlyingError: error
+                let fetchStart = DispatchTime.now()
+                if artifactURL.scheme == "file" {
+                    try fileSystem.copy(from: AbsolutePath(validating: artifactURL.path), to: destination)
+                } else {
+                    var headers = HTTPClientHeaders()
+                    headers.add(name: "Accept", value: "application/octet-stream")
+                    var request = HTTPClient.Request.download(
+                        url: artifactURL,
+                        headers: headers,
+                        fileSystem: self.fileSystem,
+                        destination: destination
                     )
-                    self.delegate?.didDownloadPrebuilt(
+                    request.options.authorizationProvider =
+                    self.authorizationProvider?.httpAuthorizationHeader(for:)
+                    request.options.retryStrategy = .exponentialBackoff(
+                        maxAttempts: 3,
+                        baseDelay: .milliseconds(50)
+                    )
+                    request.options.validResponseCodes = [200]
+
+                    self.delegate?.willDownloadPrebuilt(
                         from: artifactURL.absoluteString,
-                        result: .failure(error),
-                        duration: fetchStart.distance(to: .now())
+                        fromCache: false
                     )
-                    return nil
+                    do {
+                        _ = try await self.httpClient.execute(request) {
+                            bytesDownloaded,
+                            totalBytesToDownload in
+                            self.delegate?.downloadingPrebuilt(
+                                from: artifactURL.absoluteString,
+                                bytesDownloaded: bytesDownloaded,
+                                totalBytesToDownload: totalBytesToDownload
+                            )
+                        }
+                    } catch {
+                        observabilityScope.emit(
+                            info: "Prebuilt artifact \(artifactFile)",
+                            underlyingError: error
+                        )
+                        self.delegate?.didDownloadPrebuilt(
+                            from: artifactURL.absoluteString,
+                            result: .failure(error),
+                            duration: fetchStart.distance(to: .now())
+                        )
+                        return nil
+                    }
                 }
 
                 // Check the checksum
@@ -472,7 +494,7 @@ extension Workspace {
         ) {
             guard
                 let manifest = manifests.allDependencyManifests[
-                    prebuilt.packageRef.identity
+                    prebuilt.identity
                 ],
                 let packageVersion = manifest.manifest.version,
                 let prebuiltManifest = try await prebuiltsManager
@@ -504,7 +526,7 @@ extension Workspace {
                     {
                         // Add to workspace state
                         let managedPrebuilt = ManagedPrebuilt(
-                            packageRef: prebuilt.packageRef,
+                            identity: prebuilt.identity,
                             libraryName: library.name,
                             path: path,
                             products: library.products,

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -200,7 +200,7 @@ extension WorkspaceStateStorage {
             self.object = .init(
                 dependencies: dependencies.map { .init($0) }.sorted { $0.packageRef.identity < $1.packageRef.identity },
                 artifacts: artifacts.map { .init($0) }.sorted { $0.packageRef.identity < $1.packageRef.identity },
-                prebuilts: prebuilts.map { .init($0) }.sorted { $0.packageRef.identity < $1.packageRef.identity }
+                prebuilts: prebuilts.map { .init($0) }.sorted { $0.identity < $1.identity }
             )
         }
 
@@ -446,14 +446,14 @@ extension WorkspaceStateStorage {
         }
 
         struct Prebuilt: Codable {
-            let packageRef: PackageReference
+            let identity: PackageIdentity
             let libraryName: String
             let path: AbsolutePath
             let products: [String]
             let cModules: [String]
 
             init(_ managedPrebuilt: Workspace.ManagedPrebuilt) {
-                self.packageRef = .init(managedPrebuilt.packageRef)
+                self.identity = managedPrebuilt.identity
                 self.libraryName = managedPrebuilt.libraryName
                 self.path = managedPrebuilt.path
                 self.products = managedPrebuilt.products
@@ -525,8 +525,8 @@ extension Workspace.ManagedArtifact {
 
 extension Workspace.ManagedPrebuilt {
     fileprivate init(_ prebuilt: WorkspaceStateStorage.V7.Prebuilt) throws {
-        try self.init(
-            packageRef: .init(prebuilt.packageRef),
+        self.init(
+            identity: prebuilt.identity,
             libraryName: prebuilt.libraryName,
             path: prebuilt.path,
             products: prebuilt.products,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -567,7 +567,8 @@ public class Workspace {
             cachePath: customPrebuiltsManager?.useCache == false || !configuration.sharedDependenciesCacheEnabled ? .none : location.sharedPrebuiltsCacheDirectory,
             customHTTPClient: customPrebuiltsManager?.httpClient,
             customArchiver: customPrebuiltsManager?.archiver,
-            delegate: delegate.map(WorkspacePrebuiltsManagerDelegate.init(workspaceDelegate:))
+            delegate: delegate.map(WorkspacePrebuiltsManagerDelegate.init(workspaceDelegate:)),
+            prebuiltsDownloadURL: configuration.prebuiltsDownloadURL
         ) : .none
         // register the prebuilt packages downloader with the cancellation handler
         if let prebuiltsManager {
@@ -962,9 +963,9 @@ extension Workspace {
             }
 
         let prebuilts: [PackageIdentity: [String: PrebuiltLibrary]] = self.state.prebuilts.reduce(into: .init()) {
-            let prebuilt = PrebuiltLibrary(packageRef: $1.packageRef, libraryName: $1.libraryName, path: $1.path, products: $1.products, cModules: $1.cModules)
+            let prebuilt = PrebuiltLibrary(identity: $1.identity, libraryName: $1.libraryName, path: $1.path, products: $1.products, cModules: $1.cModules)
             for product in $1.products {
-                $0[$1.packageRef.identity, default: [:]][product] = prebuilt
+                $0[$1.identity, default: [:]][product] = prebuilt
             }
         }
 

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -355,7 +355,8 @@ public final class MockWorkspace {
                 sourceControlToRegistryDependencyTransformation: self.sourceControlToRegistryDependencyTransformation,
                 defaultRegistry: self.defaultRegistry,
                 manifestImportRestrictions: .none,
-                usePrebuilts: customPrebuiltsManager != nil
+                usePrebuilts: customPrebuiltsManager != nil,
+                prebuiltsDownloadURL: nil
             ),
             customFingerprints: self.fingerprints,
             customMirrors: self.mirrors,


### PR DESCRIPTION
Re-enable use of prebuilts for tests that depend on macro targets. These are guaranteed to be built for host as the macros are.

Add a hidden option to override the prebuilts download URL for swift-syntax for testing. Also added support for this to be a file URL.

Add support for using the ssh GitHub URL for swift-syntax, allowing multiple PackageReferences for prebuilts. Also elevated the PackageIdentity to the root structures that need it.

Fixed the build prebuilts script to generate into a versioned directory so we can support generating multiple versions at the same time.