### PR TITLE
SourceKitLSPAPI: export library as an interface

### DIFF
--- a/Sources/SourceKitLSPAPI/CMakeLists.txt
+++ b/Sources/SourceKitLSPAPI/CMakeLists.txt
@@ -16,3 +16,5 @@ target_link_libraries(SourceKitLSPAPI PUBLIC
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(SourceKitLSPAPI PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS SourceKitLSPAPI)


### PR DESCRIPTION
This is consumed by SourceKit-LSP, so export the library target to allow the library to be consumed properly to manage dependencies and flags.