### PR TITLE
Android: remove build flags that are no longer needed and force unwrap dlerror()

### DIFF
--- a/Sources/PackagePlugin/Plugin.swift
+++ b/Sources/PackagePlugin/Plugin.swift
@@ -595,7 +595,7 @@ fileprivate enum Library: Sendable {
         return LibraryHandle(rawValue: handle)
         #else
         guard let handle = dlopen(nil, RTLD_NOW | RTLD_LOCAL) else {
-            throw LibraryOpenError(message: String(cString: dlerror()))
+            throw LibraryOpenError(message: String(cString: dlerror()!))
         }
         return LibraryHandle(rawValue: handle)
         #endif

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -934,10 +934,6 @@ def get_swiftpm_flags(args):
         build_flags.extend(["-Xcc", "-I/usr/local/include"])
         build_flags.extend(["-Xlinker", "-L/usr/local/lib"])
 
-    # Don't use GNU strerror_r on Android.
-    if '-android' in args.build_target:
-        build_flags.extend(["-Xswiftc", "-Xcc", "-Xswiftc", "-U_GNU_SOURCE"])
-
     cross_compile_hosts = args.cross_compile_hosts
     if cross_compile_hosts:
         if '-apple-macosx' in args.build_target and cross_compile_hosts.startswith('macosx-'):


### PR DESCRIPTION
Removing the definition of `_GNU_SOURCE` is no longer needed since swiftlang/swift-tools-support-core#500 made sure the right `strerror_r()` is used, and `dlerror()` has to be unwrapped because of its `_Nullable` annotation.