### PR TITLE
Exclude unused files from SwiftBuildSupport target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -479,6 +479,10 @@ let package = Package(
             dependencies: [
                 "SPMBuildCore",
                 "PackageGraph",
+            ],
+            exclude: [
+                "CMakeLists.txt",
+                "README.md",
             ]
         ),
         .target(


### PR DESCRIPTION
Remove warnings generated by unused files in the SwiftBuildSupport target.
