### PR TITLE
Fix prepare for indexing so plugin tools are properly built.

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -981,9 +981,7 @@ extension BuildDescription {
             fileSystem: fileSystem,
             observabilityScope: config.observabilityScope
         )
-        let buildManifest = plan.destinationBuildParameters.prepareForIndexing == .off
-            ? try llbuild.generateManifest(at: config.manifestPath)
-            : try llbuild.generatePrepareManifest(at: config.manifestPath)
+        let buildManifest = try llbuild.generateManifest(at: config.manifestPath)
 
         let swiftCommands = llbuild.manifest.getCmdToolMap(kind: SwiftCompilerTool.self)
         let swiftFrontendCommands = llbuild.manifest.getCmdToolMap(kind: SwiftFrontendTool.self)

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -37,7 +37,7 @@ class PrepareForIndexTests: XCTestCase {
         )
 
         let builder = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: scope)
-        let manifest = try builder.generatePrepareManifest(at: "/manifest")
+        let manifest = try builder.generateManifest(at: "/manifest")
 
         // Make sure we're building the swift modules
         let outputs = manifest.commands.flatMap(\.value.tool.outputs).map(\.name)
@@ -84,7 +84,7 @@ class PrepareForIndexTests: XCTestCase {
             observabilityScope: scope
         )
         let builder = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: scope)
-        let manifest = try builder.generatePrepareManifest(at: "/manifest")
+        let manifest = try builder.generateManifest(at: "/manifest")
 
         // Ensure our C module is here.
         let lib = try XCTUnwrap(graph.module(for: "lib"))
@@ -128,7 +128,7 @@ class PrepareForIndexTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         let debugBuilder = LLBuildManifestBuilder(debugPlan, fileSystem: fs, observabilityScope: scope)
-        let debugManifest = try debugBuilder.generatePrepareManifest(at: "/manifest")
+        let debugManifest = try debugBuilder.generateManifest(at: "/manifest")
 
         XCTAssertNil(debugManifest.commands.values.first(where: {
             guard let swiftCommand = $0.tool as? SwiftCompilerTool,
@@ -149,7 +149,7 @@ class PrepareForIndexTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         let releaseBuilder = LLBuildManifestBuilder(releasePlan, fileSystem: fs, observabilityScope: scope)
-        let releaseManifest = try releaseBuilder.generatePrepareManifest(at: "/manifest")
+        let releaseManifest = try releaseBuilder.generateManifest(at: "/manifest")
 
         XCTAssertEqual(releaseManifest.commands.values.filter({
             guard let swiftCommand = $0.tool as? SwiftCompilerTool,
@@ -174,7 +174,7 @@ class PrepareForIndexTests: XCTestCase {
         )
 
         let builder = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: scope)
-        let manifest = try builder.generatePrepareManifest(at: "/manifest")
+        let manifest = try builder.generateManifest(at: "/manifest")
 
         // Ensure swiftmodules built with correct arguments
         let coreCommands = manifest.commands.values.filter {


### PR DESCRIPTION
Eliminate the special generatePrepareManifest and just reuse the real one and add a couple of checks for the target/product prepareForIndexing buildParameter instead. This then enables us to make sure we're doing a full build of the plugin tools so they can generate code to be properly indexed.

Addresses #8216 for openapi generator.
