### PR TITLE
Disable the testLTO test in MiscellaneousTests

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -334,6 +334,7 @@ final class MiscellaneousTestCase: XCTestCase {
     }
 
     func testLTO() async throws {
+        throw XCTSkip("No longer works with newer toolchains")
         #if os(macOS)
         // FIXME: this test requires swift-driver to be installed
         // Currently swift-ci does not build/install swift-driver before running


### PR DESCRIPTION
This test seems to be broken with the latest CI infrastructure changes.

Skip it until we can figure out why.