### PR TITLE
Align --build-system xcode language mode validation with --build-system native

### DIFF
--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -1819,7 +1819,6 @@ extension PIF.BuildSettings {
 
         func computeEffectiveSwiftVersions(for versions: [SwiftLanguageVersion]) -> [String] {
             versions
-                .filter { target.declaredSwiftVersions.contains($0) }
                 .filter { isSupportedVersion($0) }.map(\.description)
         }
 
@@ -1937,7 +1936,7 @@ extension PIFGenerationError: CustomStringConvertible {
             versions: let given,
             supportedVersions: let supported
         ):
-            "Some of the Swift language versions used in target '\(target)' settings are supported. (given: \(given), supported: \(supported))"
+            "Some of the Swift language versions used in target '\(target)' settings are unsupported. (given: \(given), supported: \(supported))"
         }
     }
 }

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -2947,7 +2947,8 @@ final class PIFBuilderTests: XCTestCase {
             emptyFiles:
             "/Foo/Sources/foo/main.swift",
             "/Foo/Sources/bar/main.swift",
-            "/Foo/Sources/baz/main.swift"
+            "/Foo/Sources/baz/main.swift",
+            "/Foo/Sources/qux/main.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2958,7 +2959,7 @@ final class PIFBuilderTests: XCTestCase {
                     displayName: "Foo",
                     path: "/Foo",
                     toolsVersion: .v5_3,
-                    swiftLanguageVersions: [.v4_2, .v5],
+                    swiftLanguageVersions: [.v4_2],
                     targets: [
                         .init(name: "foo", dependencies: [], settings: [
                             .init(
@@ -2984,6 +2985,12 @@ final class PIFBuilderTests: XCTestCase {
                                 condition: .init(platformNames: ["macOS"])
                             ),
                         ]),
+                        .init(name: "qux", dependencies: [], settings: [
+                            .init(
+                                tool: .swift,
+                                kind: .swiftLanguageMode(.v5)
+                            )
+                        ]),
                     ]
                 ),
             ],
@@ -3001,13 +3008,14 @@ final class PIFBuilderTests: XCTestCase {
 
         testDiagnostics(observability.diagnostics) { result in
             result.check(
-                diagnostic: "Some of the Swift language versions used in target 'bar' settings are supported. (given: [6], supported: [4.2, 5])",
+                diagnostic: "Some of the Swift language versions used in target 'bar' settings are unsupported. (given: [6], supported: [4.2, 5])",
                 severity: .error
             )
             result.check(
-                diagnostic: "Some of the Swift language versions used in target 'baz' settings are supported. (given: [3], supported: [4.2, 5])",
+                diagnostic: "Some of the Swift language versions used in target 'baz' settings are unsupported. (given: [3], supported: [4.2, 5])",
                 severity: .error
             )
+            result.checkIsEmpty()
         }
     }
 }


### PR DESCRIPTION

Fix a bug where builds using --build-system xcode would fail if a target was configured to use a language mode which was not also specified at the top level of the package manifest

