### PR TITLE
Allow creation of non-existent directory during `swift package init`

### DIFF
--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -49,6 +49,9 @@ extension SwiftPackageCommand {
         @Option(name: .customLong("name"), help: "Provide custom package name")
         var packageName: String?
 
+        // This command should support creating the supplied --package-path if it isn't created.
+        var createPackagePath = true
+
         func run(_ swiftCommandState: SwiftCommandState) throws {
             guard let cwd = swiftCommandState.fileSystem.currentWorkingDirectory else {
                 throw InternalError("Could not find the current working directory")

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -110,6 +110,7 @@ extension _SwiftCommand {
 public protocol SwiftCommand: ParsableCommand, _SwiftCommand {
     func run(_ swiftCommandState: SwiftCommandState) throws
 }
+
 extension SwiftCommand {
     public static var _errorLabel: String { "error" }
 

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -208,6 +208,7 @@ class PrepareForIndexTests: XCTestCase {
                     observabilityScope: $1
                 )
             },
+            createPackagePath: false,
             hostTriple: .arm64Linux,
             fileSystem: localFileSystem,
             environment: .current

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -489,7 +489,7 @@ final class SwiftCommandStateTests: CommandsTestCase {
     }
 
     func testPackagePathWithMissingFolder() async throws {
-        try fixture(name: "Miscellaneous/Simple") { fixturePath in
+        try withTemporaryDirectory { fixturePath in
             let packagePath = fixturePath.appending(component: "Foo")
             let options = try GlobalOptions.parse(["--package-path", packagePath.pathString])
 

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -495,9 +495,7 @@ final class SwiftCommandStateTests: CommandsTestCase {
 
             do {
                 let outputStream = BufferedOutputByteStream()
-                XCTAssertThrowsError(try SwiftCommandState.makeMockState(outputStream: outputStream, options: options), "error expected") { error in
-                    XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: No such file or directory"))
-                }
+                XCTAssertThrowsError(try SwiftCommandState.makeMockState(outputStream: outputStream, options: options), "error expected")
             }
 
             do {


### PR DESCRIPTION
Running `swift package init --package-path <dir-does-not-exists>` results in an error when SwiftPM attempts to change directories in to the directory that doesn't exist.

### Motivation:

It is rare that a user wants to do a `swift package init` in a folder that already has content. A typical pattern is to `mkdir mypackage && cd my package && swift package init`. SwiftPM already has a `--package-path` flag indicating the package folder that the command should operate on, but attempting to use this to create a folder that doesn't exist during `swift package init` results in an error when SwiftPM attempts to chdir to the --package-path that doesn't exist.

### Modifications:

Add a new boolean to the `_SwiftCommand` protocol that lets commands opt in to creating the directory at `--package-path` if it doesn't exist. Opt in `InitCommand` to this behaviour.

### Result:

`swift package init --package-path ./mypackage` successfully initializes a package in `./mypackage`, even if `./mypackage` doesn't exist.

Issue: #8393
