### PR TITLE
Remove trailing comma in RegistryDownloadsManager.swift

### DIFF
--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -137,7 +137,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
                 version: version,
                 observabilityScope: observabilityScope,
                 delegateQueue: delegateQueue,
-                callbackQueue: callbackQueue,
+                callbackQueue: callbackQueue
             )
         }
     }


### PR DESCRIPTION
I missed this in my last PR.