### PR TITLE
Move files when using `package add-target` on single target package

### DIFF
--- a/Sources/Commands/PackageCommands/AddTarget.swift
+++ b/Sources/Commands/PackageCommands/AddTarget.swift
@@ -89,6 +89,14 @@ extension SwiftPackageCommand {
                 }
             }
 
+            // Move sources into their own folder if they're directly in `./Sources`.
+            try PackageModelSyntax.AddTarget.moveSingleTargetSources(
+                packagePath: packagePath,
+                manifest: manifestSyntax,
+                fileSystem: fileSystem,
+                verbose: !globalOptions.logging.quiet
+            )
+
             // Map the target type.
             let type: TargetDescription.TargetKind = switch self.type {
                 case .library: .regular

--- a/Sources/PackageModelSyntax/AddTarget.swift
+++ b/Sources/PackageModelSyntax/AddTarget.swift
@@ -64,7 +64,7 @@ public enum AddTarget {
         packagePath: AbsolutePath,
         manifest: SourceFileSyntax,
         fileSystem: any FileSystem,
-        verbose: Bool
+        verbose: Bool = false
     ) throws {
         // Make sure we have a suitable tools version in the manifest.
         try manifest.checkEditManifestToolsVersion()

--- a/Sources/PackageModelSyntax/AddTarget.swift
+++ b/Sources/PackageModelSyntax/AddTarget.swift
@@ -60,7 +60,7 @@ public enum AddTarget {
     // Check if the package has a single target with that target's sources located
     // directly in `./Sources`. If so, move the sources into a folder named after
     // the target before adding a new target.
-    public static func moveSingleTargetSources(
+    package static func moveSingleTargetSources(
         packagePath: AbsolutePath,
         manifest: SourceFileSyntax,
         fileSystem: any FileSystem,

--- a/Sources/PackageModelSyntax/AddTarget.swift
+++ b/Sources/PackageModelSyntax/AddTarget.swift
@@ -57,6 +57,62 @@ public enum AddTarget {
         }
     }
 
+    // Check if the package has a single target with that target's sources located
+    // directly in `./Sources`. If so, move the sources into a folder named after
+    // the target before adding a new target.
+    public static func moveSingleTargetSources(
+        packagePath: AbsolutePath,
+        manifest: SourceFileSyntax,
+        fileSystem: any FileSystem,
+        verbose: Bool
+    ) throws {
+        // Make sure we have a suitable tools version in the manifest.
+        try manifest.checkEditManifestToolsVersion()
+
+        guard let packageCall = manifest.findCall(calleeName: "Package") else {
+            throw ManifestEditError.cannotFindPackage
+        }
+
+        if let arg = packageCall.findArgument(labeled: "targets") {
+            guard let argArray = arg.expression.findArrayArgument() else {
+                throw ManifestEditError.cannotFindArrayLiteralArgument(
+                    argumentName: "targets",
+                    node: Syntax(arg.expression)
+                )
+            }
+
+            // Check the contents of the `targets` array to see if there is only one target defined.
+            guard argArray.elements.count == 1,
+                let firstTarget = argArray.elements.first?.expression.as(FunctionCallExprSyntax.self),
+                let targetStringLiteral = firstTarget.arguments.first?.expression.as(StringLiteralExprSyntax.self) else {
+                return
+            }
+
+            let targetName = targetStringLiteral.segments.description
+            let sourcesFolder = packagePath.appending("Sources")
+            let expectedTargetFolder = sourcesFolder.appending(targetName)
+
+            // If there is one target then pull its name out and use that to look for a folder in `Sources/TargetName`.
+            // If the folder doesn't exist then we know we have a single target package and we need to migrate files
+            // into this folder before we can add a new target.
+            if !fileSystem.isDirectory(expectedTargetFolder) {
+                if verbose {
+                    print("Moving existing files in \(sourcesFolder.relative(to: packagePath)) to \(expectedTargetFolder.relative(to: packagePath))...", terminator: "")
+                }
+                let contentsToMove = try fileSystem.getDirectoryContents(sourcesFolder)
+                try fileSystem.createDirectory(expectedTargetFolder)
+                for file in contentsToMove {
+                    let source = sourcesFolder.appending(file)
+                    let destination = expectedTargetFolder.appending(file)
+                    try fileSystem.move(from: source, to: destination)
+                }
+                if verbose {
+                    print(" done.")
+                }
+            }
+        }
+    }
+
     /// Add the given target to the manifest, producing a set of edit results
     /// that updates the manifest and adds some source files to stub out the
     /// new target.

--- a/Sources/PackageModelSyntax/AddTarget.swift
+++ b/Sources/PackageModelSyntax/AddTarget.swift
@@ -97,7 +97,16 @@ public enum AddTarget {
             // into this folder before we can add a new target.
             if !fileSystem.isDirectory(expectedTargetFolder) {
                 if verbose {
-                    print("Moving existing files in \(sourcesFolder.relative(to: packagePath)) to \(expectedTargetFolder.relative(to: packagePath))...", terminator: "")
+                    print(
+                        """
+                        Moving existing files from \(
+                            sourcesFolder.relative(to: packagePath)
+                        ) to \(
+                            expectedTargetFolder.relative(to: packagePath)
+                        )...
+                        """,
+                        terminator: ""
+                    )
                 }
                 let contentsToMove = try fileSystem.getDirectoryContents(sourcesFolder)
                 try fileSystem.createDirectory(expectedTargetFolder)

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -1120,7 +1120,6 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
         }
     }
 
-
     func testPackageAddTarget() async throws {
         try await testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
@@ -1149,6 +1148,58 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             XCTAssertMatch(contents, .contains(#"dependencies:"#))
             XCTAssertMatch(contents, .contains(#""MyLib""#))
             XCTAssertMatch(contents, .contains(#""OtherLib""#))
+        }
+    }
+
+    func testPackageAddTargetWithoutModuleSourcesFolder() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
+            let fs = localFileSystem
+            let manifest = tmpPath.appending("Package.swift")
+            try fs.writeFileContents(manifest, string:
+                """
+                // swift-tools-version: 5.9
+                import PackageDescription
+                let package = Package(
+                    name: "SimpleExecutable",
+                    targets: [
+                        .executableTarget(name: "SimpleExecutable"),
+                    ]
+                )
+                """
+            )
+
+            let sourcesFolder = tmpPath.appending("Sources")
+            try fs.createDirectory(sourcesFolder)
+
+            try fs.writeFileContents(sourcesFolder.appending("main.swift"), string:
+                """
+                print("Hello World")
+                """
+            )
+
+            _ = try await execute(["add-target", "client"], packagePath: tmpPath)
+
+            XCTAssertFileExists(manifest)
+            let contents: String = try fs.readFileContents(manifest)
+
+            XCTAssertMatch(contents, .contains(#"targets:"#))
+            XCTAssertMatch(contents, .contains(#".executableTarget"#))
+            XCTAssertMatch(contents, .contains(#"name: "client""#))
+
+            let fileStructure = try fs.getDirectoryContents(sourcesFolder)
+            XCTAssertEqual(fileStructure, ["SimpleExecutable", "client"])
+            XCTAssertTrue(fs.isDirectory(sourcesFolder.appending("SimpleExecutable")))
+            XCTAssertTrue(fs.isDirectory(sourcesFolder.appending("client")))
+            XCTAssertEqual(try fs.getDirectoryContents(sourcesFolder.appending("SimpleExecutable")), ["main.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(sourcesFolder.appending("client")), ["client.swift"])
+        }
+    }
+
+    func testAddTargetWithoutManifestThrows() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
+            await XCTAssertThrowsCommandExecutionError(try await execute(["add-target", "client"], packagePath: tmpPath)) { error in
+                XCTAssertMatch(error.stderr, .contains("error: Could not find Package.swift in this directory or any of its parent directories."))
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation:

Currently running `swift package init --type executable` in a folder called `Example` creates a project with the following structure:

```
./Example/Sources
./Example/Sources/main.swift
./Example/Package.swift
```

Following this up with a `swift package add-target Foo` produces a package that no longer builds. It now has the structure:

```
./Example/Sources
./Example/Sources/main.swift
./Example/Sources/Foo/Foo.swift
./Example/Package.swift
```

Packages with multiple targets cannot have code directly in `./Sources`, and the user gets the error:

`Source files for target Example should be located under 'Sources/Example'`

### Modifications:

To work around this in the AddTarget command we can check if a package is structured as a single target package with sources directly in `./Sources` and move these files into a new folder located at `./Sources/Example`. 

### Result:

This allows the project to build after the new target has been added.

Issue: #8410