### PR TITLE
Set candidate URL for prebuilts download.

### DIFF
--- a/Sources/Basics/Concurrency/SendableBox.swift
+++ b/Sources/Basics/Concurrency/SendableBox.swift
@@ -16,24 +16,24 @@ import struct Foundation.Date
 /// an `async` closure. This type serves as a replacement for `ThreadSafeBox`
 /// implemented with Swift Concurrency primitives.
 public actor SendableBox<Value: Sendable> {
-    init(_ value: Value? = nil) {
+    public init(_ value: Value) {
         self.value = value
     }
 
-    var value: Value?
+    public var value: Value
+
+    public func set(_ value: Value) {
+        self.value = value
+    }
 }
 
 extension SendableBox where Value == Int {
     func increment() {
-        if let value {
-            self.value = value + 1
-        }
+        self.value = value + 1
     }
 
     func decrement() {
-        if let value {
-            self.value = value - 1
-        }
+        self.value = value - 1
     }
 }
 

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -227,15 +227,15 @@ final class HTTPClientTests: XCTestCase {
 
     func testExponentialBackoff() async throws {
         let counter = SendableBox(0)
-        let lastCall = SendableBox<Date>()
+        let lastCall = SendableBox<Date>(Date())
         let maxAttempts = 5
         let errorCode = Int.random(in: 500 ..< 600)
         let delay = SendableTimeInterval.milliseconds(100)
 
         let httpClient = HTTPClient { _, _ in
-            let count = await counter.value!
+            let count = await counter.value
             let expectedDelta = pow(2.0, Double(count - 1)) * delay.timeInterval()!
-            let delta = await lastCall.value.flatMap { Date().timeIntervalSince($0) } ?? 0
+            let delta = await Date().timeIntervalSince(lastCall.value)
             XCTAssertEqual(delta, expectedDelta, accuracy: 0.1)
 
             await counter.increment()
@@ -404,7 +404,7 @@ final class HTTPClientTests: XCTestCase {
         let httpClient = HTTPClient(configuration: configuration) { request, _ in
             await concurrentRequests.increment()
 
-            if await concurrentRequests.value! > maxConcurrentRequests {
+            if await concurrentRequests.value > maxConcurrentRequests {
                 XCTFail("too many concurrent requests \(concurrentRequests), expected \(maxConcurrentRequests)")
             }
 

--- a/Tests/WorkspaceTests/PrebuiltsTests.swift
+++ b/Tests/WorkspaceTests/PrebuiltsTests.swift
@@ -134,10 +134,10 @@ final class PrebuiltsTests: XCTestCase {
                 throw StringError("invalid request \(request.kind)")
             }
 
-            if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-manifest.json" {
+            if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-manifest.json" {
                 try fileSystem.writeFileContents(destination, data: manifestData)
                 return .okay()
-            } else if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
+            } else if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
                 try fileSystem.writeFileContents(destination, data: artifact)
                 return .okay()
             } else {
@@ -191,17 +191,17 @@ final class PrebuiltsTests: XCTestCase {
                 throw StringError("invalid request \(request.kind)")
             }
 
-            if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-manifest.json" {
+            if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-manifest.json" {
                 try fileSystem.writeFileContents(destination, data: manifestData)
                 return .okay()
-            } else if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
+            } else if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
                 try fileSystem.writeFileContents(destination, data: artifact)
                 return .okay()
             } else {
                 // make sure it's the updated one
                 XCTAssertEqual(
                     request.url,
-                    "https://github.com/dschaefer2/swift-syntax/releases/download/601.0.0/\(self.swiftVersion)-manifest.json"
+                    "https://download.swift.org/prebuilts/swift-syntax/601.0.0/\(self.swiftVersion)-manifest.json"
                 )
                 return .notFound()
             }
@@ -295,10 +295,10 @@ final class PrebuiltsTests: XCTestCase {
                 throw StringError("invalid request \(request.kind)")
             }
 
-            if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-manifest.json" {
+            if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-manifest.json" {
                 try fileSystem.writeFileContents(destination, data: manifestData)
                 return .okay()
-            } else if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
+            } else if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
                 try fileSystem.writeFileContents(destination, data: artifact)
                 return .okay()
              } else {
@@ -355,10 +355,10 @@ final class PrebuiltsTests: XCTestCase {
                 throw StringError("invalid request \(request.kind)")
             }
 
-            if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-manifest.json" {
+            if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-manifest.json" {
                 try fileSystem.writeFileContents(destination, data: manifestData)
                 return .okay()
-            } else if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
+            } else if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
                 XCTFail("Unexpect download of archive")
                 try fileSystem.writeFileContents(destination, data: artifact)
                 return .okay()
@@ -408,7 +408,7 @@ final class PrebuiltsTests: XCTestCase {
         let (_, rootPackage, swiftSyntax) = try initData(artifact: artifact, swiftSyntaxVersion: "600.0.2")
 
         let httpClient = HTTPClient { request, progressHandler in
-            if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.2/\(self.swiftVersion)-manifest.json" {
+            if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.2/\(self.swiftVersion)-manifest.json" {
                 return .notFound()
              } else {
                 XCTFail("Unexpected URL \(request.url)")
@@ -459,7 +459,7 @@ final class PrebuiltsTests: XCTestCase {
                 throw StringError("invalid request \(request.kind)")
             }
 
-            if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-manifest.json" {
+            if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-manifest.json" {
                 try fileSystem.writeFileContents(destination, data: manifestData)
                 return .okay()
              } else {
@@ -507,7 +507,7 @@ final class PrebuiltsTests: XCTestCase {
         let (_, rootPackage, swiftSyntax) = try initData(artifact: artifact, swiftSyntaxVersion: "600.0.1")
 
         let httpClient = HTTPClient { request, progressHandler in
-            if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-manifest.json" {
+            if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-manifest.json" {
                 // Pretend it's a different swift version
                 return .notFound()
              } else {
@@ -561,10 +561,10 @@ final class PrebuiltsTests: XCTestCase {
                 throw StringError("invalid request \(request.kind)")
             }
 
-            if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-manifest.json" {
+            if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-manifest.json" {
                 try fileSystem.writeFileContents(destination, data: manifestData)
                 return .okay()
-            } else if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
+            } else if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
                 try fileSystem.writeFileContents(destination, data: fakeArtifact)
                 return .okay()
              } else {
@@ -621,10 +621,10 @@ final class PrebuiltsTests: XCTestCase {
                 throw StringError("invalid request \(request.kind)")
             }
 
-            if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-manifest.json" {
+            if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-manifest.json" {
                 try fileSystem.writeFileContents(destination, data: manifestData)
                 return .okay()
-            } else if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
+            } else if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
                 try fileSystem.writeFileContents(destination, data: artifact)
                 return .okay()
              } else {
@@ -678,7 +678,7 @@ final class PrebuiltsTests: XCTestCase {
                 throw StringError("invalid request \(request.kind)")
             }
 
-            if request.url == "https://github.com/dschaefer2/swift-syntax/releases/download/600.0.1/\(self.swiftVersion)-manifest.json" {
+            if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-manifest.json" {
                 let badManifestData = manifestData + Data("bad".utf8)
                 try fileSystem.writeFileContents(destination, data: badManifestData)
                 return .okay()


### PR DESCRIPTION
I was using my fork of swift-syntax to host my test artifacts. Switch that to a more realistic yet not yet approved one.

Also cuts down how often we reach out to fetch a manifest. We instead create an empty one in the scratch directory if it's not found on the download site. And we always now check the scratch directory first.
