### PR TITLE
Found another place where we specify the swift-syntax version.

### DIFF
--- a/Utilities/config.json
+++ b/Utilities/config.json
@@ -1,3 +1,3 @@
 {"version":1,
-  "swiftSyntaxVersionForMacroTemplate":{"major":600,"minor":0,"patch":0, "prereleaseIdentifier":"latest"},
-  "swiftTestingVersionForTestTemplate":{"major":0,"minor":8,"patch":0}}
+  "swiftSyntaxVersionForMacroTemplate":{"major":601,"minor":0,"patch":0, "prereleaseIdentifier":"latest"},
+ "swiftTestingVersionForTestTemplate":{"major":0,"minor":8,"patch":0}}


### PR DESCRIPTION
Updates the config.json to swift-syntax 601.
