### PR TITLE
Fix Swift 6.0 trailing comma compatibility

### DIFF
--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -137,7 +137,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
                 version: version,
                 observabilityScope: observabilityScope,
                 delegateQueue: delegateQueue,
-                callbackQueue: callbackQueue,
+                callbackQueue: callbackQueue
             )
         }
     }


### PR DESCRIPTION
Fix build error on `main` branch.

### Motivation:

I was debugging https://github.com/swiftlang/swift-package-manager/issues/8341 and noticed that I could not build `swift-package-manager` on the `main` branch.

### Modifications:

Simple build error fix.

### Result:

`main` now builds correctly.
