### PR TITLE
[WIP] Provide mechanism to disable color diagnostics

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -244,13 +244,16 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         fileSystem: Basics.FileSystem,
         observabilityScope: ObservabilityScope
     ) {
-        /// Checks if stdout stream is tty.
+        /// Checks if stdout stream is tty. If user specifies --no-color-diagnostics flag, then stdout stream is not colorized
         var productsBuildParameters = productsBuildParameters
-        productsBuildParameters.outputParameters.isColorized = outputStream.isTTY
-
+        if productsBuildParameters.outputParameters.isColorized {
+            productsBuildParameters.outputParameters.isColorized = outputStream.isTTY
+        }
         var toolsBuildParameters = toolsBuildParameters
-        toolsBuildParameters.outputParameters.isColorized = outputStream.isTTY
-
+    
+        if toolsBuildParameters.outputParameters.isColorized{
+            toolsBuildParameters.outputParameters.isColorized = outputStream.isTTY
+        }
         self.config = LLBuildSystemConfiguration(
             toolsBuildParameters: toolsBuildParameters,
             destinationBuildParameters: productsBuildParameters,
@@ -261,7 +264,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             outputStream: outputStream,
             observabilityScope: observabilityScope.makeChildScope(description: "Build Operation")
         )
-
+        
         self.cacheBuildManifest = cacheBuildManifest
         self.packageGraphLoader = packageGraphLoader
         self.additionalFileRules = additionalFileRules
@@ -393,14 +396,14 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         guard !self.config.shouldSkipBuilding(for: .target) else {
             return
         }
-
+        
         let buildStartTime = DispatchTime.now()
 
         // Get the build description (either a cached one or newly created).
-
+        
         // Get the build description
         let buildDescription = try await self.getBuildDescription(subset: subset)
-
+        
         // Verify dependency imports on the described targets
         try verifyTargetImports(in: buildDescription)
 
@@ -670,7 +673,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         } else {
             pluginTools = [:]
         }
-
+        
         // Create the build plan based on the modules graph and any information from plugins.
         let plan = try await BuildPlan(
             destinationBuildParameters: self.config.destinationBuildParameters,
@@ -685,7 +688,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             observabilityScope: self.observabilityScope
         )
         self._buildPlan = plan
-
+        
         // Emit warnings about any unhandled files in authored packages. We do this after applying build tool plugins, once we know what files they handled.
         // rdar://113256834 This fix works for the plugins that do not have PreBuildCommands.
         let targetsToConsider: [ResolvedModule]

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -208,8 +208,11 @@ public struct LoggingOptions: ParsableArguments {
     /// Whether logging output should be limited to `.error`.
     @Flag(name: .shortAndLong, help: "Decrease verbosity to only include error output.")
     public var quiet: Bool = false
+    
+    @Flag(name: .customLong("no-color-diagnostics"), help: "Disable colored diagnostics")
+    public var noColorDiagnostics: Bool = false
 }
-
+  
 public struct SecurityOptions: ParsableArguments {
     public init() {}
 
@@ -534,7 +537,7 @@ public struct BuildOptions: ParsableArguments {
     // this can be removed once the backtracer uses DWARF instead of frame pointers
     @Flag(inversion: .prefixedNo,  help: .hidden)
     public var omitFramePointers: Bool? = nil
-
+    
     // @Flag works best when there is a default value present
     // if true, false aren't enough and a third state is needed
     // nil should not be the goto. Instead create an enum

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -112,7 +112,7 @@ extension SwiftCommand {
             workspaceDelegateProvider: self.workspaceDelegateProvider,
             workspaceLoaderProvider: self.workspaceLoaderProvider
         )
-
+    
         // We use this to attempt to catch misuse of the locking APIs since we only release the lock from here.
         swiftCommandState.setNeedsLocking()
 
@@ -156,7 +156,7 @@ extension AsyncSwiftCommand {
 
         // We use this to attempt to catch misuse of the locking APIs since we only release the lock from here.
         swiftCommandState.setNeedsLocking()
-
+        
         swiftCommandState.buildSystemProvider = try buildSystemProvider(swiftCommandState)
         var toolError: Error? = .none
         do {
@@ -314,7 +314,8 @@ public final class SwiftCommandState {
         self.environment = environment
         // first, bootstrap the observability system
         self.logLevel = options.logging.logLevel
-        self.observabilityHandler = SwiftCommandObservabilityHandler(outputStream: outputStream, logLevel: self.logLevel)
+        self.observabilityHandler = SwiftCommandObservabilityHandler(outputStream: outputStream, logLevel: self.logLevel, noColorDiagnostics: options.logging.noColorDiagnostics)
+        
         let observabilitySystem = ObservabilitySystem(self.observabilityHandler)
         let observabilityScope = observabilitySystem.topScope
         self.observabilityScope = observabilityScope
@@ -825,6 +826,7 @@ public final class SwiftCommandState {
                 shouldDisableLocalRpath: options.linker.shouldDisableLocalRpath
             ),
             outputParameters: .init(
+                isColorized: !self.options.logging.noColorDiagnostics,
                 isVerbose: self.logLevel <= .info
             ),
             testingParameters: .init(


### PR DESCRIPTION
Added the no-color-diagnostics option to disable colorful diagnostics
### Motivation:

Users prefer disabling coloured diagnostics due to readability, color blindness, consistency with their terminal, and performance. Based on the following [issue](https://github.com/swiftlang/swift-package-manager/issues/4776)

### Modifications:

Added the "no-color-diagnostics" subcommand in loggingOptions, in order to initialize the noColorDiagnostics boolean. Then, a simple check is made to determine if the outputParameters are coloured (if are, then checked for if the terminal is a tty). Finally, edited the handleDiagnostics function by adding a formatDiagnostics function that checks for if user wanted colorDiagnostics and emitting warnings and errors, accordingly.

### Result:

Users will now have the option of specifying the no-color-diagnostics option when running SPM in order to disable coloured output