### PR TITLE
Remove trailing comma in RegistryDownloadsManager.swift

### DIFF
--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -98,7 +98,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
                             packagePath: packagePath,
                             observabilityScope: observabilityScope,
                             delegateQueue: delegateQueue,
-                            callbackQueue: callbackQueue,
+                            callbackQueue: callbackQueue
                         )
                         // inform delegate that we finished to fetch
                         let duration = start.distance(to: .now())


### PR DESCRIPTION
This restores the ability to build SwiftPM using a Swift 6.0 compiler.
