### PR TITLE
Revert "Tests: Canary Swift Testing test"

### DIFF
--- a/Tests/BasicsTests/SampleTests.swift
+++ b/Tests/BasicsTests/SampleTests.swift
@@ -1,9 +1,0 @@
-import Testing
-
-struct Foo {
-
-    @Test
-    func myTest() {
-        #expect(Bool(true))
-    }
-}


### PR DESCRIPTION
Reverts swiftlang/swift-package-manager#8222

Reverting this as it appears to be causing a toolchain build failures.