### PR TITLE
[6.1] Fix retain cycle in `LLBuildProgressTracker`

### DIFF
--- a/Sources/Build/LLBuildProgressTracker.swift
+++ b/Sources/Build/LLBuildProgressTracker.swift
@@ -180,8 +180,10 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
         } ?? [:]
         self.swiftParsers = swiftParsers
 
-        self.taskTracker.onTaskProgressUpdateText = { progressText, _ in
-            self.queue.async {
+        self.taskTracker.onTaskProgressUpdateText = { [weak self] progressText, _ in
+            guard let self else { return }
+            self.queue.async { [weak self] in
+                guard let self else { return }
                 self.delegate?.buildSystem(self.buildSystem, didUpdateTaskProgress: progressText)
             }
         }


### PR DESCRIPTION
- **Explanation**: `self.taskTracker.onTaskProgressUpdateText` captured `self` strongly, creating a reference cycle in `LLBuildProgressTracker`, which caused it to never get deallocated.
- **Scope**: Manifested as a memory leak in SourceKit-LSP
- **Issue**: n/a
- **Original PR**: https://github.com/swiftlang/swift-package-manager/pull/8305
- **Risk**: Low, just captures a delegate weakly
- **Testing**: Verified that this fixes the memory leak we saw
- **Reviewer**: @MaxDesiatov 