### PR TITLE
Fix: preserve symlinks in ZipArchive compress function

### DIFF
--- a/Sources/Basics/Archiver/ZipArchiver.swift
+++ b/Sources/Basics/Archiver/ZipArchiver.swift
@@ -120,7 +120,7 @@ public struct ZipArchiver: Archiver, Cancellable {
             arguments: [
                 "/bin/sh",
                 "-c",
-                "cd \(directory.parentDirectory.underlying.pathString) && zip -r \(destinationPath.pathString) \(directory.basename)",
+                "cd \(directory.parentDirectory.underlying.pathString) && zip -ry \(destinationPath.pathString) \(directory.basename)",
             ]
         )
         #endif

--- a/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
@@ -119,6 +119,8 @@ final class ZipArchiverTests: XCTestCase {
              try localFileSystem.writeFileContents(dir2.appending("file3.txt"), string: "Hello World 3!")
              try localFileSystem.writeFileContents(dir2.appending("file4.txt"), string: "Hello World 4!")
 
+             try localFileSystem.createSymbolicLink(rootDir.appending("file2.txt"), pointingAt: dir1.appending("file2.txt"), relative: true)
+
              let archivePath = tmpdir.appending(component: UUID().uuidString + ".zip")
              try await archiver.compress(directory: rootDir, to: archivePath)
              XCTAssertFileExists(archivePath)
@@ -153,6 +155,12 @@ final class ZipArchiverTests: XCTestCase {
              XCTAssertEqual(
                  try? localFileSystem.readFileContents(extractedDir2.appending("file4.txt")),
                  "Hello World 4!"
+             )
+            
+            XCTAssertTrue(localFileSystem.isSymlink(extractRootDir.appending("file2.txt")))
+            XCTAssertEqual(
+                 try? localFileSystem.readFileContents(extractRootDir.appending("file2.txt")),
+                 try? localFileSystem.readFileContents(extractedDir1.appending("file2.txt"))
              )
          }
      }

--- a/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
@@ -118,8 +118,7 @@ final class ZipArchiverTests: XCTestCase {
              try localFileSystem.createDirectory(dir2)
              try localFileSystem.writeFileContents(dir2.appending("file3.txt"), string: "Hello World 3!")
              try localFileSystem.writeFileContents(dir2.appending("file4.txt"), string: "Hello World 4!")
-
-             try localFileSystem.createSymbolicLink(rootDir.appending("file2.txt"), pointingAt: dir1.appending("file2.txt"), relative: true)
+             try localFileSystem.createSymbolicLink(dir2.appending("file5.txt"), pointingAt: dir1.appending("file2.txt"), relative: true)
 
              let archivePath = tmpdir.appending(component: UUID().uuidString + ".zip")
              try await archiver.compress(directory: rootDir, to: archivePath)
@@ -157,9 +156,9 @@ final class ZipArchiverTests: XCTestCase {
                  "Hello World 4!"
              )
             
-            XCTAssertTrue(localFileSystem.isSymlink(extractRootDir.appending("file2.txt")))
-            XCTAssertEqual(
-                 try? localFileSystem.readFileContents(extractRootDir.appending("file2.txt")),
+             XCTAssertTrue(localFileSystem.isSymlink(extractedDir2.appending("file5.txt")))
+             XCTAssertEqual(
+                 try? localFileSystem.readFileContents(extractedDir2.appending("file5.txt")),
                  try? localFileSystem.readFileContents(extractedDir1.appending("file2.txt"))
              )
          }


### PR DESCRIPTION
This PR fixes #8248, by adding the `y` flag to the `zip` command that is executed when archiving a package's sources for publication to a registry on a non-Windows OS.

### Motivation:

Without this change, packages which contain symlinks in their sources will produce invalid and potentially non-buildable archives when publishing to a registry, since any symlinks are currently transformed into duplicate files during the archive creation, instead of being preserved.  

### Modifications:

I've added the following flag to the `zip` call:
>   -y   store symbolic links as the link instead of the referenced file

I've additionally modified the associated `testCompress()` test case, adding logic to ensure that symlinks are preserved correctly. 

### Result:

With this change, the resulting zipfile that is uploaded to a registry will contain symlinks consistent with the original package sources. 
