### PR TITLE
add support to TarArchiver for more common compression suffixes

### DIFF
--- a/Sources/Basics/Archiver/TarArchiver.swift
+++ b/Sources/Basics/Archiver/TarArchiver.swift
@@ -16,7 +16,14 @@ import struct TSCBasic.FileSystemError
 
 /// An `Archiver` that handles Tar archives using the command-line `tar` tool.
 public struct TarArchiver: Archiver {
-    public let supportedExtensions: Set<String> = ["tar", "tar.gz"]
+
+    public let supportedExtensions: Set<String> = [
+        "tar",
+        "gz", "tgz", // gzip
+        "bz2", "tz2", "tbz2", "tbz", // bzip2
+        "lzma", // lzma
+        "xz" // xz
+    ]
 
     /// The file-system implementation used for various file-system operations and checks.
     private let fileSystem: FileSystem


### PR DESCRIPTION
- include more suffixes for: gzip, bzip2, lzma, xz

### Motivation:

Add support for compression algorithms that can achieve higher compression ratios than gzip.
Support another common extension for gzip as well.

### Modifications:

I modified the list of supported extensions for the TarArchiver.

I researched various manpages to see what was commonly supported.

- The [GNU tar manpage](https://www.gnu.org/software/tar/manual/html_section/Compression.html) has the most extensive list of suffixes.
- [FreeBSD tar](https://man.freebsd.org/cgi/man.cgi?tar(1)) i
- [OpenBSD tar](https://man.openbsd.org/tar) doesn't support the `a` flag used for auto-compress which `TarArchiver.compress` uses [ref](https://github.com/swiftlang/swift-package-manager/pull/6368/files#r1156324814). It also doesn't seem to have anything beyond gzip and bzip2 (no lzma or xz).
- [NetBSD tar](https://man.netbsd.org/tar.1) has gzip, bzip2, lzma, xz
- [Windows tar.exe](https://ss64.com/nt/tar.html) seems to be a port of BSD tar similar in support to NetBSD.
- macOS tar is an older FreeBSD tar, similar support to NetBSD.

### Result:

More compression algorithms will be supported.
