### PR TITLE
Add missing `self` in SwiftBuildSystem

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -257,7 +257,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             )
 
         do {
-            try await withSession(service: service, name: buildParameters.pifManifest.pathString) { session, _ in
+            try await withSession(service: service, name: self.buildParameters.pifManifest.pathString) { session, _ in
                 // Load the workspace, and set the system information to the default
                 do {
                     try await session.loadWorkspace(containerPath: self.buildParameters.pifManifest.pathString)


### PR DESCRIPTION
https://github.com/swiftlang/swift-package-manager/pull/8366 is a revert, but it reverted back to a point before there was an outer `withService` block wrapping the code. As a result a `self` is missing on `buildParameters`, causing a build failure.
