### PR TITLE
[6.1] Add include dir from a clang module into the build args.

### DIFF
--- a/Fixtures/Miscellaneous/APIDiff/CIncludePath/Package.swift
+++ b/Fixtures/Miscellaneous/APIDiff/CIncludePath/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Sample",
+    products: [
+        .library(
+            name: "Sample",
+            targets: ["Sample"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CSample",
+            sources: ["./vendorsrc/src"],
+            cSettings: [
+                .headerSearchPath("./vendorsrc/include"),
+            ]
+        ),
+        .target(
+            name: "Sample",
+            dependencies: ["CSample"]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/include/CSample.h
+++ b/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/include/CSample.h
@@ -1,0 +1,3 @@
+
+#include "config.h"
+#include "../vendorsrc/include/vendor.h"

--- a/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/include/config.h
+++ b/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/include/config.h
@@ -1,0 +1,1 @@
+#define HAVE_VENDOR_CONFIG

--- a/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/vendorsrc/include/vendor.h
+++ b/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/vendorsrc/include/vendor.h
@@ -1,0 +1,2 @@
+
+#include "config.h"

--- a/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/vendorsrc/src/vendor.c
+++ b/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/CSample/vendorsrc/src/vendor.c
@@ -1,0 +1,6 @@
+#include "vendor.h"
+
+int vendor__func(int n)
+{
+  return 0;
+}

--- a/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/Sample/Sample.swift
+++ b/Fixtures/Miscellaneous/APIDiff/CIncludePath/Sources/Sample/Sample.swift
@@ -1,0 +1,1 @@
+import CSample

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -593,6 +593,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 if let includeDir = targetDescription.moduleMap?.parentDirectory {
                     arguments += ["-I", includeDir.pathString]
                 }
+                arguments += ["-I", targetDescription.clangTarget.includeDir.pathString]
             }
         }
 

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -273,6 +273,16 @@ final class APIDiffTests: CommandsTestCase {
         }
     }
 
+    func testAPIDiffOfVendoredCDependency() async throws {
+        try skipIfApiDigesterUnsupportedOrUnset()
+        try await fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending("CIncludePath")
+            let (output, _) = try await execute(["diagnose-api-breaking-changes", "main"], packagePath: packageRoot)
+
+            XCTAssertMatch(output, .contains("No breaking changes detected in Sample"))
+        }
+    }
+
     func testNoBreakingChanges() async throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try await fixture(name: "Miscellaneous/APIDiff/") { fixturePath in


### PR DESCRIPTION
 - Description: Fix build error for `diagnose-api-breaking-changes` command when C code is in non-standard location
 - Scope: Package
 - Risk: Low
 - Testing: New test for this specific scenario. However, the test suite is deactivated in 6.1 unless [#8196](https://github.com/swiftlang/swift-package-manager/pull/8196) is cherry-picked too.
 - Issue: https://github.com/swiftlang/swift-package-manager/issues/8073
 - Cherry-picked from: https://github.com/swiftlang/swift-package-manager/pull/8209
 - Author: @yyvch 
 - Reviewers: @plemarquand @jakepetroules 