### PR TITLE
Fixup deprecation warning in PluginContext.Tool initializer

### DIFF
--- a/Sources/PackagePlugin/Context.swift
+++ b/Sources/PackagePlugin/Context.swift
@@ -102,16 +102,20 @@ public struct PluginContext {
 
         /// Full path of the built or provided tool in the file system.
         @available(_PackageDescription, deprecated: 6.0, renamed: "url")
-        public let path: Path
+        public var path: Path {
+            get { _path }
+        }
 
         /// Full path of the built or provided tool in the file system.
         @available(_PackageDescription, introduced: 6.0)
         public let url: URL
 
+        private let _path: Path
+
         @_spi(PackagePluginInternal) public init(name: String, path: Path, url: URL) {
             self.name = name
-            self.path = path
             self.url = url
+            self._path = path
         }
     }
 }


### PR DESCRIPTION
Setting `path` directly in the initializer of PluginContext.Tool triggers a deprecation warning, because `path` is marked as deprecated. Set a private field, and have the deprecated public field use a getter to access it. This resolves the warning.