### PR TITLE
Do not try to add rpath arguments on noneOS

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -270,7 +270,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
         // Set rpath such that dynamic libraries are looked up
         // adjacent to the product, unless overridden.
-        if !self.buildParameters.linkingParameters.shouldDisableLocalRpath {
+        if triple.os != .noneOS, !self.buildParameters.linkingParameters.shouldDisableLocalRpath {
             switch triple.objectFormat {
             case .elf:
                 args += ["-Xlinker", "-rpath=$ORIGIN"]


### PR DESCRIPTION
Updates the ProductBuildDescription linkArgument's logic to avoid adding local rpaths for noneOS which does not support dynamically linked executables.
