### PR TITLE
Move from `@_implementationOnly` to `internal` imports

### DIFF
--- a/Fixtures/Resources/FoundationlessClient/UtilsWithFoundationPkg/Package.swift
+++ b/Fixtures/Resources/FoundationlessClient/UtilsWithFoundationPkg/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 // This package acts as a regression test for the FoundationlessPackages to
 // assert that Swift targets with resources are not affected by using
-// `@_implementationOnly import Foundation` in the generated resource accessor.
+// `internal import Foundation` in the generated resource accessor.
 let package = Package(
     name: "UtilsWithFoundationPkg",
     targets: [

--- a/Sources/Basics/Concurrency/AsyncProcess.swift
+++ b/Sources/Basics/Concurrency/AsyncProcess.swift
@@ -20,11 +20,8 @@ import Android
 
 #if os(Linux)
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly
-import func TSCclibc.SPM_posix_spawn_file_actions_addchdir_np_supported
-
-@_implementationOnly
-import func TSCclibc.SPM_posix_spawn_file_actions_addchdir_np
+internal import func TSCclibc.SPM_posix_spawn_file_actions_addchdir_np_supported
+internal import func TSCclibc.SPM_posix_spawn_file_actions_addchdir_np
 #else
 private import func TSCclibc.SPM_posix_spawn_file_actions_addchdir_np_supported
 private import func TSCclibc.SPM_posix_spawn_file_actions_addchdir_np

--- a/Sources/Basics/SQLite.swift
+++ b/Sources/Basics/SQLite.swift
@@ -14,13 +14,13 @@ import Foundation
 
 #if SWIFT_PACKAGE && (os(Windows) || os(Android))
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import SwiftToolchainCSQLite
+internal import SwiftToolchainCSQLite
 #else
 import SwiftToolchainCSQLite
 #endif
 #else
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import SPMSQLite3
+internal import SPMSQLite3
 #else
 import SPMSQLite3
 #endif

--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import TSCclibc
+internal import TSCclibc
 #else
 private import TSCclibc
 #endif

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -23,7 +23,7 @@ import PackageModel
 import SPMBuildCore
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import DriverSupport
+internal import DriverSupport
 #else
 import DriverSupport
 #endif

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -23,8 +23,8 @@ import func TSCBasic.topologicalSort
 import struct Basics.Environment
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import class DriverSupport.SPMSwiftDriverExecutor
-@_implementationOnly import SwiftDriver
+internal import class DriverSupport.SPMSwiftDriverExecutor
+internal import SwiftDriver
 #else
 import class DriverSupport.SPMSwiftDriverExecutor
 import SwiftDriver

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -17,7 +17,7 @@ import PackageModel
 import SPMBuildCore
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import SwiftDriver
+internal import SwiftDriver
 #else
 import SwiftDriver
 #endif

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -29,8 +29,8 @@ import struct TSCBasic.RegEx
 import enum TSCUtility.Diagnostics
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import DriverSupport
-@_implementationOnly import SwiftDriver
+internal import DriverSupport
+internal import SwiftDriver
 #else
 import DriverSupport
 import SwiftDriver

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -21,7 +21,7 @@ import PackageModel
 import SPMBuildCore
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import SwiftDriver
+internal import SwiftDriver
 #else
 import SwiftDriver
 #endif

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -17,7 +17,7 @@ import PackageModel
 import SPMBuildCore
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import DriverSupport
+internal import DriverSupport
 #else
 import DriverSupport
 #endif

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -24,9 +24,8 @@ import SPMBuildCore
 import Workspace
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly
 @_spi(SwiftPMInternal)
-import DriverSupport
+internal import DriverSupport
 #else
 @_spi(SwiftPMInternal)
 import DriverSupport

--- a/Sources/PackageCollectionsSigning/CertificatePolicy.swift
+++ b/Sources/PackageCollectionsSigning/CertificatePolicy.swift
@@ -16,8 +16,8 @@ import Foundation
 import Basics
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import SwiftASN1
-@_implementationOnly import X509
+internal import SwiftASN1
+internal import X509
 #else
 import SwiftASN1
 import X509

--- a/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
+++ b/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
@@ -17,9 +17,9 @@ import Foundation
 import PackageCollectionsModel
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import _CryptoExtras
-@_implementationOnly import Crypto
-@_implementationOnly import X509
+internal import _CryptoExtras
+internal import Crypto
+internal import X509
 #else
 import _CryptoExtras
 import Crypto

--- a/Sources/PackageCollectionsSigning/Signature.swift
+++ b/Sources/PackageCollectionsSigning/Signature.swift
@@ -26,9 +26,9 @@
 import Foundation
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import _CryptoExtras
-@_implementationOnly import Crypto
-@_implementationOnly import X509
+internal import _CryptoExtras
+internal import Crypto
+internal import X509
 #else
 import _CryptoExtras
 import Crypto

--- a/Sources/PackageCollectionsSigning/X509Extensions.swift
+++ b/Sources/PackageCollectionsSigning/X509Extensions.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import SwiftASN1
-@_implementationOnly import X509
+internal import SwiftASN1
+internal import X509
 #else
 import SwiftASN1
 import X509

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(ucrt) && canImport(WinSDK)
-@_implementationOnly import ucrt
-@_implementationOnly import struct WinSDK.HANDLE
+internal import ucrt
+internal import struct WinSDK.HANDLE
 #endif
-@_implementationOnly import Foundation
+internal import Foundation
 
 /// The configuration of a Swift package.
 ///

--- a/Sources/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerialization.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import Foundation
+internal import Foundation
 #else
 import Foundation
 #endif

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import Foundation
+internal import Foundation
 
 /// The basic building block of a Swift package.
 ///

--- a/Sources/PackageLoading/ContextModel.swift
+++ b/Sources/PackageLoading/ContextModel.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import Foundation
+internal import Foundation
 #else
 import Foundation
 #endif

--- a/Sources/PackagePlugin/Plugin.swift
+++ b/Sources/PackagePlugin/Plugin.swift
@@ -12,8 +12,8 @@
 
 import Foundation
 #if os(Windows)
-@_implementationOnly import ucrt
-@_implementationOnly import WinSDK
+internal import ucrt
+internal import WinSDK
 
 internal func dup(_ fd: CInt) -> CInt {
     return _dup(fd)

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
@@ -21,7 +21,7 @@ import PackageSigning
 import Workspace
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import X509 // FIXME: need this import or else SwiftSigningIdentity initializer fails
+internal import X509 // FIXME: need this import or else SwiftSigningIdentity initializer fails
 #else
 import X509
 #endif

--- a/Sources/PackageSigning/CertificateStores.swift
+++ b/Sources/PackageSigning/CertificateStores.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import X509
+internal import X509
 #else
 import X509
 #endif

--- a/Sources/PackageSigning/SignatureProvider.swift
+++ b/Sources/PackageSigning/SignatureProvider.swift
@@ -15,11 +15,11 @@ import struct Foundation.Date
 
 #if USE_IMPL_ONLY_IMPORTS
 #if canImport(Security)
-@_implementationOnly import Security
+internal import Security
 #endif
 
-@_implementationOnly import SwiftASN1
-@_implementationOnly @_spi(CMS) import X509
+internal import SwiftASN1
+@_spi(CMS) internal import X509
 #else
 #if canImport(Security)
 import Security

--- a/Sources/PackageSigning/SigningEntity/SigningEntity.swift
+++ b/Sources/PackageSigning/SigningEntity/SigningEntity.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import SwiftASN1
-@_implementationOnly import X509
+internal import SwiftASN1
+internal import X509
 #else
 import SwiftASN1
 import X509

--- a/Sources/PackageSigning/SigningIdentity.swift
+++ b/Sources/PackageSigning/SigningIdentity.swift
@@ -12,11 +12,11 @@
 
 #if USE_IMPL_ONLY_IMPORTS
 #if canImport(Security)
-@_implementationOnly import Security
+internal import Security
 #endif
 
-@_implementationOnly import Crypto
-@_implementationOnly import X509
+internal import Crypto
+internal import X509
 #else
 #if canImport(Security)
 import Security

--- a/Sources/PackageSigning/VerifierPolicies.swift
+++ b/Sources/PackageSigning/VerifierPolicies.swift
@@ -18,8 +18,8 @@ import struct Foundation.URL
 import Basics
 
 #if USE_IMPL_ONLY_IMPORTS
-@_implementationOnly import SwiftASN1
-@_implementationOnly @_spi(DisableValidityCheck) import X509
+internal import SwiftASN1
+@_spi(DisableValidityCheck) internal import X509
 #else
 import SwiftASN1
 @_spi(DisableValidityCheck) import X509

--- a/Sources/PackageSigning/X509Extensions.swift
+++ b/Sources/PackageSigning/X509Extensions.swift
@@ -14,11 +14,11 @@ import struct Foundation.Data
 
 #if USE_IMPL_ONLY_IMPORTS
 #if canImport(Security)
-@_implementationOnly import Security
+internal import Security
 #endif
 
-@_implementationOnly import SwiftASN1
-@_implementationOnly import X509
+internal import SwiftASN1
+internal import X509
 #else
 #if canImport(Security)
 import Security


### PR DESCRIPTION
Fixes up several Swift 6 warnings now that `@_implementationOnly` has been deprecated in favour of `internal`.