### PR TITLE
Add a `defaultIsolation` static method on `SwiftSetting`.

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -462,6 +462,30 @@ public struct SwiftSetting: Sendable {
         return SwiftSetting(
             name: "swiftLanguageMode", value: [.init(describing: mode)], condition: condition)
     }
+
+    /// Set the default isolation to the given global actor type.
+    ///
+    /// - Since: First available in PackageDescription 6.2.
+    ///
+    /// - Parameters:
+    ///   - isolation: The type of global actor to use for default actor isolation
+    ///     inference. The only valid arguments are `MainActor.self` and `nil`.
+    ///   - condition: A condition that restricts the application of the build
+    ///     setting.
+    @available(_PackageDescription, introduced: 6.2)
+    public static func defaultIsolation(
+        _ isolation: MainActor.Type?,
+        _ condition: BuildSettingCondition? = nil
+    ) -> SwiftSetting {
+        let isolationString =
+            if isolation == nil {
+                "nil"
+            } else {
+                "MainActor.self"
+            }
+        return SwiftSetting(
+            name: "defaultIsolation", value: [isolationString], condition: condition)
+    }
 }
 
 /// A linker build setting.

--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -479,9 +479,9 @@ public struct SwiftSetting: Sendable {
     ) -> SwiftSetting {
         let isolationString =
             if isolation == nil {
-                "nil"
+                "nonisolated"
             } else {
-                "MainActor.self"
+                "MainActor"
             }
         return SwiftSetting(
             name: "defaultIsolation", value: [isolationString], condition: condition)

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -749,6 +749,11 @@ extension TargetBuildSettingDescription.Kind {
             }
 
             return .swiftLanguageMode(version)
+        case "defaultIsolation":
+            guard let value = values.first else {
+                throw InternalError("invalid (empty) build settings value")
+            }
+            return .defaultIsolation(value)
         default:
             throw InternalError("invalid build setting \(name)")
         }

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -750,10 +750,14 @@ extension TargetBuildSettingDescription.Kind {
 
             return .swiftLanguageMode(version)
         case "defaultIsolation":
-            guard let value = values.first else {
+            guard let rawValue = values.first else {
                 throw InternalError("invalid (empty) build settings value")
             }
-            return .defaultIsolation(value)
+            guard let isolation = TargetBuildSettingDescription.DefaultIsolation(rawValue: rawValue) else {
+                throw InternalError("unknown default isolation: \(rawValue)")
+            }
+
+            return .defaultIsolation(isolation)
         default:
             throw InternalError("invalid build setting \(name)")
         }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1261,13 +1261,8 @@ public final class PackageBuilder {
                 case .swift:
                     decl = .OTHER_SWIFT_FLAGS
                 }
-                
-                // Strip off the '.self' in 'MainActor.self'
-                guard let argument = isolation.components(separatedBy: ".").first else {
-                    throw InternalError("incorrect isolation argument")
-                }
 
-                values = ["-default-isolation", argument]
+                values = ["-default-isolation", isolation.rawValue]
             }
 
             // Create an assignment for this setting.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1252,6 +1252,22 @@ public final class PackageBuilder {
                 }
 
                 values = [version.rawValue]
