### PR TITLE
Cherry pick swbuild support to 6.1

### DIFF
--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -100,10 +100,19 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         } else {
             let xcodeSelectOutput = try AsyncProcess.popen(args: "xcode-select", "-p").utf8Output().spm_chomp()
             let xcodeDirectory = try AbsolutePath(validating: xcodeSelectOutput)
-            xcbuildPath = try AbsolutePath(
-                validating: "../SharedFrameworks/XCBuild.framework/Versions/A/Support/xcbuild",
-                relativeTo: xcodeDirectory
-            )
+            xcbuildPath = try {
+                let newPath = try AbsolutePath(
+                    validating: "../SharedFrameworks/SwiftBuild.framework/Versions/A/Support/swbuild",
+                    relativeTo: xcodeDirectory
+                )
+                if fileSystem.exists(newPath) {
+                    return newPath
+                }
+                return try AbsolutePath(
+                    validating: "../SharedFrameworks/XCBuild.framework/Versions/A/Support/xcbuild",
+                    relativeTo: xcodeDirectory
+                )
+            }()
         }
 
         guard fileSystem.exists(xcbuildPath) else {


### PR DESCRIPTION
Update path to support swbuild if available (#8306)

Some Xcode installation no longer have `xcbuild` binary, and instead
contain a `swbuild`. Update the path to look for `swbuild` first, and
then fall back to `xcbuild`.