### PR TITLE
Do not add rpath to swift-testing for CLT or custom toolchains

### DIFF
--- a/Fixtures/Miscellaneous/CheckTestLibraryEnvironmentVariable/Tests/CheckTestLibraryEnvironmentVariableTests/CheckTestLibraryEnvironmentVariableTests.swift
+++ b/Fixtures/Miscellaneous/CheckTestLibraryEnvironmentVariable/Tests/CheckTestLibraryEnvironmentVariableTests/CheckTestLibraryEnvironmentVariableTests.swift
@@ -1,8 +1,21 @@
 import XCTest
 
 final class CheckTestLibraryEnvironmentVariableTests: XCTestCase {
-    func testEnvironmentVariable() throws {
-        let envvar = ProcessInfo.processInfo.environment["SWIFT_TESTING_ENABLED"]
-        XCTAssertEqual(envvar, "0")
+    func testEnvironmentVariables() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "Test is macOS specific")
+        #endif
+
+        let testingEnabled = ProcessInfo.processInfo.environment["SWIFT_TESTING_ENABLED"]
+        XCTAssertEqual(testingEnabled, "0")
+
+        if ProcessInfo.processInfo.environment["CONTAINS_SWIFT_TESTING"] != nil {
+            let frameworkPath = try XCTUnwrap(ProcessInfo.processInfo.environment["DYLD_FRAMEWORK_PATH"])
+            let libraryPath = try XCTUnwrap(ProcessInfo.processInfo.environment["DYLD_LIBRARY_PATH"])
+            XCTAssertTrue(
+                frameworkPath.contains("testing") || libraryPath.contains("testing"),
+                "Expected 'testing' in '\(frameworkPath)' or '\(libraryPath)'"
+            )
+        }
     }
 }

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -209,12 +209,21 @@ enum TestingSupport {
         if let xctestLocation = toolchain.xctestPath {
             env.prependPath(key: .path, value: xctestLocation.pathString)
         }
-        if let swiftTestingLocation = toolchain.swiftTestingPathOnWindows {
+        if let swiftTestingLocation = toolchain.swiftTestingPath {
             env.prependPath(key: .path, value: swiftTestingLocation.pathString)
         }
         #endif
         return env
         #else
+        // Add path to swift-testing override if there is one
+        if let swiftTestingPath = toolchain.swiftTestingPath {
+            if swiftTestingPath.extension == "framework" {
+                env.appendPath(key: "DYLD_FRAMEWORK_PATH", value: swiftTestingPath.pathString)
+            } else {
+                env.appendPath(key: "DYLD_LIBRARY_PATH", value: swiftTestingPath.pathString)
+            }
+        }
+
         // Add the sdk platform path if we have it.
         // Since XCTestHelper targets macOS, we need the macOS platform paths here.
         if let sdkPlatformPaths = try? SwiftSDK.sdkPlatformPaths(for: .macOS) {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4815,10 +4815,7 @@ final class BuildPlanTests: XCTestCase {
                 "-sdk", "/fake/sdk",
             ]
         )
-        XCTAssertEqual(
-            mockToolchain.extraFlags.linkerFlags,
-            ["-rpath", "/fake/path/lib/swift/macosx/testing"]
-        )
+        XCTAssertNoMatch(mockToolchain.extraFlags.linkerFlags, ["-rpath"])
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadModulesGraph(
@@ -4853,31 +4850,23 @@ final class BuildPlanTests: XCTestCase {
 
         let testProductLinkArgs = try result.buildProduct(for: "Lib").linkArguments()
         XCTAssertMatch(testProductLinkArgs, [
-            .anySequence,
             "-I", "/fake/path/lib/swift/macosx/testing",
             "-L", "/fake/path/lib/swift/macosx/testing",
-            .anySequence,
-            "-Xlinker", "-rpath",
-            "-Xlinker", "/fake/path/lib/swift/macosx/testing",
         ])
 
         let libModuleArgs = try result.moduleBuildDescription(for: "Lib").swift().compileArguments()
         XCTAssertMatch(libModuleArgs, [
-            .anySequence,
             "-I", "/fake/path/lib/swift/macosx/testing",
             "-L", "/fake/path/lib/swift/macosx/testing",
             "-plugin-path", "/fake/path/lib/swift/host/plugins/testing",
-            .anySequence,
         ])
         XCTAssertNoMatch(libModuleArgs, ["-Xlinker"])
 
         let testModuleArgs = try result.moduleBuildDescription(for: "LibTest").swift().compileArguments()
         XCTAssertMatch(testModuleArgs, [
-            .anySequence,
             "-I", "/fake/path/lib/swift/macosx/testing",
             "-L", "/fake/path/lib/swift/macosx/testing",
             "-plugin-path", "/fake/path/lib/swift/host/plugins/testing",
-            .anySequence,
         ])
         XCTAssertNoMatch(testModuleArgs, ["-Xlinker"])
     }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -559,14 +559,15 @@ final class TestCommandTests: CommandsTestCase {
     }
 #endif
 
-#if os(macOS)
-    // "SWIFT_TESTING_ENABLED" is set only on macOS, skip the check on other platforms.
     func testLibraryEnvironmentVariable() async throws {
         try await fixture(name: "Miscellaneous/CheckTestLibraryEnvironmentVariable") { fixturePath in
-            await XCTAssertAsyncNoThrow(try await SwiftPM.Test.execute(packagePath: fixturePath))
+            var extraEnv = Environment()
+            if try UserToolchain.default.swiftTestingPath != nil {
+              extraEnv["CONTAINS_SWIFT_TESTING"] = "1"
+            }
+            await XCTAssertAsyncNoThrow(try await SwiftPM.Test.execute(packagePath: fixturePath, env: extraEnv))
         }
     }
-#endif
 
     func testXCTestOnlyDoesNotLogAboutNoMatchingTests() async throws {
         try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in


### PR DESCRIPTION
This was added so that test binaries could find swift-testing, but we should insert those paths into `DYLD_*_PATH` rather than add to the rpath. The current behavior adds an absolute rpath to *all* binaries, not even just test binaries.