### PR TITLE
Remove trailing comma

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -480,7 +480,7 @@ let package = Package(
                 "SPMBuildCore",
                 "PackageGraph",
             ],
-            exclude: ["CMakeLists.txt", "README.md"],
+            exclude: ["CMakeLists.txt", "README.md"]
         ),
         .target(
             /** High level functionality */


### PR DESCRIPTION
This restores the ability to build SwiftPM using a Swift 6.0 compiler.
