### PR TITLE
build: define build path structure in BuildSystemProvider.Kind

### DIFF
--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -441,7 +441,7 @@ public final class SwiftCommandState {
             self.observabilityHandler.progress,
             self.observabilityHandler.prompt
         )
-        let isXcodeBuildSystemEnabled = self.options.build.buildSystem == .xcode
+        let isXcodeBuildSystemEnabled = self.options.build.buildSystem.usesXcodeBuildEngine
         let workspace = try Workspace(
             fileSystem: self.fileSystem,
             location: .init(
@@ -459,7 +459,7 @@ public final class SwiftCommandState {
             configuration: .init(
                 skipDependenciesUpdates: options.resolver.skipDependencyUpdate,
                 prefetchBasedOnResolvedFile: options.resolver.shouldEnableResolverPrefetching,
-                shouldCreateMultipleTestProducts: toolWorkspaceConfiguration.wantsMultipleTestProducts || options.build.buildSystem == .xcode,
+                shouldCreateMultipleTestProducts: toolWorkspaceConfiguration.wantsMultipleTestProducts || options.build.buildSystem.usesXcodeBuildEngine,
                 createREPLProduct: toolWorkspaceConfiguration.wantsREPLProduct,
                 additionalFileRules: isXcodeBuildSystemEnabled ? FileRuleDescription.xcbuildFileTypes : FileRuleDescription.swiftpmFileTypes,
                 sharedDependenciesCacheEnabled: self.options.caching.useDependenciesCache,
@@ -795,7 +795,7 @@ public final class SwiftCommandState {
             workers: options.build.jobs ?? UInt32(ProcessInfo.processInfo.activeProcessorCount),
             sanitizers: options.build.enabledSanitizers,
             indexStoreMode: options.build.indexStoreMode.buildParameter,
-            isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
+            isXcodeBuildSystemEnabled: options.build.buildSystem.usesXcodeBuildEngine,
             prepareForIndexing: prepareForIndexingMode,
             debuggingParameters: .init(
                 debugInfoFormat: options.build.debugInfoFormat.buildParameter,

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -168,6 +168,14 @@ public struct BuildSystemProvider {
     }
 }
 
+extension BuildSystemProvider.Kind {
+    public var usesXcodeBuildEngine: Bool {
+        switch self {
+            case .native: return false
+            case .xcode: return true
+        }
+    }
+}
 private enum Errors: Swift.Error {
     case buildSystemProviderNotRegistered(kind: BuildSystemProvider.Kind)
 }

--- a/Sources/SPMBuildCore/Triple+Extensions.swift
+++ b/Sources/SPMBuildCore/Triple+Extensions.swift
@@ -27,6 +27,6 @@ extension Triple {
         // Use "apple" as the subdirectory because in theory Xcode build system
         // can be used to build for any Apple platform and it has its own
         // conventions for build subpaths based on platforms.
-        buildSystem == .xcode ? "apple" : self.platformBuildPathComponent
+        buildSystem.usesXcodeBuildEngine ? "apple" : self.platformBuildPathComponent
     }
 }

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -289,7 +289,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
                 triple: self.hostToolchain.targetTriple,
                 flags: buildFlags,
                 architectures: architectures,
-                isXcodeBuildSystemEnabled: buildSystem == .xcode,
+                isXcodeBuildSystemEnabled: buildSystem.usesXcodeBuildEngine,
                 driverParameters: .init(
                     explicitTargetDependencyImportCheckingMode: explicitTargetDependencyImportCheck == .error ? .error : .none,
                     useIntegratedSwiftDriver: useIntegratedSwiftDriver,


### PR DESCRIPTION
There are a few places that check the BuildSystemProvider.Kind is Xcode to determine the build directory structure.  With the upcoming Swift Build integration, which uses the "Xcode path" structure, we would need to update all instances to check the two build system provider kinds.

Add an extension on the BuildSystemProvider.Kind that create a boolean variable `useXcodeBuildEngine`, which determines whether the build system should use the xcode path structure or not.  In addition, update the code that requires a  "isXcodeBuildSystemEnabled" to return this build system provider variable.

This will hopefully help address #8272 when #8271 is merged and added `case .swiftbuild: return true` to the `useXcodeBuildEngine `


Fixes #8272
rdar://144023142