### PR TITLE
Provide context necessary to resolve identity conflict.

### DIFF
--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -36,11 +36,19 @@ enum PackageGraphError: Swift.Error {
     )
 
     /// The package dependency already satisfied by a different dependency package
+    ///  - package: Package for which the dependency conflict was detected.
+    ///  - identity: Conflicting identity.
+    ///  - dependencyLocation: Dependency from the current package which triggered the conflict.
+    ///  - otherDependencyLocation: Conflicting dependency from another package.
+    ///  - dependencyPath: a dependency path as a list of locations from the root to the dependency that triggered the conflict.
+    ///  - otherDependencyPath: a dependency path as a list of locations from the root to the conflicting dependency from another package.
     case dependencyAlreadySatisfiedByIdentifier(
         package: String,
+        identity: PackageIdentity,
         dependencyLocation: String,
-        otherDependencyURL: String,
-        identity: PackageIdentity
+        otherDependencyLocation: String,
+        dependencyPath: [String] = [],
+        otherDependencyPath: [String] = []
     )
 
     /// The package dependency already satisfied by a different dependency package
@@ -300,8 +308,23 @@ extension PackageGraphError: CustomStringConvertible {
                 }
                 return description
             }
-        case .dependencyAlreadySatisfiedByIdentifier(let package, let dependencyURL, let otherDependencyURL, let identity):
-            return "'\(package)' dependency on '\(dependencyURL)' conflicts with dependency on '\(otherDependencyURL)' which has the same identity '\(identity)'"
+        case .dependencyAlreadySatisfiedByIdentifier(
+            _,
+            let identity,
+            let dependencyURL,
+            let otherDependencyURL,
+            let dependencyPath,
+            let otherDependencyPath
+        ):
+            var description =
+                "Conflicting identity for \(identity): dependency '\(dependencyURL)' and dependency '\(otherDependencyURL)' both point to the same package identity '\(identity)'."
+            if !dependencyPath.isEmpty && !otherDependencyPath.isEmpty {
+                let chainA = dependencyPath.map { String(describing: $0) }.joined(separator: "->")
+                let chainB = otherDependencyPath.map { String(describing: $0) }.joined(separator: "->")
+                description +=
+                    " The dependencies are introduced through the following chains: (A) \(chainA) (B) \(chainB). If there are multiple chains that lead to the same dependency, only the first chain is shown here. To see all chains use debug output option. To resolve the conflict, coordinate with the maintainer of the package that introduces the conflicting dependency."
+            }
+            return description
 
         case .dependencyAlreadySatisfiedByName(let package, let dependencyURL, let otherDependencyURL, let name):
             return "'\(package)' dependency on '\(dependencyURL)' conflicts with dependency on '\(otherDependencyURL)' which has the same explicit name '\(name)'"

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -413,7 +413,7 @@ struct PackageIdentityParser {
 ///   ```
 ///   file:///Users/mona/LinkedList → /Users/mona/LinkedList
 ///   ```
-public struct CanonicalPackageLocation: Equatable, CustomStringConvertible {
+public struct CanonicalPackageLocation: Equatable, CustomStringConvertible, Hashable {
     /// A textual representation of this instance.
     public let description: String
 


### PR DESCRIPTION
Update error messaging to be a bit more clear where the conflict of identities is coming from.

### Motivation:

#8311 — when multiple packages share the same identity (for example: `gh/swiftlang/swift-driver` and `gh/apple/swift-driver` share the same identity `swift-driver`) then the error doesn't help to resolve the conflict. It is particularly confusing when the conflicting package is pulled from transitive dependencies. I wanted to offer more context to resolve these types of conflicts, particularly:

 - how the conflict is introduced in relation to the root package
 - itemize all paths for both sides of the conflict, so that users can better understand how to approach resolution, but not overwhelm the error message with too many details

### Modifications:

 - Rephrase error message for clarity, add a suggestion to work with maintainers of transitive dependencies.
 - Reconstruct the dependency chains from roots to the conflicting packages.

### Result:

Before: 

```
'swift-build': 'swift-build' dependency on 'https://github.com/swiftlang/swift-driver.git' conflicts with dependency on 'https://github.com/apple/swift-driver.git' which has the same identity 'swift-driver'.
```

After:

```
'swift-build': Conflicting identity for swift-driver: dependency 'github.com/swiftlang/swift-driver' and dependency 'github.com/apple/swift-driver' both point to the same package identity 'swift-driver'. The dependencies are introduced through the following chains: (A) /users/yy/pub/tst/swift-package-manager->github.com/swiftlang/swift-build->github.com/swiftlang/swift-driver (B) /users/yy/pub/swift-package-manager->github.com/apple/swift-driver. If there are multiple chains that lead to the same dependency, only the first chain is shown here. To see all chains use debug output option. To resolve the conflict, coordinate with the maintainer of the package that introduces the conflicting dependency.
```

Plus also debug logs:

```
debug: 'swift-build': Conflicting identity for swift-driver: chains of dependencies for https://github.com/swiftlang/swift-driver.git: [[/users/yy/pub/swift-package-manager, github.com/swiftlang/swift-build, github.com/swiftlang/swift-driver]]
debug: 'swift-build':  Conflicting identity for swift-driver: chains of dependencies for https://github.com/apple/swift-driver.git: [[/users/yy/pub/swift-package-manager, github.com/apple/swift-driver]]
```
