### PR TITLE
Add testing trait to indicate a CI environment that has restricted network access

### DIFF
--- a/IntegrationTests/Sources/IntegrationTestSupport/SkippedTestSupport.swift
+++ b/IntegrationTests/Sources/IntegrationTestSupport/SkippedTestSupport.swift
@@ -40,6 +40,13 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
+    /// Skip test if the test environment has a restricted network access, i.e. cannot get to internet.
+    public static func requireUnrestrictedNetworkAccess(_ comment: Comment? = nil) -> Self {
+        disabled(comment ?? "CI Environment has restricted network access") {
+            ProcessInfo.processInfo.environment["SWIFTCI_RESTRICTED_NETWORK_ACCESS"] != nil
+        }
+    }
+
     /// Skip test if built by XCode.
     public static func skipIfXcodeBuilt() -> Self {
         disabled("Tests built by Xcode") {

--- a/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
@@ -22,7 +22,8 @@ private struct BasicTests {
     @Test(
         .skipSwiftCISelfHosted(
             "These packages don't use the latest runtime library, which doesn't work with self-hosted builds."
-        )
+        ),
+        .requireUnrestrictedNetworkAccess("Test requires access to https://github.com")
     )
     func testExamplePackageDealer() throws {
         try withTemporaryDirectory { tempDir in


### PR DESCRIPTION
In some testing environments, network access is limited not allowing for hosts to access the public internet.  Add a testing condition trait that can be used to determine if the test has unrestricted network access.

Environments that have this constraint can set `SWIFTCI_RESTRICTED_NETWORK_ACCESS=1` to affect this condition.