### PR TITLE
Implement --enable-parseable-module-interfaces for swift-build buildsystem

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -470,6 +470,11 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             settings["ARCHS"] = architectures.joined(separator: " ")
         }
 
+        // support for --enable-parseable-module-interfaces
+        if buildParameters.driverParameters.enableParseableModuleInterfaces {
+            settings["SWIFT_EMIT_MODULE_INTERFACE"] = "YES"
+        }
+
         // Generate the build parameters.
         var params = SwiftBuild.SWBBuildParameters()
         params.configurationName = buildParameters.configuration.swiftbuildName

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -38,7 +38,7 @@ class BuildCommandTestCases: CommandsBuildProviderTestCase {
     }
 
     @discardableResult
-    private func execute(
+    func execute(
         _ args: [String] = [],
         environment: Environment? = nil,
         packagePath: AbsolutePath? = nil
@@ -70,7 +70,19 @@ class BuildCommandTestCases: CommandsBuildProviderTestCase {
                 // is what `binContents` is meant to represent.
                 return contents != ["output-file-map.json"]
             }
-            let moduleContents = (try? localFileSystem.getDirectoryContents(binPath.appending(component: "Modules"))) ?? []
+            var moduleContents: [String] = []
+            if buildSystemProvider == .native { 
+                moduleContents = (try? localFileSystem.getDirectoryContents(binPath.appending(component: "Modules"))) ?? []
+            } else {
+                let moduleDirs = (try? localFileSystem.getDirectoryContents(binPath).filter {
+                    $0.hasSuffix(".swiftmodule")
+                }) ?? []
+                for dir: String in moduleDirs {
+                    moduleContents +=
+                        (try? localFileSystem.getDirectoryContents(binPath.appending(component: dir)).map { "\(dir)/\($0)" }) ?? []
+                }
+            }
+            
 
             if cleanAfterward {
                 try! await executeSwiftPackage(
@@ -101,6 +113,10 @@ class BuildCommandTestCases: CommandsBuildProviderTestCase {
     func testUsage() async throws {
         let stdout = try await execute(["-help"]).stdout
         XCTAssertMatch(stdout, .contains("USAGE: swift build"))
+    }
+
+    func testBinSymlink() async throws {
+        XCTAssertTrue(false, "Must be implemented at build system test class.")
     }
 
     func testSeeAlso() async throws {
@@ -187,48 +203,6 @@ class BuildCommandTestCases: CommandsBuildProviderTestCase {
                     "got stdout: \(String(describing: stdout)), stderr: \(String(describing: stderr))"
                 )
             }
-        }
-    }
-
-    func testBinSymlink() async throws {
-        try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
-            let fullPath = try resolveSymlinks(fixturePath)
-            let targetPath = try fullPath.appending(
-                components: ".build",
-                UserToolchain.default.targetTriple.platformBuildPathComponent
-            )
-            let xcbuildTargetPath = fullPath.appending(components: ".build", "apple")
-            try await XCTAssertAsyncEqual(
-                try await self.execute(["--show-bin-path"], packagePath: fullPath).stdout,
-                "\(targetPath.appending("debug").pathString)\n"
-            )
-            try await XCTAssertAsyncEqual(
-                try await self.execute(["-c", "release", "--show-bin-path"], packagePath: fullPath).stdout,
-                "\(targetPath.appending("release").pathString)\n"
-            )
-
-            guard buildSystemProvider == .xcode  || buildSystemProvider == .swiftbuild else {
-                // The remainder of this test only applies to XCBuild or Swift Build
-                return
-            }
-
-            // Print correct path when building with XCBuild or Swift Build
-            let xcodeDebugOutput = try await execute(
-                ["-c", "debug", "--show-bin-path"],
-                packagePath: fullPath)
-            .stdout
-            let xcodeReleaseOutput = try await execute(
-                ["-c", "release", "--show-bin-path"],
-                packagePath: fullPath
-            ).stdout
-            XCTAssertEqual(
-                xcodeDebugOutput,
-                "\(xcbuildTargetPath.appending(components: "Products", "Debug").pathString)\n"
-            )
-            XCTAssertEqual(
-                xcodeReleaseOutput,
-                "\(xcbuildTargetPath.appending(components: "Products", "Release").pathString)\n"
-            )
         }
     }
 
@@ -792,6 +766,25 @@ class BuildCommandNativeTests: BuildCommandTestCases {
     override func testUsage() async throws {
         try await super.testUsage()
     }
+
+    override func testBinSymlink() async throws {
+        try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
+            let fullPath = try resolveSymlinks(fixturePath)
+            let targetPath = try fullPath.appending(
+                components: ".build",
+                UserToolchain.default.targetTriple.platformBuildPathComponent
+            )
+            try await XCTAssertAsyncEqual(
+                try await self.execute(["--show-bin-path"], packagePath: fullPath).stdout,
+                "\(targetPath.appending("debug").pathString)\n"
+            )
+            try await XCTAssertAsyncEqual(
+                try await self.execute(["-c", "release", "--show-bin-path"], packagePath: fullPath)
+                    .stdout,
+                "\(targetPath.appending("release").pathString)\n"
+            )
+        }
+    }
 }
 
 #if os(macOS)
@@ -806,51 +799,51 @@ class BuildCommandXcodeTests: BuildCommandTestCases {
     }
 
     override func testAutomaticParseableInterfacesWithLibraryEvolution() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testNonReachableProductsAndTargetsFunctional() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testCodeCoverage() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testBuildStartMessage() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testBinSymlink() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testSymlink() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testSwiftGetVersion() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testParseableInterfaces() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testProductAndTarget() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testImportOfMissedDepWarning() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testGetTaskAllowEntitlement() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testBuildCompleteMessage() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 }
 #endif
