### PR TITLE
Forward port fixes for macro build prebuilts

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -188,10 +188,19 @@ public struct CachingOptions: ParsableArguments {
     }
 
     /// Whether to use macro prebuilts or not
-    @Flag(name: .customLong("experimental-prebuilts"),
-          inversion: .prefixedEnableDisable,
-          help: "Whether to use prebuilt swift-syntax libraries for macros")
+    @Flag(
+        name: .customLong("experimental-prebuilts"),
+        inversion: .prefixedEnableDisable,
+        help: "Whether to use prebuilt swift-syntax libraries for macros"
+    )
     public var usePrebuilts: Bool = false
+
+    /// Hidden option to override the prebuilts download location for testing
+    @Option(
+        name: .customLong("experimental-prebuilts-download-url"),
+        help: .hidden
+    )
+    public var prebuiltsDownloadURL: String?
 }
 
 public struct LoggingOptions: ParsableArguments {

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -472,7 +472,8 @@ public final class SwiftCommandState {
                     .init(url: $0, supportsAvailability: true)
                 },
                 manifestImportRestrictions: .none,
-                usePrebuilts: options.caching.usePrebuilts
+                usePrebuilts: options.caching.usePrebuilts,
+                prebuiltsDownloadURL: options.caching.prebuiltsDownloadURL
             ),
             cancellator: self.cancellator,
             initializationWarningHandler: { self.observabilityScope.emit(warning: $0) },

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -672,8 +672,21 @@ private func createResolvedPackages(
                 }
 
                 if let package = productRef.package, prebuilts[.plain(package)]?[productRef.name] != nil {
-                    // using a prebuilt instead.
-                    continue
+                    // See if we're using a prebuilt instead
+                    if moduleBuilder.module.type == .macro {
+                        continue
+                    } else if moduleBuilder.module.type == .test {
+                        // use prebuilt if this is a test that depends a macro target
+                        // these are guaranteed built for host
+                        if moduleBuilder.module.dependencies.contains(where: { dep in
+                            guard let module = dep.module else {
+                                return false
+                            }
+                            return module.type == .macro
+                        }) {
+                            continue
+                        }
+                    }
                 }
 
                 // Find the product in this package's dependency products.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -270,8 +270,8 @@ public struct BinaryArtifact {
 
 /// A structure representing a prebuilt library to be used instead of a source dependency
 public struct PrebuiltLibrary {
-    /// The package reference.
-    public let packageRef: PackageReference
+    /// The package identity.
+    public let identity: PackageIdentity
 
     /// The name of the binary target the artifact corresponds to.
     public let libraryName: String
@@ -285,8 +285,8 @@ public struct PrebuiltLibrary {
     /// The C modules that need their includes directory added to the include path
     public let cModules: [String]
 
-    public init(packageRef: PackageReference, libraryName: String, path: AbsolutePath, products: [String], cModules: [String]) {
-        self.packageRef = packageRef
+    public init(identity: PackageIdentity, libraryName: String, path: AbsolutePath, products: [String], cModules: [String]) {
+        self.identity = identity
         self.libraryName = libraryName
         self.path = path
         self.products = products
@@ -1242,31 +1242,34 @@ public final class PackageBuilder {
             table.add(assignment, for: .SWIFT_ACTIVE_COMPILATION_CONDITIONS)
         }
 
-        // Add in flags for prebuilts
-        let prebuiltLibraries: [String: PrebuiltLibrary] = target.dependencies.reduce(into: .init()) {
-            guard case let .product(name: name, package: package, moduleAliases: _, condition: _) = $1,
-                  let package = package,
-                  let prebuilt = prebuilts[.plain(package)]?[name]
-            else {
-                return
+        // Add in flags for prebuilts if the target is a macro or a macro test.
+        // Currently we only support prebuilts for macros.
+        if target.type == .macro || target.isMacroTest(in: manifest) {
+            let prebuiltLibraries: [String: PrebuiltLibrary] = target.dependencies.reduce(into: .init()) {
+                guard case let .product(name: name, package: package, moduleAliases: _, condition: _) = $1,
+                      let package = package,
+                      let prebuilt = prebuilts[.plain(package)]?[name]
+                else {
+                    return
+                }
+
+                $0[prebuilt.libraryName] = prebuilt
             }
 
-            $0[prebuilt.libraryName] = prebuilt
-        }
+            for prebuilt in prebuiltLibraries.values {
+                let lib = prebuilt.path.appending(components: ["lib", "lib\(prebuilt.libraryName).a"]).pathString
+                var ldFlagsAssignment = BuildSettings.Assignment()
+                ldFlagsAssignment.values = [lib]
+                table.add(ldFlagsAssignment, for: .OTHER_LDFLAGS)
 
-        for prebuilt in prebuiltLibraries.values {
-            let lib = prebuilt.path.appending(components: ["lib", "lib\(prebuilt.libraryName).a"]).pathString
-            var ldFlagsAssignment = BuildSettings.Assignment()
-            ldFlagsAssignment.values = [lib]
-            table.add(ldFlagsAssignment, for: .OTHER_LDFLAGS)
-
-            var includeDirs: [AbsolutePath] = [prebuilt.path.appending(component: "Modules")]
-            for cModule in prebuilt.cModules {
-                includeDirs.append(prebuilt.path.appending(components: "include", cModule))
+                var includeDirs: [AbsolutePath] = [prebuilt.path.appending(component: "Modules")]
+                for cModule in prebuilt.cModules {
+                    includeDirs.append(prebuilt.path.appending(components: "include", cModule))
+                }
+                var includeAssignment = BuildSettings.Assignment()
+                includeAssignment.values = includeDirs.map({ "-I\($0.pathString)" })
+                table.add(includeAssignment, for: .OTHER_SWIFT_FLAGS)
             }
-            var includeAssignment = BuildSettings.Assignment()
-            includeAssignment.values = includeDirs.map({ "-I\($0.pathString)" })
-            table.add(includeAssignment, for: .OTHER_SWIFT_FLAGS)
         }
 
         return table
@@ -1852,5 +1855,27 @@ extension Sequence {
 extension TargetDescription {
     fileprivate var usesUnsafeFlags: Bool {
         settings.filter(\.kind.isUnsafeFlags).isEmpty == false
+    }
+
+    fileprivate func isMacroTest(in manifest: Manifest) -> Bool {
+        guard self.type == .test else { return false }
+
+        return self.dependencies.contains(where: {
+            let name: String
+            switch $0 {
+            case .byName(name: let n, condition: _):
+                name = n
+            case .target(name: let n, condition: _):
+                name = n
+            default:
+                return false
+            }
+
+            guard let target = manifest.targetMap[name] else {
+                return false
+            }
+
+            return target.type == .macro
+        })
     }
 }

--- a/Sources/Workspace/ManagedPrebuilt.swift
+++ b/Sources/Workspace/ManagedPrebuilt.swift
@@ -16,8 +16,8 @@ import PackageModel
 extension Workspace {
     /// A downloaded prebuilt managed by the workspace.
     public struct ManagedPrebuilt {
-        /// The package reference.
-        public let packageRef: PackageReference
+        /// The package identity
+        public let identity: PackageIdentity
 
         /// The name of the binary target the artifact corresponds to.
         public let libraryName: String
@@ -35,7 +35,7 @@ extension Workspace {
 
 extension Workspace.ManagedPrebuilt: CustomStringConvertible {
     public var description: String {
-        return "<ManagedArtifact: \(self.packageRef.identity).\(self.libraryName)>"
+        return "<ManagedArtifact: \(self.identity).\(self.libraryName)>"
     }
 }
 
@@ -56,7 +56,7 @@ extension Workspace {
         }
 
         init(_ artifacts: [ManagedPrebuilt]) throws {
-            let artifactsByPackagePath = Dictionary(grouping: artifacts, by: { $0.packageRef.identity })
+            let artifactsByPackagePath = Dictionary(grouping: artifacts, by: { $0.identity })
             self.artifactMap = try artifactsByPackagePath.mapValues{ artifacts in
                 try Dictionary(artifacts.map { ($0.libraryName, $0) }, uniquingKeysWith: { _, _ in
                     // should be unique
@@ -70,7 +70,7 @@ extension Workspace {
         }
 
         public func add(_ artifact: ManagedPrebuilt) {
-            self.artifactMap[artifact.packageRef.identity, default: [:]][artifact.libraryName] = artifact
+            self.artifactMap[artifact.identity, default: [:]][artifact.libraryName] = artifact
         }
 
         public func remove(packageIdentity: PackageIdentity, targetName: String) {

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -792,6 +792,9 @@ public struct WorkspaceConfiguration {
     /// Whether or not to use prebuilt swift-syntax for macros
     public var usePrebuilts: Bool
 
+    /// String URL to allow override of the prebuilts download location
+    public var prebuiltsDownloadURL: String?
+
     public init(
         skipDependenciesUpdates: Bool,
         prefetchBasedOnResolvedFile: Bool,
@@ -805,7 +808,8 @@ public struct WorkspaceConfiguration {
         sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation,
         defaultRegistry: Registry?,
         manifestImportRestrictions: (startingToolsVersion: ToolsVersion, allowedImports: [String])?,
-        usePrebuilts: Bool
+        usePrebuilts: Bool,
+        prebuiltsDownloadURL: String?
     ) {
         self.skipDependenciesUpdates = skipDependenciesUpdates
         self.prefetchBasedOnResolvedFile = prefetchBasedOnResolvedFile
@@ -820,6 +824,7 @@ public struct WorkspaceConfiguration {
         self.defaultRegistry = defaultRegistry
         self.manifestImportRestrictions = manifestImportRestrictions
         self.usePrebuilts = usePrebuilts
+        self.prebuiltsDownloadURL = prebuiltsDownloadURL
     }
 
     /// Default instance of WorkspaceConfiguration
@@ -837,7 +842,8 @@ public struct WorkspaceConfiguration {
             sourceControlToRegistryDependencyTransformation: .disabled,
             defaultRegistry: .none,
             manifestImportRestrictions: .none,
-            usePrebuilts: false
+            usePrebuilts: false,
+            prebuiltsDownloadURL: nil
         )
     }
 

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import struct TSCUtility.Version
+
 import Basics
 import Foundation
 import PackageGraph
@@ -447,6 +449,7 @@ extension WorkspaceStateStorage {
 
         struct Prebuilt: Codable {
             let identity: PackageIdentity
+            let version: TSCUtility.Version
             let libraryName: String
             let path: AbsolutePath
             let products: [String]
@@ -454,6 +457,7 @@ extension WorkspaceStateStorage {
 
             init(_ managedPrebuilt: Workspace.ManagedPrebuilt) {
                 self.identity = managedPrebuilt.identity
+                self.version = managedPrebuilt.version
                 self.libraryName = managedPrebuilt.libraryName
                 self.path = managedPrebuilt.path
                 self.products = managedPrebuilt.products
@@ -527,6 +531,7 @@ extension Workspace.ManagedPrebuilt {
     fileprivate init(_ prebuilt: WorkspaceStateStorage.V7.Prebuilt) throws {
         self.init(
             identity: prebuilt.identity,
+            version: prebuilt.version,
             libraryName: prebuilt.libraryName,
             path: prebuilt.path,
             products: prebuilt.products,

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -200,7 +200,7 @@ extension WorkspaceStateStorage {
             self.object = .init(
                 dependencies: dependencies.map { .init($0) }.sorted { $0.packageRef.identity < $1.packageRef.identity },
                 artifacts: artifacts.map { .init($0) }.sorted { $0.packageRef.identity < $1.packageRef.identity },
-                prebuilts: prebuilts.map { .init($0) }.sorted { $0.packageRef.identity < $1.packageRef.identity }
+                prebuilts: prebuilts.map { .init($0) }.sorted { $0.identity < $1.identity }
             )
         }
 
@@ -446,14 +446,14 @@ extension WorkspaceStateStorage {
         }
 
         struct Prebuilt: Codable {
-            let packageRef: PackageReference
+            let identity: PackageIdentity
             let libraryName: String
             let path: AbsolutePath
             let products: [String]
             let cModules: [String]
 
             init(_ managedPrebuilt: Workspace.ManagedPrebuilt) {
-                self.packageRef = .init(managedPrebuilt.packageRef)
+                self.identity = managedPrebuilt.identity
                 self.libraryName = managedPrebuilt.libraryName
                 self.path = managedPrebuilt.path
                 self.products = managedPrebuilt.products
@@ -525,8 +525,8 @@ extension Workspace.ManagedArtifact {
 
 extension Workspace.ManagedPrebuilt {
     fileprivate init(_ prebuilt: WorkspaceStateStorage.V7.Prebuilt) throws {
-        try self.init(
-            packageRef: .init(prebuilt.packageRef),
+        self.init(
+            identity: prebuilt.identity,
             libraryName: prebuilt.libraryName,
             path: prebuilt.path,
             products: prebuilt.products,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -567,7 +567,8 @@ public class Workspace {
             cachePath: customPrebuiltsManager?.useCache == false || !configuration.sharedDependenciesCacheEnabled ? .none : location.sharedPrebuiltsCacheDirectory,
             customHTTPClient: customPrebuiltsManager?.httpClient,
             customArchiver: customPrebuiltsManager?.archiver,
-            delegate: delegate.map(WorkspacePrebuiltsManagerDelegate.init(workspaceDelegate:))
+            delegate: delegate.map(WorkspacePrebuiltsManagerDelegate.init(workspaceDelegate:)),
+            prebuiltsDownloadURL: configuration.prebuiltsDownloadURL
         ) : .none
         // register the prebuilt packages downloader with the cancellation handler
         if let prebuiltsManager {
@@ -962,9 +963,9 @@ extension Workspace {
             }
 
         let prebuilts: [PackageIdentity: [String: PrebuiltLibrary]] = self.state.prebuilts.reduce(into: .init()) {
-            let prebuilt = PrebuiltLibrary(packageRef: $1.packageRef, libraryName: $1.libraryName, path: $1.path, products: $1.products, cModules: $1.cModules)
+            let prebuilt = PrebuiltLibrary(identity: $1.identity, libraryName: $1.libraryName, path: $1.path, products: $1.products, cModules: $1.cModules)
             for product in $1.products {
-                $0[$1.packageRef.identity, default: [:]][product] = prebuilt
+                $0[$1.identity, default: [:]][product] = prebuilt
             }
         }
 

--- a/Sources/_InternalTestSupport/ManifestExtensions.swift
+++ b/Sources/_InternalTestSupport/ManifestExtensions.swift
@@ -266,4 +266,27 @@ extension Manifest {
             traits: self.traits
         )
     }
+
+    public func with(dependencies: [PackageDependency]) -> Manifest {
+        Manifest(
+            displayName: self.displayName,
+            path: self.path,
+            packageKind: self.packageKind,
+            packageLocation: self.packageLocation,
+            defaultLocalization: self.defaultLocalization,
+            platforms: self.platforms,
+            version: self.version,
+            revision: self.revision,
+            toolsVersion: self.toolsVersion,
+            pkgConfig: self.pkgConfig,
+            providers: self.providers,
+            cLanguageStandard: self.cLanguageStandard,
+            cxxLanguageStandard: self.cxxLanguageStandard,
+            swiftLanguageVersions: self.swiftLanguageVersions,
+            dependencies: dependencies,
+            products: self.products,
+            targets: self.targets,
+            traits: self.traits
+        )
+    }
 }

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -507,7 +507,7 @@ public final class MockWorkspace {
     public func checkPackageGraph(
         roots: [String] = [],
         deps: [MockDependency],
-        _ result: (ModulesGraph, [Basics.Diagnostic]) -> Void
+        _ result: (ModulesGraph, [Basics.Diagnostic]) throws -> Void
     ) async throws {
         let dependencies = try deps.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
         try await self.checkPackageGraph(roots: roots, dependencies: dependencies, result)

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -355,7 +355,8 @@ public final class MockWorkspace {
                 sourceControlToRegistryDependencyTransformation: self.sourceControlToRegistryDependencyTransformation,
                 defaultRegistry: self.defaultRegistry,
                 manifestImportRestrictions: .none,
-                usePrebuilts: customPrebuiltsManager != nil
+                usePrebuilts: customPrebuiltsManager != nil,
+                prebuiltsDownloadURL: nil
             ),
             customFingerprints: self.fingerprints,
             customMirrors: self.mirrors,

--- a/Sources/swift-build-prebuilts/BuildPrebuilts.swift
+++ b/Sources/swift-build-prebuilts/BuildPrebuilts.swift
@@ -104,6 +104,11 @@ struct BuildPrebuilts: AsyncParsableCommand {
             try await shell("git clone \(repo.url)")
 
             for version in repo.versions {
+                let versionDir = stageDir.appending(version.tag)
+                if !fm.fileExists(atPath: versionDir.pathString) {
+                    try fm.createDirectory(atPath: versionDir.pathString, withIntermediateDirectories: true)
+                }
+
                 _ = fm.changeCurrentDirectoryPath(repoDir.pathString)
                 try await shell("git checkout \(version.tag)")
 
@@ -159,7 +164,7 @@ struct BuildPrebuilts: AsyncParsableCommand {
 
                         // Zip it up
                         _ = fm.changeCurrentDirectoryPath(stageDir.pathString)
-                        let zipFile = stageDir.appending("\(swiftVersion)-\(library.name)-\(platform).zip")
+                        let zipFile = versionDir.appending("\(swiftVersion)-\(library.name)-\(platform).zip")
                         let contentDirs = ["lib", "Modules"] + (library.cModules.isEmpty ? [] : ["include"])
 #if os(Windows)
                         try await shell("tar -acf \(zipFile.pathString) \(contentDirs.joined(separator: " "))")
@@ -211,7 +216,7 @@ struct BuildPrebuilts: AsyncParsableCommand {
                 let encoder = JSONEncoder()
                 encoder.outputFormatting = .prettyPrinted
                 let manifestData = try encoder.encode(newManifest)
-                let manifestFile = stageDir.appending("\(swiftVersion)-manifest.json")
+                let manifestFile = versionDir.appending("\(swiftVersion)-manifest.json")
                 try manifestData.write(to: manifestFile.asURL)
             }
         }
@@ -264,7 +269,7 @@ struct BuildPrebuilts: AsyncParsableCommand {
     func downloadManifest(version: PrebuiltRepos.Version) async throws -> Workspace.PrebuiltsManifest? {
         let fm = FileManager.default
         let manifestFile = swiftVersion + "-manifest.json"
-        let destination = stageDir.appending(manifestFile)
+        let destination = stageDir.appending(components: version.tag, manifestFile)
         if fm.fileExists(atPath: destination.pathString) {
             do {
                 return try JSONDecoder().decode(

--- a/Tests/WorkspaceTests/PrebuiltsTests.swift
+++ b/Tests/WorkspaceTests/PrebuiltsTests.swift
@@ -18,6 +18,7 @@ import Basics
 import struct TSCBasic.SHA256
 import struct TSCBasic.ByteString
 import struct TSCUtility.Version
+import PackageGraph
 import PackageModel
 import Workspace
 import XCTest
@@ -26,7 +27,9 @@ import _InternalTestSupport
 final class PrebuiltsTests: XCTestCase {
     let swiftVersion = "\(SwiftVersion.current.major).\(SwiftVersion.current.minor)"
 
-    func initData(artifact: Data, swiftSyntaxVersion: String) throws -> (Workspace.PrebuiltsManifest, MockPackage, MockPackage) {
+    func initData(artifact: Data, swiftSyntaxVersion: String, swiftSyntaxURL: String? = nil) throws -> (Workspace.PrebuiltsManifest, MockPackage, MockPackage) {
+        let swiftSyntaxURL = swiftSyntaxURL ?? "https://github.com/swiftlang/swift-syntax"
+
         let manifest = Workspace.PrebuiltsManifest(libraries: [
             .init(
                 name: "MacroSupport",
@@ -72,12 +75,13 @@ final class PrebuiltsTests: XCTestCase {
                     dependencies: [
                         "FooMacros",
                         .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
-                    ]
-                )
+                    ],
+                    type: .test
+                ),
             ],
             dependencies: [
                 .sourceControl(
-                    url: "https://github.com/swiftlang/swift-syntax",
+                    url: swiftSyntaxURL,
                     requirement: .exact(try XCTUnwrap(Version(swiftSyntaxVersion)))
                 )
             ]
@@ -85,7 +89,7 @@ final class PrebuiltsTests: XCTestCase {
 
         let swiftSyntax = try MockPackage(
             name: "swift-syntax",
-            url: "https://github.com/swiftlang/swift-syntax",
+            url: swiftSyntaxURL,
             targets: [
                 MockTarget(name: "SwiftSyntaxMacrosTestSupport"),
                 MockTarget(name: "SwiftCompilerPlugin"),
@@ -102,7 +106,8 @@ final class PrebuiltsTests: XCTestCase {
         return (manifest, rootPackage, swiftSyntax)
     }
 
-    func checkSettings(_ target: Module, usePrebuilt: Bool) throws {
+    func checkSettings(_ rootPackage: ResolvedPackage, _ targetName: String, usePrebuilt: Bool) throws {
+        let target = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == targetName }))
         if usePrebuilt {
             let swiftFlags = try XCTUnwrap(target.buildSettings.assignments[.OTHER_SWIFT_FLAGS]).flatMap({ $0.values })
             XCTAssertTrue(swiftFlags.contains("-I/tmp/ws/.build/prebuilts/swift-syntax/\(self.swiftVersion)-MacroSupport-macos_aarch64/Modules".fixwin))
@@ -141,7 +146,7 @@ final class PrebuiltsTests: XCTestCase {
         }
 
         let archiver = MockArchiver(handler: { _, archivePath, destination, completion in
-            XCTAssertEqual(archivePath.pathString, "/home/user/caches/org.swift.swiftpm/prebuilts/swift-syntax/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip".fixwin)
+            XCTAssertEqual(archivePath.pathString, "/home/user/caches/org.swift.swiftpm/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip".fixwin)
             XCTAssertEqual(destination.pathString, "/tmp/ws/.build/prebuilts/swift-syntax/\(self.swiftVersion)-MacroSupport-macos_aarch64".fixwin)
             completion(.success(()))
         })
@@ -165,19 +170,75 @@ final class PrebuiltsTests: XCTestCase {
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
             XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
             let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
-            let macroTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooMacros" }))
-            try checkSettings(macroTarget, usePrebuilt: true)
-            let testTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooTests" }))
-            try checkSettings(testTarget, usePrebuilt: true)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: true)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: true)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
         }
     }
 
+    func testSSHURL() async throws {
+        let sandbox = AbsolutePath("/tmp/ws")
+        let fs = InMemoryFileSystem()
+
+        let artifact = Data()
+        let (manifest, rootPackage, swiftSyntax) = try initData(artifact: artifact, swiftSyntaxVersion: "600.0.1", swiftSyntaxURL: "git@github.com:swiftlang/swift-syntax.git")
+        let manifestData = try JSONEncoder().encode(manifest)
+
+        let httpClient = HTTPClient { request, progressHandler in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
+            }
+
+            if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-manifest.json" {
+                try fileSystem.writeFileContents(destination, data: manifestData)
+                return .okay()
+            } else if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
+                try fileSystem.writeFileContents(destination, data: artifact)
+                return .okay()
+             } else {
+                XCTFail("Unexpected URL \(request.url)")
+                return .notFound()
+            }
+        }
+
+        let archiver = MockArchiver(handler: { _, archivePath, destination, completion in
+            XCTAssertEqual(archivePath.pathString, "/home/user/caches/org.swift.swiftpm/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip".fixwin)
+            XCTAssertEqual(destination.pathString, "/tmp/ws/.build/prebuilts/swift-syntax/\(self.swiftVersion)-MacroSupport-macos_aarch64".fixwin)
+            completion(.success(()))
+        })
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                rootPackage
+            ],
+            packages: [
+                swiftSyntax
+            ],
+            prebuiltsManager: .init(
+                httpClient: httpClient,
+                archiver: archiver
+            ),
+            customHostTriple: Triple("arm64-apple-macosx15.0")
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
+            XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
+            let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: true)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: true)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
+        }
+    }
     func testCachedArtifact() async throws {
         let sandbox = AbsolutePath("/tmp/ws")
         let fs = InMemoryFileSystem()
 
         let artifact = Data()
-        let cacheFile = try AbsolutePath(validating: "/home/user/caches/org.swift.swiftpm/prebuilts/swift-syntax/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip")
+        let cacheFile = try AbsolutePath(validating: "/home/user/caches/org.swift.swiftpm/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip")
         try fs.writeFileContents(cacheFile, data: artifact)
 
         let (manifest, rootPackage, swiftSyntax) = try initData(artifact: artifact, swiftSyntaxVersion: "600.0.1")
@@ -202,7 +263,7 @@ final class PrebuiltsTests: XCTestCase {
         }
 
         let archiver = MockArchiver(handler: { _, archivePath, destination, completion in
-            XCTAssertEqual(archivePath.pathString, "/home/user/caches/org.swift.swiftpm/prebuilts/swift-syntax/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip".fixwin)
+            XCTAssertEqual(archivePath.pathString, "/home/user/caches/org.swift.swiftpm/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip".fixwin)
             XCTAssertEqual(destination.pathString, "/tmp/ws/.build/prebuilts/swift-syntax/\(self.swiftVersion)-MacroSupport-macos_aarch64".fixwin)
             completion(.success(()))
         })
@@ -226,10 +287,10 @@ final class PrebuiltsTests: XCTestCase {
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
             XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
             let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
-            let macroTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooMacros" }))
-            try checkSettings(macroTarget, usePrebuilt: true)
-            let testTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooTests" }))
-            try checkSettings(testTarget, usePrebuilt: true)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: true)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: true)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
         }
     }
 
@@ -272,10 +333,10 @@ final class PrebuiltsTests: XCTestCase {
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
             XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
             let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
-            let macroTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooMacros" }))
-            try checkSettings(macroTarget, usePrebuilt: false)
-            let testTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooTests" }))
-            try checkSettings(testTarget, usePrebuilt: false)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: false)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
         }
     }
 
@@ -325,10 +386,10 @@ final class PrebuiltsTests: XCTestCase {
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
             XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
             let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
-            let macroTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooMacros" }))
-            try checkSettings(macroTarget, usePrebuilt: false)
-            let testTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooTests" }))
-            try checkSettings(testTarget, usePrebuilt: false)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: false)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
         }
     }
 
@@ -372,12 +433,11 @@ final class PrebuiltsTests: XCTestCase {
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
             XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
             let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
-            let macroTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooMacros" }))
-            try checkSettings(macroTarget, usePrebuilt: false)
-            let testTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooTests" }))
-            try checkSettings(testTarget, usePrebuilt: false)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: false)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
         }
-
     }
 
     func testBadChecksumHttp() async throws {
@@ -431,10 +491,10 @@ final class PrebuiltsTests: XCTestCase {
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
             XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
             let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
-            let macroTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooMacros" }))
-            try checkSettings(macroTarget, usePrebuilt: false)
-            let testTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooTests" }))
-            try checkSettings(testTarget, usePrebuilt: false)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: false)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
         }
     }
 
@@ -468,7 +528,7 @@ final class PrebuiltsTests: XCTestCase {
         }
 
         let archiver = MockArchiver(handler: { _, archivePath, destination, completion in
-            XCTAssertEqual(archivePath.pathString, "/home/user/caches/org.swift.swiftpm/prebuilts/swift-syntax/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip".fixwin)
+            XCTAssertEqual(archivePath.pathString, "/home/user/caches/org.swift.swiftpm/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip".fixwin)
             XCTAssertEqual(destination.pathString, "/tmp/ws/.build/prebuilts/swift-syntax/\(self.swiftVersion)-MacroSupport-macos_aarch64".fixwin)
             completion(.success(()))
         })
@@ -492,10 +552,10 @@ final class PrebuiltsTests: XCTestCase {
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
             XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
             let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
-            let macroTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooMacros" }))
-            try checkSettings(macroTarget, usePrebuilt: true)
-            let testTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooTests" }))
-            try checkSettings(testTarget, usePrebuilt: true)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: true)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: true)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
         }
     }
 
@@ -545,10 +605,10 @@ final class PrebuiltsTests: XCTestCase {
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
             XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
             let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
-            let macroTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooMacros" }))
-            try checkSettings(macroTarget, usePrebuilt: false)
-            let testTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooTests" }))
-            try checkSettings(testTarget, usePrebuilt: false)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: false)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
         }
     }
 
@@ -574,10 +634,10 @@ final class PrebuiltsTests: XCTestCase {
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
             XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
             let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
-            let macroTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooMacros" }))
-            try checkSettings(macroTarget, usePrebuilt: false)
-            let testTarget = try XCTUnwrap(rootPackage.underlying.modules.first(where: { $0.name == "FooTests" }))
-            try checkSettings(testTarget, usePrebuilt: false)
+            try checkSettings(rootPackage, "FooMacros", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooTests", usePrebuilt: false)
+            try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+            try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
         }
     }
 }


### PR DESCRIPTION
Forward port of macro build prebuilts fixes from release/6.1.

#8229

Re-enable use of prebuilts for tests that depend on macro targets. These are guaranteed to be built for host as the macros are.

Add a hidden option to override the prebuilts download URL for swift-syntax for testing. Also added support for this to be a file URL.

Add support for using the ssh GitHub URL for swift-syntax, allowing multiple PackageReferences for prebuilts. Also elevated the PackageIdentity to the root structures that need it.

Fixed the build prebuilts script to generate into a versioned directory so we can support generating multiple versions at the same time.

 #8232 

I found a bug where if you change swift syntax version in your manifest, we were not changing the use of prebuilts to match. I have added a scan to do so. Also requires that we add the version of the prebuilt to the workspace state. Assume dependent products from prebuilts are being used to remove the warning for swift-syntax.

Fixes warning about swift-syntax not being used when all uses were replaced by the prebuilts.
