### PR TITLE
Remove usages of deprecated registry methods

### DIFF
--- a/Sources/PackageMetadata/PackageMetadata.swift
+++ b/Sources/PackageMetadata/PackageMetadata.swift
@@ -174,8 +174,8 @@ public struct PackageSearchClient {
             package: package,
             version: version,
             fileSystem: self.fileSystem,
-            observabilityScope: observabilityScope,
-            callbackQueue: DispatchQueue.sharedConcurrent)
+            observabilityScope: observabilityScope
+        )
 
         return Metadata(
             licenseURL: metadata.licenseURL,
@@ -285,7 +285,10 @@ public struct PackageSearchClient {
         }
         let metadata: RegistryClient.PackageMetadata
         do {
-            metadata = try await self.registryClient.getPackageMetadata(package: identity, observabilityScope: observabilityScope, callbackQueue: DispatchQueue.sharedConcurrent)
+            metadata = try await self.registryClient.getPackageMetadata(
+                package: identity,
+                observabilityScope: observabilityScope
+            )
         } catch {
             return try await fetchStandalonePackageByURL(error)
         }
@@ -403,7 +406,7 @@ extension Package.Author {
             url: author.url
         )
     }
-    
+
     fileprivate init(_ author: PackageCollectionsModel.Package.Author) {
         self.init(
             name: author.username,

--- a/Sources/PackageRegistry/ChecksumTOFU.swift
+++ b/Sources/PackageRegistry/ChecksumTOFU.swift
@@ -43,22 +43,26 @@ struct PackageVersionChecksumTOFU {
         version: Version,
         checksum: String,
         timeout: DispatchTimeInterval?,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
+        observabilityScope: ObservabilityScope
     ) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            self.validateSourceArchive(
-                registry: registry,
-                package: package,
-                version: version,
-                checksum: checksum,
-                timeout: timeout,
-                observabilityScope: observabilityScope,
-                callbackQueue: callbackQueue,
-                completion: {
-                    continuation.resume(with: $0)
-                }
-            )
+        let expectedChecksum = try await self.getExpectedChecksum(
+            registry: registry,
+            package: package,
+            version: version,
+            timeout: timeout,
+            observabilityScope: observabilityScope
+        )
+
+        if checksum != expectedChecksum {
+            switch self.fingerprintCheckingMode {
+            case .strict:
+                throw RegistryError.invalidChecksum(expected: expectedChecksum, actual: checksum)
+            case .warn:
+                observabilityScope
+                    .emit(
+                        warning: "the checksum \(checksum) for source archive of \(package) \(version) does not match previously recorded value \(expectedChecksum)"
+                    )
+            }
         }
     }
 
@@ -73,28 +77,14 @@ struct PackageVersionChecksumTOFU {
         callbackQueue: DispatchQueue,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
-        self.getExpectedChecksum(
-            registry: registry,
-            package: package,
-            version: version,
-            timeout: timeout,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue
-        ) { result in
-            completion(
-                result.tryMap { expectedChecksum in
-                    if checksum != expectedChecksum {
-                        switch self.fingerprintCheckingMode {
-                        case .strict:
-                            throw RegistryError.invalidChecksum(expected: expectedChecksum, actual: checksum)
-                        case .warn:
-                            observabilityScope
-                                .emit(
-                                    warning: "the checksum \(checksum) for source archive of \(package) \(version) does not match previously recorded value \(expectedChecksum)"
-                                )
-                        }
-                    }
-                }
+        callbackQueue.asyncResult(completion) {
+            try await self.validateSourceArchive(
+                registry: registry,
+                package: package,
+                version: version,
+                checksum: checksum,
+                timeout: timeout,
+                observabilityScope: observabilityScope
             )
         }
     }
@@ -105,53 +95,47 @@ struct PackageVersionChecksumTOFU {
         version: Version,
         timeout: DispatchTimeInterval?,
         observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        completion: @escaping (Result<String, Error>) -> Void
-    ) {
+    ) async throws -> String {
         // We either use a previously recorded checksum, or fetch it from the registry.
         if let savedChecksum = try? self.readFromStorage(package: package, version: version, contentType: .sourceCode, observabilityScope: observabilityScope) {
-            return completion(.success(savedChecksum))
+            return savedChecksum
         }
 
         // Try fetching checksum from registry if:
         //   - No storage available
         //   - Checksum not found in storage
         //   - Reading from storage resulted in error
-        Task {
-            do {
-                let versionMetadata = try await self.versionMetadataProvider(package, version)
-                guard let sourceArchiveResource = versionMetadata.sourceArchive else {
-                    throw RegistryError.missingSourceArchive
-                }
-                guard let checksum = sourceArchiveResource.checksum else {
-                    throw RegistryError.sourceArchiveMissingChecksum(
-                        registry: registry,
-                        package: package.underlying,
-                        version: version
-                    )
-                }
-                do {
-                    try self.writeToStorage(
-                        registry: registry,
-                        package: package,
-                        version: version,
-                        checksum: checksum,
-                        contentType: .sourceCode,
-                        observabilityScope: observabilityScope
-                    )
-                    completion(.success(checksum))
-                } catch {
-                    completion(.failure(error))
-                }
-            } catch {
-                completion(.failure(RegistryError.failedRetrievingReleaseChecksum(
+        var checksum: String
+        do {
+            let versionMetadata = try await self.versionMetadataProvider(package, version)
+            guard let sourceArchiveResource = versionMetadata.sourceArchive else {
+                throw RegistryError.missingSourceArchive
+            }
+            guard let archiveChecksum = sourceArchiveResource.checksum else {
+                throw RegistryError.sourceArchiveMissingChecksum(
                     registry: registry,
                     package: package.underlying,
-                    version: version,
-                    error: error
-                )))
+                    version: version
+                )
             }
+            checksum = archiveChecksum
+        } catch {
+            throw RegistryError.failedRetrievingReleaseChecksum(
+                registry: registry,
+                package: package.underlying,
+                version: version,
+                error: error
+            )
         }
+        try self.writeToStorage(
+            registry: registry,
+            package: package,
+            version: version,
+            checksum: checksum,
+            contentType: .sourceCode,
+            observabilityScope: observabilityScope
+        )
+        return checksum
     }
 
     func validateManifest(

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -54,8 +54,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
         package: PackageIdentity,
         version: Version,
         observabilityScope: ObservabilityScope,
-        delegateQueue: DispatchQueue,
-        callbackQueue: DispatchQueue
+        delegateQueue: DispatchQueue
     ) async throws -> AbsolutePath {
         let packageRelativePath: RelativePath
         let packagePath: AbsolutePath
@@ -97,8 +96,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
                             version: version,
                             packagePath: packagePath,
                             observabilityScope: observabilityScope,
-                            delegateQueue: delegateQueue,
-                            callbackQueue: callbackQueue,
+                            delegateQueue: delegateQueue
                         )
                         // inform delegate that we finished to fetch
                         let duration = start.distance(to: .now())
@@ -131,13 +129,12 @@ public class RegistryDownloadsManager: AsyncCancellable {
         callbackQueue: DispatchQueue,
         completion: @escaping (Result<AbsolutePath, Error>) -> Void
     ) {
-        self.executeAsync(completion, on: callbackQueue) {
+        callbackQueue.asyncResult(completion) {
             try await self.lookup(
                 package: package,
                 version: version,
                 observabilityScope: observabilityScope,
-                delegateQueue: delegateQueue,
-                callbackQueue: callbackQueue,
+                delegateQueue: delegateQueue
             )
         }
     }
@@ -152,8 +149,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
         version: Version,
         packagePath: AbsolutePath,
         observabilityScope: ObservabilityScope,
-        delegateQueue: DispatchQueue,
-        callbackQueue: DispatchQueue
+        delegateQueue: DispatchQueue
     ) async throws -> FetchDetails {
         if let cachePath {
             do {
@@ -184,8 +180,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
                                 destinationPath: cachedPackagePath,
                                 progressHandler: updateDownloadProgress,
                                 fileSystem: self.fileSystem,
-                                observabilityScope: observabilityScope,
-                                callbackQueue: callbackQueue
+                                observabilityScope: observabilityScope
                             )
 
                             // extra validation to defend from racy edge cases
@@ -219,8 +214,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
                     destinationPath: packagePath,
                     progressHandler: updateDownloadProgress,
                     fileSystem: self.fileSystem,
-                    observabilityScope: observabilityScope,
-                    callbackQueue: callbackQueue
+                    observabilityScope: observabilityScope
                 )
                 return FetchDetails(fromCache: false, updatedCache: false)
             }
@@ -235,8 +229,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
                 destinationPath: packagePath,
                 progressHandler: updateDownloadProgress,
                 fileSystem: self.fileSystem,
-                observabilityScope: observabilityScope,
-                callbackQueue: callbackQueue
+                observabilityScope: observabilityScope
             )
             return FetchDetails(fromCache: false, updatedCache: false)
         }
@@ -312,21 +305,6 @@ public class RegistryDownloadsManager: AsyncCancellable {
     private func initializeCacheIfNeeded(cachePath: AbsolutePath) throws {
         if !self.fileSystem.exists(cachePath) {
             try self.fileSystem.createDirectory(cachePath, recursive: true)
-        }
-    }
-
-    private func executeAsync<T>(
-        _ callback: @escaping (Result<T, Error>) -> Void,
-        on queue: DispatchQueue,
-        _ closure: @escaping () async throws -> T
-    ) {
-        let completion: (Result<T, Error>) -> Void = { result in queue.async { callback(result) } }
-        Task {
-            do {
-                completion(.success(try await closure()))
-            } catch {
-                completion(.failure(error))
-            }
         }
     }
 }

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -35,6 +35,10 @@ struct SignatureValidation {
         .PackageVersionMetadata
     private let delegate: Delegate
 
+    private enum ValidationError: Error {
+        case passthrough(Error)
+    }
+
     init(
         skipSignatureValidation: Bool,
         signingEntityStorage: PackageSigningEntityStorage?,
@@ -61,25 +65,34 @@ struct SignatureValidation {
         configuration: RegistryConfiguration.Security.Signing,
         timeout: DispatchTimeInterval?,
         fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
+        observabilityScope: ObservabilityScope
     ) async throws -> SigningEntity? {
-        try await withCheckedThrowingContinuation { continuation in
-            self.validate(
-                registry: registry,
-                package: package,
-                version: version, 
-                content: content,
-                configuration: configuration,
-                timeout: timeout,
-                fileSystem: fileSystem,
-                observabilityScope: observabilityScope, 
-                callbackQueue: callbackQueue,
-                completion: { continuation.resume(with: $0) }
-            )
+        guard !self.skipSignatureValidation else {
+            return .none
         }
+
+        let signingEntity = try await self.getAndValidateSourceArchiveSignature(
+            registry: registry,
+            package: package,
+            version: version,
+            content: content,
+            configuration: configuration,
+            timeout: timeout,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope
+        )
+        // Always do signing entity TOFU check at the end,
+        // whether the package is signed or not.
+        let _ = try await self.signingEntityTOFU.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity,
+            observabilityScope: observabilityScope
+        )
+        return signingEntity;
     }
-    
+
     @available(*, noasync, message: "Use the async alternative")
     func validate(
         registry: Registry,
@@ -90,41 +103,19 @@ struct SignatureValidation {
         timeout: DispatchTimeInterval?,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
         completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
     ) {
-        guard !self.skipSignatureValidation else {
-            return completion(.success(.none))
-        }
-
-        self.getAndValidateSourceArchiveSignature(
-            registry: registry,
-            package: package,
-            version: version,
-            content: content,
-            configuration: configuration,
-            timeout: timeout,
-            fileSystem: fileSystem,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue
-        ) { result in
-            switch result {
-            case .success(let signingEntity):
-                // Always do signing entity TOFU check at the end,
-                // whether the package is signed or not.
-                self.signingEntityTOFU.validate(
-                    registry: registry,
-                    package: package,
-                    version: version,
-                    signingEntity: signingEntity,
-                    observabilityScope: observabilityScope,
-                    callbackQueue: callbackQueue
-                ) { _ in
-                    completion(.success(signingEntity))
-                }
-            case .failure(let error):
-                completion(.failure(error))
-            }
+        DispatchQueue.sharedConcurrent.asyncResult(completion) {
+            try await self.validate(
+                registry: registry,
+                package: package,
+                version: version,
+                content: content,
+                configuration: configuration,
+                timeout: timeout,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope
+            )
         }
     }
 
@@ -136,36 +127,34 @@ struct SignatureValidation {
         configuration: RegistryConfiguration.Security.Signing,
         timeout: DispatchTimeInterval?,
         fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
-    ) {
-        Task {
+        observabilityScope: ObservabilityScope
+    ) async throws -> SigningEntity? {
+        do {
+            let versionMetadata = try await self.versionMetadataProvider(package, version)
+
+            guard let sourceArchiveResource = versionMetadata.sourceArchive else {
+                throw RegistryError.missingSourceArchive
+            }
+            guard let signatureBase64Encoded = sourceArchiveResource.signing?.signatureBase64Encoded else {
+                throw RegistryError.sourceArchiveNotSigned(
+                    registry: registry,
+                    package: package.underlying,
+                    version: version
+                )
+            }
+
+            guard let signatureData = Data(base64Encoded: signatureBase64Encoded) else {
+                throw RegistryError.failedLoadingSignature
+            }
+            guard let signatureFormatString = sourceArchiveResource.signing?.signatureFormat else {
+                throw RegistryError.missingSignatureFormat
+            }
+            guard let signatureFormat = SignatureFormat(rawValue: signatureFormatString) else {
+                throw RegistryError.unknownSignatureFormat(signatureFormatString)
+            }
+
             do {
-                let versionMetadata = try await self.versionMetadataProvider(package, version)
-
-                guard let sourceArchiveResource = versionMetadata.sourceArchive else {
-                    throw RegistryError.missingSourceArchive
-                }
-                guard let signatureBase64Encoded = sourceArchiveResource.signing?.signatureBase64Encoded else {
-                    throw RegistryError.sourceArchiveNotSigned(
-                        registry: registry,
-                        package: package.underlying,
-                        version: version
-                    )
-                }
-
-                guard let signatureData = Data(base64Encoded: signatureBase64Encoded) else {
-                    throw RegistryError.failedLoadingSignature
-                }
-                guard let signatureFormatString = sourceArchiveResource.signing?.signatureFormat else {
-                    throw RegistryError.missingSignatureFormat
-                }
-                guard let signatureFormat = SignatureFormat(rawValue: signatureFormatString) else {
-                    throw RegistryError.unknownSignatureFormat(signatureFormatString)
-                }
-
-                self.validateSourceArchiveSignature(
+                return try await self.validateSourceArchiveSignature(
                     registry: registry,
                     package: package,
                     version: version,
@@ -174,61 +163,66 @@ struct SignatureValidation {
                     content: Array(content),
                     configuration: configuration,
                     fileSystem: fileSystem,
-                    observabilityScope: observabilityScope,
-                    completion: completion
+                    observabilityScope: observabilityScope
                 )
-            } catch RegistryError.sourceArchiveNotSigned {
-                observabilityScope.emit(
-                    info: "\(package) \(version) from \(registry) is unsigned",
-                    metadata: .registryPackageMetadata(identity: package)
-                )
-                guard let onUnsigned = configuration.onUnsigned else {
-                    return completion(.failure(RegistryError.missingConfiguration(details: "security.signing.onUnsigned")))
-                }
+            } catch {
+                throw ValidationError.passthrough(error)
+            }
+        } catch RegistryError.sourceArchiveNotSigned {
+            observabilityScope.emit(
+                info: "\(package) \(version) from \(registry) is unsigned",
+                metadata: .registryPackageMetadata(identity: package)
+            )
+            guard let onUnsigned = configuration.onUnsigned else {
+                throw RegistryError.missingConfiguration(details: "security.signing.onUnsigned")
+            }
 
-                let sourceArchiveNotSignedError = RegistryError.sourceArchiveNotSigned(
-                    registry: registry,
-                    package: package.underlying,
-                    version: version
-                )
+            let sourceArchiveNotSignedError = RegistryError.sourceArchiveNotSigned(
+                registry: registry,
+                package: package.underlying,
+                version: version
+            )
 
-                switch onUnsigned {
-                case .prompt:
+            switch onUnsigned {
+            case .prompt:
+                return try await withCheckedThrowingContinuation { continuation in
                     self.delegate
                         .onUnsigned(registry: registry, package: package.underlying, version: version) { `continue` in
                             if `continue` {
-                                completion(.success(.none))
+                                continuation.resume(returning: .none)
                             } else {
-                                completion(.failure(sourceArchiveNotSignedError))
+                                continuation.resume(throwing: sourceArchiveNotSignedError)
                             }
                         }
-                case .error:
-                    completion(.failure(sourceArchiveNotSignedError))
-                case .warn:
-                    observabilityScope.emit(
-                        warning: "\(sourceArchiveNotSignedError)",
-                        metadata: .registryPackageMetadata(identity: package)
-                    )
-                    completion(.success(.none))
-                case .silentAllow:
-                    // Continue without logging
-                    completion(.success(.none))
                 }
-            } catch RegistryError.failedRetrievingReleaseInfo(_, _, _, let error) {
-                completion(.failure(RegistryError.failedRetrievingSourceArchiveSignature(
-                    registry: registry,
-                    package: package.underlying,
-                    version: version,
-                    error: error
-                )))
-            } catch {
-                completion(.failure(RegistryError.failedRetrievingSourceArchiveSignature(
-                    registry: registry,
-                    package: package.underlying,
-                    version: version,
-                    error: error
-                )))
+            case .error:
+                throw sourceArchiveNotSignedError
+            case .warn:
+                observabilityScope.emit(
+                    warning: "\(sourceArchiveNotSignedError)",
+                    metadata: .registryPackageMetadata(identity: package)
+                )
+                return .none
+            case .silentAllow:
+                // Continue without logging
+                return .none
             }
+        } catch RegistryError.failedRetrievingReleaseInfo(_, _, _, let error) {
+            throw RegistryError.failedRetrievingSourceArchiveSignature(
+                registry: registry,
+                package: package.underlying,
+                version: version,
+                error: error
+            )
+        } catch ValidationError.passthrough(let underlyingError) {
+            throw underlyingError
+        } catch {
+            throw RegistryError.failedRetrievingSourceArchiveSignature(
+                registry: registry,
+                package: package.underlying,
+                version: version,
+                error: error
+            )
         }
     }
 
@@ -241,47 +235,48 @@ struct SignatureValidation {
         content: [UInt8],
         configuration: RegistryConfiguration.Security.Signing,
         fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope,
-        completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
-    ) {
-        Task {
-            do {
-                let signatureStatus = try await SignatureProvider.status(
-                    signature: signature,
-                    content: content,
-                    format: signatureFormat,
-                    verifierConfiguration: try VerifierConfiguration.from(configuration, fileSystem: fileSystem),
-                    observabilityScope: observabilityScope
+        observabilityScope: ObservabilityScope
+    ) async throws -> SigningEntity? {
+        do {
+            let signatureStatus = try await SignatureProvider.status(
+                signature: signature,
+                content: content,
+                format: signatureFormat,
+                verifierConfiguration: try VerifierConfiguration.from(configuration, fileSystem: fileSystem),
+                observabilityScope: observabilityScope
+            )
+
+            switch signatureStatus {
+            case .valid(let signingEntity):
+                observabilityScope
+                    .emit(
+                        info: "\(package) \(version) from \(registry) is signed with a valid entity '\(signingEntity)'"
+                    )
+                return signingEntity
+            case .invalid(let reason):
+                throw ValidationError.passthrough(RegistryError.invalidSignature(reason: reason))
+            case .certificateInvalid(let reason):
+                throw ValidationError.passthrough(RegistryError.invalidSigningCertificate(reason: reason))
+            case .certificateNotTrusted(let signingEntity):
+                observabilityScope
+                    .emit(
+                        info: "\(package) \(version) from \(registry) signing entity '\(signingEntity)' is untrusted",
+                        metadata: .registryPackageMetadata(identity: package)
+                    )
+
+                guard let onUntrusted = configuration.onUntrustedCertificate else {
+                    throw ValidationError.passthrough(
+                        RegistryError.missingConfiguration(details: "security.signing.onUntrustedCertificate")
+                    )
+                }
+
+                let signerNotTrustedError = ValidationError.passthrough(
+                    RegistryError.signerNotTrusted(package.underlying, signingEntity)
                 )
 
-                switch signatureStatus {
-                case .valid(let signingEntity):
-                    observabilityScope
-                        .emit(
-                            info: "\(package) \(version) from \(registry) is signed with a valid entity '\(signingEntity)'"
-                        )
-                    completion(.success(signingEntity))
-                case .invalid(let reason):
-                    completion(.failure(RegistryError.invalidSignature(reason: reason)))
-                case .certificateInvalid(let reason):
-                    completion(.failure(RegistryError.invalidSigningCertificate(reason: reason)))
-                case .certificateNotTrusted(let signingEntity):
-                    observabilityScope
-                        .emit(
-                            info: "\(package) \(version) from \(registry) signing entity '\(signingEntity)' is untrusted",
-                            metadata: .registryPackageMetadata(identity: package)
-                        )
-
-                    guard let onUntrusted = configuration.onUntrustedCertificate else {
-                        return completion(.failure(
-                            RegistryError.missingConfiguration(details: "security.signing.onUntrustedCertificate")
-                        ))
-                    }
-
-                    let signerNotTrustedError = RegistryError.signerNotTrusted(package.underlying, signingEntity)
-
-                    switch onUntrusted {
-                    case .prompt:
+                switch onUntrusted {
+                case .prompt:
+                    return try await withCheckedThrowingContinuation { continuation in
                         self.delegate
                             .onUntrusted(
                                 registry: registry,
@@ -289,27 +284,29 @@ struct SignatureValidation {
                                 version: version
                             ) { `continue` in
                                 if `continue` {
-                                    completion(.success(.none))
+                                    continuation.resume(returning: .none)
                                 } else {
-                                    completion(.failure(signerNotTrustedError))
+                                    continuation.resume(throwing: signerNotTrustedError)
                                 }
                             }
-                    case .error:
-                        completion(.failure(signerNotTrustedError))
-                    case .warn:
-                        observabilityScope.emit(
-                            warning: "\(signerNotTrustedError)",
-                            metadata: .registryPackageMetadata(identity: package)
-                        )
-                        completion(.success(.none))
-                    case .silentAllow:
-                        // Continue without logging
-                        completion(.success(.none))
                     }
+                case .error:
+                    throw signerNotTrustedError
+                case .warn:
+                    observabilityScope.emit(
+                        warning: "\(signerNotTrustedError)",
+                        metadata: .registryPackageMetadata(identity: package)
+                    )
+                    return .none
+                case .silentAllow:
+                    // Continue without logging
+                    return .none
                 }
-            } catch {
-                completion(.failure(RegistryError.failedToValidateSignature(error)))
             }
+        } catch ValidationError.passthrough(let underlyingError) {
+            throw underlyingError
+        } catch {
+            throw RegistryError.failedToValidateSignature(error)
         }
     }
 
@@ -323,25 +320,34 @@ struct SignatureValidation {
         configuration: RegistryConfiguration.Security.Signing,
         timeout: DispatchTimeInterval?,
         fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
+        observabilityScope: ObservabilityScope
     ) async throws -> SigningEntity? {
-        try await withCheckedThrowingContinuation { continuation in
-            self.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                toolsVersion: toolsVersion,
-                manifestContent: manifestContent,
-                configuration: configuration,
-                timeout: timeout,
-                fileSystem:fileSystem,
-                observabilityScope: observabilityScope, 
-                callbackQueue: callbackQueue,
-                completion: { continuation.resume(with: $0) }
-            )
+        guard !self.skipSignatureValidation else {
+            return .none
         }
+
+        let signingEntity = try await self.getAndValidateManifestSignature(
+            registry: registry,
+            package: package,
+            version: version,
+            toolsVersion: toolsVersion,
+            manifestContent: manifestContent,
+            configuration: configuration,
+            timeout: timeout,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope
+        )
+
+        let _ = try await self.signingEntityTOFU.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity,
+            observabilityScope: observabilityScope
+        )
+        return signingEntity;
     }
+
 
     @available(*, noasync, message: "Use the async alternative")
     func validate(
@@ -354,42 +360,20 @@ struct SignatureValidation {
         timeout: DispatchTimeInterval?,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
         completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
     ) {
-        guard !self.skipSignatureValidation else {
-            return completion(.success(.none))
-        }
-
-        self.getAndValidateManifestSignature(
-            registry: registry,
-            package: package,
-            version: version,
-            toolsVersion: toolsVersion,
-            manifestContent: manifestContent,
-            configuration: configuration,
-            timeout: timeout,
-            fileSystem: fileSystem,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue
-        ) { result in
-            switch result {
-            case .success(let signingEntity):
-                // Always do signing entity TOFU check at the end,
-                // whether the manifest is signed or not.
-                self.signingEntityTOFU.validate(
-                    registry: registry,
-                    package: package,
-                    version: version,
-                    signingEntity: signingEntity,
-                    observabilityScope: observabilityScope,
-                    callbackQueue: callbackQueue
-                ) { _ in
-                    completion(.success(signingEntity))
-                }
-            case .failure(let error):
-                completion(.failure(error))
-            }
+        DispatchQueue.sharedConcurrent.asyncResult(completion) {
+            try await self.validate(
+                registry: registry,
+                package: package,
+                version: version,
+                toolsVersion: toolsVersion,
+                manifestContent: manifestContent,
+                configuration: configuration,
+                timeout: timeout,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope
+            )
         }
     }
 
@@ -402,46 +386,44 @@ struct SignatureValidation {
         configuration: RegistryConfiguration.Security.Signing,
         timeout: DispatchTimeInterval?,
         fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
-    ) {
+        observabilityScope: ObservabilityScope
+    ) async throws -> SigningEntity? {
         let manifestName = toolsVersion.map { "Package@swift-\($0).swift" } ?? Manifest.filename
-        Task {
-            do {
-                let versionMetadata = try await self.versionMetadataProvider(package, version)
+        do {
+            let versionMetadata = try await self.versionMetadataProvider(package, version)
 
-                guard let sourceArchiveResource = versionMetadata.sourceArchive else {
-                    observabilityScope
-                        .emit(
-                            debug: "cannot determine if \(manifestName) should be signed because source archive for \(package) \(version) is not found in \(registry)",
-                            metadata: .registryPackageMetadata(identity: package)
-                        )
-                    return completion(.success(.none))
-                }
-                guard sourceArchiveResource.signing?.signatureBase64Encoded != nil else {
-                    throw RegistryError.sourceArchiveNotSigned(
-                        registry: registry,
-                        package: package.underlying,
-                        version: version
+            guard let sourceArchiveResource = versionMetadata.sourceArchive else {
+                observabilityScope
+                    .emit(
+                        debug: "cannot determine if \(manifestName) should be signed because source archive for \(package) \(version) is not found in \(registry)",
+                        metadata: .registryPackageMetadata(identity: package)
                     )
-                }
+                return .none
+            }
+            guard sourceArchiveResource.signing?.signatureBase64Encoded != nil else {
+                throw RegistryError.sourceArchiveNotSigned(
+                    registry: registry,
+                    package: package.underlying,
+                    version: version
+                )
+            }
 
-                // source archive is signed, so the manifest must also be signed
-                guard let manifestSignature = try ManifestSignatureParser.parse(utf8String: manifestContent) else {
-                    return completion(.failure(RegistryError.manifestNotSigned(
-                        registry: registry,
-                        package: package.underlying,
-                        version: version,
-                        toolsVersion: toolsVersion
-                    )))
-                }
+            // source archive is signed, so the manifest must also be signed
+            guard let manifestSignature = try ManifestSignatureParser.parse(utf8String: manifestContent) else {
+                throw ValidationError.passthrough(RegistryError.manifestNotSigned(
+                    registry: registry,
+                    package: package.underlying,
+                    version: version,
+                    toolsVersion: toolsVersion
+                ))
+            }
 
-                guard let signatureFormat = SignatureFormat(rawValue: manifestSignature.signatureFormat) else {
-                    return completion(.failure(RegistryError.unknownSignatureFormat(manifestSignature.signatureFormat)))
-                }
+            guard let signatureFormat = SignatureFormat(rawValue: manifestSignature.signatureFormat) else {
+                throw ValidationError.passthrough(RegistryError.unknownSignatureFormat(manifestSignature.signatureFormat))
+            }
 
-                self.validateManifestSignature(
+            do {
+                return try await self.validateManifestSignature(
                     registry: registry,
                     package: package,
                     version: version,
@@ -451,52 +433,56 @@ struct SignatureValidation {
                     content: manifestSignature.contents,
                     configuration: configuration,
                     fileSystem: fileSystem,
-                    observabilityScope: observabilityScope,
-                    completion: completion
+                    observabilityScope: observabilityScope
                 )
-            } catch RegistryError.sourceArchiveNotSigned {
-                observabilityScope.emit(
-                    debug: "\(manifestName) is not signed because source archive for \(package) \(version) from \(registry) is not signed",
-                    metadata: .registryPackageMetadata(identity: package)
-                )
-                guard let onUnsigned = configuration.onUnsigned else {
-                    return completion(.failure(RegistryError.missingConfiguration(details: "security.signing.onUnsigned")))
-                }
+            } catch {
+                throw ValidationError.passthrough(error)
+            }
+        } catch ValidationError.passthrough(let underlyingError) {
+            throw underlyingError
+        } catch RegistryError.sourceArchiveNotSigned {
+            observabilityScope.emit(
+                debug: "\(manifestName) is not signed because source archive for \(package) \(version) from \(registry) is not signed",
+                metadata: .registryPackageMetadata(identity: package)
+            )
+            guard let onUnsigned = configuration.onUnsigned else {
+                throw RegistryError.missingConfiguration(details: "security.signing.onUnsigned")
+            }
 
-                let sourceArchiveNotSignedError = RegistryError.sourceArchiveNotSigned(
-                    registry: registry,
-                    package: package.underlying,
-                    version: version
-                )
+            let sourceArchiveNotSignedError = RegistryError.sourceArchiveNotSigned(
+                registry: registry,
+                package: package.underlying,
+                version: version
+            )
 
-                // Prompt if configured, otherwise just continue (this differs
-                // from source archive to minimize duplicate loggings).
-                switch onUnsigned {
-                case .prompt:
+            // Prompt if configured, otherwise just continue (this differs
+            // from source archive to minimize duplicate loggings).
+            switch onUnsigned {
+            case .prompt:
+                return try await withCheckedThrowingContinuation { continuation in
                     self.delegate
                         .onUnsigned(registry: registry, package: package.underlying, version: version) { `continue` in
                             if `continue` {
-                                completion(.success(.none))
+                                continuation.resume(returning: .none)
                             } else {
-                                completion(.failure(sourceArchiveNotSignedError))
+                                continuation.resume(throwing: sourceArchiveNotSignedError)
                             }
                         }
-                default:
-                    completion(.success(.none))
                 }
-            } catch ManifestSignatureParser.Error.malformedManifestSignature {
-                completion(.failure(RegistryError.invalidSignature(reason: "manifest signature is malformed")))
-            } catch {
-                observabilityScope
-                    .emit(
-                        debug: "cannot determine if \(manifestName) should be signed because retrieval of source archive signature for \(package) \(version) from \(registry) failed",
-                        metadata: .registryPackageMetadata(identity: package),
-                        underlyingError: error
-                    )
-                completion(.success(.none))
+            default:
+                return .none
             }
+        } catch ManifestSignatureParser.Error.malformedManifestSignature {
+            throw RegistryError.invalidSignature(reason: "manifest signature is malformed")
+        } catch {
+            observabilityScope
+                .emit(
+                    debug: "cannot determine if \(manifestName) should be signed because retrieval of source archive signature for \(package) \(version) from \(registry) failed",
+                    metadata: .registryPackageMetadata(identity: package),
+                    underlyingError: error
+                )
+            return .none
         }
-
     }
 
     private func validateManifestSignature(
@@ -509,49 +495,48 @@ struct SignatureValidation {
         content: [UInt8],
         configuration: RegistryConfiguration.Security.Signing,
         fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope,
-        completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
-    ) {
-        Task {
-            do {
-                let signatureStatus = try await SignatureProvider.status(
-                    signature: signature,
-                    content: content,
-                    format: signatureFormat,
-                    verifierConfiguration: try VerifierConfiguration.from(configuration, fileSystem: fileSystem),
-                    observabilityScope: observabilityScope
+        observabilityScope: ObservabilityScope
+    ) async throws -> SigningEntity? {
+        do {
+            let signatureStatus = try await SignatureProvider.status(
+                signature: signature,
+                content: content,
+                format: signatureFormat,
+                verifierConfiguration: try VerifierConfiguration.from(configuration, fileSystem: fileSystem),
+                observabilityScope: observabilityScope
+            )
+
+            switch signatureStatus {
+            case .valid(let signingEntity):
+                observabilityScope
+                    .emit(
+                        info: "\(package) \(version) \(manifestName) from \(registry) is signed with a valid entity '\(signingEntity)'"
+                    )
+                return signingEntity
+            case .invalid(let reason):
+                throw ValidationError.passthrough(RegistryError.invalidSignature(reason: reason))
+            case .certificateInvalid(let reason):
+                throw ValidationError.passthrough(RegistryError.invalidSigningCertificate(reason: reason))
+            case .certificateNotTrusted(let signingEntity):
+                observabilityScope
+                    .emit(
+                        debug: "the signer '\(signingEntity)' of \(package) \(version) \(manifestName) from \(registry) is not trusted",
+                        metadata: .registryPackageMetadata(identity: package)
+                    )
+
+                guard let onUntrusted = configuration.onUntrustedCertificate else {
+                    throw RegistryError.missingConfiguration(details: "security.signing.onUntrustedCertificate")
+                }
+
+                let signerNotTrustedError = ValidationError.passthrough(
+                    RegistryError.signerNotTrusted(package.underlying, signingEntity)
                 )
 
-                switch signatureStatus {
-                case .valid(let signingEntity):
-                    observabilityScope
-                        .emit(
-                            info: "\(package) \(version) \(manifestName) from \(registry) is signed with a valid entity '\(signingEntity)'"
-                        )
-                    completion(.success(signingEntity))
-                case .invalid(let reason):
-                    completion(.failure(RegistryError.invalidSignature(reason: reason)))
-                case .certificateInvalid(let reason):
-                    completion(.failure(RegistryError.invalidSigningCertificate(reason: reason)))
-                case .certificateNotTrusted(let signingEntity):
-                    observabilityScope
-                        .emit(
-                            debug: "the signer '\(signingEntity)' of \(package) \(version) \(manifestName) from \(registry) is not trusted",
-                            metadata: .registryPackageMetadata(identity: package)
-                        )
-
-                    guard let onUntrusted = configuration.onUntrustedCertificate else {
-                        return completion(.failure(
-                            RegistryError.missingConfiguration(details: "security.signing.onUntrustedCertificate")
-                        ))
-                    }
-
-                    let signerNotTrustedError = RegistryError.signerNotTrusted(package.underlying, signingEntity)
-
-                    // Prompt if configured, otherwise just continue (this differs
-                    // from source archive to minimize duplicate loggings).
-                    switch onUntrusted {
-                    case .prompt:
+                // Prompt if configured, otherwise just continue (this differs
+                // from source archive to minimize duplicate loggings).
+                switch onUntrusted {
+                case .prompt:
+                    return try await withCheckedThrowingContinuation { continuation in
                         self.delegate
                             .onUntrusted(
                                 registry: registry,
@@ -559,18 +544,20 @@ struct SignatureValidation {
                                 version: version
                             ) { `continue` in
                                 if `continue` {
-                                    completion(.success(.none))
+                                    continuation.resume(returning: .none)
                                 } else {
-                                    completion(.failure(signerNotTrustedError))
+                                    continuation.resume(throwing: signerNotTrustedError)
                                 }
                             }
-                    default:
-                        completion(.success(.none))
                     }
+                default:
+                    return .none
                 }
-            } catch {
-                completion(.failure(RegistryError.failedToValidateSignature(error)))
             }
+        } catch ValidationError.passthrough(let underlyingError) {
+            throw underlyingError
+        } catch {
+            throw RegistryError.failedToValidateSignature(error)
         }
     }
 

--- a/Sources/PackageRegistry/SigningEntityTOFU.swift
+++ b/Sources/PackageRegistry/SigningEntityTOFU.swift
@@ -30,26 +30,50 @@ struct PackageSigningEntityTOFU {
         self.signingEntityStorage = signingEntityStorage
         self.signingEntityCheckingMode = signingEntityCheckingMode
     }
-    
+
     func validate(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,
         version: Version,
         signingEntity: SigningEntity?,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
+        observabilityScope: ObservabilityScope
     ) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            self.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: signingEntity,
-                observabilityScope: observabilityScope,
-                callbackQueue: callbackQueue,
-                completion: { continuation.resume(with: $0) }
-            )
+        guard let signingEntityStorage else {
+            return
         }
+
+        let packageSigners: PackageSigners
+        do {
+            packageSigners = try signingEntityStorage.get(package: package.underlying, observabilityScope: observabilityScope)
+        } catch {
+            observabilityScope.emit(
+                error: "Failed to get signing entity for \(package) from storage",
+                underlyingError: error
+            )
+            throw error
+        }
+
+        let shouldWrite = try await self.validateSigningEntity(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity,
+            packageSigners: packageSigners,
+            observabilityScope: observabilityScope
+        )
+
+        // We only use certain type(s) of signing entity for TOFU
+        guard shouldWrite, let signingEntity = signingEntity, case .recognized = signingEntity else {
+            return
+        }
+
+        try self.writeToStorage(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity,
+            observabilityScope: observabilityScope
+        )
     }
 
     @available(*, noasync, message: "Use the async alternative")
@@ -59,54 +83,16 @@ struct PackageSigningEntityTOFU {
         version: Version,
         signingEntity: SigningEntity?,
         observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
-        guard let signingEntityStorage else {
-            return completion(.success(()))
-        }
-        Task {
-            let packageSigners: PackageSigners
-            do {
-                packageSigners = try signingEntityStorage.get(package: package.underlying, observabilityScope: observabilityScope)
-            } catch {
-                observabilityScope.emit(
-                    error: "Failed to get signing entity for \(package) from storage",
-                    underlyingError: error
-                )
-                return completion(.failure(error))
-            }
-            self.validateSigningEntity(
+        DispatchQueue.sharedConcurrent.asyncResult(completion) {
+            try await self.validate(
                 registry: registry,
                 package: package,
                 version: version,
                 signingEntity: signingEntity,
-                packageSigners: packageSigners,
                 observabilityScope: observabilityScope
-            ) { validateResult in
-                switch validateResult {
-                case .success(let shouldWrite):
-                    // We only use certain type(s) of signing entity for TOFU
-                    guard shouldWrite, let signingEntity = signingEntity, case .recognized = signingEntity else {
-                        return completion(.success(()))
-                    }
-                    do {
-                        try self.writeToStorage(
-                            registry: registry,
-                            package: package,
-                            version: version,
-                            signingEntity: signingEntity,
-                            observabilityScope: observabilityScope
-                        )
-                        return completion(.success(()))
-                    } catch {
-                        return completion(.failure(error))
-                    }
-
-                case .failure(let error):
-                    completion(.failure(error))
-                }
-            }
+            )
         }
     }
 
@@ -116,19 +102,18 @@ struct PackageSigningEntityTOFU {
         version: Version,
         signingEntity: SigningEntity?,
         packageSigners: PackageSigners,
-        observabilityScope: ObservabilityScope,
-        completion: @escaping (Result<Bool, Error>) -> Void
-    ) {
+        observabilityScope: ObservabilityScope
+    ) async throws -> Bool {
         // Package is never signed.
         // If signingEntity is nil, it means package remains unsigned, which is OK. (none -> none)
         // Otherwise, package has gained a signer, which is also OK. (none -> some)
         if packageSigners.isEmpty {
-            return completion(.success(true))
+            return true
         }
 
         // If we get to this point, it means we have seen a signed version of the package.
-
         let signingEntitiesForVersion = packageSigners.signingEntities(of: version)
+
         // We recorded the version's signer(s) previously
         if !signingEntitiesForVersion.isEmpty {
             guard let signingEntityToCheck = signingEntity,
@@ -139,22 +124,18 @@ struct PackageSigningEntityTOFU {
                 //   - If signingEntity is nil, it could mean the package author has stopped signing the package.
                 //   - If signingEntity is non-nil, it could mean the package has changed ownership and the new owner
                 //     is re-signing all of the package versions.
-                do {
-                    try self.handleSigningEntityForPackageVersionChanged(
-                        registry: registry,
-                        package: package,
-                        version: version,
-                        latest: signingEntity,
-                        existing: signingEntitiesForVersion.first!, // !-safe since signingEntitiesForVersion is non-empty
-                        observabilityScope: observabilityScope
-                    )
-                    return completion(.success(false))
-                } catch {
-                    return completion(.failure(error))
-                }
+                try self.handleSigningEntityForPackageVersionChanged(
+                    registry: registry,
+                    package: package,
+                    version: version,
+                    latest: signingEntity,
+                    existing: signingEntitiesForVersion.first!, // !-safe since signingEntitiesForVersion is non-empty
+                    observabilityScope: observabilityScope
+                )
+                return false
             }
             // Signer remains the same for the version
-            return completion(.success(false))
+            return false
         }
 
         // Check signer(s) of other version(s)
@@ -167,7 +148,7 @@ struct PackageSigningEntityTOFU {
             {
                 // Signer is as expected
                 if signingEntity == expectedSigner.signingEntity {
-                    return completion(.success(true))
+                    return true
                 }
                 // If the signer is different from expected but has been seen before,
                 // we allow versions before its highest known version to be signed
@@ -181,10 +162,10 @@ struct PackageSigningEntityTOFU {
                    let highestKnownVersion = knownSigner.versions.sorted(by: >).first,
                    version < highestKnownVersion
                 {
-                    return completion(.success(true))
+                    return true
                 }
                 // Different signer than expected
-                self.handleSigningEntityForPackageChanged(
+                try self.handleSigningEntityForPackageChanged(
                     registry: registry,
                     package: package,
                     version: version,
@@ -192,13 +173,12 @@ struct PackageSigningEntityTOFU {
                     existing: expectedSigner.signingEntity,
                     existingVersion: expectedSigner.fromVersion,
                     observabilityScope: observabilityScope
-                ) { result in
-                    completion(result.tryMap { false })
-                }
+                )
+                return false
             } else {
                 // There might be other signers, but if we have seen this signer before, allow it.
                 if packageSigners.signers[signingEntity] != nil {
-                    return completion(.success(true))
+                    return true
                 }
 
                 let otherSigningEntities = packageSigners.signers.keys.filter { $0 != signingEntity }
@@ -206,7 +186,7 @@ struct PackageSigningEntityTOFU {
                     // We have not seen this signer before, and there is at least one other signer already.
                     // TODO: This could indicate a legitimate change in package ownership
                     if let existingVersion = packageSigners.signers[otherSigningEntity]?.versions.sorted(by: >).first {
-                        return self.handleSigningEntityForPackageChanged(
+                        try self.handleSigningEntityForPackageChanged(
                             registry: registry,
                             package: package,
                             version: version,
@@ -214,14 +194,13 @@ struct PackageSigningEntityTOFU {
                             existing: otherSigningEntity,
                             existingVersion: existingVersion,
                             observabilityScope: observabilityScope
-                        ) { result in
-                            completion(result.tryMap { false })
-                        }
+                        )
+                        return false
                     }
                 }
 
                 // Package doesn't have any other signer besides the given one, which is good.
-                completion(.success(true))
+                return true
             }
         // Or is the package going from having a signer to .none?
         case .none:
@@ -248,7 +227,7 @@ struct PackageSigningEntityTOFU {
                 .sorted(by: >)
             for olderSignedVersion in olderSignedVersions {
                 if let olderVersionSigner = versionSigningEntities[olderSignedVersion]?.first {
-                    return self.handleSigningEntityForPackageChanged(
+                    try self.handleSigningEntityForPackageChanged(
                         registry: registry,
                         package: package,
                         version: version,
@@ -256,13 +235,12 @@ struct PackageSigningEntityTOFU {
                         existing: olderVersionSigner,
                         existingVersion: olderSignedVersion,
                         observabilityScope: observabilityScope
-                    ) { result in
-                        completion(result.tryMap { false })
-                    }
+                    )
+                    return false
                 }
             }
             // Assume the given version is an older version before package started getting signed
-            completion(.success(false))
+            return false
         }
     }
 
@@ -329,25 +307,23 @@ struct PackageSigningEntityTOFU {
         latest: SigningEntity?,
         existing: SigningEntity,
         existingVersion: Version,
-        observabilityScope: ObservabilityScope,
-        completion: @escaping (Result<Void, Error>) -> Void
-    ) {
+        observabilityScope: ObservabilityScope
+    ) throws {
         switch self.signingEntityCheckingMode {
         case .strict:
-            completion(.failure(RegistryError.signingEntityForPackageChanged(
+            throw RegistryError.signingEntityForPackageChanged(
                 registry: registry,
                 package: package.underlying,
                 version: version,
                 latest: latest,
                 previous: existing,
                 previousVersion: existingVersion
-            )))
+            )
         case .warn:
             observabilityScope
                 .emit(
                     warning: "the signing entity '\(String(describing: latest))' from \(registry) for \(package) version \(version) is different from the previously recorded value '\(existing)' for version \(existingVersion)"
                 )
-            completion(.success(()))
         }
     }
 }

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
@@ -263,8 +263,7 @@ extension PackageRegistryCommand {
             try await registryClient.login(
                 loginURL: loginURL,
                 timeout: .seconds(5),
-                observabilityScope: swiftCommandState.observabilityScope,
-                callbackQueue: .sharedConcurrent
+                observabilityScope: swiftCommandState.observabilityScope
             )
 
             print("Login successful.")

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
@@ -221,8 +221,7 @@ extension PackageRegistryCommand {
                 metadataSignature: metadataSignature,
                 signatureFormat: self.signatureFormat,
                 fileSystem: localFileSystem,
-                observabilityScope: swiftCommandState.observabilityScope,
-                callbackQueue: .sharedConcurrent
+                observabilityScope: swiftCommandState.observabilityScope
             )
 
             switch result {

--- a/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
@@ -72,11 +72,7 @@ public class RegistryPackageContainer: PackageContainer {
 
     public func toolsVersion(for version: Version) async throws -> ToolsVersion {
         try await self.toolsVersionsCache.memoize(version) {
-            let result = try await withCheckedThrowingContinuation { continuation in
-                self.getAvailableManifestsFilesystem(version: version, completion: {
-                    continuation.resume(with: $0)
-                })
-            }
+            let result = try await self.getAvailableManifestsFilesystem(version: version)
             // find the manifest path and parse it's tools-version
             let manifestPath = try ManifestLoader.findManifest(packagePath: .root, fileSystem: result.fileSystem, currentToolsVersion: self.currentToolsVersion)
             return try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: result.fileSystem)
@@ -85,16 +81,10 @@ public class RegistryPackageContainer: PackageContainer {
 
     public func versionsDescending() async throws -> [Version] {
         try await self.knownVersionsCache.memoize {
-            let metadata = try await withCheckedThrowingContinuation { continuation in
-                self.registryClient.getPackageMetadata(
-                    package: self.package.identity,
-                    observabilityScope: self.observabilityScope,
-                    callbackQueue: .sharedConcurrent,
-                    completion: {
-                        continuation.resume(with: $0)
-                    }
-                )
-            }
+            let metadata = try await self.registryClient.getPackageMetadata(
+                package: self.package.identity,
+                observabilityScope: self.observabilityScope,
+            )
             return metadata.versions.sorted(by: >)
         }
     }
@@ -132,126 +122,93 @@ public class RegistryPackageContainer: PackageContainer {
 
     // marked internal for testing
     internal func loadManifest(version: Version) async throws -> Manifest {
-        return try await self.manifestsCache.memoize(version) {
-            try await withCheckedThrowingContinuation { continuation in
-                self.loadManifest(version: version, completion: {
-                    continuation.resume(with: $0)
-                })
-            }
+        let result = try await self.getAvailableManifestsFilesystem(version: version)
+
+        let manifests = result.manifests
+        let fileSystem = result.fileSystem
+
+        // first, decide the tools-version we should use
+        guard let defaultManifestToolsVersion = manifests.first(where: { $0.key == Manifest.filename })?.value.toolsVersion else {
+            throw StringError("Could not find the '\(Manifest.filename)' file for '\(self.package.identity)' '\(version)'")
         }
-    }
+        // find the preferred manifest path and parse it's tools-version
+        let preferredToolsVersionManifestPath = try ManifestLoader.findManifest(packagePath: .root, fileSystem: fileSystem, currentToolsVersion: self.currentToolsVersion)
+        let preferredToolsVersion = try ToolsVersionParser.parse(manifestPath: preferredToolsVersionManifestPath, fileSystem: fileSystem)
+        // load the manifest content
+        let loadManifest = {
+            try await self.manifestLoader.load(
+                packagePath: .root,
+                packageIdentity: self.package.identity,
+                packageKind: self.package.kind,
+                packageLocation: self.package.locationString,
+                packageVersion: (version: version, revision: nil),
+                currentToolsVersion: self.currentToolsVersion,
+                identityResolver: self.identityResolver,
+                dependencyMapper: self.dependencyMapper,
+                fileSystem: result.fileSystem,
+                observabilityScope: self.observabilityScope,
+                delegateQueue: .sharedConcurrent,
+                callbackQueue: .sharedConcurrent
+            )
+        }
 
-    private func loadManifest(version: Version,  completion: @escaping (Result<Manifest, Error>) -> Void) {
-        self.getAvailableManifestsFilesystem(version: version) { result in
-            switch result {
-            case .failure(let error):
-                return completion(.failure(error))
-            case .success(let result):
-                do {
-                    let manifests = result.manifests
-                    let fileSystem = result.fileSystem
-
-                    // first, decide the tools-version we should use
-                    guard let defaultManifestToolsVersion = manifests.first(where: { $0.key == Manifest.filename })?.value.toolsVersion else {
-                        throw StringError("Could not find the '\(Manifest.filename)' file for '\(self.package.identity)' '\(version)'")
-                    }
-                    // find the preferred manifest path and parse it's tools-version
-                    let preferredToolsVersionManifestPath = try ManifestLoader.findManifest(packagePath: .root, fileSystem: fileSystem, currentToolsVersion: self.currentToolsVersion)
-                    let preferredToolsVersion = try ToolsVersionParser.parse(manifestPath: preferredToolsVersionManifestPath, fileSystem: fileSystem)
-                    // load the manifest content
-                    let loadManifest = {
-                        self.manifestLoader.load(
-                            packagePath: .root,
-                            packageIdentity: self.package.identity,
-                            packageKind: self.package.kind,
-                            packageLocation: self.package.locationString,
-                            packageVersion: (version: version, revision: nil),
-                            currentToolsVersion: self.currentToolsVersion,
-                            identityResolver: self.identityResolver,
-                            dependencyMapper: self.dependencyMapper,
-                            fileSystem: result.fileSystem,
-                            observabilityScope: self.observabilityScope,
-                            delegateQueue: .sharedConcurrent,
-                            callbackQueue: .sharedConcurrent,
-                            completion: completion
-                        )
-                    }
-
-                    if preferredToolsVersion == defaultManifestToolsVersion {
-                        // default tools version - we already have the content on disk from getAvailableManifestsFileSystem()
-                        loadManifest()
-                    } else {
-                        // custom tools-version, we need to fetch the content from the server
-                        self.registryClient.getManifestContent(
-                            package: self.package.identity,
-                            version: version,
-                            customToolsVersion: preferredToolsVersion,
-                            observabilityScope: self.observabilityScope,
-                            callbackQueue: .sharedConcurrent
-                        ) { result in
-                            switch result {
-                            case .failure(let error):
-                                return completion(.failure(error))
-                            case .success(let manifestContent):
-                                do {
-                                    // find the fake manifest so we can replace it with the real manifest content
-                                    guard let placeholderManifestFileName = try fileSystem.getDirectoryContents(.root).first(where: { file in
-                                        if file == Manifest.basename + "@swift-\(preferredToolsVersion).swift" {
-                                            return true
-                                        } else if preferredToolsVersion.patch == 0, file == Manifest.basename + "@swift-\(preferredToolsVersion.major).\(preferredToolsVersion.minor).swift" {
-                                            return true
-                                        } else if preferredToolsVersion.patch == 0, preferredToolsVersion.minor == 0, file == Manifest.basename + "@swift-\(preferredToolsVersion.major).swift" {
-                                            return true
-                                        } else {
-                                            return false
-                                        }
-                                    }) else {
-                                        throw StringError("failed locating placeholder manifest for \(preferredToolsVersion)")
-                                    }
-                                    // replace the fake manifest with the real manifest content
-                                    let manifestPath = AbsolutePath.root.appending(component: placeholderManifestFileName)
-                                    try fileSystem.removeFileTree(manifestPath)
-                                    try fileSystem.writeFileContents(manifestPath, string: manifestContent)
-                                    // finally, load the manifest
-                                    loadManifest()
-                                } catch {
-                                    return completion(.failure(error))
-                                }
-                            }
-                        }
-                    }
-                } catch {
-                    return completion(.failure(error))
+        if preferredToolsVersion == defaultManifestToolsVersion {
+            // default tools version - we already have the content on disk from getAvailableManifestsFileSystem()
+            return try await loadManifest()
+        } else {
+            // custom tools-version, we need to fetch the content from the server
+            let manifestContent = try await self.registryClient.getManifestContent(
+                package: self.package.identity,
+                version: version,
+                customToolsVersion: preferredToolsVersion,
+                observabilityScope: self.observabilityScope
+            )
+            // find the fake manifest so we can replace it with the real manifest content
+            guard let placeholderManifestFileName = try fileSystem.getDirectoryContents(.root).first(where: { file in
+                if file == Manifest.basename + "@swift-\(preferredToolsVersion).swift" {
+                    return true
+                } else if preferredToolsVersion.patch == 0, file == Manifest.basename + "@swift-\(preferredToolsVersion.major).\(preferredToolsVersion.minor).swift" {
+                    return true
+                } else if preferredToolsVersion.patch == 0, preferredToolsVersion.minor == 0, file == Manifest.basename + "@swift-\(preferredToolsVersion.major).swift" {
+                    return true
+                } else {
+                    return false
                 }
+            }) else {
+                throw StringError("failed locating placeholder manifest for \(preferredToolsVersion)")
             }
+            // replace the fake manifest with the real manifest content
+            let manifestPath = AbsolutePath.root.appending(component: placeholderManifestFileName)
+            try fileSystem.removeFileTree(manifestPath)
+            try fileSystem.writeFileContents(manifestPath, string: manifestContent)
+            // finally, load the manifest
+            return try await loadManifest()
         }
     }
 
-    private func getAvailableManifestsFilesystem(version: Version, completion: @escaping (Result<(manifests: [String: (toolsVersion: ToolsVersion, content: String?)], fileSystem: FileSystem), Error>) -> Void) {
+    private func getAvailableManifestsFilesystem(version: Version) async throws -> (manifests: [String: (toolsVersion: ToolsVersion, content: String?)], fileSystem: FileSystem) {
         // try cached first
         if let availableManifests = self.availableManifestsCache[version] {
-            return completion(.success(availableManifests))
+            return availableManifests
         }
+
         // get from server
-        self.registryClient.getAvailableManifests(
+        let manifests = try await self.registryClient.getAvailableManifests(
             package: self.package.identity,
             version: version,
-            observabilityScope: self.observabilityScope,
-            callbackQueue: .sharedConcurrent
-        ) { result in
-            completion(result.tryMap { manifests in
-                // ToolsVersionLoader is designed to scan files to decide which is the best tools-version
-                // as such, this writes a fake manifest based on the information returned by the registry
-                // with only the header line which is all that is needed by ToolsVersionLoader
-                let fileSystem = InMemoryFileSystem()
-                for manifest in manifests {
-                    let content = manifest.value.content ?? "// swift-tools-version:\(manifest.value.toolsVersion)"
-                    try fileSystem.writeFileContents(AbsolutePath.root.appending(component: manifest.key), string: content)
-                }
-                self.availableManifestsCache[version] = (manifests: manifests, fileSystem: fileSystem)
-                return (manifests: manifests, fileSystem: fileSystem)
-            })
+            observabilityScope: self.observabilityScope
+        )
+
+        // ToolsVersionLoader is designed to scan files to decide which is the best tools-version
+        // as such, this writes a fake manifest based on the information returned by the registry
+        // with only the header line which is all that is needed by ToolsVersionLoader
+        let fileSystem = InMemoryFileSystem()
+        for manifest in manifests {
+            let content = manifest.value.content ?? "// swift-tools-version:\(manifest.value.toolsVersion)"
+            try fileSystem.writeFileContents(AbsolutePath.root.appending(component: manifest.key), string: content)
         }
+        self.availableManifestsCache[version] = (manifests: manifests, fileSystem: fileSystem)
+        return (manifests: manifests, fileSystem: fileSystem)
     }
 }
 

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -415,8 +415,7 @@ extension Workspace {
             package: package.identity,
             version: version,
             observabilityScope: observabilityScope,
-            delegateQueue: .sharedConcurrent,
-            callbackQueue: .sharedConcurrent
+            delegateQueue: .sharedConcurrent
         )
 
         // Record the new state.

--- a/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
@@ -1012,8 +1012,7 @@ extension PackageSigningEntityTOFU {
             package: package,
             version: version,
             signingEntity: signingEntity,
-            observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP
         )
     }
 }

--- a/Tests/PackageRegistryTests/PackageVersionChecksumTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageVersionChecksumTOFUTests.swift
@@ -882,8 +882,7 @@ extension PackageVersionChecksumTOFU {
             version: version,
             checksum: checksum,
             timeout: nil,
-            observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP
         )
     }
 

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -662,7 +662,8 @@ final class RegistryClientTests: XCTestCase {
 
         let availableManifests = try await registryClient.getAvailableManifests(
             package: identity,
-            version: version
+            version: version,
+            observabilityScope: ObservabilitySystem.NOOP
         )
         assert(availableManifests)
 
@@ -801,7 +802,8 @@ final class RegistryClientTests: XCTestCase {
         )
         let availableManifests = try await registryClient.getAvailableManifests(
             package: identity,
-            version: version
+            version: version,
+            observabilityScope: ObservabilitySystem.NOOP,
         )
 
         XCTAssertEqual(availableManifests["Package.swift"]?.toolsVersion, .v5_5)
@@ -937,7 +939,8 @@ final class RegistryClientTests: XCTestCase {
         await XCTAssertAsyncThrowsError(
             try await registryClient.getAvailableManifests(
                 package: identity,
-                version: version
+                version: version,
+                observabilityScope: ObservabilitySystem.NOOP
             )
         ) { error in
             guard case RegistryError.invalidChecksum = error else {
@@ -1136,7 +1139,13 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        await XCTAssertAsyncThrowsError(try await registryClient.getAvailableManifests(package: identity, version: version)) { error in
+        await XCTAssertAsyncThrowsError(
+            try await registryClient.getAvailableManifests(
+                package: identity,
+                version: version,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+        ) { error in
             guard case RegistryError
                 .failedRetrievingManifest(
                     registry: configuration.defaultRegistry!,
@@ -1196,7 +1205,13 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        await XCTAssertAsyncThrowsError(try await registryClient.getAvailableManifests(package: identity, version: version)) { error in
+        await XCTAssertAsyncThrowsError(
+            try await registryClient.getAvailableManifests(
+                package: identity,
+                version: version,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+        ) { error in
             guard case RegistryError
                 .failedRetrievingManifest(
                     registry: configuration.defaultRegistry!,
@@ -1224,7 +1239,13 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = registry
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        await XCTAssertAsyncThrowsError(try await registryClient.getAvailableManifests(package: identity, version: version)) { error in
+        await XCTAssertAsyncThrowsError(
+            try await registryClient.getAvailableManifests(
+                package: identity,
+                version: version,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+        ) { error in
             guard case RegistryError.registryNotAvailable(registry) = error
             else {
                 return XCTFail("unexpected error: '\(error)'")
@@ -3942,8 +3963,7 @@ extension RegistryClient {
     fileprivate func getPackageMetadata(package: PackageIdentity) async throws -> RegistryClient.PackageMetadata {
         try await self.getPackageMetadata(
             package: package,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
     }
 
@@ -3955,8 +3975,7 @@ extension RegistryClient {
             package: package,
             version: version,
             fileSystem: InMemoryFileSystem(),
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
     }
 
@@ -3964,45 +3983,11 @@ extension RegistryClient {
         package: PackageIdentity.RegistryIdentity,
         version: Version
     ) async throws -> PackageVersionMetadata {
-        return try await withCheckedThrowingContinuation { continuation in
-            self.getPackageVersionMetadata(
-                package: package.underlying,
-                version: version,
-                fileSystem: InMemoryFileSystem(),
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                completion: {
-                  continuation.resume(with: $0)
-                }
-            )
-        }
-    }
-
-    fileprivate func getAvailableManifests(
-        package: PackageIdentity,
-        version: Version,
-        observabilityScope: ObservabilityScope = ObservabilitySystem.NOOP
-    ) async throws -> [String: (toolsVersion: ToolsVersion, content: String?)] {
-        try await self.getAvailableManifests(
-            package: package,
+        return try await self.getPackageVersionMetadata(
+            package: package.underlying,
             version: version,
-            observabilityScope: observabilityScope,
-            callbackQueue: .sharedConcurrent
-        )
-    }
-
-    fileprivate func getManifestContent(
-        package: PackageIdentity,
-        version: Version,
-        customToolsVersion: ToolsVersion?,
-        observabilityScope: ObservabilityScope = ObservabilitySystem.NOOP
-    ) async throws -> String {
-        try await self.getManifestContent(
-            package: package,
-            version: version,
-            customToolsVersion: customToolsVersion,
-            observabilityScope: observabilityScope,
-            callbackQueue: .sharedConcurrent
+            fileSystem: InMemoryFileSystem(),
+            observabilityScope: ObservabilitySystem.NOOP,
         )
     }
 
@@ -4019,24 +4004,34 @@ extension RegistryClient {
             destinationPath: destinationPath,
             progressHandler: .none,
             fileSystem: fileSystem,
-            observabilityScope: observabilityScope,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: observabilityScope
         )
     }
 
     fileprivate func lookupIdentities(scmURL: SourceControlURL) async throws -> Set<PackageIdentity> {
         try await self.lookupIdentities(
             scmURL: scmURL,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
+        )
+    }
+
+    fileprivate func getManifestContent(
+        package: PackageIdentity,
+        version: Version,
+        customToolsVersion: ToolsVersion?
+    ) async throws -> String {
+        try await self.getManifestContent(
+            package: package,
+            version: version,
+            customToolsVersion: customToolsVersion,
+            observabilityScope: ObservabilitySystem.NOOP
         )
     }
 
     fileprivate func login(loginURL: URL) async throws {
         try await self.login(
             loginURL: loginURL,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
     }
 
@@ -4061,8 +4056,7 @@ extension RegistryClient {
             metadataSignature: metadataSignature,
             signatureFormat: signatureFormat,
             fileSystem: fileSystem,
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: ObservabilitySystem.NOOP
         )
     }
 

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -295,7 +295,7 @@ final class RegistryDownloadsManagerTests: XCTestCase {
                 for packageVersion in packageVersions {
                     group.addTask {
                         delegate.prepare(fetchExpected: true)
-                        results[packageVersion] = try await manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope, delegateQueue: .sharedConcurrent, callbackQueue: .sharedConcurrent)
+                        results[packageVersion] = try await manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
                     }
                 }
                 try await group.waitForAll()
@@ -335,7 +335,7 @@ final class RegistryDownloadsManagerTests: XCTestCase {
                     group.addTask {
                         delegate.prepare(fetchExpected: index < concurrency / repeatRatio)
                         let packageVersion = Version(index % (concurrency / repeatRatio), 0 , 0)
-                        results[packageVersion] = try await manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope, delegateQueue: .sharedConcurrent, callbackQueue: .sharedConcurrent)
+                        results[packageVersion] = try await manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
                     }
                 }
                 try await group.waitForAll()
@@ -415,8 +415,7 @@ extension RegistryDownloadsManager {
             package: package,
             version: version,
             observabilityScope: observabilityScope,
-            delegateQueue: .sharedConcurrent,
-            callbackQueue: .sharedConcurrent
+            delegateQueue: .sharedConcurrent
         )
     }
 }

--- a/Tests/PackageRegistryTests/SignatureValidationTests.swift
+++ b/Tests/PackageRegistryTests/SignatureValidationTests.swift
@@ -1958,8 +1958,7 @@ extension SignatureValidation {
             configuration: configuration,
             timeout: nil,
             fileSystem: localFileSystem,
-            observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP
         )
     }
 
@@ -1981,8 +1980,7 @@ extension SignatureValidation {
             configuration: configuration,
             timeout: nil,
             fileSystem: localFileSystem,
-            observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP
         )
     }
 }

--- a/Tests/WorkspaceTests/WorkspaceStateTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceStateTests.swift
@@ -486,7 +486,7 @@ final class WorkspaceStateTests: XCTestCase {
 }
 
 extension WorkspaceState {
-    fileprivate convenience init(fileSystem: FileSystem, storageDirectory: AbsolutePath) {
+    fileprivate init(fileSystem: FileSystem, storageDirectory: AbsolutePath) {
         self.init(fileSystem: fileSystem, storageDirectory: storageDirectory, initializationWarningHandler: { _ in })
     }
 }


### PR DESCRIPTION

_[One line description of your change]_

### Motivation:

Fix the warnings around using the sync versions of PackageRegistry methods.

### Modifications:

Convert the remainder of the PackageRegistry code to be async first., and move existing usages of the old sync methods in PackageRegistryCommand over to the new async alternatives. Clean up unnecessary plumbing of callbackQueues through the async methods.

### Result:

All asynchronous methods are `async` based inside Sources/PackageRegistry, and warnings about using deprecated methods have been fixed.