### PR TITLE
Tests: Improve testVersion assertion and add duplicate symbol test

### DIFF
--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -89,9 +89,15 @@ final class BuildCommandTests: CommandsTestCase {
         XCTAssertMatch(stdout, .contains("SEE ALSO: swift run, swift package, swift test"))
     }
 
+    func testCommandDoesNotEmitDuplicateSymbols() async throws {
+        let (stdout, stderr) = try await execute(["--help"])
+        XCTAssertNoMatch(stdout, duplicateSymbolRegex)
+        XCTAssertNoMatch(stderr, duplicateSymbolRegex)
+    }
+
     func testVersion() async throws {
         let stdout = try await execute(["--version"]).stdout
-        XCTAssertMatch(stdout, .contains("Swift Package Manager"))
+        XCTAssertMatch(stdout, .regex(#"Swift Package Manager -( \w+ )?\d+.\d+.\d+(-\w+)?"#))
     }
 
     func testCreatingSanitizers() throws {

--- a/Tests/CommandsTests/CommandsTestCase.swift
+++ b/Tests/CommandsTests/CommandsTestCase.swift
@@ -12,12 +12,15 @@
 
 import Basics
 import XCTest
-
+import _InternalTestSupport
 class CommandsTestCase: XCTestCase {
     
     /// Original working directory before the test ran (if known).
     private var originalWorkingDirectory: AbsolutePath? = .none
-    
+    public let duplicateSymbolRegex = StringPattern.regex(
+        #"objc[83768]: (.*) is implemented in both .* \(.*\) and .* \(.*\) . One of the two will be used. Which one is undefined."#
+    )
+
     override func setUp() {
         originalWorkingDirectory = localFileSystem.currentWorkingDirectory
     }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -65,9 +65,15 @@ final class PackageCommandTests: CommandsTestCase {
         XCTAssertMatch(stdout, .contains("SEE ALSO: swift build, swift run, swift test"))
     }
 
+    func testCommandDoesNotEmitDuplicateSymbols() async throws {
+        let (stdout, stderr) = try await execute(["--help"])
+        XCTAssertNoMatch(stdout, duplicateSymbolRegex)
+        XCTAssertNoMatch(stderr, duplicateSymbolRegex)
+    }
+
     func testVersion() async throws {
         let stdout = try await execute(["--version"]).stdout
-        XCTAssertMatch(stdout, .contains("Swift Package Manager"))
+        XCTAssertMatch(stdout, .regex(#"Swift Package Manager -( \w+ )?\d+.\d+.\d+(-\w+)?"#))
     }
 	
     func testCompletionTool() async throws {

--- a/Tests/CommandsTests/PackageRegistryCommandTests.swift
+++ b/Tests/CommandsTests/PackageRegistryCommandTests.swift
@@ -70,6 +70,12 @@ final class PackageRegistryCommandTests: CommandsTestCase {
         XCTAssert(stdout.contains("SEE ALSO: swift package"), "got stdout:\n" + stdout)
     }
 
+    func testCommandDoesNotEmitDuplicateSymbols() async throws {
+        let (stdout, stderr) = try await execute(["--help"])
+        XCTAssertNoMatch(stdout, duplicateSymbolRegex)
+        XCTAssertNoMatch(stderr, duplicateSymbolRegex)
+    }
+
     func testVersion() async throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the
         // plugin APIs require).
@@ -79,7 +85,7 @@ final class PackageRegistryCommandTests: CommandsTestCase {
         )
 
         let stdout = try await execute(["--version"]).stdout
-        XCTAssert(stdout.contains("Swift Package Manager"), "got stdout:\n" + stdout)
+        XCTAssertMatch(stdout, .regex(#"Swift Package Manager -( \w+ )?\d+.\d+.\d+(-\w+)?"#))
     }
 
     func testLocalConfiguration() async throws {

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -35,9 +35,15 @@ final class RunCommandTests: CommandsTestCase {
         XCTAssert(stdout.contains("SEE ALSO: swift build, swift package, swift test"), "got stdout:\n" + stdout)
     }
 
+    func testCommandDoesNotEmitDuplicateSymbols() async throws {
+        let (stdout, stderr) = try await execute(["--help"])
+        XCTAssertNoMatch(stdout, duplicateSymbolRegex)
+        XCTAssertNoMatch(stderr, duplicateSymbolRegex)
+    }
+
     func testVersion() async throws {
         let stdout = try await execute(["--version"]).stdout
-        XCTAssert(stdout.contains("Swift Package Manager"), "got stdout:\n" + stdout)
+        XCTAssertMatch(stdout, .regex(#"Swift Package Manager -( \w+ )?\d+.\d+.\d+(-\w+)?"#))
     }
 
 // echo.sh script from the toolset won't work on Windows

--- a/Tests/CommandsTests/SwiftSDKCommandTests.swift
+++ b/Tests/CommandsTests/SwiftSDKCommandTests.swift
@@ -32,10 +32,19 @@ final class SwiftSDKCommandTests: CommandsTestCase {
         }
     }
 
-    func testVersion() async throws {
+     func testCommandDoesNotEmitDuplicateSymbols() async throws {
+        for command in [SwiftPM.sdk, SwiftPM.experimentalSDK] {
+            let (stdout, stderr) = try await command.execute(["--help"])
+            XCTAssertNoMatch(stdout, duplicateSymbolRegex)
+            XCTAssertNoMatch(stderr, duplicateSymbolRegex)
+        }
+    }
+
+
+    func testVersionS() async throws {
         for command in [SwiftPM.sdk, SwiftPM.experimentalSDK] {
             let stdout = try await command.execute(["--version"]).stdout
-            XCTAssert(stdout.contains("Swift Package Manager"), "got stdout:\n" + stdout)
+            XCTAssertMatch(stdout, .regex(#"Swift Package Manager -( \w+ )?\d+.\d+.\d+(-\w+)?"#))
         }
     }
 

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -48,9 +48,15 @@ final class TestCommandTests: CommandsTestCase {
         XCTAssert(stdout.contains("SEE ALSO: swift build, swift run, swift package"), "got stdout:\n" + stdout)
     }
 
+    func testCommandDoesNotEmitDuplicateSymbols() async throws {
+        let (stdout, stderr) = try await execute(["--help"])
+        XCTAssertNoMatch(stdout, duplicateSymbolRegex)
+        XCTAssertNoMatch(stderr, duplicateSymbolRegex)
+    }
+
     func testVersion() async throws {
         let stdout = try await execute(["--version"]).stdout
-        XCTAssert(stdout.contains("Swift Package Manager"), "got stdout:\n" + stdout)
+        XCTAssertMatch(stdout, .regex(#"Swift Package Manager -( \w+ )?\d+.\d+.\d+(-\w+)?"#))
     }
 
     // `echo.sh` script from the toolset won't work on Windows


### PR DESCRIPTION
The various CommandTestCases 'testVersion' tests were only asserting the output contains a string.  Update the assertion to check the output matches a regular expression.

Also, add a test that ensured the command does not emit duplicate symbol on stdout and stderr.

rdar://144103998
