### PR TITLE
Include the output paths for clang files in the `sources` property of a `BuildDescription`

### DIFF
--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -32,8 +32,10 @@ struct PluginTargetBuildDescription: BuildTarget {
         self.isPartOfRootPackage = isPartOfRootPackage
     }
 
-    var sources: [URL] {
-        return target.sources.paths.map(\.asURL)
+    var sources: [SourceItem] {
+        return target.sources.paths.map {
+          SourceItem(sourceFile: $0.asURL, outputFile: nil)
+        }
     }
 
     var headers: [URL] { [] }
@@ -74,7 +76,7 @@ struct PluginTargetBuildDescription: BuildTarget {
         // FIXME: This is very odd and we should clean this up by merging `ManifestLoader` and `DefaultPluginScriptRunner` again.
         var args = ManifestLoader.interpreterFlags(for: self.toolsVersion, toolchain: toolchain)
         // Note: we ignore the `fileURL` here as the expectation is that we get a commandline for the entire target in case of Swift. Plugins are always assumed to only consist of Swift files.
-        args += try sources.map { try $0.filePath }
+        args += try sources.map { try $0.sourceFile.filePath }
         return args
     }
 }

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -361,8 +361,8 @@ final class SourceKitLSPAPITests: XCTestCase {
 
         let target = try XCTUnwrap(description.getBuildTarget(for: XCTUnwrap(graph.module(for: "lib")), destination: .target))
         XCTAssertEqual(target.compiler, .clang)
-        XCTAssertEqual(try target.outputPaths.count, 1)
-        XCTAssertEqual(try target.outputPaths.last?.lastPathComponent, "lib.cpp.o")
+        XCTAssertEqual(target.sources.count, 1)
+        XCTAssertEqual(target.sources.last?.outputFile?.lastPathComponent, "lib.cpp.o")
     }
 }
 
@@ -384,7 +384,7 @@ extension SourceKitLSPAPI.BuildDescription {
         XCTAssertEqual(buildTarget.ignored, ignoredFiles, "build target \(targetName) contains unexpected ignored files")
         XCTAssertEqual(buildTarget.others, otherFiles, "build target \(targetName) contains unexpected other files")
 
-        guard let source = buildTarget.sources.first else {
+        guard let source = buildTarget.sources.first?.sourceFile else {
             XCTFail("build target \(targetName) contains no source files")
             return false
         }


### PR DESCRIPTION
We need the mapping from source file to output file in SourceKit-LSP, so the old approach of returning all output paths in a separate property does not work. Return them in a single property instead.

This will be used in SourceKit-LSP by https://github.com/swiftlang/sourcekit-lsp/pull/2038.