### PR TITLE
Fix some broken links in Documentation

### DIFF
--- a/Documentation/Design/EvolutionIdeas.md
+++ b/Documentation/Design/EvolutionIdeas.md
@@ -190,7 +190,7 @@ Bug: N/A
 We need an easy way to edit the Package.swift manifest from automated tools, for
 cases where you don't want users to have to update the Swift code directly. We
 think that it's possible to provide an API to allow this, probably using
-[`SwiftSyntax`](https://github.com/apple/swift/tree/master/tools/SwiftSyntax).
+[`SwiftSyntax`](https://github.com/swiftlang/swift-syntax).
 
 Thread: N/A
 Bug: N/A

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -140,7 +140,7 @@ You can link against system libraries using the package manager. To do so, you'l
 need to add a special `target` of type `.systemLibrary`, and a `module.modulemap`
 for each system library you're using.
 
-Let's see an example of adding [libgit2](https://libgit2.github.com) as a
+Let's see an example of adding [libgit2](https://github.com/libgit2/libgit2) as a
 dependency to an executable target.
 
 Create a directory called `example`, and initialize it as a package that


### PR DESCRIPTION
I periodically run a broken link checker over swiftlang repositories. There were a few links pointing to outdated locations in swift-package-manager.
