### PR TITLE
Test: disable a SwiftBuild test on linux

### DIFF
--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -938,4 +938,12 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
 
         try await super.testBuildSystemDefaultSettings()
     }
+
+    override func testBuildCompleteMessage() async throws {
+        #if os(Linux)
+        try XCTSkip("SWBINTTODO: Need to properly set LD_LIBRARY_PATH on linux")
+        #endif
+        try await super.testBuildCompleteMessage()
+    }
+
 }


### PR DESCRIPTION
We have to ensure LD_LIBRARY_PATH is set correctly on linux, until then, skip a test