### PR TITLE
Update RegistryDownloadsManager.swift

### DIFF
--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -137,7 +137,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
                 version: version,
                 observabilityScope: observabilityScope,
                 delegateQueue: delegateQueue,
-                callbackQueue: callbackQueue,
+                callbackQueue: callbackQueue
             )
         }
     }


### PR DESCRIPTION
Fixed this error when building a package where swift-package-manager is a dependency:

```
 error: unexpected ',' separator
139 |                 delegateQueue: delegateQueue,
140 |                 callbackQueue: callbackQueue,
141 |             )
    |             `- error: unexpected ',' separator
142 |         }
143 |     }
```