### PR TITLE
Avoid testing library package with swiftbuild build system on Windows

### DIFF
--- a/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
@@ -69,6 +69,8 @@ final class SwiftPMTests: XCTestCase {
             }
         }
 
+        #if !os(Windows)
+        // SWBINTTODO: Windows fails to link this library package due to a "lld-link: error: subsystem must be defined" error. See https://github.com/swiftlang/swift-build/issues/310
         do {
             try withTemporaryDirectory { tmpDir in
                 let packagePath = tmpDir.appending(component: "foo")
@@ -79,6 +81,7 @@ final class SwiftPMTests: XCTestCase {
                 //try sh(swiftTest, "--package-path", packagePath, "--build-system", "swiftbuild")
             }
         }
+        #endif
     }
 
     func testArchCustomization() throws {


### PR DESCRIPTION
This section of the test will compile on Windows, but it doesn't succeed with Windows. Do an OS condition on there to avoid failures when tests are run with Windows.