+
+            case .defaultIsolation(let isolation):
+                switch setting.tool {
+                case .c, .cxx, .linker:
+                    throw InternalError("only Swift supports default isolation")
+
+                case .swift:
+                    decl = .OTHER_SWIFT_FLAGS
+                }
+                
+                // Strip off the '.self' in 'MainActor.self'
+                guard let argument = isolation.components(separatedBy: ".").first else {
+                    throw InternalError("incorrect isolation argument")
+                }
+
+                values = ["-default-isolation", argument]
             }
 
             // Create an assignment for this setting.

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -42,13 +42,16 @@ public enum TargetBuildSettingDescription {
 
         case swiftLanguageMode(SwiftLanguageVersion)
 
+        case defaultIsolation(String)
+
         public var isUnsafeFlags: Bool {
             switch self {
             case .unsafeFlags(let flags):
                 // If `.unsafeFlags` is used, but doesn't specify any flags, we treat it the same way as not specifying it.
                 return !flags.isEmpty
             case .headerSearchPath, .define, .linkedLibrary, .linkedFramework, .interoperabilityMode,
-                .enableUpcomingFeature, .enableExperimentalFeature, .strictMemorySafety, .swiftLanguageMode:
+                 .enableUpcomingFeature, .enableExperimentalFeature, .strictMemorySafety, .swiftLanguageMode,
+                 .defaultIsolation:
                 return false
             }
         }

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -25,6 +25,11 @@ public enum TargetBuildSettingDescription {
         case Cxx
     }
 
+    public enum DefaultIsolation: String, Codable, Hashable, Sendable {
+        case MainActor
+        case nonisolated
+    }
+
     /// The kind of the build setting, with associate configuration
     public enum Kind: Codable, Hashable, Sendable {
         case headerSearchPath(String)
@@ -42,7 +47,7 @@ public enum TargetBuildSettingDescription {
 
         case swiftLanguageMode(SwiftLanguageVersion)
 
-        case defaultIsolation(String)
+        case defaultIsolation(DefaultIsolation)
 
         public var isUnsafeFlags: Bool {
             switch self {

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -574,7 +574,12 @@ fileprivate extension SourceCodeFragment {
             }
             self.init(enum: setting.kind.name, subnodes: params)
         case .defaultIsolation(let isolation):
-            params.append(SourceCodeFragment(isolation))
+            switch isolation {
+            case .MainActor:
+                params.append(SourceCodeFragment("MainActor.self"))
+            case .nonisolated:
+                params.append(SourceCodeFragment("nil"))
+            }
             if let condition = setting.condition {
                 params.append(SourceCodeFragment(from: condition))
             }

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -573,6 +573,12 @@ fileprivate extension SourceCodeFragment {
                 params.append(SourceCodeFragment(from: condition))
             }
             self.init(enum: setting.kind.name, subnodes: params)
+        case .defaultIsolation(let isolation):
+            params.append(SourceCodeFragment(isolation))
+            if let condition = setting.condition {
+                params.append(SourceCodeFragment(from: condition))
+            }
+            self.init(enum: setting.kind.name, subnodes: params)
         }
     }
 
@@ -1010,6 +1016,8 @@ extension TargetBuildSettingDescription.Kind {
             return "strictMemorySafety"
         case .swiftLanguageMode:
             return "swiftLanguageMode"
+        case .defaultIsolation:
+            return "defaultIsolation"
         }
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4308,6 +4308,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                             condition: .init(platformNames: ["macos"], config: "debug")
                         ),
                         .init(tool: .swift, kind: .strictMemorySafety),
+                        .init(tool: .swift, kind: .defaultIsolation("MainActor.self")),
                     ]
                 ),
                 TargetDescription(
@@ -4433,6 +4434,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                     "-Xcc", "-std=c++17",
                     "-enable-upcoming-feature", "BestFeature",
                     "-strict-memory-safety",
+                    "-default-isolation", "MainActor",
                     "-g",
                     "-Xcc", "-g",
                     "-Xcc", "-fno-omit-frame-pointer",
@@ -4498,6 +4500,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                     "-enable-upcoming-feature",
                     "BestFeature",
                     "-strict-memory-safety",
+                    "-default-isolation", "MainActor",
                     "-g",
                     "-Xcc", "-g",
                     "-Xcc", "-fomit-frame-pointer",
@@ -4554,6 +4557,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                     "-enable-upcoming-feature",
                     "BestFeature",
                     "-strict-memory-safety",
+                    "-default-isolation", "MainActor",
                     "-g",
                     "-Xcc", "-g",
                     "-Xcc", "-fno-omit-frame-pointer",
@@ -4599,6 +4603,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                     "-enable-upcoming-feature", "BestFeature",
                     "-enable-upcoming-feature", "WorstFeature",
                     "-strict-memory-safety",
+                    "-default-isolation", "MainActor",
                     "-g",
                     "-Xcc", "-g",
                     .end,

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4308,7 +4308,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                             condition: .init(platformNames: ["macos"], config: "debug")
                         ),
                         .init(tool: .swift, kind: .strictMemorySafety),
-                        .init(tool: .swift, kind: .defaultIsolation("MainActor.self")),
+                        .init(tool: .swift, kind: .defaultIsolation(.MainActor)),
                     ]
                 ),
                 TargetDescription(
@@ -4342,6 +4342,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                             condition: .init(platformNames: ["macos"])
                         ),
                         .init(tool: .linker, kind: .unsafeFlags(["-Ilfoo", "-L", "lbar"])),
+                        .init(tool: .swift, kind: .defaultIsolation(.nonisolated)),
                     ]
                 ),
                 TargetDescription(
@@ -4443,7 +4444,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             )
 
             let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
-            XCTAssertMatch(exe, [.anySequence, "-swift-version", "5", "-DFOO", "-g", "-Xcc", "-g", "-Xcc", "-fno-omit-frame-pointer", .end])
+            XCTAssertMatch(exe, [.anySequence, "-swift-version", "5", "-DFOO", "-default-isolation", "nonisolated", "-g", "-Xcc", "-g", "-Xcc", "-fno-omit-frame-pointer", .end])
 
             let linkExe = try result.buildProduct(for: "exe").linkArguments()
             XCTAssertMatch(linkExe, [.anySequence, "-lsqlite3", "-llibz", "-Ilfoo", "-L", "lbar", "-g", .end])
