### PR TITLE
Enable building prebuilts on linux hosts without docker.

### DIFF
--- a/Sources/Workspace/Workspace+Prebuilts.swift
+++ b/Sources/Workspace/Workspace+Prebuilts.swift
@@ -93,7 +93,8 @@ extension Workspace {
             case ubuntu_focal_aarch64
             case ubuntu_focal_x86_64
             // bookworm is currently missing
-            // fedora39 is currently missing
+            case fedora_39_aarch64
+            case fedora_39_x86_64
             case amazonlinux2_aarch64
             case amazonlinux2_x86_64
             case rhel_ubi9_aarch64
@@ -556,11 +557,13 @@ extension Workspace.PrebuiltsManifest.Platform {
         switch self {
         case .macos_aarch64, .windows_aarch64,
             .ubuntu_noble_aarch64, .ubuntu_jammy_aarch64, .ubuntu_focal_aarch64,
+            .fedora_39_aarch64,
             .amazonlinux2_aarch64,
             .rhel_ubi9_aarch64:
             return .aarch64
         case .macos_x86_64, .windows_x86_64,
             .ubuntu_noble_x86_64, .ubuntu_jammy_x86_64, .ubuntu_focal_x86_64,
+            .fedora_39_x86_64,
             .amazonlinux2_x86_64,
             .rhel_ubi9_x86_64:
             return .x86_64
@@ -576,6 +579,7 @@ extension Workspace.PrebuiltsManifest.Platform {
         case .ubuntu_noble_aarch64, .ubuntu_noble_x86_64,
             .ubuntu_jammy_aarch64, .ubuntu_jammy_x86_64,
             .ubuntu_focal_aarch64, .ubuntu_focal_x86_64,
+            .fedora_39_aarch64, .fedora_39_x86_64,
             .amazonlinux2_aarch64, .amazonlinux2_x86_64,
             .rhel_ubi9_aarch64, .rhel_ubi9_x86_64:
             return .linux
@@ -644,6 +648,18 @@ extension Workspace.PrebuiltsManifest.Platform {
                     return .ubuntu_focal_aarch64
                 case .x86_64:
                     return .ubuntu_focal_x86_64
+                }
+            default:
+                return nil
+            }
+        case "fedora":
+            switch osDict["VERSION_ID"] {
+            case "39", "41":
+                switch arch {
+                case .aarch64:
+                    return .fedora_39_aarch64
+                case .x86_64:
+                    return .fedora_39_x86_64
                 }
             default:
                 return nil

--- a/Sources/Workspace/Workspace+Prebuilts.swift
+++ b/Sources/Workspace/Workspace+Prebuilts.swift
@@ -92,13 +92,14 @@ extension Workspace {
             case ubuntu_jammy_x86_64
             case ubuntu_focal_aarch64
             case ubuntu_focal_x86_64
-            // bookworm is currently missing
             case fedora_39_aarch64
             case fedora_39_x86_64
             case amazonlinux2_aarch64
             case amazonlinux2_x86_64
             case rhel_ubi9_aarch64
             case rhel_ubi9_x86_64
+            case debian_12_aarch64
+            case debian_12_x86_64
 
             public enum Arch: String {
                 case x86_64
@@ -559,13 +560,15 @@ extension Workspace.PrebuiltsManifest.Platform {
             .ubuntu_noble_aarch64, .ubuntu_jammy_aarch64, .ubuntu_focal_aarch64,
             .fedora_39_aarch64,
             .amazonlinux2_aarch64,
-            .rhel_ubi9_aarch64:
+            .rhel_ubi9_aarch64,
+            .debian_12_aarch64:
             return .aarch64
         case .macos_x86_64, .windows_x86_64,
             .ubuntu_noble_x86_64, .ubuntu_jammy_x86_64, .ubuntu_focal_x86_64,
             .fedora_39_x86_64,
             .amazonlinux2_x86_64,
-            .rhel_ubi9_x86_64:
+            .rhel_ubi9_x86_64,
+            .debian_12_x86_64:
             return .x86_64
         }
     }
@@ -581,7 +584,8 @@ extension Workspace.PrebuiltsManifest.Platform {
             .ubuntu_focal_aarch64, .ubuntu_focal_x86_64,
             .fedora_39_aarch64, .fedora_39_x86_64,
             .amazonlinux2_aarch64, .amazonlinux2_x86_64,
-            .rhel_ubi9_aarch64, .rhel_ubi9_x86_64:
+            .rhel_ubi9_aarch64, .rhel_ubi9_x86_64,
+            .debian_12_aarch64, .debian_12_x86_64:
             return .linux
         }
     }
@@ -687,6 +691,18 @@ extension Workspace.PrebuiltsManifest.Platform {
                     return .rhel_ubi9_aarch64
                 case .x86_64:
                     return .rhel_ubi9_x86_64
+                }
+            default:
+                return nil
+            }
+        case "debian":
+            switch osDict["VERSION_ID"] {
+            case "12":
+                switch arch {
+                case .aarch64:
+                    return .debian_12_aarch64
+                case .x86_64:
+                    return .debian_12_x86_64
                 }
             default:
                 return nil

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -23,7 +23,7 @@ import XCTest
 import struct TSCUtility.Version
 
 extension UserToolchain {
-    package static func mockHostToolchain(_ fileSystem: InMemoryFileSystem, hostTriple: Triple = hostTriple) throws -> UserToolchain {
+    package static func mockHostToolchain(_ fileSystem: InMemoryFileSystem) throws -> UserToolchain {
         var hostSwiftSDK = try SwiftSDK.hostSwiftSDK(environment: .mockEnvironment, fileSystem: fileSystem)
         hostSwiftSDK.targetTriple = hostTriple
 
@@ -106,8 +106,7 @@ public final class MockWorkspace {
         customPackageContainerProvider: MockPackageContainerProvider? = .none,
         skipDependenciesUpdates: Bool = false,
         sourceControlToRegistryDependencyTransformation: WorkspaceConfiguration.SourceControlToRegistryDependencyTransformation = .disabled,
-        defaultRegistry: Registry? = .none,
-        customHostTriple: Triple = hostTriple
+        defaultRegistry: Registry? = .none
     ) async throws {
         try fileSystem.createMockToolchain()
 
@@ -143,7 +142,7 @@ public final class MockWorkspace {
             archiver: MockArchiver()
         )
         self.customPrebuiltsManager = customPrebuiltsManager
-        self.customHostToolchain = try UserToolchain.mockHostToolchain(fileSystem, hostTriple: customHostTriple)
+        self.customHostToolchain = try UserToolchain.mockHostToolchain(fileSystem)
         try await self.create()
     }
 

--- a/Tests/WorkspaceTests/PrebuiltsTests.swift
+++ b/Tests/WorkspaceTests/PrebuiltsTests.swift
@@ -163,9 +163,9 @@ final class PrebuiltsTests: XCTestCase {
             ],
             prebuiltsManager: .init(
                 httpClient: httpClient,
-                archiver: archiver
-            ),
-            customHostTriple: Triple("arm64-apple-macosx15.0")
+                archiver: archiver,
+                hostPlatform: .macos_aarch64
+            )
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
@@ -224,9 +224,9 @@ final class PrebuiltsTests: XCTestCase {
             ],
             prebuiltsManager: .init(
                 httpClient: httpClient,
-                archiver: archiver
-            ),
-            customHostTriple: Triple("arm64-apple-macosx15.0")
+                archiver: archiver,
+                hostPlatform: .macos_aarch64
+            )
         )
 
         try await workspace.checkPackageGraph(roots: [rootPackage.name]) { modulesGraph, diagnostics in
@@ -324,9 +324,9 @@ final class PrebuiltsTests: XCTestCase {
             ],
             prebuiltsManager: .init(
                 httpClient: httpClient,
-                archiver: archiver
-            ),
-            customHostTriple: Triple("arm64-apple-macosx15.0")
+                archiver: archiver,
+                hostPlatform: .macos_aarch64
+            )
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
@@ -385,9 +385,9 @@ final class PrebuiltsTests: XCTestCase {
             ],
             prebuiltsManager: .init(
                 httpClient: httpClient,
-                archiver: archiver
-            ),
-            customHostTriple: Triple("arm64-apple-macosx15.0")
+                archiver: archiver,
+                hostPlatform: .macos_aarch64
+            )
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
@@ -499,9 +499,9 @@ final class PrebuiltsTests: XCTestCase {
             ],
             prebuiltsManager: .init(
                 httpClient: httpClient,
-                archiver: archiver
-            ),
-            customHostTriple: Triple("86_64-unknown-linux-gnu")
+                archiver: archiver,
+                hostPlatform: .ubuntu_noble_x86_64
+            )
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
@@ -604,9 +604,9 @@ final class PrebuiltsTests: XCTestCase {
             ],
             prebuiltsManager: .init(
                 httpClient: httpClient,
-                archiver: archiver
-            ),
-            customHostTriple: Triple("arm64-apple-macosx15.0")
+                archiver: archiver,
+                hostPlatform: .macos_aarch64
+            )
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
@@ -665,9 +665,9 @@ final class PrebuiltsTests: XCTestCase {
             ],
             prebuiltsManager: .init(
                 httpClient: httpClient,
-                archiver: archiver
-            ),
-            customHostTriple: Triple("arm64-apple-macosx15.0")
+                archiver: archiver,
+                hostPlatform: .macos_aarch64
+            )
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
@@ -748,8 +748,7 @@ final class PrebuiltsTests: XCTestCase {
             ],
             packages: [
                 swiftSyntax
-            ],
-            customHostTriple: Triple("arm64-apple-macosx15.0")
+            ]
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in


### PR DESCRIPTION
Made discovery of the Linux distro reusable for the build-prebuilts script. Changed it to use arch and os conditions instead of the host toolchain.

Added support for Ubuntu noble, Fedora and Debian.

Removed the deletion of the stage directory so we can share it across docker invocations for each distro. Fixed the Modules directory name which wasn't working on case sensitive file systems.