### PR TITLE
PluginAPI: Optionally animate build progress in console

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Plugins/diagnostics-stub/diagnostics_stub.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Plugins/diagnostics-stub/diagnostics_stub.swift
@@ -11,7 +11,10 @@ struct diagnostics_stub: CommandPlugin {
             // SwiftPM does not add a prefix to these logs.
             let result = try packageManager.build(
                 .product("placeholder"),
-                parameters: .init(echoLogs: arguments.contains("echologs"))
+                parameters: .init(
+                    echoLogs: arguments.contains("echologs"),
+                    progressToConsole: arguments.contains("progresstoconsole")
+                )
             )
 
             // To verify that logs are also returned correctly to the plugin,

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -52,6 +52,7 @@ package struct LLBuildSystemConfiguration {
 
     let logLevel: Basics.Diagnostic.Severity
     let outputStream: OutputByteStream
+    let progressOutputStream: OutputByteStream
 
     let observabilityScope: ObservabilityScope
 
@@ -66,6 +67,7 @@ package struct LLBuildSystemConfiguration {
         fileSystem: any Basics.FileSystem,
         logLevel: Basics.Diagnostic.Severity,
         outputStream: OutputByteStream,
+        progressOutputStream: OutputByteStream,
         observabilityScope: ObservabilityScope
     ) {
         self.toolsBuildParameters = toolsBuildParameters
@@ -78,6 +80,7 @@ package struct LLBuildSystemConfiguration {
         self.fileSystem = fileSystem
         self.logLevel = logLevel
         self.outputStream = outputStream
+        self.progressOutputStream = progressOutputStream
         self.observabilityScope = observabilityScope
     }
 
@@ -208,6 +211,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         additionalFileRules: [FileRuleDescription],
         pkgConfigDirectories: [AbsolutePath],
         outputStream: OutputByteStream,
+        progressOutputStream: OutputByteStream? = nil,
         logLevel: Basics.Diagnostic.Severity,
         fileSystem: Basics.FileSystem,
         observabilityScope: ObservabilityScope
@@ -223,6 +227,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             additionalFileRules: additionalFileRules,
             pkgConfigDirectories: pkgConfigDirectories,
             outputStream: outputStream,
+            progressOutputStream: progressOutputStream ?? outputStream,
             logLevel: logLevel,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
@@ -240,6 +245,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         additionalFileRules: [FileRuleDescription],
         pkgConfigDirectories: [AbsolutePath],
         outputStream: OutputByteStream,
+        progressOutputStream: OutputByteStream? = nil,
         logLevel: Basics.Diagnostic.Severity,
         fileSystem: Basics.FileSystem,
         observabilityScope: ObservabilityScope
@@ -259,6 +265,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             fileSystem: fileSystem,
             logLevel: logLevel,
             outputStream: outputStream,
+            progressOutputStream: progressOutputStream ?? outputStream,
             observabilityScope: observabilityScope.makeChildScope(description: "Build Operation")
         )
 
@@ -795,7 +802,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     ) throws -> (buildSystem: SPMLLBuild.BuildSystem, tracker: LLBuildProgressTracker) {
         // Figure out which progress bar we have to use during the build.
         let progressAnimation = ProgressAnimation.ninja(
-            stream: config.outputStream,
+            stream: config.progressOutputStream,
             verbose: config.logLevel.isVerbose
         )
         let buildExecutionContext = BuildExecutionContext(

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -165,6 +165,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         if parameters.echoLogs {
             outputStream.addStream(swiftCommandState.outputStream)
         }
+        let progressOutputStream = parameters.progressToConsole ? swiftCommandState.outputStream : outputStream
 
         let buildSystem = try await swiftCommandState.createBuildSystem(
             explicitBuildSystem: .native,
@@ -173,6 +174,7 @@ final class PluginDelegate: PluginInvocationDelegate {
             cacheBuildManifest: false,
             productsBuildParameters: buildParameters,
             outputStream: outputStream,
+            progressOutputStream: progressOutputStream,
             logLevel: logLevel
         )
 

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -33,6 +33,7 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
         toolsBuildParameters: BuildParameters?,
         packageGraphLoader: (() async throws -> ModulesGraph)?,
         outputStream: OutputByteStream?,
+        progressOutputStream: OutputByteStream?,
         logLevel: Diagnostic.Severity?,
         observabilityScope: ObservabilityScope?
     ) async throws -> any BuildSystem {
@@ -64,6 +65,7 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
             additionalFileRules: FileRuleDescription.swiftpmFileTypes,
             pkgConfigDirectories: self.swiftCommandState.options.locations.pkgConfigDirectories,
             outputStream: outputStream ?? self.swiftCommandState.outputStream,
+            progressOutputStream: progressOutputStream ?? self.swiftCommandState.outputStream,
             logLevel: logLevel ?? self.swiftCommandState.logLevel,
             fileSystem: self.swiftCommandState.fileSystem,
             observabilityScope: observabilityScope ?? self.swiftCommandState.observabilityScope)
@@ -81,6 +83,7 @@ private struct XcodeBuildSystemFactory: BuildSystemFactory {
         toolsBuildParameters: BuildParameters?,
         packageGraphLoader: (() async throws -> ModulesGraph)?,
         outputStream: OutputByteStream?,
+        progressOutputStream: OutputByteStream?,
         logLevel: Diagnostic.Severity?,
         observabilityScope: ObservabilityScope?
     ) throws -> any BuildSystem {
@@ -111,6 +114,7 @@ private struct SwiftBuildSystemFactory: BuildSystemFactory {
         toolsBuildParameters: BuildParameters?,
         packageGraphLoader: (() async throws -> ModulesGraph)?,
         outputStream: OutputByteStream?,
+        progressOutputStream: OutputByteStream?,
         logLevel: Diagnostic.Severity?,
         observabilityScope: ObservabilityScope?
     ) throws -> any BuildSystem {

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -754,6 +754,7 @@ public final class SwiftCommandState {
         toolsBuildParameters: BuildParameters? = .none,
         packageGraphLoader: (() async throws -> ModulesGraph)? = .none,
         outputStream: OutputByteStream? = .none,
+        progressOutputStream: OutputByteStream? = .none,
         logLevel: Basics.Diagnostic.Severity? = nil,
         observabilityScope: ObservabilityScope? = .none
     ) async throws -> BuildSystem {
@@ -773,6 +774,7 @@ public final class SwiftCommandState {
             toolsBuildParameters: toolsBuildParameters,
             packageGraphLoader: packageGraphLoader,
             outputStream: outputStream,
+            progressOutputStream: progressOutputStream,
             logLevel: logLevel ?? self.logLevel,
             observabilityScope: observabilityScope
         )

--- a/Sources/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/PackagePlugin/PackageManagerProxy.swift
@@ -62,6 +62,12 @@ public struct PackageManager {
         /// Whether to print build logs to the console
         public var echoLogs: Bool
 
+        /// Whether to print build progress to the console
+        ///
+        /// If this is set to true, `BuildResult.logText` will not contain any
+        /// progress information.
+        public var progressToConsole: Bool
+
         /// Additional flags to pass to all C compiler invocations.
         public var otherCFlags: [String] = []
 
@@ -77,11 +83,13 @@ public struct PackageManager {
         public init(
             configuration: BuildConfiguration = .debug,
             logging: BuildLogVerbosity = .concise,
-            echoLogs: Bool = false
+            echoLogs: Bool = false,
+            progressToConsole: Bool = false
         ) {
             self.configuration = configuration
             self.logging = logging
             self.echoLogs = echoLogs
+            self.progressToConsole = progressToConsole
         }
     }
 
@@ -331,6 +339,7 @@ extension PluginToHostMessage.BuildParameters {
         self.configuration = .init(parameters.configuration)
         self.logging = .init(parameters.logging)
         self.echoLogs = parameters.echoLogs
+        self.progressToConsole = parameters.progressToConsole
         self.otherCFlags = parameters.otherCFlags
         self.otherCxxFlags = parameters.otherCxxFlags
         self.otherSwiftcFlags = parameters.otherSwiftcFlags

--- a/Sources/PackagePlugin/PluginMessages.swift
+++ b/Sources/PackagePlugin/PluginMessages.swift
@@ -372,6 +372,7 @@ enum PluginToHostMessage: Codable {
                 case concise, verbose, debug
             }
             var echoLogs: Bool
+            var progressToConsole: Bool
             var otherCFlags: [String]
             var otherCxxFlags: [String]
             var otherSwiftcFlags: [String]

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -121,6 +121,7 @@ public protocol BuildSystemFactory {
         toolsBuildParameters: BuildParameters?,
         packageGraphLoader: (() async throws -> ModulesGraph)?,
         outputStream: OutputByteStream?,
+        progressOutputStream: OutputByteStream?,
         logLevel: Diagnostic.Severity?,
         observabilityScope: ObservabilityScope?
     ) async throws -> any BuildSystem
@@ -149,6 +150,7 @@ public struct BuildSystemProvider {
         toolsBuildParameters: BuildParameters? = .none,
         packageGraphLoader: (() async throws -> ModulesGraph)? = .none,
         outputStream: OutputByteStream? = .none,
+        progressOutputStream: OutputByteStream? = .none,
         logLevel: Diagnostic.Severity? = .none,
         observabilityScope: ObservabilityScope? = .none
     ) async throws -> any BuildSystem {
@@ -163,6 +165,7 @@ public struct BuildSystemProvider {
             toolsBuildParameters: toolsBuildParameters,
             packageGraphLoader: packageGraphLoader,
             outputStream: outputStream,
+            progressOutputStream: progressOutputStream,
             logLevel: logLevel,
             observabilityScope: observabilityScope
         )

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -965,6 +965,7 @@ public struct PluginInvocationBuildParameters {
         case concise, verbose, debug
     }
     public var echoLogs: Bool
+    public var progressToConsole: Bool
     public var otherCFlags: [String]
     public var otherCxxFlags: [String]
     public var otherSwiftcFlags: [String]
@@ -1078,6 +1079,7 @@ fileprivate extension PluginInvocationBuildParameters {
         self.configuration = .init(parameters.configuration)
         self.logging = .init(parameters.logging)
         self.echoLogs = parameters.echoLogs
+        self.progressToConsole = parameters.progressToConsole
         self.otherCFlags = parameters.otherCFlags
         self.otherCxxFlags = parameters.otherCxxFlags
         self.otherSwiftcFlags = parameters.otherSwiftcFlags

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2648,6 +2648,8 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
         // Echoed logs have no prefix
         let containsLogecho = StringPattern.contains("Building for debugging...\n")
 
+        let containsProgressLog = StringPattern.contains("Compiling placeholder")
+
         // These tests involve building a target, so each test must run with a fresh copy of the fixture
         // otherwise the logs may be different in subsequent tests.
 
@@ -2682,7 +2684,16 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
         try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
             let (stdout, stderr) = try await self.execute(["print-diagnostics", "build", "printlogs", "echologs"], packagePath: fixturePath, env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"])
             XCTAssertMatch(stdout, containsLogtext)
+            XCTAssertMatch(stdout, containsProgressLog)
             XCTAssertMatch(stderr, containsLogecho)
+            XCTAssertMatch(stderr, containsProgressLog)
+        }
+
+        try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+            let (stdout, stderr) = try await self.execute(["print-diagnostics", "build", "printlogs", "progresstoconsole"], packagePath: fixturePath, env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"])
+            XCTAssertMatch(stdout, containsLogtext)
+            XCTAssertNoMatch(stdout, containsProgressLog)
+            XCTAssertMatch(stderr, containsProgressLog)
         }
     }
 


### PR DESCRIPTION
Introduce a way to animate build progress in console triggered by PackagePlugin API.

### Motivation:

When a package plugin asks SwiftPM to build a target, SwiftPM captures the whole build output including the progress messages and compiler diagnostics into a non-TTY output buffer stream. Use of the non-TTY output buffer stream makes the `[n/N] Compiling ...` progress messages always to be newlined. This is not ideal when building a large scale project as it consumes a lot of space in the terminal buffer.

### Modifications:

This commit introduces a new parameter `progressToConsole` to the `BuildParameters` to allow the package plugin to decide whether to write the progress messages to the console or capture them into `logText` buffer.

Compiler diagnostics are still "tee"ed and they are not colored and are included in `logText`.

### Result:

Package plugin developers will be able to provide a better build output to plugin users.

| `progressToConsole: false` | `progressToConsole: true` |
|:---------------------------:|:------------------------:|
| <video src="https://github.com/user-attachments/assets/6dae08dc-e53d-43c7-b574-9db3354be185" /> |  <video src="https://github.com/user-attachments/assets/c0502a42-36b6-4f90-9cb9-21de56e13a72" /> |

