### PR TITLE
Revert "Add toolchain swift stdlib to env when swift run."

### DIFF
--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
-@_spi(SwiftPMInternal) import Basics
+import Basics
 import CoreCommands
 import Foundation
 import PackageGraph
@@ -233,9 +233,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                 let runnerPath: AbsolutePath
                 let arguments: [String]
 
-                let toolchain = try swiftCommandState.getTargetToolchain()
-
-                if let debugger = toolchain.swiftSDK.toolset.knownTools[.debugger],
+                if let debugger = try swiftCommandState.getTargetToolchain().swiftSDK.toolset.knownTools[.debugger],
                    let debuggerPath = debugger.path {
                     runnerPath = debuggerPath
                     arguments = debugger.extraCLIOptions + [productAbsolutePath.pathString] + options.arguments
@@ -244,23 +242,11 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                     arguments = options.arguments
                 }
 
-                // For Linux, need to point LD_LIBRARY_PATH at the swift runtime
-                let environment: [String: String]?
-                if toolchain.targetTriple.isLinux() {
-                    var current = Environment.current
-                    let pathVar: EnvironmentKey = "LD_LIBRARY_PATH"
-                    current.prependPath(key: pathVar, value: try toolchain.linuxSwiftStdlib.pathString)
-                    environment = .init(current)
-                } else {
-                    environment = nil
-                }
-
                 try self.run(
                     fileSystem: swiftCommandState.fileSystem,
                     executablePath: runnerPath,
                     originalWorkingDirectory: swiftCommandState.originalWorkingDirectory,
-                    arguments: arguments,
-                    environment: environment
+                    arguments: arguments
                 )
             } catch Diagnostics.fatalError {
                 throw ExitCode.failure
@@ -308,8 +294,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
         fileSystem: FileSystem,
         executablePath: AbsolutePath,
         originalWorkingDirectory: AbsolutePath,
-        arguments: [String],
-        environment: [String: String]? = nil
+        arguments: [String]
     ) throws {
         // Make sure we are running from the original working directory.
         let cwd: AbsolutePath? = fileSystem.currentWorkingDirectory
@@ -318,7 +303,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
         }
 
         let pathRelativeToWorkingDirectory = executablePath.relative(to: originalWorkingDirectory)
-        try execute(path: executablePath.pathString, args: [pathRelativeToWorkingDirectory.pathString] + arguments, env: environment)
+        try execute(path: executablePath.pathString, args: [pathRelativeToWorkingDirectory.pathString] + arguments)
     }
 
     /// Determines if a path points to a valid swift file.
@@ -342,7 +327,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
     }
 
     /// A safe wrapper of TSCBasic.exec.
-    private func execute(path: String, args: [String], env: [String: String]?) throws -> Never {
+    private func execute(path: String, args: [String]) throws -> Never {
         #if !os(Windows)
         // Dispatch will disable almost all asynchronous signals on its worker threads, and this is called from `async`
         // context. To correctly `exec` a freshly built binary, we will need to:
@@ -372,13 +357,6 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
         }
         #endif /* os(FreeBSD) || os(OpenBSD) */
         #endif
-
-        if let env {
-            // set the env before we exec.
-            // TODO: we should really use execve here.
-            // Though, Windows doesn't really exec anyway.
-            try env.forEach { try ProcessEnv.setVar($0, value: $1) }
-        }
 
         try TSCBasic.exec(path: path, args: args)
     }

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -88,14 +88,6 @@ extension Toolchain {
         }
     }
 
-    public var linuxSwiftStdlib: AbsolutePath {
-        get throws {
-            try Self.toolchainLibDir(swiftCompilerPath: self.swiftCompilerPath).appending(
-                components: ["swift", "linux"]
-            )
-        }
-    }
-
     public var toolchainLibDir: AbsolutePath {
         get throws {
             // FIXME: Not sure if it's better to base this off of Swift compiler or our own binary.

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -866,7 +866,7 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
     }
 
     override func testGetTaskAllowEntitlement() async throws {
-        throw XCTSkip("SWBINTTODO: Test failed because swiftbuild doesn't output the codesign commands that the test expects.")
+        throw XCTSkip("SWBINTTODO: Test failed because swiftbuild doesn't output precis codesign commands. Once swift run works with swiftbuild the test can be investigated.")
     }
 
     override func testCodeCoverage() async throws {

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -72,10 +72,8 @@ class RunCommandTestCase: CommandsBuildProviderTestCase {
             XCTAssertMatch(stdout, .contains("sentinel"))
 
             // swift-build-tool output should go to stderr.
-            XCTAssertMatch(stderr, .contains("Building for debugging"))
-            if self.buildSystemProvider == .native {
-                XCTAssertMatch(stderr, .contains("Linking"))
-            }
+            XCTAssertMatch(stderr, .regex("Compiling"))
+            XCTAssertMatch(stderr, .contains("Linking"))
         }
     }
 #endif
@@ -91,10 +89,8 @@ class RunCommandTestCase: CommandsBuildProviderTestCase {
                 """))
 
             // swift-build-tool output should go to stderr.
-            XCTAssertMatch(stderr, .contains("Building for debugging"))
-            if self.buildSystemProvider == .native {
-                XCTAssertMatch(stderr, .contains("Linking"))
-            }
+            XCTAssertMatch(stderr, .regex("Compiling"))
+            XCTAssertMatch(stderr, .contains("Linking"))
 
             await XCTAssertThrowsCommandExecutionError(try await execute(["unknown"], packagePath: fixturePath)) { error in
                 XCTAssertMatch(error.stderr, .contains("error: no executable product named 'unknown'"))
@@ -256,5 +252,21 @@ class RunCommandSwiftBuildTests: RunCommandTestCase {
 
     override func testUsage() async throws {
         try await super.testUsage()
+    }
+
+    override func testMultipleExecutableAndExplicitExecutable() async throws {
+        throw XCTSkip("SWBINTTODO: https://github.com/swiftlang/swift-package-manager/issues/8279: Swift run using Swift Build does not output executable content to the terminal")
+    }
+
+    override func testUnknownProductAndArgumentPassing() async throws {
+        throw XCTSkip("SWBINTTODO: https://github.com/swiftlang/swift-package-manager/issues/8279: Swift run using Swift Build does not output executable content to the terminal")
+    }
+
+    override func testToolsetDebugger() async throws {
+        throw XCTSkip("SWBINTTODO: Test fixture fails to build")
+    }
+
+    override func testUnreachableExecutable() async throws {
+        throw XCTSkip("SWBINTTODO: Test fails because of build layout differences.")
     }
 }


### PR DESCRIPTION
Revert https://github.com/swiftlang/swift-package-manager/pull/8364 (and https://github.com/swiftlang/swift-package-manager/pull/8375)

This is causing a runtime dynamic linking error in swift-syntax PR testing:
https://ci.swift.org/job/swift-syntax-PR-Linux/4674/console
```
/home/build-user/build/buildbot_incremental/toolchain-linux-x86_64/usr/bin/swift: symbol lookup error: /home/build-user/build/buildbot_incremental/earlyswiftdriver-linux-x86_64/release/dependencies/llbuild/lib/libllbuildSwift.so: undefined symbol: $sSayxG10Foundation15ContiguousBytesABs5UInt8VRszlWP
```