### PR TITLE
_AsyncFileSystem: reduce visibility of import (NFCI)

### DIFF
--- a/Sources/_AsyncFileSystem/ReadableFileStream.swift
+++ b/Sources/_AsyncFileSystem/ReadableFileStream.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 package import _Concurrency
-package import SystemPackage
+internal import SystemPackage
 internal import class Dispatch.DispatchQueue
 
 /// Type-erasure wrapper over underlying file system readable streams.


### PR DESCRIPTION
This reduces the visibility of the import as it is only used in internal declarations. This cleans up a recently introduced warning.