### PR TITLE
[6.1] Fix registry package swizzling when package name casing differs

### DIFF
--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -152,7 +152,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
                 return settings.nameForTargetDependencyResolutionOnly ?? PackageIdentityParser.computeDefaultName(fromURL: url)
             }
         case .registry:
-            return self.identity.description
+            return self.identity.description.lowercased()
         }
     }
 

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -220,7 +220,7 @@ extension Workspace {
                                     info: "swizzling '\(dependency.locationString)' with registry dependency '\(registryIdentity)'."
                                 )
                             targetDependencyPackageNameTransformations[dependency
-                                .nameForModuleDependencyResolutionOnly] = registryIdentity.description
+                                .nameForModuleDependencyResolutionOnly.lowercased()] = registryIdentity.description
                             modifiedDependency = .registry(
                                 identity: registryIdentity,
                                 requirement: requirement,
@@ -266,7 +266,7 @@ extension Workspace {
                         ):
                             if let packageName,
                                // makes sure we use the updated package name for target based dependencies
-                               let modifiedPackageName = targetDependencyPackageNameTransformations[packageName]
+                               let modifiedPackageName = targetDependencyPackageNameTransformations[packageName.lowercased()]
                             {
                                 modifiedDependency = .product(
                                     name: name,
@@ -276,7 +276,7 @@ extension Workspace {
                                 )
                             }
                         case .byName(name: let packageName, condition: let condition):
-                            if let modifiedPackageName = targetDependencyPackageNameTransformations[packageName] {
+                            if let modifiedPackageName = targetDependencyPackageNameTransformations[packageName.lowercased()] {
                                 modifiedDependency = .product(
                                     name: packageName,
                                     package: modifiedPackageName,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -13079,6 +13079,70 @@ final class WorkspaceTests: XCTestCase {
             }
         }
     }
+    
+    func testTransitiveResolutionFromRegistryWithDifferentPackageNameCasing() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    path: "root",
+                    targets: [
+                        MockTarget(name: "RootTarget", dependencies: [
+                            .product(name: "FooProduct", package: "Foo"),
+                        ]),
+                    ],
+                    products: [],
+                    dependencies: [
+                        .sourceControl(url: "https://git/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    toolsVersion: .v5_6
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "FooPackage",
+                    identity: "org.foo",
+                    alternativeURLs: ["https://git/org/foo"],
+                    targets: [
+                        MockTarget(name: "FooTarget"),
+                    ],
+                    products: [
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(url: "https://git/org/bar", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    versions: ["1.0.0", "1.1.0", "1.2.0"]
+                ),
+            ]
+        )
+
+        workspace.sourceControlToRegistryDependencyTransformation = .swizzle
+
+        try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTester(graph) { result in
+                result.check(roots: "Root")
+                result.check(packages: "org.foo", "Root")
+                result.check(modules: "FooTarget", "RootTarget")
+                result.checkTarget("RootTarget") { result in
+                    result.check(dependencies: "FooProduct")
+                }
+                result.checkTarget("FooTarget") { result in
+                    result.check(dependencies: [])
+                }
+            }
+        }
+
+        workspace.checkManagedDependencies { result in
+            result.check(dependency: "org.foo", at: .registryDownload("1.2.0"))
+        }
+    }
 
     // duplicate package at root level
     func testResolutionMixedRegistryAndSourceControl2() async throws {


### PR DESCRIPTION
Description: Fixes a case sensitivity issue when swizzling package names during a package resolution from a package registry.
Scope: Packages
Risk: Low
Testing: New test for this specific case
Issue: https://github.com/swiftlang/swift-package-manager/pull/8194
Author: @fortmarek
Reviewer: @plemarquand