### PR TITLE
Fixed update of swift-syntax package version in swiftpm macro templates

### DIFF
--- a/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
+++ b/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
@@ -37,7 +37,7 @@ public struct InstalledSwiftPMConfiguration {
         return .init(
             version: 0,
             swiftSyntaxVersionForMacroTemplate: .init(
-                major: 600,
+                major: 601,
                 minor: 0,
                 patch: 0,
                 prereleaseIdentifier: "latest"

--- a/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
+++ b/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
@@ -524,7 +524,7 @@ class ManifestEditTests: XCTestCase {
             let package = Package(
                 name: "packages",
                 dependencies: [
-                    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-latest"),
+                    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "601.0.0-latest"),
                 ],
                 targets: [
                     .macro(


### PR DESCRIPTION
Fixed SwiftPM macro template manifest depending on new swift syntax release
### Motivation:

Use the latest version of swift-syntax package in SwiftPM macro templates
### Modifications:ss
changed the default version to 601 and edited a test case to reflect change

### Result:
If user does not have a toolchain with a config.json, the default version of swift-syntax is 601