### PR TITLE
update CLanguageStandard c89 description

### DIFF
--- a/Sources/PackageDescription/LanguageStandardSettings.swift
+++ b/Sources/PackageDescription/LanguageStandardSettings.swift
@@ -14,7 +14,7 @@
 /// package.
 public enum CLanguageStandard: String {
 
-    /// The identifier for the ISO C 1990 language standard.
+    /// The identifier for the ISO C 1989 language standard.
     case c89
 
     /// The identifier for the ISO C 1990 language standard.


### PR DESCRIPTION
update `CLanguageStandard` description for `c89`

### Motivation:

update typo in `CLanguageStandard` description.

### Modifications:

- Update description for `c89` standard to use correct year, 1989, instead of 1990.

### Result:

- Documentation is improved!
