### PR TITLE
Tests: Canary Swift Testing test

### DIFF
--- a/Tests/BasicsTests/SampleTests.swift
+++ b/Tests/BasicsTests/SampleTests.swift
@@ -1,0 +1,9 @@
+import Testing
+
+struct Foo {
+
+    @Test
+    func myTest() {
+        #expect(Bool(true))
+    }
+}

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -400,11 +400,6 @@ def test(args):
     build(args)
 
     logging.info("Testing")
-
-    # Ensure cross compilation is disabled so we only exeucte the tests against the
-    # host architecture
-    args.cross_compile_hosts = False
-
     parse_test_args(args)
     cmd = [
         os.path.join(args.bin_dir, "swift-test")

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -400,6 +400,11 @@ def test(args):
     build(args)
 
     logging.info("Testing")
+
+    # Ensure cross compilation is disabled so we only exeucte the tests against the
+    # host architecture
+    args.cross_compile_hosts = False
+
     parse_test_args(args)
     cmd = [
         os.path.join(args.bin_dir, "swift-test")


### PR DESCRIPTION
Add a canary swift testing tests to ensure we do not regress.

This test will be removed sometime after #8092, #8093 or #8100 are merged

(cherry picked from commit 257e6713dbd283bd952f49a2695c3746cb677444)

Re-adds #8222, after it was reverted in #8266 
Depends on https://github.com/swiftlang/swift/pull/79074