### PR TITLE
Add additional information

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -832,7 +832,7 @@ def get_swiftpm_flags(args):
         build_flags.append("--disable-local-rpath")
 
     if args.verbose:
-        build_flags.append("--verbose")
+        build_flags.append("--very-verbose")
 
     if args.llbuild_link_framework:
         build_flags.extend([

--- a/Utilities/helpers.py
+++ b/Utilities/helpers.py
@@ -42,15 +42,24 @@ def call(cmd, cwd=None, verbose=False):
         subprocess.check_call(cmd, cwd=cwd)
     except subprocess.CalledProcessError as cpe:
         logging.debug("executing command >>> %s", ' '.join(cmd))
-        logging.error("Process failure: %s", str(cpe))
+        logging.error(
+            "Process failure: %s\n[---- START OUTPUT ----]\n%s\n[---- END OUTPUT ----]",
+            str(cpe),
+            cpe.output,
+        )
         raise cpe
 
 def call_output(cmd, cwd=None, stderr=False, verbose=False):
     """Calls a subprocess for its return data."""
+    stderr = subprocess.STDOUT if stderr else False
     logging.info(' '.join(cmd))
     try:
         return subprocess.check_output(cmd, cwd=cwd, stderr=stderr, universal_newlines=True).strip()
     except subprocess.CalledProcessError as cpe:
         logging.debug(' '.join(cmd))
-        logging.error(str(cpe))
+        logging.error(
+            "%s\n[---- START OUTPUT ----]\n%s\n[---- END OUTPUT ----]",
+            str(cpe),
+            cpe.output,
+        )
         raise cpe


### PR DESCRIPTION
There have been cases where CI build failurse did not have sufficient logs when it failed during a Swift PM build/test. Augment the Swift PM build/test by enabling verbosity.  Update `Utilities/bootstrap` to call swift pm executable targets using `--very-verbose` instead of `--versobe` when the tool is invoked with `--verbose`.

Requires https://github.com/swiftlang/swift/pull/79330
