### PR TITLE
Fetch Git LFS files after clone

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -201,6 +201,24 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
             ["--mirror"],
             progress: progressHandler
         )
+
+        do {
+            try self.callGit(
+                [
+                    "-C",
+                    path.pathString,
+                    "lfs",
+                    "fetch"
+                ],
+                repository: repository,
+                failureMessage: "Failed to fetch Git LFS files for \(repository.location)"
+            )
+        } catch {
+            // Ignore the error if lfs fetch fails, likely the repository either isn't using
+            // git lfs or it isn't installed.
+
+            // TODO: If the repo _is_ using git lfs and it isn't installed can we show a nice error?
+        }
     }
 
     public func isValidDirectory(_ directory: Basics.AbsolutePath) throws -> Bool {


### PR DESCRIPTION
### Motivation:

Currently SPM clones repositories with `--mirror`, creating a bare repository. If the cloned repository uses git lfs, the files in lfs are never pulled and so the package resolution ultimately fails.

### Modifications:

This is a naive implementation of LFS support that simply does a `lfs fetch` on the mirrored repository, without regard for whether there are LFS files to clone or even if the user has git lfs installed. It does, however, allow packages using LFS to resolve correctly.

Issue: #8233

