### PR TITLE
Support dynamic linking on Linux via Artifactbundles

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan+Swift.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Swift.swift
@@ -41,7 +41,7 @@ extension BuildPlan {
             case let target as BinaryModule:
                 switch target.kind {
                 case .artifactsArchive:
-                    let libraries = try self.parseArtifactbundle(for: target, triple: swiftTarget.buildParameters.triple)
+                    let libraries = try self.parseLibraries(in: target, triple: swiftTarget.buildParameters.triple)
                     for library in libraries {
                         library.headersPaths.forEach {
                             swiftTarget.additionalFlags += ["-I", $0.pathString]

--- a/Sources/Build/BuildPlan/BuildPlan+Swift.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Swift.swift
@@ -39,7 +39,16 @@ extension BuildPlan {
                 swiftTarget.additionalFlags += ["-Xcc", "-fmodule-map-file=\(target.moduleMapPath.pathString)"]
                 swiftTarget.additionalFlags += try pkgConfig(for: target).cFlags
             case let target as BinaryModule:
-                if case .xcframework = target.kind {
+                switch target.kind {
+                case .artifactsArchive:
+                    let libraries = try self.parseArtifactbundle(for: target, triple: swiftTarget.buildParameters.triple)
+                    for library in libraries {
+                        library.headersPaths.forEach {
+                            swiftTarget.additionalFlags += ["-I", $0.pathString]
+                        }
+                    }
+
+                case .xcframework:
                     let libraries = try self.parseXCFramework(for: target, triple: swiftTarget.buildParameters.triple)
                     for library in libraries {
                         library.headersPaths.forEach {
@@ -47,11 +56,13 @@ extension BuildPlan {
                         }
                         swiftTarget.libraryBinaryPaths.insert(library.libraryPath)
                     }
+
+                default:
+                    break
                 }
             default:
                 break
             }
         }
     }
-
 }

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -680,13 +680,20 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         return result
     }
 
-    /// Extracts the library information from an Artifact Bundle.
-    func parseArtifactbundle(for binaryTarget: BinaryModule, triple: Basics.Triple) throws -> [LibraryInfo] {
-        try self.externalLibrariesCache.memoize(key: binaryTarget) {
-            try binaryTarget.parseLibraryArtifacts(for: triple, fileSystem: self.fileSystem)
+    /// Extracts the information about executables in an Artifact Bundle, with caching.
+    func parseExecutables(in binaryTarget: BinaryModule, triple: Basics.Triple) throws -> [ExecutableInfo] {
+        try self.externalExecutablesCache.memoize(key: binaryTarget) {
+            let execInfos = try binaryTarget.parseExecutables(for: triple, fileSystem: self.fileSystem)
+            return execInfos.filter { !$0.supportedTriples.isEmpty }
         }
     }
-    /// Extracts the library information from an XCFramework.
+    /// Extracts the information about libraries in an Artifact Bundle, with caching.
+    func parseLibraries(in binaryTarget: BinaryModule, triple: Basics.Triple) throws -> [LibraryInfo] {
+        try self.externalLibrariesCache.memoize(key: binaryTarget) {
+            try binaryTarget.parseLibraries(for: triple, fileSystem: self.fileSystem)
+        }
+    }
+    /// Extracts the library information from an XCFramework, with caching.
     func parseXCFramework(for binaryTarget: BinaryModule, triple: Basics.Triple) throws -> [LibraryInfo] {
         try self.externalLibrariesCache.memoize(key: binaryTarget) {
             try binaryTarget.parseXCFrameworks(for: triple, fileSystem: self.fileSystem)

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -680,6 +680,12 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         return result
     }
 
+    /// Extracts the library information from an Artifact Bundle.
+    func parseArtifactbundle(for binaryTarget: BinaryModule, triple: Basics.Triple) throws -> [LibraryInfo] {
+        try self.externalLibrariesCache.memoize(key: binaryTarget) {
+            try binaryTarget.parseLibraryArtifacts(for: triple, fileSystem: self.fileSystem)
+        }
+    }
     /// Extracts the library information from an XCFramework.
     func parseXCFramework(for binaryTarget: BinaryModule, triple: Basics.Triple) throws -> [LibraryInfo] {
         try self.externalLibrariesCache.memoize(key: binaryTarget) {

--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -44,6 +44,7 @@ public struct ArtifactsArchiveMetadata: Equatable {
     // 3d models along with associated textures, or fonts, etc.
     public enum ArtifactType: String, RawRepresentable, Decodable {
         case executable
+        case library
         case swiftSDK
 
         // Can't be marked as formally deprecated as we still need to use this value for warning users.

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -55,8 +55,7 @@ extension BinaryModule {
             .map { [try AbsolutePath(validating: $0, relativeTo: libraryDir)] } ?? [] + [libraryDir]
         return [LibraryInfo(libraryPath: libraryFile, headersPaths: headersDirs)]
     }
-
-    public func parseLibraryArtifacts(for triple: Triple, fileSystem: FileSystem) throws -> [LibraryInfo] {
+    public func parseLibraries(for triple: Triple, fileSystem: FileSystem) throws -> [LibraryInfo] {
         let metadata = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: self.artifactPath)
         return metadata.artifacts.reduce(into: []) {
             guard case .library = $1.value.type else {
@@ -68,9 +67,8 @@ extension BinaryModule {
 
             $0.append(.init(libraryPath: libraryFile, headersPaths: [libraryDir]))
         }
-
     }
-    public func parseArtifactArchives(for triple: Triple, fileSystem: FileSystem) throws -> [ExecutableInfo] {
+    public func parseExecutables(for triple: Triple, fileSystem: FileSystem) throws -> [ExecutableInfo] {
         // The host triple might contain a version which we don't want to take into account here.
         let versionLessTriple = try triple.withoutVersion()
         // We return at most a single variant of each artifact.
@@ -95,6 +93,11 @@ extension BinaryModule {
                 )
             }
         }
+    }
+
+    @available(*, deprecated, renamed: "parseExecutables(for:fileSystem:)")
+    public func parseArtifactArchives(for triple: Triple, fileSystem: FileSystem) throws -> [ExecutableInfo] {
+        try self.parseExecutables(for: triple, fileSystem: fileSystem)
     }
 }
 

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -621,7 +621,7 @@ fileprivate func collectAccessibleTools(
         // For a binary target we create a `vendedTool`.
         if let module = executableOrBinaryModule as? BinaryModule {
             // TODO: Memoize this result for the host triple
-            let execInfos = try module.parseArtifactArchives(for: hostTriple, fileSystem: fileSystem)
+            let execInfos = try module.parseExecutables(for: hostTriple, fileSystem: fileSystem)
             return try execInfos.map{ .vendedTool(name: $0.name, path: $0.executablePath, supportedTriples: try $0.supportedTriples.map{ try $0.withoutVersion().tripleString }) }
         }
         // For an executable target we create a `builtTool`.


### PR DESCRIPTION
proof-of-concept for enabling [self-managed dynamic library dependencies](https://forums.swift.org/t/can-you-dynamically-link-swift-libraries-on-linux/77442) on Linux!

### Motivation:

see [Forums discussion](https://forums.swift.org/t/can-you-dynamically-link-swift-libraries-on-linux/77442), https://github.com/swiftlang/swift-package-manager/issues/5714 

### Modifications:

* adds an `ArtifactType` called “`library`”, which can be used in `info.json` inside an Artifactbundle. variant/triple checking is not implemented yet, and we expect this to be very limited and geared towards self-managed deployment use cases, as we intentionally do not want to design a compatibility checking system that covers all possible host–target combinations of “Linux”.

```json
{
    "schemaVersion": "1.0",
    "artifacts": {
        "MyLibrary": {
            "type": "library",
            "version": "0.17.0",
            "variants": [
                {
                    "path": "MyLibrary",
                    "supportedTriples": [
                        "x86_64-unknown-linux-gnu"
                    ]
                }
            ]
        }
    }
}
```

* adds logic to `Sources/Build/BuildPlan/BuildPlan+Swift.swift` that injects the necessary `.swiftmodule` search paths to the `swiftc` build command.

* adds logic to `Sources/Build/BuildPlan/BuildPlan+Product.swift` that populates the necessary linker flags to compile products that include dependencies on non-XCFramework binary targets

* does a small amount of refactoring around the additions i made, in an effort to leave the code base in a slightly better shape than i found it in

### Result:

SwiftPM can now dynamically link binary library dependencies into executables on Linux, although the executables of course will require the shared libraries to be installed in the expected locations to actually run.

sample manifest:

```
// swift-tools-version:6.0
import PackageDescription

let package = Package(
    name: "DynamicLinkingTest",
    products: [
        // .library(name: "MyLibrary", type: .dynamic, targets: ["MyLibrary"]),
        .executable(name: "Client", targets: ["Client"]),
    ],
    dependencies: [
    ],
    targets: [
        .binaryTarget(
            name: "MyLibrary",
            path: "test.artifactbundle"),

        .executableTarget(name: "Client",
            dependencies: [
                .target(name: "MyLibrary"),
            ]),

        // .target(name: "MyLibrary",
        //     swiftSettings: [
        //         .unsafeFlags(["-enable-library-evolution"]),
        //     ]),
    ]
)
```

sample Artifactbundle

```
- test.artifactbundle
    - MyLibrary
        - libMyLibrary.so
        - MyLibrary.swiftmodule
    - info.json
```
