### PR TITLE
Utilities: remove Yams from the bootstrap script

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -221,7 +221,6 @@ def parse_global_args(args):
     args.build_dir                            = os.path.abspath(args.build_dir)
     args.project_root                         = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     args.source_dirs["tsc"]                   = os.path.join(args.project_root, "..", "swift-tools-support-core")
-    args.source_dirs["yams"]                  = os.path.join(args.project_root, "..", "yams")
     args.source_dirs["swift-argument-parser"] = os.path.join(args.project_root, "..", "swift-argument-parser")
     args.source_dirs["swift-crypto"]          = os.path.join(args.project_root, "..", "swift-crypto")
     args.source_dirs["swift-driver"]          = os.path.join(args.project_root, "..", "swift-driver")
@@ -372,19 +371,17 @@ def build(args):
 
         # tsc depends on swift-system so they must be built first.
         build_dependency(args, "swift-system")
-        # swift-driver depends on tsc, swift-argument-parser, and yams so they must be built first.
+        # swift-driver depends on tsc and swift-argument-parser so they must be built first.
         tsc_cmake_flags = [
             "-DSwiftSystem_DIR="    + os.path.join(args.build_dirs["swift-system"], "cmake/modules"),
         ]
         build_dependency(args, "tsc", tsc_cmake_flags)
         build_dependency(args, "swift-argument-parser", ["-DBUILD_TESTING=NO", "-DBUILD_EXAMPLES=NO"])
-        build_dependency(args, "yams", [], [get_foundation_cmake_arg(args)] if args.foundation_build_dir else [])
 
         swift_driver_cmake_flags = [
             get_llbuild_cmake_arg(args),
             "-DSwiftSystem_DIR="    + os.path.join(args.build_dirs["swift-system"], "cmake/modules"),
             "-DTSC_DIR=" + os.path.join(args.build_dirs["tsc"], "cmake/modules"),
-            "-DYams_DIR=" + os.path.join(args.build_dirs["yams"], "cmake/modules"),
             "-DArgumentParser_DIR=" + os.path.join(args.build_dirs["swift-argument-parser"], "cmake/modules"),
         ]
         build_dependency(args, "swift-driver", swift_driver_cmake_flags)
@@ -665,7 +662,6 @@ def build_swiftpm_with_cmake(args):
         add_rpath_for_cmake_build(args, args.build_dirs["llbuild"])
 
     if platform.system() == "Darwin":
-        add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["yams"],                  "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-argument-parser"], "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-crypto"],          "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-driver"],          "lib"))
@@ -796,7 +792,6 @@ def get_swiftpm_env_cmd(args):
             os.path.join(args.bootstrap_dir,                       "lib"),
             os.path.join(args.build_dirs["tsc"],                   "lib"),
             os.path.join(args.build_dirs["llbuild"],               "lib"),
-            os.path.join(args.build_dirs["yams"],                  "lib"),
             os.path.join(args.build_dirs["swift-argument-parser"], "lib"),
             os.path.join(args.build_dirs["swift-crypto"],          "lib"),
             os.path.join(args.build_dirs["swift-driver"],          "lib"),


### PR DESCRIPTION
Yams is no longer a dependency for swift-driver, remove the dependency building to reduce the build times.