### PR TITLE
Add titles to global option groups for better help screens

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -57,10 +57,10 @@ public struct GlobalOptions: ParsableArguments {
     @OptionGroup(title: "Resolution")
     public var resolver: ResolverOptions
 
-    @OptionGroup(title: "Compiler Flags")
+    @OptionGroup(title: "Build Options")
     public var build: BuildOptions
 
-    @OptionGroup(title: "Linker Settings")
+    @OptionGroup(title: "Build Options")
     public var linker: LinkerOptions
 }
 

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -42,25 +42,25 @@ import struct Workspace.WorkspaceConfiguration
 public struct GlobalOptions: ParsableArguments {
     public init() {}
 
-    @OptionGroup()
+    @OptionGroup(title: "Paths & Locations")
     public var locations: LocationOptions
 
-    @OptionGroup()
+    @OptionGroup(title: "Caching")
     public var caching: CachingOptions
 
-    @OptionGroup()
+    @OptionGroup(title: "Logging")
     public var logging: LoggingOptions
 
-    @OptionGroup()
+    @OptionGroup(title: "Security")
     public var security: SecurityOptions
 
-    @OptionGroup()
+    @OptionGroup(title: "Resolution")
     public var resolver: ResolverOptions
 
-    @OptionGroup()
+    @OptionGroup(title: "Compiler Flags")
     public var build: BuildOptions
 
-    @OptionGroup()
+    @OptionGroup(title: "Linker Settings")
     public var linker: LinkerOptions
 }
 


### PR DESCRIPTION
_2/10/25: Updated example output to match changes._

Adds titles to the option groups that comprise the `GlobalOptions` struct, for better help screen formatting.

### Motivation:

The current help screen includes a long list of flags and options, with no categorization, making it hard for users to understand what kinds of options are available.

### Modifications:

This change adds titles to all the `@OptionGroup` declarations inside the global options struct, which results in each group being labeled in the help screens for `swift package`, `swift run`, etc.

### Result:

The new, categorized screen for `swift run` is below.

> [!NOTE]  
> These are just initial guesses at what the appropriate names should be – reviewers, please discuss/revise what's here!

