### PR TITLE
Fix unhandled platform condition w/ `freeBSDFilters` for `PIFBuilder` 

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -1756,7 +1756,10 @@ extension [PackageCondition] {
 
             case .openbsd:
                 result += PIF.PlatformFilter.openBSDFilters
-
+            
+            case .freebsd:
+                result += PIF.PlatformFilter.freeBSDFilters
+            
             default:
                 assertionFailure("Unhandled platform condition: \(condition)")
             }
@@ -1830,6 +1833,11 @@ extension PIF.PlatformFilter {
         .init(platform: "xros", environment: "simulator"),
         .init(platform: "visionos"),
         .init(platform: "visionos", environment: "simulator"),
+    ]
+    
+    /// FreeBSD filters.
+    public static let freeBSDFilters: [PIF.PlatformFilter] = [
+        .init(platform: "freebsd"),
     ]
 }
 

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -1360,7 +1360,7 @@ final class RegistryClientTests: XCTestCase {
                     version: version,
                     customToolsVersion: nil,
                     observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: .sharedConcurrent,
+                    callbackQueue: .sharedConcurrent
                 ) { continuation.resume(with: $0) }
             }
             let parsedToolsVersion = try ToolsVersionParser.parse(utf8String: manifestSync)
@@ -3419,7 +3419,7 @@ final class RegistryClientTests: XCTestCase {
                     signatureFormat: .none,
                     fileSystem: localFileSystem,
                     observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: .sharedConcurrent,
+                    callbackQueue: .sharedConcurrent
                 ) { result in continuation.resume(with: result) }
             }
 

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -326,7 +326,7 @@ final class SourceKitLSPAPITests: XCTestCase {
     func testClangOutputPaths() async throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/lib/include/lib.h",
-            "/Pkg/Sources/lib/lib.cpp",
+            "/Pkg/Sources/lib/lib.cpp"
         )
 
         let observability = ObservabilitySystem.makeForTesting()


### PR DESCRIPTION
Handled case where SwiftBuild is run on a freeBSD OS.

### Motivation:

Currently, when using the new build system, you come across the following fatal error when building on a freeBSD OS:

Fatal error: Unhandled platform condition: Platform (name: "free bsd", oldestSupportedVersion: PackageModel.PlatformVersion(version: 0.0.0))

### Modifications:

All I have done is, similar to Sources/XCBuildSupport/PIFBuilder, I added the case and handled it just like XCBuild's PIFBuilder does.

### Result:

After changes, no more fatal error occurs and building proceeds as it should.