@@ -4509,7 +4510,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             )
 
             let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
-            XCTAssertMatch(exe, [.anySequence, "-swift-version", "5", "-DFOO", "-g", "-Xcc", "-g", "-Xcc", "-fomit-frame-pointer", .end])
+            XCTAssertMatch(exe, [.anySequence, "-swift-version", "5", "-DFOO", "-default-isolation", "nonisolated", "-g", "-Xcc", "-g", "-Xcc", "-fomit-frame-pointer", .end])
         }
 
         // omit frame pointers explicitly set to false
@@ -4566,7 +4567,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             )
 
             let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
-            XCTAssertMatch(exe, [.anySequence, "-swift-version", "5", "-DFOO", "-g", "-Xcc", "-g", "-Xcc", "-fno-omit-frame-pointer", .end])
+            XCTAssertMatch(exe, [.anySequence, "-swift-version", "5", "-DFOO", "-default-isolation", "nonisolated", "-g", "-Xcc", "-g", "-Xcc", "-fno-omit-frame-pointer", .end])
         }
 
         do {
@@ -4619,6 +4620,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                     "-DFOO",
                     "-cxx-interoperability-mode=default",
                     "-Xcc", "-std=c++17",
+                    "-default-isolation", "nonisolated",
                     "-g",
                     "-Xcc", "-g",
                     .end,

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -3185,6 +3185,76 @@ final class PackageBuilderTests: XCTestCase {
             }
         }
     }
+
+    func testDefaultIsolationPerTarget() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/A/a.swift",
+            "/Sources/B/b.swift"
+        )
+
+        let manifest = Manifest.createRootManifest(
+            displayName: "pkg",
+            toolsVersion: .v6_2,
+            targets: [
+                try TargetDescription(
+                    name: "A",
+                    settings: [
+                        .init(tool: .swift, kind: .defaultIsolation(.MainActor))
+                    ]
+                ),
+                try TargetDescription(
+                    name: "B",
+                    settings: [
+                        .init(tool: .swift, kind: .defaultIsolation(.nonisolated), condition: .init(platformNames: ["linux"])),
+                        .init(tool: .swift, kind: .defaultIsolation(.MainActor), condition: .init(platformNames: ["macos"], config: "debug"))
+                    ]
+                ),
+            ]
+        )
+
+        PackageBuilderTester(manifest, in: fs) { package, _ in
+            package.checkModule("A") { package in
+                let macosDebugScope = BuildSettings.Scope(
+                    package.target.buildSettings,
+                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                )
+                XCTAssertMatch(macosDebugScope.evaluate(.OTHER_SWIFT_FLAGS),
+                               [.anySequence, "-default-isolation", "MainActor", .anySequence])
+
+                let macosReleaseScope = BuildSettings.Scope(
+                    package.target.buildSettings,
+                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                )
+                XCTAssertMatch(macosReleaseScope.evaluate(.OTHER_SWIFT_FLAGS),
+                               [.anySequence, "-default-isolation", "MainActor", .anySequence])
+
+            }
+
+            package.checkModule("B") { package in
+                let linuxDebugScope = BuildSettings.Scope(
+                    package.target.buildSettings,
+                    environment: BuildEnvironment(platform: .linux, configuration: .debug)
+                )
+                XCTAssertMatch(linuxDebugScope.evaluate(.OTHER_SWIFT_FLAGS),
+                               [.anySequence, "-default-isolation", "nonisolated", .anySequence])
+
+                let macosDebugScope = BuildSettings.Scope(
+                    package.target.buildSettings,
+                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                )
+                XCTAssertMatch(macosDebugScope.evaluate(.OTHER_SWIFT_FLAGS),
+                               [.anySequence, "-default-isolation", "MainActor", .anySequence])
+
+                let macosReleaseScope = BuildSettings.Scope(
+                    package.target.buildSettings,
+                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                )
+                XCTAssertNoMatch(macosReleaseScope.evaluate(.OTHER_SWIFT_FLAGS),
+                                 [.anySequence, "-default-isolation", "MainActor", .anySequence])
+
+            }
+        }
+    }
 }
 
 final class PackageBuilderTester {

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -858,4 +858,38 @@ final class ManifestSourceGenerationTests: XCTestCase {
         let contents = try manifest.generateManifestFileContents(packageDirectory: manifest.path.parentDirectory)
         try await testManifestWritingRoundTrip(manifestContents: contents, toolsVersion: .v6_0)
     }
+
+    func testDefaultIsolation() async throws {
+        let manifest = Manifest.createRootManifest(
+            displayName: "pkg",
+            path: "/pkg",
+            toolsVersion: .v6_2,
+            dependencies: [],
+            targets: [
+                try TargetDescription(
+                    name: "A",
+                    type: .executable,
+                    settings: [
+                        .init(tool: .swift, kind: .defaultIsolation(.nonisolated))
+                    ]
+                ),
+                try TargetDescription(
+                    name: "B",
+                    type: .executable,
+                    settings: [
+                        .init(tool: .swift, kind: .defaultIsolation(.MainActor))
+                    ]
+                ),
+                try TargetDescription(
+                    name: "conditional",
+                    type: .executable,
+                    settings: [
+                        .init(tool: .swift, kind: .defaultIsolation(.nonisolated), condition: .init(platformNames: ["linux"])),
+                        .init(tool: .swift, kind: .defaultIsolation(.MainActor), condition: .init(platformNames: ["macos"], config: "debug"))
+                    ]
+                )
+            ])
+        let contents = try manifest.generateManifestFileContents(packageDirectory: manifest.path.parentDirectory)
+        try await testManifestWritingRoundTrip(manifestContents: contents, toolsVersion: .v6_2)
+    }
 }

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -3019,6 +3019,110 @@ final class PIFBuilderTests: XCTestCase {
             result.checkIsEmpty()
         }
     }
