### PR TITLE
Use `@main` instead of top level code when initializing executable

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -577,7 +577,7 @@ public final class InitPackage {
         let moduleDir = sources.appending("\(pkgname)")
         try makeDirectories(moduleDir)
 
-        // If we're creating an executable we can't 't have both a @main declaration and a main.swift file.
+        // If we're creating an executable we can't have both a @main declaration and a main.swift file.
         // Handle the edge case of a user creating a project called "main" by give the generated file a different name.
         let sourceFileName = ((packageType == .executable || packageType == .tool) && typeName == "main") ? "MainEntrypoint.swift" : "\(typeName).swift"
         let sourceFile = try AbsolutePath(validating: sourceFileName, relativeTo: moduleDir)

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -581,7 +581,7 @@ public final class InitPackage {
 
         // If we're creating an executable we can't 't have both a @main delcaration and a Main.swift file.
         // Handle the edge case of a user creating a project called "Main" by give the generated file a different name.
-        let sourceFileName = (packageType == .executable && typeName.lowercased() == "main") ? "MainEntrypoint.swift" : "\(typeName).swift"
+        let sourceFileName = (packageType == .executable && typeName == "main") ? "MainEntrypoint.swift" : "\(typeName).swift"
         let sourceFile = try AbsolutePath(validating: sourceFileName, relativeTo: moduleDir)
 
         let content: String

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -579,12 +579,7 @@ public final class InitPackage {
         }
         try makeDirectories(moduleDir)
 
-        let sourceFileName: String
-        if packageType == .executable {
-            sourceFileName = "main.swift"
-        } else {
-            sourceFileName = "\(typeName).swift"
-        }
+        let sourceFileName = "\(typeName).swift"
         let sourceFile = try AbsolutePath(validating: sourceFileName, relativeTo: moduleDir)
 
         let content: String

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -597,7 +597,7 @@ public final class InitPackage {
 
                 @main
                 struct \(typeName) {
-                    static func main() {
+                    static func main() async throws {
                         print("Hello, world!")
                     }
                 }

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -600,7 +600,12 @@ public final class InitPackage {
                 // The Swift Programming Language
                 // https://docs.swift.org/swift-book
 
-                print("Hello, world!")
+                @main
+                struct \(typeName) {
+                    static func main() {
+                        print("Hello, world!")
+                    }
+                }
 
                 """
         case .tool:

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -239,7 +239,8 @@ public final class InitPackage {
                         // Products define the executables and libraries a package produces, making them visible to other packages.
                         .library(
                             name: "\(pkgname)",
-                            targets: ["\(pkgname)"]),
+                            targets: ["\(pkgname)"]
+                        ),
                     ]
                 """)
             } else if packageType == .buildToolPlugin || packageType == .commandPlugin {
@@ -248,7 +249,8 @@ public final class InitPackage {
                         // Products can be used to vend plugins, making them visible to other packages.
                         .plugin(
                             name: "\(pkgname)",
-                            targets: ["\(pkgname)"]),
+                            targets: ["\(pkgname)"]
+                        ),
                     ]
                 """)
             } else if packageType == .macro {
@@ -299,7 +301,8 @@ public final class InitPackage {
                 if packageType == .executable {
                     param += """
                             .executableTarget(
-                                name: "\(pkgname)"),
+                                name: "\(pkgname)"
+                            ),
                         ]
                     """
                 } else if packageType == .tool {
@@ -394,7 +397,8 @@ public final class InitPackage {
 
                     param += """
                             .target(
-                                name: "\(pkgname)"),
+                                name: "\(pkgname)"
+                            ),
                     \(testTarget)
                         ]
                     """
@@ -570,18 +574,12 @@ public final class InitPackage {
         progressReporter?("Creating \(sources.relative(to: destinationPath))")
         try makeDirectories(sources)
 
-        let moduleDir: AbsolutePath
-        switch packageType {
-        case .executable, .tool:
-            moduleDir = sources
-        default:
-            moduleDir = sources.appending("\(pkgname)")
-        }
+        let moduleDir = sources.appending("\(pkgname)")
         try makeDirectories(moduleDir)
 
         // If we're creating an executable we can't 't have both a @main declaration and a main.swift file.
         // Handle the edge case of a user creating a project called "main" by give the generated file a different name.
-        let sourceFileName = (packageType == .executable && typeName == "main") ? "MainEntrypoint.swift" : "\(typeName).swift"
+        let sourceFileName = ((packageType == .executable || packageType == .tool) && typeName == "main") ? "MainEntrypoint.swift" : "\(typeName).swift"
         let sourceFile = try AbsolutePath(validating: sourceFileName, relativeTo: moduleDir)
 
         let content: String
@@ -688,7 +686,6 @@ public final class InitPackage {
         }
         content += "@testable import \(moduleName)\n"
 
-
         if options.supportedTestingLibraries.contains(.swiftTesting) {
             content += """
 
