### PR TITLE
build: add missing dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -314,6 +314,7 @@ let package = Package(
                 "Basics",
                 "PackageLoading",
                 "PackageModel",
+                .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             exclude: ["CMakeLists.txt", "README.md"],
             swiftSettings: [
@@ -397,6 +398,7 @@ let package = Package(
             dependencies: [
                 "Basics",
                 "PackageGraph",
+                .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
@@ -413,6 +415,7 @@ let package = Package(
                 "SPMBuildCore",
                 "SPMLLBuild",
                 .product(name: "SwiftDriver", package: "swift-driver"),
+                .product(name: "OrderedCollections", package: "swift-collections"),
                 "DriverSupport",
             ],
             exclude: ["CMakeLists.txt"],
@@ -438,6 +441,7 @@ let package = Package(
             dependencies: [
                 "SPMBuildCore",
                 "PackageGraph",
+                .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
@@ -456,6 +460,7 @@ let package = Package(
                 "PackageSigning",
                 "SourceControl",
                 "SPMBuildCore",
+                .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
@@ -603,6 +608,7 @@ let package = Package(
             name: "swift-bootstrap",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "OrderedCollections", package: "swift-collections"),
                 "Basics",
                 "Build",
                 "PackageGraph",
@@ -706,6 +712,7 @@ let package = Package(
                 "PackageSigning",
                 "SourceControl",
                 .product(name: "TSCTestSupport", package: "swift-tools-support-core"),
+                .product(name: "OrderedCollections", package: "swift-collections"),
                 "Workspace",
                 "XCBuildSupport",
             ],

--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(Build
 target_link_libraries(Build PUBLIC
   TSCBasic
   Basics
+  SwiftCollections::OrderedCollections
   PackageGraph
   SPMBuildCore)
 target_link_libraries(Build PRIVATE

--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(PackageGraph
   Version+Extensions.swift
   VersionSetSpecifier.swift)
 target_link_libraries(PackageGraph PUBLIC
+  SwiftCollections::OrderedCollections
   TSCBasic
   Basics
   PackageLoading

--- a/Sources/SPMBuildCore/CMakeLists.txt
+++ b/Sources/SPMBuildCore/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(SPMBuildCore PUBLIC
   TSCBasic
   TSCUtility
   Basics
+  SwiftCollections::OrderedCollections
   PackageGraph)
 
 

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(Workspace PUBLIC
   TSCUtility
   Basics
   SPMBuildCore
+  SwiftCollections::OrderedCollections
   PackageFingerprint
   PackageGraph
   PackageLoading

--- a/Sources/XCBuildSupport/CMakeLists.txt
+++ b/Sources/XCBuildSupport/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(XCBuildSupport PUBLIC
   DriverSupport
   TSCBasic
   TSCUtility
+  SwiftCollections::OrderedCollections
   PackageGraph
 )
 


### PR DESCRIPTION
The `OrderedCollections` module has been more aggressively adopted in SPM. Update the dependencies to reflect this dependency.