### PR TITLE
Add a SourceKit-LSP API to get the output paths of a clang target

### DIFF
--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -54,9 +54,20 @@ struct PluginTargetBuildDescription: BuildTarget {
         return target.name
     }
 
+    var compiler: BuildTargetCompiler { .swift }
+
     var destination: BuildDestination {
         // Plugins are always built for the host.
         .host
+    }
+
+    var outputPaths: [URL] {
+        get throws {
+            struct NotSupportedError: Error, CustomStringConvertible {
+                var description: String { "Getting output paths for a plugin target is not supported" }
+            }
+            throw NotSupportedError()
+        }
     }
 
     func compileArguments(for fileURL: URL) throws -> [String] {

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -319,6 +319,51 @@ final class SourceKitLSPAPITests: XCTestCase {
             )
         }
     }
+
+    func testClangOutputPaths() async throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Pkg/Sources/lib/include/lib.h",
+            "/Pkg/Sources/lib/lib.cpp",
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: "/Pkg",
+                    toolsVersion: .v5_10,
+                    targets: [
+                        TargetDescription(
+                            name: "lib",
+                            dependencies: []
+                        )
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let plan = try await BuildPlan(
+            destinationBuildParameters: mockBuildParameters(
+                destination: .target,
+                shouldLinkStaticSwiftStdlib: true
+            ),
+            toolsBuildParameters: mockBuildParameters(
+                destination: .host,
+                shouldLinkStaticSwiftStdlib: true
+            ),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let description = BuildDescription(buildPlan: plan)
+
+        let target = try XCTUnwrap(description.getBuildTarget(for: XCTUnwrap(graph.module(for: "lib")), destination: .target))
+        XCTAssertEqual(target.compiler, .clang)
+        XCTAssertEqual(try target.outputPaths.count, 1)
+        XCTAssertEqual(try target.outputPaths.last?.lastPathComponent, "lib.cpp.o")
+    }
 }
 
 extension SourceKitLSPAPI.BuildDescription {


### PR DESCRIPTION
To facilitate https://github.com/swiftlang/sourcekit-lsp/pull/2017.