### PR TITLE
Clean up warnings, fix handling of dep version changes

### DIFF
--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -361,7 +361,6 @@ private func checkAllDependenciesAreUsed(
                 // Consider prebuilts as used
                 let prebuilt = prebuilts[dependency.identity]?.keys.contains(product.name) ?? false
 
-                // If the product is either used directly or guarded by a trait we consider it as used
                 return usedByPackage || traitGuarded || prebuilt
             }
 

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -260,7 +260,12 @@ extension ModulesGraph {
         )
 
         let rootPackages = resolvedPackages.filter { root.manifests.values.contains($0.manifest) }
-        checkAllDependenciesAreUsed(packages: resolvedPackages, rootPackages, observabilityScope: observabilityScope)
+        checkAllDependenciesAreUsed(
+            packages: resolvedPackages,
+            rootPackages,
+            prebuilts: prebuilts,
+            observabilityScope: observabilityScope
+        )
 
         return try ModulesGraph(
             rootPackages: rootPackages,
@@ -275,6 +280,7 @@ extension ModulesGraph {
 private func checkAllDependenciesAreUsed(
     packages: IdentifiableSet<ResolvedPackage>,
     _ rootPackages: [ResolvedPackage],
+    prebuilts: [PackageIdentity: [String: PrebuiltLibrary]],
     observabilityScope: ObservabilityScope
 ) {
     for package in rootPackages {
@@ -352,9 +358,11 @@ private func checkAllDependenciesAreUsed(
                 let usedByPackage = productDependencies.contains { $0.name == product.name }
                 // We check if any of the products of this dependency is guarded by a trait.
                 let traitGuarded = traitGuardedProductDependencies.contains(product.name)
+                // Consider prebuilts as used
+                let prebuilt = prebuilts[dependency.identity]?.keys.contains(product.name) ?? false
 
                 // If the product is either used directly or guarded by a trait we consider it as used
-                return usedByPackage || traitGuarded
+                return usedByPackage || traitGuarded || prebuilt
             }
 
             if !dependencyIsUsed && !observabilityScope.errorsReportedInAnyScope {

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import struct TSCUtility.Version
+
 import Basics
 import Foundation
 import PackageGraph
@@ -447,6 +449,7 @@ extension WorkspaceStateStorage {
 
         struct Prebuilt: Codable {
             let identity: PackageIdentity
+            let version: TSCUtility.Version
             let libraryName: String
             let path: AbsolutePath
             let products: [String]
@@ -454,6 +457,7 @@ extension WorkspaceStateStorage {
 
             init(_ managedPrebuilt: Workspace.ManagedPrebuilt) {
                 self.identity = managedPrebuilt.identity
+                self.version = managedPrebuilt.version
                 self.libraryName = managedPrebuilt.libraryName
                 self.path = managedPrebuilt.path
                 self.products = managedPrebuilt.products
@@ -527,6 +531,7 @@ extension Workspace.ManagedPrebuilt {
     fileprivate init(_ prebuilt: WorkspaceStateStorage.V7.Prebuilt) throws {
         self.init(
             identity: prebuilt.identity,
+            version: prebuilt.version,
             libraryName: prebuilt.libraryName,
             path: prebuilt.path,
             products: prebuilt.products,

--- a/Sources/_InternalTestSupport/ManifestExtensions.swift
+++ b/Sources/_InternalTestSupport/ManifestExtensions.swift
@@ -266,4 +266,27 @@ extension Manifest {
             traits: self.traits
         )
     }
+
+    public func with(dependencies: [PackageDependency]) -> Manifest {
+        Manifest(
+            displayName: self.displayName,
+            path: self.path,
+            packageKind: self.packageKind,
+            packageLocation: self.packageLocation,
+            defaultLocalization: self.defaultLocalization,
+            platforms: self.platforms,
+            version: self.version,
+            revision: self.revision,
+            toolsVersion: self.toolsVersion,
+            pkgConfig: self.pkgConfig,
+            providers: self.providers,
+            cLanguageStandard: self.cLanguageStandard,
+            cxxLanguageStandard: self.cxxLanguageStandard,
+            swiftLanguageVersions: self.swiftLanguageVersions,
+            dependencies: dependencies,
+            products: self.products,
+            targets: self.targets,
+            traits: self.traits
+        )
+    }
 }

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -507,7 +507,7 @@ public final class MockWorkspace {
     public func checkPackageGraph(
         roots: [String] = [],
         deps: [MockDependency],
-        _ result: (ModulesGraph, [Basics.Diagnostic]) -> Void
+        _ result: (ModulesGraph, [Basics.Diagnostic]) throws -> Void
     ) async throws {
         let dependencies = try deps.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
         try await self.checkPackageGraph(roots: roots, dependencies: dependencies, result)

--- a/Tests/WorkspaceTests/PrebuiltsTests.swift
+++ b/Tests/WorkspaceTests/PrebuiltsTests.swift
@@ -87,6 +87,7 @@ final class PrebuiltsTests: XCTestCase {
             ]
         )
 
+
         let swiftSyntax = try MockPackage(
             name: "swift-syntax",
             url: swiftSyntaxURL,
@@ -100,7 +101,7 @@ final class PrebuiltsTests: XCTestCase {
                 MockProduct(name: "SwiftCompilerPlugin", modules: ["SwiftCompilerPlugin"]),
                 MockProduct(name: "SwiftSyntaxMacros", modules: ["SwiftSyntaxMacros"]),
             ],
-            versions: ["600.0.1", "600.0.2"]
+            versions: ["600.0.1", "600.0.2", "601.0.0"]
         )
 
         return (manifest, rootPackage, swiftSyntax)
@@ -139,7 +140,7 @@ final class PrebuiltsTests: XCTestCase {
             } else if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
                 try fileSystem.writeFileContents(destination, data: artifact)
                 return .okay()
-             } else {
+            } else {
                 XCTFail("Unexpected URL \(request.url)")
                 return .notFound()
             }
@@ -168,6 +169,110 @@ final class PrebuiltsTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
+            XCTAssertTrue(diagnostics.filter({ $0.severity == .error || $0.severity == .warning }).isEmpty)
+            let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: true)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: true)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
+        }
+    }
+
+    func testVersionChange() async throws {
+        let sandbox = AbsolutePath("/tmp/ws")
+        let fs = InMemoryFileSystem()
+
+        let artifact = Data()
+        let (manifest, rootPackage, swiftSyntax) = try initData(artifact: artifact, swiftSyntaxVersion: "600.0.1")
+        let manifestData = try JSONEncoder().encode(manifest)
+
+        let httpClient = HTTPClient { request, progressHandler in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
+            }
+
+            if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-manifest.json" {
+                try fileSystem.writeFileContents(destination, data: manifestData)
+                return .okay()
+            } else if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
+                try fileSystem.writeFileContents(destination, data: artifact)
+                return .okay()
+            } else {
+                // make sure it's the updated one
+                XCTAssertEqual(
+                    request.url,
+                    "https://github.com/dschaefer2/swift-syntax/releases/download/601.0.0/\(self.swiftVersion)-manifest.json"
+                )
+                return .notFound()
+            }
+        }
+
+        let archiver = MockArchiver(handler: { _, archivePath, destination, completion in
+            XCTAssertEqual(archivePath.pathString, "/home/user/caches/org.swift.swiftpm/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip".fixwin)
+            XCTAssertEqual(destination.pathString, "/tmp/ws/.build/prebuilts/swift-syntax/\(self.swiftVersion)-MacroSupport-macos_aarch64".fixwin)
+            completion(.success(()))
+        })
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                rootPackage
+            ],
+            packages: [
+                swiftSyntax
+            ],
+            prebuiltsManager: .init(
+                httpClient: httpClient,
+                archiver: archiver
+            ),
+            customHostTriple: Triple("arm64-apple-macosx15.0")
+        )
+
+        try await workspace.checkPackageGraph(roots: [rootPackage.name]) { modulesGraph, diagnostics in
+            XCTAssertTrue(diagnostics.filter({ $0.severity == .error || $0.severity == .warning }).isEmpty)
+            let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: true)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: true)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
+        }
+
+        // Change the version of swift syntax to one that doesn't have prebuilts
+        try workspace.closeWorkspace(resetState: false, resetResolvedFile: false)
+        let key = MockManifestLoader.Key(url: sandbox.appending(components: "roots", rootPackage.name).pathString)
+        let oldManifest = try XCTUnwrap(workspace.manifestLoader.manifests[key])
+        let oldSCM: PackageDependency.SourceControl
+        if case let .sourceControl(scm) = oldManifest.dependencies[0] {
+            oldSCM = scm
+        } else {
+            XCTFail("not source control")
+            return
+        }
+        let newDep = PackageDependency.sourceControl(
+            identity: oldSCM.identity,
+            nameForTargetDependencyResolutionOnly: oldSCM.nameForTargetDependencyResolutionOnly,
+            location: oldSCM.location,
+            requirement: .exact(try XCTUnwrap(Version("601.0.0"))),
+            productFilter: oldSCM.productFilter
+        )
+        let newManifest = oldManifest.with(dependencies: [newDep])
+        workspace.manifestLoader.manifests[key] = newManifest
+
+        try await workspace.checkPackageGraph(roots: [rootPackage.name]) { modulesGraph, diagnostics in
+            XCTAssertTrue(diagnostics.filter({ $0.severity == .error || $0.severity == .warning }).isEmpty)
+            let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: false)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
+        }
+
+        // Change it back
+        try workspace.closeWorkspace(resetState: false, resetResolvedFile: false)
+        workspace.manifestLoader.manifests[key] = oldManifest
+
+        try await workspace.checkPackageGraph(roots: [rootPackage.name]) { modulesGraph, diagnostics in
             XCTAssertTrue(diagnostics.filter({ $0.severity == .error || $0.severity == .warning }).isEmpty)
             let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
             try checkSettings(rootPackage, "FooMacros", usePrebuilt: true)
@@ -233,6 +338,7 @@ final class PrebuiltsTests: XCTestCase {
             try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
         }
     }
+
     func testCachedArtifact() async throws {
         let sandbox = AbsolutePath("/tmp/ws")
         let fs = InMemoryFileSystem()

--- a/Tests/WorkspaceTests/PrebuiltsTests.swift
+++ b/Tests/WorkspaceTests/PrebuiltsTests.swift
@@ -168,7 +168,7 @@ final class PrebuiltsTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
-            XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
+            XCTAssertTrue(diagnostics.filter({ $0.severity == .error || $0.severity == .warning }).isEmpty)
             let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
             try checkSettings(rootPackage, "FooMacros", usePrebuilt: true)
             try checkSettings(rootPackage, "FooTests", usePrebuilt: true)


### PR DESCRIPTION
Assume dependent products from prebuilts are being used.
