### PR TITLE
Add build times to swiftbuild build system

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -480,7 +480,7 @@ let package = Package(
                 "SPMBuildCore",
                 "PackageGraph",
             ],
-            exclude: ["CMakeLists.txt", "README.md"],
+            exclude: ["CMakeLists.txt", "README.md"]
         ),
         .target(
             /** High level functionality */

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -251,7 +251,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
     #if canImport(SwiftBuild)
     private func startSWBuildOperation(pifTargetName: String) async throws {
-        let buildStartTime = DispatchTime.now()
+        let buildStartTime = ContinuousClock.Instant.now
 
         try await withService(connectionMode: .inProcessStatic(swiftbuildServiceEntryPoint)) { service in
             let parameters = try self.makeBuildParameters()
@@ -389,7 +389,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                     case .succeeded:
                         progressAnimation.update(step: 100, total: 100, text: "")
                         progressAnimation.complete(success: true)
-                        let duration = buildStartTime.distance(to: .now())
+                        let duration = ContinuousClock.Instant.now - buildStartTime
                         self.outputStream.send("Build complete! (\(duration))\n")
                         self.outputStream.flush()
                     case .failed:

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -243,6 +243,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         try self.fileSystem.writeIfChanged(path: buildParameters.pifManifest, string: pif)
 
         try await startSWBuildOperation(pifTargetName: subset.pifTargetName)
+
         #else
         fatalError("Swift Build support is not linked in.")
         #endif
@@ -250,6 +251,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
     #if canImport(SwiftBuild)
     private func startSWBuildOperation(pifTargetName: String) async throws {
+        let buildStartTime = DispatchTime.now()
+
         try await withService(connectionMode: .inProcessStatic(swiftbuildServiceEntryPoint)) { service in
             let parameters = try self.makeBuildParameters()
             let derivedDataPath = self.buildParameters.dataPath.pathString
@@ -386,7 +389,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                     case .succeeded:
                         progressAnimation.update(step: 100, total: 100, text: "")
                         progressAnimation.complete(success: true)
-                        self.outputStream.send("Build complete!\n")
+                        let duration = buildStartTime.distance(to: .now())
+                        self.outputStream.send("Build complete! (\(duration))\n")
                         self.outputStream.flush()
                     case .failed:
                         self.observabilityScope.emit(error: "Build failed")

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -416,14 +416,13 @@ class BuildCommandTestCases: CommandsBuildProviderTestCase {
     }
 
     func testBuildCompleteMessage() async throws {
-        try XCTSkipIf(true, "This test fails to match the 'Compiling' regex; rdar://101815761")
-
         try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             do {
                 let result = try await execute(packagePath: fixturePath)
-                XCTAssertMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
+                // This test fails to match the 'Compiling' regex; rdar://101815761
+                // XCTAssertMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
                 let lines = result.stdout.split(whereSeparator: { $0.isNewline })
-                XCTAssertMatch(String(lines.last!), .regex("Build complete! \\([0-9]*\\.[0-9]*s\\)"))
+                XCTAssertMatch(String(lines.last!), .regex("Build complete! \\([0-9]*\\.[0-9]*\\s*s(econds)?\\)"))
             }
 
             do {
@@ -434,9 +433,10 @@ class BuildCommandTestCases: CommandsBuildProviderTestCase {
             do {
                 // test third time, to make sure message is presented even when nothing to build (cached)
                 let result = try await execute(packagePath: fixturePath)
-                XCTAssertNoMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
+                // This test fails to match the 'Compiling' regex; rdar://101815761
+                // XCTAssertNoMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
                 let lines = result.stdout.split(whereSeparator: { $0.isNewline })
-                XCTAssertMatch(String(lines.last!), .regex("Build complete! \\([0-9]*\\.[0-9]*s\\)"))
+                XCTAssertMatch(String(lines.last!), .regex("Build complete! \\([0-9]*\\.[0-9]*\\s*s(econds)?\\)"))
             }
         }
     }
@@ -846,6 +846,10 @@ class BuildCommandXcodeTests: BuildCommandTestCases {
     }
 
     override func testGetTaskAllowEntitlement() async throws {
+        try XCTSkip("Test not implemented for xcode build system.")
+    }
+
+    override func testBuildCompleteMessage() async throws {
         try XCTSkip("Test not implemented for xcode build system.")
     }
 }


### PR DESCRIPTION
The native build system will output the time it took building. This can be
useful for ad-hoc measurement of the time. Add the same kind of measurement
for build times of the swiftbuild build system.