### PR TITLE
[6.1] Remove trailing comma in function call

### DIFF
--- a/Sources/Workspace/Workspace+Prebuilts.swift
+++ b/Sources/Workspace/Workspace+Prebuilts.swift
@@ -207,7 +207,7 @@ extension Workspace {
                             identity: .plain("swift-syntax"),
                             kind: .remoteSourceControl("git@github.com:swiftlang/swift-syntax.git")
                         ),
-                    ],
+                    ]
                 ),
             ]
         }


### PR DESCRIPTION
- **Explanation**: This restores the ability to build SwiftPM using a Swift 6.0 compiler.
- **Scope**: None
- **Issue**: n/a
- **Original PR**: n/a
- **Risk**: Very low
- **Testing**: Project builds
- **Reviewer**: @dschaefer2 @jakepetroules 