### PR TITLE
Correct "Did you mean XYZ" messages when a dependency is not found.

### DIFF
--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -831,7 +831,7 @@ private func prepareProductDependencyNotFoundError(
     // if indeed the dependency matches any of the products.
     let declProductsAsDependency = packageBuilder.package.products.filter { product in
         lookupByProductIDs ? product.identity == dependency.identity : product.name == dependency.name
-    }.map(\.modules).flatMap { $0 }.filter { t in
+    }.flatMap(\.modules).filter { t in
         t.name != dependency.name
     }
     if !declProductsAsDependency.isEmpty {

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -2868,11 +2868,11 @@ final class ModulesGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(
                             name: "aaa",
-                            dependencies: ["zzy"],
+                            dependencies: ["mmm"],
                             type: .executable
                         )
                     ]),
-                Manifest.createRootManifest(
+                Manifest.createFileSystemManifest(
                     displayName: "zzz",
                     path: "/zzz",
                     products: [
@@ -2893,7 +2893,7 @@ final class ModulesGraphTests: XCTestCase {
 
         testDiagnostics(observability.diagnostics) { result in
             result.check(
-                diagnostic: "product 'zzy' required by package 'aaa' target 'aaa' not found. Did you mean 'zzz'?",
+                diagnostic: "product 'mmm' required by package 'aaa' target 'aaa' not found.",
                 severity: .error
             )
         }

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -1003,7 +1003,7 @@ final class ModulesGraphTests: XCTestCase {
                     displayName: "weather",
                     path: "/weather",
                     products: [
-                        ProductDescription(name: "Rain", type: .library(.automatic), targets: ["Rain"])
+                        ProductDescription(name: "Rain", type: .library(.automatic), targets: ["Rain"]),
                     ],
                     targets: [
                         TargetDescription(name: "Rain"),
@@ -1023,7 +1023,152 @@ final class ModulesGraphTests: XCTestCase {
 
         testDiagnostics(observability.diagnostics) { result in
             result.check(
-                diagnostic: "product 'Rail' required by package 'forecast' target 'Forecast' not found. Did you mean 'Rain'?",
+                diagnostic: "product 'Rail' required by package 'forecast' target 'Forecast' not found. Did you mean '.product(name: \"Rain\", package: \"weather\")'?",
+                severity: .error
+            )
+        }
+    }
+
+    func testProductDependencyWithSimilarNamesFromMultiplePackages() throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/flavors/Sources/Bitter/Bitter.swift",
+            "/farm/Sources/Butter/Butter.swift",
+            "/grocery/Sources/Grocery/Grocery.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createFileSystemManifest(
+                    displayName: "flavors",
+                    path: "/flavors",
+                    products: [ProductDescription(name: "Bitter", type: .library(.automatic), targets: ["Bitter"])],
+                    targets: [
+                        TargetDescription(name: "Bitter"),
+                    ]
+                ),
+                Manifest.createFileSystemManifest(
+                    displayName: "farm",
+                    path: "/farm",
+                    products: [ProductDescription(name: "Butter", type: .library(.automatic), targets: ["Butter"])],
+                    targets: [
+                        TargetDescription(name: "Butter"),
+                    ]
+                ),
+                Manifest.createRootManifest(
+                    displayName: "grocery",
+                    path: "/grocery",
+                    dependencies: [.fileSystem(path: "/farm"), .fileSystem(path: "/flavors")],
+                    targets: [
+                        TargetDescription(name: "Grocery", dependencies: [
+                            .product(name: "Biter", package: "farm"),
+                            .product(name: "Bitter", package: "flavors"),
+                        ]),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        // We should expect matching to work only within the package we want even
+        // though there are lexically closer candidates in other packages.
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(
+                diagnostic: "product 'Biter' required by package 'grocery' target 'Grocery' not found in package 'farm'. Did you mean '.product(name: \"Butter\", package: \"farm\")'?",
+                severity: .error
+            )
+        }
+    }
+
+    func testProductDependencyWithSimilarNamesFromProductTargetsNotProducts() throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/lunch/Sources/Lunch/Lunch.swift",
+            "/sandwich/Sources/Sandwich/Sandwich.swift",
+            "/sandwich/Sources/Bread/Bread.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createFileSystemManifest(
+                    displayName: "sandwich",
+                    path: "/sandwich",
+                    products: [ProductDescription(
+                        name: "Sandwich",
+                        type: .library(.automatic),
+                        targets: ["Sandwich"]
+                    )],
+                    targets: [
+                        TargetDescription(name: "Sandwich", dependencies: ["Bread"]),
+                        TargetDescription(name: "Bread"),
+                    ]
+                ),
+                Manifest.createRootManifest(
+                    displayName: "lunch",
+                    path: "/lunch",
+                    // Depends on a product which isn't actually declared in sandwich,
+                    // but there's a target with the same name.
+                    dependencies: [.fileSystem(path: "/sandwich")],
+                    targets: [
+                        TargetDescription(name: "Lunch", dependencies: [.product(name: "Bread", package: "sandwich")]),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(
+                diagnostic: "product 'Bread' required by package 'lunch' target 'Lunch' not found in package 'sandwich'.",
+                severity: .error
+            )
+        }
+    }
+
+    func testProductDependencyWithSimilarNamesFromLocalTargetsNotPackageProducts() throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/gauges/Sources/Chart/Chart.swift",
+            "/gauges/Sources/Value/Value.swift",
+            "/controls/Sources/Valve/Valve.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createFileSystemManifest(
+                    displayName: "controls",
+                    path: "/controls",
+                    products: [ProductDescription(name: "Valve", type: .library(.automatic), targets: ["Valve"])],
+                    targets: [
+                        TargetDescription(name: "Valve"),
+                    ]
+                ),
+                Manifest.createRootManifest(
+                    displayName: "gauges",
+                    path: "/gauges",
+                    // Target dependency should show the local target dependency, even though
+                    // there's a lexically-close product name in a different package.
+                    dependencies: [.fileSystem(path: "/controls")],
+                    targets: [
+                        TargetDescription(name: "Chart", dependencies: [
+                            "Valv",
+                            .product(name: "Valve", package: "controls")]),
+                        TargetDescription(name: "Value"),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(
+                diagnostic: "product 'Valv' required by package 'gauges' target 'Chart' not found. Did you mean 'Value'?",
                 severity: .error
             )
         }


### PR DESCRIPTION
Correct "Did you mean XYZ" messages when a dependency is not found.

### Motivation:

I found that "Did you mean XYZ" messages quite often aren't helpful. Specifically, scenarios which I found very frustrating:

*Scenario 1*:
  - I have a package MylibKit, and I forgot to declare a product there. I have a module Awesomeness there.
  - I have a package NeatPak and I want to use Awesomeness there. I add package dependency to MylibKit and a product dependency `.product(name="Awesomeness", package="MylibKit")`
  - SwiftPM errors out and adds `Did you mean '.product(name="Awesomeness", package="MylibKit")'`. I triple-checked what it suggested vs what I had, and after some staring, I checked MylibKit and indeed, it was missing a product definition. It was pretty frustrating that it errored out with suggestion which clearly wasn't working.

*Scenario 2*:
  - I have a package MylibKit that I refactored out of my existing package, and I declared product Awesomeness there.
  - I have a package NeatPak and I want to use Awesomeness there. I add package dependency to MylibKit and a dependency by name `"Awesomenes"`, making a typo.
  - SwiftPM errors out and adds `Did you mean 'Awesomeness` with correct spelling.
  - I update dependency to `"Awesomeness"`.
  - Now SwiftPM suggests `Did you mean '.product(name="Awesomeness", package="MylibKit")'`, and it's pretty frustrating why it didn't suggest it in the first place.

### Modifications:

 - Update implementation of how SwiftPM gathers what's acceptable destinations for the dependency, fixing the mentioned scenarios.
 - Expanded tests to include the mentioned scenarios.
 - Extracted error generation from createResolvedPackages ever so slightly reducing its complexity

### Result:

 - All tests pass.
 - More accurate error messages with better suggestions.