### PR TITLE
[Traits] Fix traits omitting used package dependencies

### DIFF
--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -204,11 +204,13 @@ public final class SwiftCommandState {
 
     /// Get the current workspace root object.
     public func getWorkspaceRoot(traitConfiguration: TraitConfiguration? = nil) throws -> PackageGraphRootInput {
-        let packages: [AbsolutePath] = if let workspace = options.locations.multirootPackageDataFile {
-            try self.workspaceLoaderProvider(self.fileSystem, self.observabilityScope)
+        let packages: [AbsolutePath]
+
+        if let workspace = options.locations.multirootPackageDataFile {
+            packages = try self.workspaceLoaderProvider(self.fileSystem, self.observabilityScope)
                 .load(workspace: workspace)
         } else {
-            try [self.getPackageRoot()]
+            packages = [try getPackageRoot()]
         }
 
         return PackageGraphRootInput(packages: packages, traitConfiguration: traitConfiguration)
@@ -715,7 +717,7 @@ public final class SwiftCommandState {
         try self._manifestLoader.get()
     }
 
-    public func canUseCachedBuildManifest() async throws -> Bool {
+    public func canUseCachedBuildManifest(_ traitConfiguration: TraitConfiguration? = nil) async throws -> Bool {
         if !self.options.caching.cacheBuildManifest {
             return false
         }
@@ -732,7 +734,7 @@ public final class SwiftCommandState {
         // Perform steps for build manifest caching if we can enabled it.
         //
         // FIXME: We don't add edited packages in the package structure command yet (SR-11254).
-        let hasEditedPackages = try await self.getActiveWorkspace().state.dependencies.contains(where: \.isEdited)
+        let hasEditedPackages = try await self.getActiveWorkspace(traitConfiguration: traitConfiguration).state.dependencies.contains(where: \.isEdited)
         if hasEditedPackages {
             return false
         }

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -876,9 +876,9 @@ extension Manifest {
     ///    - lowercasedKeys: A flag that determines whether the keys in the resulting dictionary are lowercased.
     /// - Returns: A dictionary that maps the name of a `TargetDescription` to a list of its dependencies that are
     /// guarded by traits.
-    public func traitGuardedTargetDependencies(lowercasedKeys: Bool = false)
-        -> [String: [TargetDescription.Dependency]]
-    {
+    public func traitGuardedTargetDependencies(
+        lowercasedKeys: Bool = false
+    ) -> [String: [TargetDescription.Dependency]] {
         self.targets.reduce(into: [String: [TargetDescription.Dependency]]()) { depMap, target in
             let traitGuardedTargetDependencies = traitGuardedTargetDependencies(
                 for: target

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -866,7 +866,8 @@ extension Manifest {
     }
 
 
-    // TODO: bp add description
+    /// Computes the list of target dependencies per target that are guarded by traits.
+    /// A  target dependency is considered potentially trait-guarded if it defines a condition wherein there exists a list of traits.
     public func traitGuardedDependencies(lowercasedKeys: Bool = false) -> [String: [TargetDescription.Dependency]] {
         self.targets.reduce(into: [String: [TargetDescription.Dependency]]()) { depMap, target in
             let traitGuardedTargetDependencies = traitGuardedTargetDependencies(lowercasedKeys: lowercasedKeys, for: target)
@@ -878,7 +879,8 @@ extension Manifest {
         }
     }
 
-    // TODO: bp add description
+    /// Computes the list of target dependencies that are guarded by traits for given target.
+    /// A  target dependency is considered potentially trait-guarded if it defines a condition wherein there exists a list of traits.
     public func traitGuardedTargetDependencies(lowercasedKeys: Bool = false, for target: TargetDescription) -> [TargetDescription.Dependency: Set<String>] {
         target.dependencies.filter {
             !($0.condition?.traits?.isEmpty ?? true)

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -870,7 +870,7 @@ extension Manifest {
     }
 
     /// Computes the list of target dependencies per target that are guarded by traits.
-    /// A  target dependency is considered potentially trait-guarded if it defines a condition wherein there exists a
+    /// A target dependency is considered potentially trait-guarded if it defines a condition wherein there exists a
     /// list of traits.
     /// - Parameters:
     ///    - lowercasedKeys: A flag that determines whether the keys in the resulting dictionary are lowercased.
@@ -892,7 +892,7 @@ extension Manifest {
     }
 
     /// Computes the list of target dependencies that are guarded by traits for given target.
-    /// A  target dependency is considered potentially trait-guarded if it defines a condition wherein there exists a
+    /// A target dependency is considered potentially trait-guarded if it defines a condition wherein there exists a
     /// list of traits.
     /// - Parameters:
     ///    - target: A `TargetDescription` for which the trait-guarded target dependencies are calculated.

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -485,7 +485,7 @@ class ManifestTests: XCTestCase {
                 traits: traits
             )
 
-            let traitGuardedDependencies = manifest.traitGuardedDependencies()
+            let traitGuardedDependencies = manifest.traitGuardedTargetDependencies()
 
             XCTAssertEqual(
                 traitGuardedDependencies,

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -508,16 +508,26 @@ class ManifestTests: XCTestCase {
             ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
         ]
 
-        let unguardedTargetDependency: TargetDescription.Dependency = .product(name: "Bar", package: "Blah")
+        let unguardedTargetDependency: TargetDescription.Dependency = .product(
+            name: "Bar",
+            package: "Blah"
+        )
+
         let trait3GuardedTargetDependency: TargetDescription.Dependency = .product(
             name: "Baz",
             package: "Buzz",
             condition: .init(traits: ["Trait3"])
         )
+
         let defaultTraitGuardedTargetDependency: TargetDescription.Dependency = .product(
             name: "Bam",
             package: "Boom",
             condition: .init(traits: ["Trait2"])
+        )
+
+        let enabledTargetDependencyWithSamePackage: TargetDescription.Dependency = .product(
+            name: "Kaboom",
+            package: "Boom"
         )
 
         let target = try TargetDescription(
@@ -526,6 +536,7 @@ class ManifestTests: XCTestCase {
                 unguardedTargetDependency,
                 trait3GuardedTargetDependency,
                 defaultTraitGuardedTargetDependency,
+                enabledTargetDependencyWithSamePackage,
             ]
         )
 
@@ -591,6 +602,14 @@ class ManifestTests: XCTestCase {
             XCTAssertFalse(try manifest.isTargetDependencyEnabled(
                 target: "Foo",
                 defaultTraitGuardedTargetDependency,
+                enabledTraits: []
+            ))
+
+            // Test if a target dependency that isn't guarded by traits wherein it uses a product
+            // from the same package as another target dependency that is guarded by traits; should be true.
+            XCTAssertTrue(try manifest.isTargetDependencyEnabled(
+                target: "Foo",
+                enabledTargetDependencyWithSamePackage,
                 enabledTraits: []
             ))
         }

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -459,6 +459,10 @@ class ManifestTests: XCTestCase {
                         name: "Baz",
                         package: "Baz"
                     ),
+                    .product(
+                        name: "Bar2",
+                        package: "Bar"
+                    )
                 ]
             ),
         ]
@@ -482,10 +486,13 @@ class ManifestTests: XCTestCase {
             )
 
             let traitGuardedDependencies = manifest.traitGuardedDependencies()
+
             XCTAssertEqual(
                 traitGuardedDependencies,
                 [
-                    "Bar": ["Foo": ["Trait2"]],
+                    "Bar": [
+                        .product(name: "Bar", package: "Bar", condition: .init(traits: ["Trait2"]))
+                    ]
                 ]
             )
         }


### PR DESCRIPTION
Fixes #8398 

Used package dependencies of a manifest were considered trait-guarded if a target dependency in the manifest:

1. used a product from said package and
2. was trait-guarded

regardless as to whether the same package dependency was used elsewhere (whether in the same target or another in the same manifest) and was not guarded by traits.

This change ensures that this is considered when doing the calculations for package dependencies that should be omitted if *every* target dependency that uses said package dependency is guarded.