@@ -751,7 +748,6 @@ public final class InitPackage {
 
 
             """##
-
 
         // XCTest is only added if it was explicitly asked for, so add tests
         // for it *and* Testing if it is enabled.

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -597,7 +597,7 @@ public final class InitPackage {
 
                 @main
                 struct \(typeName) {
-                    static func main() async throws {
+                    static func main() {
                         print("Hello, world!")
                     }
                 }

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -579,7 +579,9 @@ public final class InitPackage {
         }
         try makeDirectories(moduleDir)
 
-        let sourceFileName = "\(typeName).swift"
+        // If we're creating an executable we can't 't have both a @main delcaration and a Main.swift file.
+        // Handle the edge case of a user creating a project called "Main" by give the generated file a different name.
+        let sourceFileName = (packageType == .executable && typeName.lowercased() == "main") ? "MainEntrypoint.swift" : "\(typeName).swift"
         let sourceFile = try AbsolutePath(validating: sourceFileName, relativeTo: moduleDir)
 
         let content: String

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -579,8 +579,8 @@ public final class InitPackage {
         }
         try makeDirectories(moduleDir)
 
-        // If we're creating an executable we can't 't have both a @main delcaration and a Main.swift file.
-        // Handle the edge case of a user creating a project called "Main" by give the generated file a different name.
+        // If we're creating an executable we can't 't have both a @main declaration and a main.swift file.
+        // Handle the edge case of a user creating a project called "main" by give the generated file a different name.
         let sourceFileName = (packageType == .executable && typeName == "main") ? "MainEntrypoint.swift" : "\(typeName).swift"
         let sourceFile = try AbsolutePath(validating: sourceFileName, relativeTo: moduleDir)
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -840,7 +840,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertFileExists(manifest)
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["main.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["Foo.swift"])
         }
     }
 
@@ -871,7 +871,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertFileExists(manifest)
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["main.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["CustomName.swift"])
         }
     }
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -871,7 +871,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertFileExists(manifest)
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["CustomName.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources").appending("CustomName")), ["CustomName.swift"])
         }
     }
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -840,7 +840,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertFileExists(manifest)
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["Foo.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources").appending(("Foo"))), ["Foo.swift"])
         }
     }
 

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -101,7 +101,7 @@ final class InitTests: XCTestCase {
     func testInitPackageExecutableCalledMain() async throws {
         try await testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
-            let path = tmpPath.appending("Main")
+            let path = tmpPath.appending("main")
             let name = path.basename
             try fs.createDirectory(path)
 

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -85,7 +85,7 @@ final class InitTests: XCTestCase {
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["Foo.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources").appending("Foo")), ["Foo.swift"])
             await XCTAssertBuilds(path)
             let triple = try UserToolchain.default.targetTriple
             let binPath = path.appending(components: ".build", triple.platformBuildPathComponent, "debug")
@@ -114,7 +114,7 @@ final class InitTests: XCTestCase {
             )
             try initPackage.writePackageStructure()
 
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["MainEntrypoint.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources").appending("main")), ["MainEntrypoint.swift"])
             await XCTAssertBuilds(path)
         }
     }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -85,7 +85,7 @@ final class InitTests: XCTestCase {
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["main.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["Foo.swift"])
             await XCTAssertBuilds(path)
             let triple = try UserToolchain.default.targetTriple
             let binPath = path.appending(components: ".build", triple.platformBuildPathComponent, "debug")

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -98,6 +98,27 @@ final class InitTests: XCTestCase {
         }
     }
 
+    func testInitPackageExecutableCalledMain() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
+            let fs = localFileSystem
+            let path = tmpPath.appending("Main")
+            let name = path.basename
+            try fs.createDirectory(path)
+
+            // Create the package
+            let initPackage = try InitPackage(
+                name: name,
+                packageType: .executable,
+                destinationPath: path,
+                fileSystem: localFileSystem
+            )
+            try initPackage.writePackageStructure()
+
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["MainEntrypoint.swift"])
+            await XCTAssertBuilds(path)
+        }
+    }
+
     func testInitPackageLibraryWithXCTestOnly() async throws {
         try await testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem

--- a/Tests/WorkspaceTests/WorkspaceStateTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceStateTests.swift
@@ -486,7 +486,7 @@ final class WorkspaceStateTests: XCTestCase {
 }
 
 extension WorkspaceState {
-    fileprivate convenience init(fileSystem: FileSystem, storageDirectory: AbsolutePath) {
+    fileprivate init(fileSystem: FileSystem, storageDirectory: AbsolutePath) {
         self.init(fileSystem: fileSystem, storageDirectory: storageDirectory, initializationWarningHandler: { _ in })
     }
 }


### PR DESCRIPTION
### Motivation:

Since `@main` is the general purpose way of marking the entry point to executables, use it over top level code when generating an executable template.

### Modifications:

Update the template output when the specified `--type` is executable.

### Result:

The template is now:

```swift
@main
struct MyProject {
  static func main() {
    print("Hello, world!")
  }
}
```

This patch reverts https://github.com/swiftlang/swift-package-manager/pull/6197 and partially reverts https://github.com/swiftlang/swift-package-manager/pull/6144