### PR TITLE
Remove trailing comma from `downloadAndPopulateCache`

### DIFF
--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -153,7 +153,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
         packagePath: AbsolutePath,
         observabilityScope: ObservabilityScope,
         delegateQueue: DispatchQueue,
-        callbackQueue: DispatchQueue,
+        callbackQueue: DispatchQueue
     ) async throws -> FetchDetails {
         if let cachePath {
             do {


### PR DESCRIPTION
This restores the ability to build SwiftPM using a Swift 6.0 compiler.