### PR TITLE
Add `package` access level to access level enums

### DIFF
--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -442,6 +442,8 @@ final class PluginDelegate: PluginInvocationDelegate {
             symbolGraphExtractor.minimumAccessLevel = .fileprivate
         case .internal:
             symbolGraphExtractor.minimumAccessLevel = .internal
+        case .package:
+            symbolGraphExtractor.minimumAccessLevel = .package
         case .public:
             symbolGraphExtractor.minimumAccessLevel = .public
         case .open:

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -40,8 +40,8 @@ package struct SymbolGraphExtract {
 
     /// Access control levels.
     public enum AccessLevel: String, RawRepresentable, CaseIterable, ExpressibleByArgument {
-        // The cases reflect those found in `include/swift/AST/AttrKind.h` of the swift compiler (at commit 03f55d7bb4204ca54841218eb7cc175ae798e3bd)
-        case `private`, `fileprivate`, `internal`, `public`, `open`
+        // The cases reflect those found in `include/swift/AST/AttrKind.h` of the swift compiler (at commit ca96a2b)
+        case `private`, `fileprivate`, `internal`, `package`, `public`, `open`
     }
 
     /// Output format of the generated symbol graph.

--- a/Sources/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/PackagePlugin/PackageManagerProxy.swift
@@ -245,7 +245,7 @@ public struct PackageManager {
 
         /// Represents a Swift access level.
         public enum AccessLevel: String, CaseIterable {
-            case `private`, `fileprivate`, `internal`, `public`, open
+            case `private`, `fileprivate`, `internal`, `package`, `public`, open
         }
 
         /// Whether to include synthesized members.
@@ -472,6 +472,8 @@ extension PluginToHostMessage.SymbolGraphOptions.AccessLevel {
             self = .internal
         case .public:
             self = .public
+        case .package:
+            self = .package
         case .open:
             self = .open
         }

--- a/Sources/PackagePlugin/PluginMessages.swift
+++ b/Sources/PackagePlugin/PluginMessages.swift
@@ -331,7 +331,7 @@ enum PluginToHostMessage: Codable {
         struct SymbolGraphOptions: Codable {
             var minimumAccessLevel: AccessLevel
             enum AccessLevel: String, Codable {
-                case `private`, `fileprivate`, `internal`, `public`, `open`
+                case `private`, `fileprivate`, `internal`, `package`, `public`, `open`
             }
             var includeSynthesized: Bool
             var includeSPI: Bool

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -881,7 +881,7 @@ final class DefaultPluginInvocationDelegate: PluginInvocationDelegate {
 public struct PluginInvocationSymbolGraphOptions {
     public var minimumAccessLevel: AccessLevel
     public enum AccessLevel: String {
-        case `private`, `fileprivate`, `internal`, `public`, `open`
+        case `private`, `fileprivate`, `internal`, `package`, `public`, `open`
     }
     public var includeSynthesized: Bool
     public var includeSPI: Bool
@@ -1163,6 +1163,8 @@ fileprivate extension PluginInvocationSymbolGraphOptions.AccessLevel {
             self = .fileprivate
         case .internal:
             self = .internal
+        case .package:
+            self = .package
         case .public:
             self = .public
         case .open:


### PR DESCRIPTION
Currently the symbol graph generator defaults to "public" minimum access level even if the user tries to initialize the options with "package" this is because the internal enums representing access level don't have a notion of `package` access control.

### Motivation:

Currently it is not possible to generate documentation only for `package` and `public` symbols. This changes that

### Modifications:

Adds `package` values to enums representing access control along the symbol graph generation code path.

### Result:

When invoking [swift-docc-plugin](https://github.com/apple/swift-docc-plugin) with `--symbol-graph-minimum-access-level package` the resulting documentation contains `public` and `package` access controlled symbols.
