### PR TITLE
Remove ALTERNATE_LINKER build setting when building for Windows

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -433,10 +433,6 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         // Always specify the path of the effective Swift compiler, which was determined in the same way as for the
         // native build system.
         settings["SWIFT_EXEC"] = buildParameters.toolchain.swiftCompilerPath.pathString
-        // Use lld linker instead of Visual Studio link.exe when targeting Windows
-        if buildParameters.triple.isWindows() {
-            settings["ALTERNATE_LINKER"] = "lld-link"
-        }
         // FIXME: workaround for old Xcode installations such as what is in CI
         settings["LM_SKIP_METADATA_EXTRACTION"] = "YES"
 


### PR DESCRIPTION
The default linker for Windows in swift-build is now lld-link so this is no longer needed.