### PR TITLE
Basics,Commands,PackageLoading,SPMBuildCore: internalize Collections

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -398,7 +398,6 @@ let package = Package(
             dependencies: [
                 "Basics",
                 "PackageGraph",
-                .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
@@ -441,7 +440,6 @@ let package = Package(
             dependencies: [
                 "SPMBuildCore",
                 "PackageGraph",
-                .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
@@ -713,7 +711,6 @@ let package = Package(
                 "PackageSigning",
                 "SourceControl",
                 .product(name: "TSCTestSupport", package: "swift-tools-support-core"),
-                .product(name: "OrderedCollections", package: "swift-collections"),
                 "Workspace",
             ],
             swiftSettings: [

--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -79,11 +79,11 @@ add_library(Basics
   Vendor/Triple+Platforms.swift)
 target_link_libraries(Basics PUBLIC
   _AsyncFileSystem
-  SwiftCollections::OrderedCollections
   TSCBasic
   TSCUtility)
 target_link_libraries(Basics PRIVATE
   SwiftCollections::DequeModule
+  SwiftCollections::OrderedCollections
   SPMSQLite3
   TSCclibc)
 

--- a/Sources/Basics/Collections/IdentifiableSet.swift
+++ b/Sources/Basics/Collections/IdentifiableSet.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct OrderedCollections.OrderedDictionary
+private import OrderedCollections
 
 /// Replacement for `Set` elements that can't be `Hashable`, but can be `Identifiable`.
 public struct IdentifiableSet<Element: Identifiable>: Collection {

--- a/Sources/Basics/Graph/GraphAlgorithms.swift
+++ b/Sources/Basics/Graph/GraphAlgorithms.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct OrderedCollections.OrderedSet
+private import OrderedCollections
 
 /// Implements a pre-order depth-first search.
 ///

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -12,12 +12,11 @@
 
 import Basics
 import PackageGraph
-
 @_spi(SwiftPMInternal)
 import PackageModel
-
-import OrderedCollections
 import SPMBuildCore
+
+private import OrderedCollections
 
 import struct TSCBasic.SortedArray
 

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -14,11 +14,12 @@ import _Concurrency
 import Basics
 import Foundation
 import LLBuildManifest
-import OrderedCollections
 import PackageGraph
 import PackageLoading
 import PackageModel
 import SPMBuildCore
+
+private import OrderedCollections
 
 #if USE_IMPL_ONLY_IMPORTS
 @_implementationOnly import SwiftDriver
@@ -665,7 +666,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         }
 
         // Build cache
-        var cflagsCache: OrderedCollections.OrderedSet<String> = []
+        var cflagsCache: OrderedSet<String> = []
         var libsCache: [String] = []
         for tuple in ret {
             for cFlag in tuple.cFlags {

--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -33,13 +33,13 @@ add_library(Build
 target_link_libraries(Build PUBLIC
   TSCBasic
   Basics
-  SwiftCollections::OrderedCollections
   PackageGraph
   SPMBuildCore)
 target_link_libraries(Build PRIVATE
   DriverSupport
   LLBuildManifest
   SPMLLBuild
+  SwiftCollections::OrderedCollections
   SwiftDriver)
 target_link_libraries(Build INTERFACE
   llbuildSwift)

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -54,7 +54,6 @@ add_library(Commands
   Utilities/TestingSupport.swift
   Utilities/XCTEvents.swift)
 target_link_libraries(Commands PUBLIC
-  SwiftCollections::OrderedCollections
   ArgumentParser
   Basics
   Build
@@ -69,6 +68,7 @@ target_link_libraries(Commands PUBLIC
   XCBuildSupport)
 target_link_libraries(Commands PRIVATE
   DriverSupport
+  SwiftCollections::OrderedCollections
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(Commands PROPERTIES

--- a/Sources/Commands/CommandWorkspaceDelegate.swift
+++ b/Sources/Commands/CommandWorkspaceDelegate.swift
@@ -15,11 +15,12 @@ import CoreCommands
 import Dispatch
 import class Foundation.NSLock
 import struct Foundation.URL
-import OrderedCollections
 import PackageGraph
 import PackageModel
 import SPMBuildCore
 import Workspace
+
+private import OrderedCollections
 
 import protocol TSCBasic.OutputByteStream
 import struct TSCUtility.Version
@@ -36,11 +37,11 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
     }
 
     /// The progress of binary downloads.
-    private var binaryDownloadProgress = OrderedCollections.OrderedDictionary<String, DownloadProgress>()
+    private var binaryDownloadProgress = OrderedDictionary<String, DownloadProgress>()
     private let binaryDownloadProgressLock = NSLock()
 
     /// The progress of package  fetch operations.
-    private var fetchProgress = OrderedCollections.OrderedDictionary<PackageIdentity, FetchProgress>()
+    private var fetchProgress = OrderedDictionary<PackageIdentity, FetchProgress>()
     private let fetchProgressLock = NSLock()
 
     private let observabilityScope: ObservabilityScope

--- a/Sources/Commands/Utilities/MermaidPackageSerializer.swift
+++ b/Sources/Commands/Utilities/MermaidPackageSerializer.swift
@@ -10,7 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct OrderedCollections.OrderedDictionary
+private import OrderedCollections
+
 import class PackageModel.Package
 import class PackageModel.Product
 import class PackageModel.Module

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(PackageLoading PUBLIC
 target_link_libraries(PackageLoading PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 target_link_libraries(PackageLoading PRIVATE
+  SwiftCollections::OrderedCollections
   SourceControl)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(PackageLoading PROPERTIES

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -12,8 +12,9 @@
 
 import Basics
 import Dispatch
-import OrderedCollections
 import PackageModel
+
+private import OrderedCollections
 
 import func TSCBasic.findCycle
 import struct TSCBasic.KeyedPair
@@ -1404,7 +1405,7 @@ public final class PackageBuilder {
 
     /// Collects the products defined by a package.
     private func constructProducts(_ modules: [Module]) throws -> [Product] {
-        var products = OrderedCollections.OrderedSet<KeyedPair<Product, String>>()
+        var products = OrderedSet<KeyedPair<Product, String>>()
 
         /// Helper method to append to products array.
         func append(_ product: Product) {

--- a/Sources/PackageLoading/PkgConfig.swift
+++ b/Sources/PackageLoading/PkgConfig.swift
@@ -12,9 +12,8 @@
 
 import Basics
 import Foundation
-import OrderedCollections
 
-import class Basics.AsyncProcess
+private import OrderedCollections
 
 /// Information on an individual `pkg-config` supported package.
 public struct PkgConfig {

--- a/Sources/SPMBuildCore/CMakeLists.txt
+++ b/Sources/SPMBuildCore/CMakeLists.txt
@@ -34,7 +34,6 @@ target_link_libraries(SPMBuildCore PUBLIC
   TSCBasic
   TSCUtility
   Basics
-  SwiftCollections::OrderedCollections
   PackageGraph)
 
 

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -19,8 +19,6 @@ import PackageModel
 import PackageLoading
 import PackageGraph
 
-import struct OrderedCollections.OrderedDictionary
-
 import protocol TSCBasic.DiagnosticLocation
 
 public enum PluginAction {

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -16,7 +16,6 @@ import struct Foundation.URL
 #if os(macOS)
 import class Foundation.Bundle
 #endif
-import OrderedCollections
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 import PackageGraph

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -20,12 +20,13 @@ import Dispatch
 import DriverSupport
 
 import Foundation
-import OrderedCollections
 import PackageGraph
 import PackageLoading
 import PackageModel
 import SPMBuildCore
 import XCBuildSupport
+
+private import OrderedCollections
 
 import struct TSCBasic.KeyedPair
 import func TSCBasic.topologicalSort
@@ -398,7 +399,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
             return try ModulesGraph.load(
                 root: packageGraphRoot,
                 identityResolver: identityResolver,
-                externalManifests: loadedManifests.reduce(into: OrderedCollections.OrderedDictionary<PackageIdentity, (manifest: Manifest, fs: FileSystem)>()) { partial, item in
+                externalManifests: loadedManifests.reduce(into: OrderedDictionary<PackageIdentity, (manifest: Manifest, fs: FileSystem)>()) { partial, item in
                     partial[item.key] = (manifest: item.value, fs: self.fileSystem)
                 },
                 binaryArtifacts: [:],


### PR DESCRIPTION
These modules do not require Collections to leak into the public interface. Use the opportunity to reduce the publicly visible dependencies and reduce some unnecessary imports of `OrderedCollections`.