### PR TITLE
Include Swift Build support in second stage bootstrap builds

### DIFF
--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -120,6 +120,7 @@ private struct SwiftBuildSystemFactory: BuildSystemFactory {
                     explicitProduct: explicitProduct
                 )
             },
+            packageManagerResourcesDirectory: swiftCommandState.packageManagerResourcesDirectory,
             outputStream: outputStream ?? self.swiftCommandState.outputStream,
             logLevel: logLevel ?? self.swiftCommandState.logLevel,
             fileSystem: self.swiftCommandState.fileSystem,

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -146,6 +146,12 @@ public struct LocationOptions: ParsableArguments {
         completion: .directory
     )
     public var pkgConfigDirectories: [AbsolutePath] = []
+    
+    @Option(
+        help: .init("Specify alternate path to search for SwiftPM resources.", visibility: .hidden),
+        completion: .directory
+    )
+    public var packageManagerResourcesDirectory: AbsolutePath?
 
     @Flag(name: .customLong("ignore-lock"), help: .hidden)
     public var ignoreLock: Bool = false

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -227,6 +227,9 @@ public final class SwiftCommandState {
 
     /// Path to the shared configuration directory
     public let sharedConfigurationDirectory: AbsolutePath
+    
+    /// Path to the package manager's own resources directory.
+    public let packageManagerResourcesDirectory: AbsolutePath?
 
     /// Path to the cross-compilation Swift SDKs directory.
     public let sharedSwiftSDKsDirectory: AbsolutePath
@@ -371,6 +374,17 @@ public final class SwiftCommandState {
                 warning: "`--experimental-swift-sdks-path` is deprecated and will be removed in a future version of SwiftPM. Use `--swift-sdks-path` instead."
             )
         }
+        
+        if let packageManagerResourcesDirectory = options.locations.packageManagerResourcesDirectory {
+            self.packageManagerResourcesDirectory = packageManagerResourcesDirectory
+        } else if let cwd = localFileSystem.currentWorkingDirectory {
+            self.packageManagerResourcesDirectory = try? AbsolutePath(validating: CommandLine.arguments[0], relativeTo: cwd)
+                .parentDirectory.parentDirectory.appending(components: ["share", "pm"])
+        } else {
+            self.packageManagerResourcesDirectory = try? AbsolutePath(validating: CommandLine.arguments[0])
+                .parentDirectory.parentDirectory.appending(components: ["share", "pm"])
+        }
+        
         self.sharedSwiftSDKsDirectory = try fileSystem.getSharedSwiftSDKsDirectory(
             explicitDirectory: options.locations.swiftSDKsDirectory ?? options.locations.deprecatedSwiftSDKsDirectory
         )

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -362,6 +362,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
                 return try SwiftBuildSystem(
                     buildParameters: buildParameters,
                     packageGraphLoader: asyncUnsafePackageGraphLoader,
+                    packageManagerResourcesDirectory: nil,
                     outputStream: TSCBasic.stdoutStream,
                     logLevel: logLevel,
                     fileSystem: self.fileSystem,

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -809,7 +809,6 @@ def get_swiftpm_env_cmd(args):
 
     if args.llbuild_link_framework:
         env_cmd.append("SWIFTPM_LLBUILD_FWK=1")
-    env_cmd.append("SWIFTPM_NO_SWBUILD_DEPENDENCY=1")
     env_cmd.append("SWIFTCI_USE_LOCAL_DEPS=1")
     env_cmd.append("SWIFTPM_MACOS_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -518,6 +518,11 @@ def install_swiftpm(prefix, args):
     dest = os.path.join(prefix, "lib", "swift", "pm", "PluginAPI")
     install_dylib(args, "PackagePlugin", dest, ["PackagePlugin"])
 
+    # Install resource bundles produced during the build.
+    for file in os.listdir(args.bin_dir):
+        if file.endswith('.bundle') or file.endswith('.resources'):
+            install_binary(args, file, os.path.join(os.path.join(prefix, "share"), "pm"))
+
 
 # Helper function that installs a dynamic library and a set of modules to a particular directory.
 def install_dylib(args, library_name, install_dir, module_names):


### PR DESCRIPTION
Stop setting SWIFTPM_NO_SWBUILD_DEPENDENCY in the bootstrap script - we've made changes to Swift Build which should allow it to be bootstrapped in these environments (it's still not part of swift-bootstrap itself though).