### PR TITLE
[FreeBSD] suspend all other threads before closing file descriptors

### DIFF
--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -313,6 +313,9 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
         sigprocmask(SIG_UNBLOCK, &sig_set_all, nil)
 
         #if os(FreeBSD) || os(OpenBSD)
+        #if os(FreeBSD)
+        pthread_suspend_all_np()
+        #endif
         closefrom(3)
         #else
         #if os(Android)


### PR DESCRIPTION
Suspend all other threads first before closing file descriptors and exec.

### Motivation:

See #8197 #8180, `swift run` can crash due to race condition between libdispatch controlled threads. To properly mitigate this, suspend all other threads (including those managed by libdispatch) before closing the file descriptors.

### Modifications:

Call `pthread_suspend_all_np` before closing file descriptors, this api is not portable but exists on both FreeBSD and OpenBSD. However, since the Glibc overlay for OpenBSD does not include <pthread_np.h>, we guard this and make it available for FreeBSD only.