```
OVERVIEW: Build and run an executable product

SEE ALSO: swift build, swift package, swift test

USAGE: swift run [<options>] [<executable>] [<arguments> ...]

ARGUMENTS:
  <executable>            The executable to run
  <arguments>             The arguments to pass to the executable

PATHS & LOCATIONS:
  --package-path <package-path>
                          Specify the package path to operate on (default
                          current directory). This changes the working
                          directory before any other operation
  --cache-path <cache-path>
                          Specify the shared cache directory path
  --config-path <config-path>
                          Specify the shared configuration directory path
  --security-path <security-path>
                          Specify the shared security directory path
  --scratch-path <scratch-path>
                          Specify a custom scratch directory path (default
                          .build)
  --swift-sdks-path <swift-sdks-path>
                          Path to the directory containing installed Swift SDKs
  --toolset <toolset>     Specify a toolset JSON file to use when building for
                          the target platform. Use the option multiple times to
                          specify more than one toolset. Toolsets will be
                          merged in the order they're specified into a single
                          final toolset for the current build.
  --pkg-config-path <pkg-config-path>
                          Specify alternative path to search for pkg-config
                          `.pc` files. Use the option multiple times to
                          specify more than one path.

CACHING:
  --enable-dependency-cache/--disable-dependency-cache
                          Use a shared cache when fetching dependencies
                          (default: --enable-dependency-cache)
  --enable-build-manifest-caching/--disable-build-manifest-caching
                          (default: --enable-build-manifest-caching)
  --manifest-cache <manifest-cache>
                          Caching mode of Package.swift manifests (shared:
                          shared cache, local: package's build directory, none:
                          disabled) (default: shared)
  --enable-experimental-prebuilts/--disable-experimental-prebuilts
                          Whether to use prebuilt swift-syntax libraries for
                          macros (default: --disable-experimental-prebuilts)

LOGGING:
  -v, --verbose           Increase verbosity to include informational output
  --very-verbose, --vv    Increase verbosity to include debug output
  -q, --quiet             Decrease verbosity to only include error output.

SECURITY:
  --disable-sandbox       Disable using the sandbox when executing subprocesses
  --netrc                 Use netrc file even in cases where other credential
                          stores are preferred
  --enable-netrc/--disable-netrc
                          Load credentials from a netrc file (default:
                          --enable-netrc)
  --netrc-file <netrc-file>
                          Specify the netrc file path
  --enable-keychain/--disable-keychain
                          Search credentials in macOS keychain (default:
                          --enable-keychain)
  --resolver-fingerprint-checking <resolver-fingerprint-checking>
                          (default: strict)
  --resolver-signing-entity-checking <resolver-signing-entity-checking>
                          (default: warn)
  --enable-signature-validation/--disable-signature-validation
                          Validate signature of a signed package release
                          downloaded from registry (default:
                          --enable-signature-validation)

RESOLUTION:
  --enable-prefetching/--disable-prefetching
                          (default: --enable-prefetching)
  --force-resolved-versions, --disable-automatic-resolution, --only-use-versions-from-resolved-file
                          Only use versions from the Package.resolved file and
                          fail resolution if it is out-of-date
  --skip-update           Skip updating dependencies from their remote during a
                          resolution
  --disable-scm-to-registry-transformation
                          disable source control to registry transformation
                          (default: --disable-scm-to-registry-transformation)
  --use-registry-identity-for-scm
                          look up source control dependencies in the registry
                          and use their registry identity when possible to help
                          deduplicate across the two origins
  --replace-scm-with-registry
                          look up source control dependencies in the registry
                          and use the registry to retrieve them instead of
                          source control when possible
  --default-registry-url <default-registry-url>
                          Default registry URL to use, instead of the
                          registries.json configuration file

BUILD OPTIONS:
  -c, --configuration <configuration>
                          Build with configuration (values: debug, release)
  -Xcc <Xcc>              Pass flag through to all C compiler invocations
  -Xswiftc <Xswiftc>      Pass flag through to all Swift compiler invocations
  -Xlinker <Xlinker>      Pass flag through to all linker invocations
  -Xcxx <Xcxx>            Pass flag through to all C++ compiler invocations
  --triple <triple>
  --sdk <sdk>
  --toolchain <toolchain>
  --swift-sdk <swift-sdk> Filter for selecting a specific Swift SDK to build
                          with
  --sanitize <sanitize>   Turn on runtime checks for erroneous behavior,
                          possible values: address, thread, undefined, scudo
                          (values: address, thread, undefined, scudo)
  --auto-index-store/--enable-index-store/--disable-index-store
                          Enable or disable indexing-while-building feature
                          (default: --auto-index-store)
  --enable-parseable-module-interfaces
  -j, --jobs <jobs>       The number of jobs to spawn in parallel during the
                          build process
  --use-integrated-swift-driver
  --explicit-target-dependency-import-check <explicit-target-dependency-import-check>
                          A flag that indicates this build should check whether
                          targets only import their explicitly-declared
                          dependencies (values: none, warn, error; default:
                          none)
  --experimental-explicit-module-build
  --build-system <build-system>
                          (values: native, xcode; default: native)
  -debug-info-format <debug-info-format>
                          The Debug Information Format to use (values: dwarf,
                          codeview, none; default: dwarf)
 --enable-dead-strip/--disable-dead-strip
                          Disable/enable dead code stripping by the linker
                          (default: --enable-dead-strip)
  --disable-local-rpath   Disable adding $ORIGIN/@loader_path to the rpath by
                          default

OPTIONS:
  --repl                  Launch Swift REPL for the package
  --debugger              Launch the executable in a debugger session
  --run                   Launch the executable with the provided arguments
                          (default: --run)
  --skip-build            Skip building the executable product
  --build-tests           Build both source and test targets
  --traits <traits>       Enables the passed traits of the package. Multiple
                          traits can be specified by providing a space
                          separated list e.g. `--traits Trait1 Trait2`. When
                          enabling specific traits the defaults traits need to
                          explictily enabled as well by passing `defaults` to
                          this command.
  --enable-all-traits     Enables all traits of the package.
  --disable-default-traits
                          Disables all default traits of the package.
  --version               Show the version.
  -h, -help, --help       Show help information.
```
