### PR TITLE
Basics,_AsyncFileSystem: internalise SystemPackage

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -81,7 +81,6 @@ target_link_libraries(Basics PUBLIC
   _AsyncFileSystem
   SwiftCollections::DequeModule
   SwiftCollections::OrderedCollections
-  SwiftSystem::SystemPackage
   TSCBasic
   TSCUtility)
 target_link_libraries(Basics PRIVATE

--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -13,7 +13,6 @@
 import struct Foundation.Data
 import class Foundation.FileManager
 import struct Foundation.UUID
-import SystemPackage
 
 import struct TSCBasic.ByteString
 import struct TSCBasic.FileInfo

--- a/Sources/QueryEngine/CacheKey.swift
+++ b/Sources/QueryEngine/CacheKey.swift
@@ -12,7 +12,7 @@
 
 @_exported import protocol Crypto.HashFunction
 import struct Foundation.URL
-import struct SystemPackage.FilePath
+package import struct SystemPackage.FilePath
 
 /// Indicates that values of a conforming type can be hashed with an arbitrary hashing function. Unlike `Hashable`,
 /// this protocol doesn't utilize random seed values and produces consistent hash values across process launches.

--- a/Sources/QueryEngine/FileCacheRecord.swift
+++ b/Sources/QueryEngine/FileCacheRecord.swift
@@ -13,7 +13,7 @@
 import struct _AsyncFileSystem.OpenReadableFile
 
 // FIXME: need a new swift-system tag to remove `@preconcurrency`
-@preconcurrency import struct SystemPackage.FilePath
+@preconcurrency package import struct SystemPackage.FilePath
 
 package struct FileCacheRecord: Sendable {
     package let path: FilePath

--- a/Sources/QueryEngine/Query.swift
+++ b/Sources/QueryEngine/Query.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct SystemPackage.FilePath
+package import struct SystemPackage.FilePath
 
 package protocol Query: Sendable {
     associatedtype Key: CacheKey

--- a/Sources/QueryEngine/QueryEngine.swift
+++ b/Sources/QueryEngine/QueryEngine.swift
@@ -13,7 +13,7 @@
 import _AsyncFileSystem
 import Basics
 import Crypto
-@preconcurrency import SystemPackage
+@preconcurrency package import SystemPackage
 
 package func withQueryEngine(
     _ fileSystem: some AsyncFileSystem,

--- a/Sources/_AsyncFileSystem/CMakeLists.txt
+++ b/Sources/_AsyncFileSystem/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(_AsyncFileSystem
   ReadableFileStream.swift
   WritableStream.swift
 )
-target_link_libraries(_AsyncFileSystem PUBLIC
+target_link_libraries(_AsyncFileSystem PRIVATE
   SwiftSystem::SystemPackage)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet

--- a/Sources/_AsyncFileSystem/ReadableFileStream.swift
+++ b/Sources/_AsyncFileSystem/ReadableFileStream.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 package import _Concurrency
-internal import SystemPackage
+package import SystemPackage
 internal import class Dispatch.DispatchQueue
 
 /// Type-erasure wrapper over underlying file system readable streams.


### PR DESCRIPTION
`SystemPackage` is only used as an internal implementation detail here. This package is not needed for the public API surface. Furthermore, as this dependency is a single use dependency, we are able to save some nominal space on the builds with this:

Pre:
SystemPackage.dll: 212992 bytes
_AsyncFileSystem.dll: 60416 bytes

Post:
SystemPackage.dll: 0 bytes (static)
_AsyncFileSystem.dll: 217600

This effectively shaves ~56K off the toolchain.