### PR TITLE
Remove unnecessary `@retroactive` conformances

### DIFF
--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -85,4 +85,4 @@ extension SwiftPackageCommand {
     }
 }
 
-extension InitPackage.PackageType: @retroactive ExpressibleByArgument {}
+extension InitPackage.PackageType: ExpressibleByArgument {}

--- a/Sources/Commands/Snippets/Colorful.swift
+++ b/Sources/Commands/Snippets/Colorful.swift
@@ -44,7 +44,7 @@ extension Array: Colorful where Element == Colorful {
     }
 }
 
-extension Optional: CustomStringConvertible where Wrapped: Colorful {
+extension Optional: @retroactive CustomStringConvertible where Wrapped: Colorful {
     public var description: String {
         return terminalString()
     }

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -780,11 +780,11 @@ extension URL {
     }
 }
 
-extension BuildConfiguration: @retroactive ExpressibleByArgument, CaseIterable {}
-extension AbsolutePath: @retroactive ExpressibleByArgument {}
-extension WorkspaceConfiguration.CheckingMode: @retroactive ExpressibleByArgument {}
-extension Sanitizer: @retroactive ExpressibleByArgument {}
-extension BuildSystemProvider.Kind: @retroactive ExpressibleByArgument, CaseIterable {}
+extension BuildConfiguration: ExpressibleByArgument {}
+extension AbsolutePath: ExpressibleByArgument {}
+extension WorkspaceConfiguration.CheckingMode: ExpressibleByArgument {}
+extension Sanitizer: ExpressibleByArgument {}
+extension BuildSystemProvider.Kind: ExpressibleByArgument {}
 extension Version: @retroactive ExpressibleByArgument {}
-extension PackageIdentity: @retroactive ExpressibleByArgument {}
+extension PackageIdentity: ExpressibleByArgument {}
 extension URL: @retroactive ExpressibleByArgument {}

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
@@ -247,7 +247,7 @@ extension SignatureFormat {
     }
 }
 
-extension SignatureFormat: @retroactive ExpressibleByArgument {}
+extension SignatureFormat: ExpressibleByArgument {}
 
 enum MetadataLocation {
     case sourceTree(AbsolutePath)

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1519,7 +1519,7 @@ private func warnToStderr(_ message: String) {
 }
 
 // used for manifest validation
-extension RepositoryManager: @retroactive ManifestSourceControlValidator {}
+extension RepositoryManager: ManifestSourceControlValidator {}
 
 extension ContainerUpdateStrategy {
     var repositoryUpdateStrategy: RepositoryUpdateStrategy {

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -515,8 +515,8 @@ extension InitPackage {
     }
 }
 
-extension RelativePath: @retroactive ExpressibleByStringLiteral {}
-extension RelativePath: @retroactive ExpressibleByStringInterpolation {}
+extension RelativePath: ExpressibleByStringLiteral {}
+extension RelativePath: ExpressibleByStringInterpolation {}
 extension URL: @retroactive ExpressibleByStringLiteral {}
 extension URL: @retroactive ExpressibleByStringInterpolation {}
 extension PackageIdentity: @retroactive ExpressibleByStringLiteral {}

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -496,9 +496,9 @@ extension BuildConfiguration {
     }
 }
 
-extension AbsolutePath: @retroactive ExpressibleByArgument {}
-extension BuildConfiguration: @retroactive ExpressibleByArgument, CaseIterable {}
-extension BuildSystemProvider.Kind: @retroactive ExpressibleByArgument, CaseIterable {}
+extension AbsolutePath: ExpressibleByArgument {}
+extension BuildConfiguration: ExpressibleByArgument {}
+extension BuildSystemProvider.Kind: ExpressibleByArgument {}
 
 public func topologicalSort<T: Hashable>(
     _ nodes: [T], successors: (T) async throws -> [T]

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -204,4 +204,4 @@ extension ProductFilter {
     }
 }
 
-extension ProductFilter: @retroactive JSONSerializable, @retroactive JSONMappable {}
+extension ProductFilter: JSONSerializable, JSONMappable {}

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -3494,8 +3494,8 @@ extension PackageReference {
     }
 }
 
-extension Term: @retroactive ExpressibleByStringLiteral {}
-extension PackageReference: @retroactive ExpressibleByStringLiteral {}
+extension Term: ExpressibleByStringLiteral {}
+extension PackageReference: ExpressibleByStringLiteral {}
 
 extension Result where Success == [DependencyResolverBinding] {
     var errorMsg: String? {


### PR DESCRIPTION
Several extensions to conform to common Swift protocols were unnecessarily marked as `@retroactive`, causing compiler warnings. The `@retroactive` annotation is only necessary when the type being extended is defined outside the package.