### PR TITLE
Fix typo, refine wording in `Usage.md`

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -226,8 +226,8 @@ The header file should look like this:
 #include <git2.h>
 ```
 
-**Note:** Avoiding specifying an absolute path to `git2.h` provided
-by the library in the `module.modulemap`. Doing so will break compatibility of 
+**Note:** Avoid specifying an absolute path  in the `module.modulemap` to `git2.h`
+header provided by the library. Doing so will break compatibility of 
 your project between machines that may use a different file system layout or
 install libraries to different paths.
 


### PR DESCRIPTION
`Avoiding specifying` -> `Avoid specifying`

Also reordered words in this somewhat convoluted sentence. "provided by the library in the `module.modulemap`" could've been read as if the library provides something in such modulemap file. But in fact, "in the `module.modulemap`" is related to the first part of the sentence. Moving it there makes the sentence less ambiguous.