+
+    func testPerTargetDefaultIsolation() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/foo.swift",
+            "/Foo/Sources/bar/bar.swift",
+            "/Foo/Sources/baz/baz.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Foo",
+                    path: "/Foo",
+                    toolsVersion: .v6_2,
+                    targets: [
+                        .init(name: "foo", dependencies: [], settings: [
+                            .init(
+                                tool: .swift,
+                                kind: .defaultIsolation(.MainActor)
+                            ),
+                        ]),
+                        .init(name: "bar", dependencies: [], settings: [
+                            .init(
+                                tool: .swift,
+                                kind: .defaultIsolation(.nonisolated)
+                            ),
+                        ]),
+                        .init(name: "baz", dependencies: [], settings: [
+                            .init(
+                                tool: .swift,
+                                kind: .defaultIsolation(.MainActor),
+                                condition: .init(platformNames: ["linux"])
+                            )
+                        ])
+                    ]
+                ),
+            ],
+            shouldCreateMultipleTestProducts: true,
+            observabilityScope: observability.topScope
+        )
+
+        let builder = PIFBuilder(
+            graph: graph,
+            parameters: .mock(supportedSwiftVersions: [.v6]),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let pif = try builder.construct()
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
+                project.checkTarget("PACKAGE-TARGET:foo") { target in
+                    for config in ["Debug", "Release"] {
+                        target.checkBuildConfiguration(config) { configuration in
+                            configuration.checkBuildSettings { settings in
+                                XCTAssertMatch(
+                                    settings[.OTHER_SWIFT_FLAGS] ?? [],
+                                     [.anySequence, "-default-isolation", "MainActor", .anySequence]
+                                )
+                            }
+                        }
+                    }
+                }
+
+                project.checkTarget("PACKAGE-TARGET:bar") { target in
+                    for config in ["Debug", "Release"] {
+                        target.checkBuildConfiguration(config) { configuration in
+                            configuration.checkBuildSettings { settings in
+                                XCTAssertMatch(
+                                    settings[.OTHER_SWIFT_FLAGS] ?? [],
+                                    [.anySequence, "-default-isolation", "nonisolated", .anySequence]
+                                )
+                            }
+                        }
+                    }
+                }
+
+                project.checkTarget("PACKAGE-TARGET:baz") { target in
+                    for config in ["Debug", "Release"] {
+                        target.checkBuildConfiguration(config) { configuration in
+                            configuration.checkBuildSettings { settings in
+                                XCTAssertMatch(
+                                    settings[.OTHER_SWIFT_FLAGS, for: .linux] ?? [],
+                                    [.anySequence, "-default-isolation", "MainActor", .anySequence]
+                                )
+                                XCTAssertNoMatch(
+                                    settings[.OTHER_SWIFT_FLAGS, for: .macOS] ?? [],
+                                    [.anySequence, "-default-isolation", "MainActor", .anySequence]
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 extension PIFBuilderParameters {


### PR DESCRIPTION
Add a `defaultIsolation` static method on `SwiftSetting` to allow specifying default actor isolation within a module.

### Motivation:

This is part of https://forums.swift.org/t/pitch-control-default-actor-isolation-inference/77482. Please leave feedback on the API shape in the pitch thread.

### Modifications:

I added a `defaultIsolation` case to `TargetBuildSettingDescription` and a corresponding static method to `SwiftSetting`.

### Result:

Programmers will be allowed to set `defaultIsolation` per target in a package manifest, e.g.:

```swift
swiftSettings: [
  .enableExperimentalFeature("StrictConcurrency"),
  .defaultIsolation(MainActor.self),
]
```