@@ -866,9 +859,31 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
     }
 
     override func testParseableInterfaces() async throws {
-        throw XCTSkip("SWBINTTODO: Test failed with swiftbuild engine because the --enable-parseable-module-interfaces flag doesn't yet produce .swiftinterface files. This needs to be investigated")
+        try await fixture(name: "Miscellaneous/ParseableInterfaces") { fixturePath in
+            do {
+                let result = try await build(["--enable-parseable-module-interfaces"], packagePath: fixturePath)
+                XCTAssertMatch(result.moduleContents, [.regex(#"A\.swiftmodule\/.*\.swiftinterface"#)])
+                XCTAssertMatch(result.moduleContents, [.regex(#"B\.swiftmodule\/.*\.swiftmodule"#)])
+            } catch SwiftPMError.executionFailure(_, _, let stderr) {
+                XCTFail(stderr)
+            }
+        }
     }
 
+    override func testBinSymlink() async throws {
+        try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
+            let fullPath = try resolveSymlinks(fixturePath)
+            let targetPath = try fullPath.appending(
+                components: ".build",
+                UserToolchain.default.targetTriple.platformBuildPathComponent
+            )
+            let debugPath = try await self.execute(["--show-bin-path"], packagePath: fullPath).stdout
+            XCTAssertMatch(debugPath, .regex(targetPath.appending(components: "Products", "Debug").pathString + "(\\-linux|\\-Windows)?\\n"))
+            let releasePath = try await self.execute(["-c", "release", "--show-bin-path"], packagePath: fullPath).stdout
+            XCTAssertMatch(releasePath, .regex(targetPath.appending(components: "Products", "Release").pathString + "(\\-linux|\\-Windows)?\\n"))
+        }
+    }
+    
     override func testGetTaskAllowEntitlement() async throws {
         throw XCTSkip("SWBINTTODO: Test failed because swiftbuild doesn't output precis codesign commands. Once swift run works with swiftbuild the test can be investigated.")
     }
@@ -880,13 +895,20 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
     override func testAtMainSupport() async throws {
         #if !os(macOS)
         throw XCTSkip("SWBINTTODO: File not found or missing libclang errors on non-macOS platforms. This needs to be investigated")
-        #endif
-
+        #else
         try await super.testAtMainSupport()
+        #endif
     }
 
     override func testAutomaticParseableInterfacesWithLibraryEvolution() async throws {
-        throw XCTSkip("SWBINTTODO: The test fails because when the unsafe flag for a target is set to '-enable-library-evolution' it is not producing the correct .swiftinterface files. This needs to be investigated")
+        try await fixture(name: "Miscellaneous/LibraryEvolution") { fixturePath in
+            do {
+                let result = try await build([], packagePath: fixturePath)
+                XCTAssertMatch(
+                    result.moduleContents, [.regex(#"A\.swiftmodule\/.*\.swiftinterface"#)])
+                XCTAssertMatch(result.moduleContents, [.regex(#"B\.swiftmodule\/.*\.swiftmodule"#)])
+            }
+        }
     }
 
     override func testImportOfMissedDepWarning() async throws {
@@ -899,10 +921,6 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
 
     override func testSwiftGetVersion() async throws {
         throw XCTSkip("SWBINTTODO: Test fails because the dummy-swiftc used in the test isn't accepted by swift-build. This needs to be investigated")
-    }
-
-    override func testBinSymlink() async throws {
-        throw XCTSkip("SWBINTTODO: Test fails because of a difference in the build layout. This needs to be updated to the expected path")
     }
 
     override func testSymlink() async throws {
@@ -927,7 +945,7 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
 
     override func testBuildSystemDefaultSettings() async throws {
         #if os(Linux)
-        if FileManager.default.contents(atPath: "/etc/system-release").map { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ?? false {
+        if FileManager.default.contents(atPath: "/etc/system-release").map( { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ) ?? false {
             throw XCTSkip("Skipping SwiftBuild testing on Amazon Linux because of platform issues.")
         }
         #endif
@@ -941,9 +959,10 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
 
     override func testBuildCompleteMessage() async throws {
         #if os(Linux)
-        try XCTSkip("SWBINTTODO: Need to properly set LD_LIBRARY_PATH on linux")
-        #endif
+        throw XCTSkip("SWBINTTODO: Need to properly set LD_LIBRARY_PATH on linux")
+        #else
         try await super.testBuildCompleteMessage()
+        #endif
     }
 
 }


### PR DESCRIPTION
- this also fixes -enable-library-evolution when used as a unsafeFlags

Closes: #8337

### Modifications:

sets SWIFT_EMIT_MODULE_INTERFACE build setting when option is set

### Result:

the build option will include the .swftinertface files in the module folder