### PR TITLE
Fixup several classes of warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -457,7 +457,8 @@ let package = Package(
             dependencies: [
                 "SPMBuildCore",
                 "PackageGraph",
-            ]
+            ],
+            exclude: ["CMakeLists.txt", "README.md"],
         ),
         .target(
             /** High level functionality */

--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -47,12 +47,6 @@ extension DispatchQueue {
     )
 }
 
-
-#if !canImport(Darwin)
-// As of Swift 5.7 and 5.8 swift-corelibs-foundation doesn't have `Sendable` annotations yet.
-extension URL: @unchecked Sendable {}
-#endif
-
 extension DispatchQueue {
     package func scheduleOnQueue<T>(work: @escaping @Sendable () throws -> T) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/Basics/SendableTimeInterval.swift
+++ b/Sources/Basics/SendableTimeInterval.swift
@@ -12,8 +12,6 @@
 
 import enum Dispatch.DispatchTimeInterval
 
-extension DispatchTimeInterval: @unchecked Sendable {}
-
 /// This typealias hides `DispatchTimeInterval` as an implementation detail until we can use `Swift.Duration`, as the
 /// latter requires macOS 13.
 public typealias SendableTimeInterval = DispatchTimeInterval

--- a/Sources/Commands/PackageCommands/AddDependency.swift
+++ b/Sources/Commands/PackageCommands/AddDependency.swift
@@ -93,8 +93,6 @@ extension SwiftPackageCommand {
             workspace: Workspace,
             url: String
         ) throws {
-            let identity = PackageIdentity(url: .init(url))
-
             // Collect all of the possible version requirements.
             var requirements: [PackageDependency.SourceControl.Requirement] = []
             if let exact {
@@ -156,8 +154,6 @@ extension SwiftPackageCommand {
             workspace: Workspace,
             id: String
         ) throws {
-            let identity: PackageIdentity = .plain(id)
-
             // Collect all of the possible version requirements.
             var requirements: [PackageDependency.Registry.Requirement] = []
             if let exact {

--- a/Sources/QueryEngine/QueryEngine.swift
+++ b/Sources/QueryEngine/QueryEngine.swift
@@ -13,7 +13,6 @@
 import _AsyncFileSystem
 import Basics
 import Crypto
-@preconcurrency package import SystemPackage
 
 package func withQueryEngine(
     _ fileSystem: some AsyncFileSystem,

--- a/Sources/_AsyncFileSystem/MockFileSystem.swift
+++ b/Sources/_AsyncFileSystem/MockFileSystem.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@preconcurrency package import struct SystemPackage.FilePath
+package import struct SystemPackage.FilePath
 
 /// In-memory implementation of `AsyncFileSystem` for mocking and testing purposes.
 package actor MockFileSystem: AsyncFileSystem {

--- a/Sources/_AsyncFileSystem/OpenWritableFile.swift
+++ b/Sources/_AsyncFileSystem/OpenWritableFile.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 internal import class Dispatch.DispatchQueue
-@preconcurrency internal import struct SystemPackage.FileDescriptor
+internal import struct SystemPackage.FileDescriptor
 internal import struct SystemPackage.FilePath
 
 /// A write-only thread-safe handle to an open file.

--- a/Sources/_AsyncFileSystem/ReadableFileStream.swift
+++ b/Sources/_AsyncFileSystem/ReadableFileStream.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import _Concurrency
 internal import SystemPackage
 internal import class Dispatch.DispatchQueue
 

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -519,10 +519,10 @@ extension RelativePath: ExpressibleByStringLiteral {}
 extension RelativePath: ExpressibleByStringInterpolation {}
 extension URL: @retroactive ExpressibleByStringLiteral {}
 extension URL: @retroactive ExpressibleByStringInterpolation {}
-extension PackageIdentity: @retroactive ExpressibleByStringLiteral {}
-extension PackageIdentity: @retroactive ExpressibleByStringInterpolation {}
-extension AbsolutePath: @retroactive ExpressibleByStringLiteral {}
-extension AbsolutePath: @retroactive ExpressibleByStringInterpolation {}
+extension PackageIdentity: ExpressibleByStringLiteral {}
+extension PackageIdentity: ExpressibleByStringInterpolation {}
+extension AbsolutePath: ExpressibleByStringLiteral {}
+extension AbsolutePath: ExpressibleByStringInterpolation {}
 
 public func getNumberOfMatches(of match: String, in value: String) -> Int {
     guard match.count != 0 else { return 0 }


### PR DESCRIPTION
- Remove now-redundant Sendable conformances
- Remove unused variables
- Fix a few missed unnecessary `@retroactive` conformances
- Use swiftlang/swift-llbuild.git instead of apple/swift-llbuild.git