### PR TITLE
Adopt SwiftBuild.ProjectModel API in the new PIF builder in SwiftBuildSupport

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -1641,9 +1641,9 @@ private struct PIFBuildSettingAssignment {
     let platforms: [PIF.BuildSettings.Platform]?
 }
 
-extension BuildSettings.AssignmentTable {
-    fileprivate var pifAssignments: [PIF.BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] {
-        var pifAssignments: [PIF.BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] = [:]
+extension PackageModel.BuildSettings.AssignmentTable {
+    fileprivate var pifAssignments: [BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] {
+        var pifAssignments: [BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] = [:]
 
         for (declaration, assignments) in self.assignments {
             for assignment in assignments {
@@ -1679,7 +1679,7 @@ extension BuildSettings.AssignmentTable {
     }
 }
 
-extension BuildSettings.Assignment {
+extension PackageModel.BuildSettings.Assignment {
     fileprivate var configurations: [BuildConfiguration] {
         if let configurationCondition = conditions.lazy.compactMap(\.configurationCondition).first {
             [configurationCondition.configuration]

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -1642,8 +1642,8 @@ private struct PIFBuildSettingAssignment {
 }
 
 extension PackageModel.BuildSettings.AssignmentTable {
-    fileprivate var pifAssignments: [BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] {
-        var pifAssignments: [BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] = [:]
+    fileprivate var pifAssignments: [PIF.BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] {
+        var pifAssignments: [PIF.BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] = [:]
 
         for (declaration, assignments) in self.assignments {
             for assignment in assignments {
@@ -1866,7 +1866,7 @@ extension PIF.BuildSettings {
                 .filter { isSupportedVersion($0) }.map(\.description)
         }
 
-        func computeEffectiveTargetVersion(for assignment: BuildSettings.Assignment) throws -> String {
+        func computeEffectiveTargetVersion(for assignment: PackageModel.BuildSettings.Assignment) throws -> String {
             let versions = assignment.values.compactMap { SwiftLanguageVersion(string: $0) }
             if let effectiveVersion = computeEffectiveSwiftVersions(for: versions).last {
                 return effectiveVersion

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -55,7 +55,6 @@ import struct PackageGraph.ResolvedProduct
 
 import func PackageLoading.pkgConfigArgs
 
-#if canImport(SwiftBuild)
 import enum SwiftBuild.PIF
 
 // MARK: - PIF GUID Helpers
@@ -1107,5 +1106,3 @@ extension UserDefaults {
         }
     }
 }
-
-#endif

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -55,7 +55,7 @@ import struct PackageGraph.ResolvedProduct
 
 import func PackageLoading.pkgConfigArgs
 
-import enum SwiftBuild.PIF
+import enum SWBProjectModel.PIF
 
 // MARK: - PIF GUID Helpers
 
@@ -139,8 +139,8 @@ extension PackageModel.Package {
         self.manifest.displayName
     }
 
-    var packageBaseBuildSettings: SwiftBuild.PIF.BuildSettings {
-        var settings = SwiftBuild.PIF.BuildSettings()
+    var packageBaseBuildSettings: SWBProjectModel.PIF.BuildSettings {
+        var settings = SWBProjectModel.PIF.BuildSettings()
         settings.SDKROOT = "auto"
         settings.SDK_VARIANT = "auto"
 
@@ -203,14 +203,14 @@ extension PackageModel.Platform {
 }
 
 extension Sequence<PackageModel.PackageCondition> {
-    func toPlatformFilter(toolsVersion: ToolsVersion) -> Set<SwiftBuild.PIF.PlatformFilter> {
-        let pifPlatforms = self.flatMap { packageCondition -> [SwiftBuild.PIF.BuildSettings.Platform] in
+    func toPlatformFilter(toolsVersion: ToolsVersion) -> Set<SWBProjectModel.PIF.PlatformFilter> {
+        let pifPlatforms = self.flatMap { packageCondition -> [SWBProjectModel.PIF.BuildSettings.Platform] in
             guard let platforms = packageCondition.platformsCondition?.platforms else {
                 return []
             }
 
-            var pifPlatformsForCondition: [SwiftBuild.PIF.BuildSettings.Platform] = platforms
-                .map { SwiftBuild.PIF.BuildSettings.Platform(from: $0) }
+            var pifPlatformsForCondition: [SWBProjectModel.PIF.BuildSettings.Platform] = platforms
+                .map { SWBProjectModel.PIF.BuildSettings.Platform(from: $0) }
 
             // Treat catalyst like macOS for backwards compatibility with older tools versions.
             if pifPlatformsForCondition.contains(.macOS), toolsVersion < ToolsVersion.v5_5 {
@@ -313,7 +313,7 @@ extension PackageGraph.ResolvedPackage {
 }
 
 extension PackageGraph.ResolvedPackage {
-    public var packageBaseBuildSettings: SwiftBuild.PIF.BuildSettings {
+    public var packageBaseBuildSettings: SWBProjectModel.PIF.BuildSettings {
         self.underlying.packageBaseBuildSettings
     }
 }
@@ -793,12 +793,12 @@ extension TSCUtility.Version {
 // MARK: - Swift Build PIF Helpers
 
 /// Helpers for building custom PIF targets by `PIFPackageBuilder` clients.
-extension SwiftBuild.PIF.Project {
+extension SWBProjectModel.PIF.Project {
     @discardableResult
     public func addTarget(
         packageProductName: String,
-        productType: SwiftBuild.PIF.Target.ProductType
-    ) throws -> SwiftBuild.PIF.Target {
+        productType: SWBProjectModel.PIF.Target.ProductType
+    ) throws -> SWBProjectModel.PIF.Target {
         let pifTarget = try self.addTargetThrowing(
             id: PIFPackageBuilder.targetGUID(forProductName: packageProductName),
             productType: productType,
@@ -811,8 +811,8 @@ extension SwiftBuild.PIF.Project {
     @discardableResult
     public func addTarget(
         packageModuleName: String,
-        productType: SwiftBuild.PIF.Target.ProductType
-    ) throws -> SwiftBuild.PIF.Target {
+        productType: SWBProjectModel.PIF.Target.ProductType
+    ) throws -> SWBProjectModel.PIF.Target {
         let pifTarget = try self.addTargetThrowing(
             id: PIFPackageBuilder.targetGUID(forModuleName: packageModuleName),
             productType: productType,
@@ -823,7 +823,7 @@ extension SwiftBuild.PIF.Project {
     }
 }
 
-extension SwiftBuild.PIF.BuildSettings {
+extension SWBProjectModel.PIF.BuildSettings {
     /// Internal helper function that appends list of string values to a declaration.
     /// If a platform is specified, then the values are appended to the `platformSpecificSettings`,
     /// otherwise they are appended to the platform-neutral settings.
@@ -895,7 +895,7 @@ extension SwiftBuild.PIF.BuildSettings {
     }
 }
 
-extension SwiftBuild.PIF.BuildSettings.Platform {
+extension SWBProjectModel.PIF.BuildSettings.Platform {
     init(from platform: PackageModel.Platform) {
         self = switch platform {
         case .macOS: .macOS
@@ -915,7 +915,7 @@ extension SwiftBuild.PIF.BuildSettings.Platform {
     }
 }
 
-extension SwiftBuild.PIF.BuildSettings {
+extension SWBProjectModel.PIF.BuildSettings {
     /// Configure necessary settings for a dynamic library/framework.
     mutating func configureDynamicSettings(
         productName: String,
@@ -959,7 +959,7 @@ extension SwiftBuild.PIF.BuildSettings {
     }
 }
 
-extension SwiftBuild.PIF.BuildSettings.Declaration {
+extension SWBProjectModel.PIF.BuildSettings.Declaration {
     init(from declaration: PackageModel.BuildSettings.Declaration) {
         self = switch declaration {
         // Swift.

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -55,6 +55,8 @@ import struct PackageGraph.ResolvedProduct
 
 import func PackageLoading.pkgConfigArgs
 
+#if canImport(SwiftBuild)
+
 import enum SwiftBuild.ProjectModel
 
 // MARK: - PIF GUID Helpers
@@ -1127,3 +1129,5 @@ extension UserDefaults {
         }
     }
 }
+
+#endif

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -500,7 +500,8 @@ extension PackageGraph.ResolvedModule {
     }
 
     struct AllBuildSettings {
-        typealias BuildSettingsByPlatform = [ProjectModel.BuildSettings.Platform?: [BuildSettings.Declaration: [String]]]
+        typealias BuildSettingsByPlatform =
+            [ProjectModel.BuildSettings.Platform?: [BuildSettings.Declaration: [String]]]
 
         /// Target-specific build settings declared in the manifest and that apply to the target itself.
         var targetSettings: [BuildConfiguration: BuildSettingsByPlatform] = [:]
@@ -543,7 +544,7 @@ extension PackageGraph.ResolvedModule {
 
                 for platform in platforms {
                     let pifPlatform = platform.map { ProjectModel.BuildSettings.Platform(from: $0) }
-                    
+
                     if pifDeclaration == .OTHER_LDFLAGS {
                         var settingsByDeclaration: [ProjectModel.BuildSettings.Declaration: [String]]
 
@@ -556,7 +557,7 @@ extension PackageGraph.ResolvedModule {
                     for configuration in configurations {
                         var settingsByDeclaration: [ProjectModel.BuildSettings.Declaration: [String]]
                         settingsByDeclaration = allSettings.targetSettings[configuration]?[pifPlatform] ?? [:]
-                        
+
                         if declaration.allowsMultipleValues {
                             settingsByDeclaration[pifDeclaration, default: []].append(contentsOf: values)
                         } else {
@@ -848,7 +849,7 @@ extension ProjectModel.BuildSettings {
     /// values, i.e. those in `ProjectModel.BuildSettings.Declaration`. If a platform is specified,
     /// it must be one of the known platforms in `ProjectModel.BuildSettings.Platform`.
     mutating func append(values: [String], to setting: Declaration, platform: Platform? = nil) {
-        // This dichotomy is quite unfortunate but that's currently the underlying model in `ProjectModel.BuildSettings`.
+        // This dichotomy is quite unfortunate but that's currently the underlying model in ProjectModel.BuildSettings.
         if let platform {
             switch setting {
             case .FRAMEWORK_SEARCH_PATHS,
@@ -861,10 +862,10 @@ extension ProjectModel.BuildSettings {
                  .SWIFT_ACTIVE_COMPILATION_CONDITIONS:
                 // Appending implies the setting is resilient to having ["$(inherited)"]
                 self.platformSpecificSettings[platform]![setting]!.append(contentsOf: values)
-            
+
             case .SWIFT_VERSION:
                 self.platformSpecificSettings[platform]![setting] = values // We are not resilient to $(inherited).
-            
+
             case .ARCHS, .IPHONEOS_DEPLOYMENT_TARGET, .SPECIALIZATION_SDK_OPTIONS:
                 fatalError("Unexpected BuildSettings.Declaration: \(setting)")
             }
@@ -883,7 +884,7 @@ extension ProjectModel.BuildSettings {
 
             case .SWIFT_VERSION:
                 self[.SWIFT_VERSION] = values.only.unwrap(orAssert: "Invalid values for 'SWIFT_VERSION': \(values)")
-                
+
             case .ARCHS, .IPHONEOS_DEPLOYMENT_TARGET, .SPECIALIZATION_SDK_OPTIONS:
                 fatalError("Unexpected BuildSettings.Declaration: \(setting)")
             }

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Plugins.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Plugins.swift
@@ -17,7 +17,7 @@ import let Basics.localFileSystem
 import enum Basics.Sandbox
 import struct Basics.SourceControlURL
 
-import enum SwiftBuild.PIF
+import enum SWBProjectModel.PIF
 
 extension PIFPackageBuilder {
     /// Contains all of the information resulting from applying a build tool plugin to a package target thats affect how

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Plugins.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Plugins.swift
@@ -17,7 +17,7 @@ import let Basics.localFileSystem
 import enum Basics.Sandbox
 import struct Basics.SourceControlURL
 
-import enum SWBProjectModel.PIF
+import enum SwiftBuild.ProjectModel
 
 extension PIFPackageBuilder {
     /// Contains all of the information resulting from applying a build tool plugin to a package target thats affect how

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Plugins.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Plugins.swift
@@ -17,7 +17,6 @@ import let Basics.localFileSystem
 import enum Basics.Sandbox
 import struct Basics.SourceControlURL
 
-#if canImport(SwiftBuild)
 import enum SwiftBuild.PIF
 
 extension PIFPackageBuilder {
@@ -133,5 +132,3 @@ extension PIFPackageBuilder {
         }
     }
 }
-
-#endif

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Plugins.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Plugins.swift
@@ -19,7 +19,7 @@ import struct Basics.SourceControlURL
 
 import enum SwiftBuild.ProjectModel
 
-extension PIFPackageBuilder {
+extension PackagePIFBuilder {
     /// Contains all of the information resulting from applying a build tool plugin to a package target thats affect how
     /// a target is built.
     ///

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Plugins.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Plugins.swift
@@ -17,6 +17,8 @@ import let Basics.localFileSystem
 import enum Basics.Sandbox
 import struct Basics.SourceControlURL
 
+#if canImport(SwiftBuild)
+
 import enum SwiftBuild.ProjectModel
 
 extension PackagePIFBuilder {
@@ -132,3 +134,5 @@ extension PackagePIFBuilder {
         }
     }
 }
+
+#endif

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -30,7 +30,6 @@ import struct PackageGraph.ModulesGraph
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
 
-#if canImport(SwiftBuild)
 import enum SwiftBuild.PIF
 
 /// A builder for generating the PIF object from a package.
@@ -669,5 +668,3 @@ public struct SourceLocation: Sendable {
         self.line = line
     }
 }
-
-#endif

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -33,8 +33,9 @@ import struct PackageGraph.ResolvedPackage
 import enum SwiftBuild.ProjectModel
 
 typealias GUID = SwiftBuild.ProjectModel.GUID
-typealias BuildConfig = SwiftBuild.ProjectModel.BuildConfig
 typealias BuildFile = SwiftBuild.ProjectModel.BuildFile
+typealias BuildConfig = SwiftBuild.ProjectModel.BuildConfig
+typealias BuildSettings = SwiftBuild.ProjectModel.BuildSettings
 
 /// A builder for generating the PIF object from a package.
 public final class PIFPackageBuilder {

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -47,12 +47,12 @@ public final class PackagePIFBuilder {
     let packageManifest: PackageModel.Manifest // FIXME: Can't we just use `package.manifest` instead? —— Paulo
 
     /// The built PIF project object.
-    public var pifProject: SwiftBuild.ProjectModel.Project {
+    public var pifProject: ProjectModel.Project {
         assert(self._pifProject != nil, "Call build() method to build the PIF first")
         return self._pifProject!
     }
 
-    private var _pifProject: SwiftBuild.ProjectModel.Project?
+    private var _pifProject: ProjectModel.Project?
 
     /// Scope for logging informational debug messages (intended for developers, not end users).
     let observabilityScope: ObservabilityScope
@@ -91,7 +91,7 @@ public final class PackagePIFBuilder {
 
         /// For executables — only executables for now — we check to see if there is a custom package product type
         /// provider that can provide this information.
-        func customProductType(forExecutable product: PackageModel.Product) -> SwiftBuild.ProjectModel.Target.ProductType?
+        func customProductType(forExecutable product: PackageModel.Product) -> ProjectModel.Target.ProductType?
 
         /// Returns all *device family* IDs for all SDK variants.
         func deviceFamilyIDs() -> Set<Int>
@@ -103,12 +103,12 @@ public final class PackagePIFBuilder {
         var isPluginExecutionSandboxingDisabled: Bool { get }
 
         /// Hook to customize the project-wide build settings.
-        func configureProjectBuildSettings(_ buildSettings: inout SwiftBuild.ProjectModel.BuildSettings)
+        func configureProjectBuildSettings(_ buildSettings: inout ProjectModel.BuildSettings)
 
         /// Hook to customize source module build settings.
         func configureSourceModuleBuildSettings(
             sourceModule: PackageGraph.ResolvedModule,
-            settings: inout SwiftBuild.ProjectModel.BuildSettings
+            settings: inout ProjectModel.BuildSettings
         )
 
         /// Custom install path for the specified product, if any.
@@ -124,13 +124,13 @@ public final class PackagePIFBuilder {
         func customSDKOptions(forPlatform: PackageModel.Platform) -> [String]
 
         /// Create additional custom PIF targets after all targets have been built.
-        func addCustomTargets(pifProject: SwiftBuild.ProjectModel.Project) throws -> [PackagePIFBuilder.ModuleOrProduct]
+        func addCustomTargets(pifProject: ProjectModel.Project) throws -> [PackagePIFBuilder.ModuleOrProduct]
 
         /// Should we suppresses the specific product dependency, updating the provided build settings if necessary?
         /// The specified product may be in the same package or a different one.
         func shouldSuppressProductDependency(
             product: PackageModel.Product,
-            buildSettings: inout SwiftBuild.ProjectModel.BuildSettings
+            buildSettings: inout ProjectModel.BuildSettings
         ) -> Bool
 
         /// Should we set the install path for a dynamic library/framework?
@@ -212,7 +212,7 @@ public final class PackagePIFBuilder {
 
     /// Build an empty PIF project for the specified `Package`.
 
-    public class func buildEmptyPIF(package: PackageModel.Package) -> SwiftBuild.ProjectModel.Project {
+    public class func buildEmptyPIF(package: PackageModel.Package) -> ProjectModel.Project {
         self.buildEmptyPIF(
             id: "PACKAGE:\(package.identity)",
             path: package.manifest.path.pathString,
@@ -229,7 +229,7 @@ public final class PackagePIFBuilder {
         projectDir: String,
         name: String,
         developmentRegion: String? = nil
-    ) -> SwiftBuild.ProjectModel.Project {
+    ) -> ProjectModel.Project {
         var project = ProjectModel.Project(
             id: GUID(id),
             path: path,
@@ -246,7 +246,7 @@ public final class PackagePIFBuilder {
     }
     
     public func buildPlaceholderPIF(id: String, path: String, projectDir: String, name: String) -> ModuleOrProduct {
-        var project = SwiftBuild.ProjectModel.Project(
+        var project = ProjectModel.Project(
             id: GUID(id),
             path: path,
             projectDir: projectDir,
@@ -261,7 +261,7 @@ public final class PackagePIFBuilder {
         let targetKP = try! project.addAggregateTarget { _ in
             ProjectModel.AggregateTarget(id: "PACKAGE-PLACEHOLDER:\(id)", name: id)
         }
-        let targetSettings: SwiftBuild.ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
+        let targetSettings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
 
         project[keyPath: targetKP].common.addBuildConfig { id in
             ProjectModel.BuildConfig(id: id, name: "Debug", settings: targetSettings)
@@ -350,7 +350,7 @@ public final class PackagePIFBuilder {
 
         public var description: String { rawValue }
 
-        init(from pifProductType: SwiftBuild.ProjectModel.Target.ProductType) {
+        init(from pifProductType: ProjectModel.Target.ProductType) {
             self = switch pifProductType {
             case .application: .application
             case .staticArchive: .staticArchive
@@ -525,7 +525,7 @@ public final class PackagePIFBuilder {
         self.delegate.configureProjectBuildSettings(&settings)
 
         for (platform, platformOptions) in self.package.sdkOptions(delegate: self.delegate) {
-            let pifPlatform = SwiftBuild.ProjectModel.BuildSettings.Platform(from: platform)
+            let pifPlatform = ProjectModel.BuildSettings.Platform(from: platform)
             settings.platformSpecificSettings[pifPlatform]![.SPECIALIZATION_SDK_OPTIONS]!
                 .append(contentsOf: platformOptions)
         }

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -139,7 +139,7 @@ public final class PackagePIFBuilder {
         func shouldSetInstallPathForDynamicLib(productName: String) -> Bool
 
         // FIXME: Let's try to replace `WritableKeyPath><_, Foo>` with `inout Foo` —— Paulo
-        
+
         /// Provides additional configuration and files for the specified library product.
         func configureLibraryProduct(
             product: PackageModel.Product,
@@ -246,7 +246,7 @@ public final class PackagePIFBuilder {
 
         return project
     }
-    
+
     public func buildPlaceholderPIF(id: String, path: String, projectDir: String, name: String) -> ModuleOrProduct {
         var project = ProjectModel.Project(
             id: GUID(id),
@@ -254,12 +254,12 @@ public final class PackagePIFBuilder {
             projectDir: projectDir,
             name: name
         )
-        
+
         let projectSettings = ProjectModel.BuildSettings()
 
         project.addBuildConfig { id in ProjectModel.BuildConfig(id: id, name: "Debug", settings: projectSettings) }
         project.addBuildConfig { id in ProjectModel.BuildConfig(id: id, name: "Release", settings: projectSettings) }
-        
+
         let targetKeyPath = try! project.addAggregateTarget { _ in
             ProjectModel.AggregateTarget(id: "PACKAGE-PLACEHOLDER:\(id)", name: id)
         }

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -258,15 +258,15 @@ public final class PackagePIFBuilder {
         project.addBuildConfig { id in ProjectModel.BuildConfig(id: id, name: "Debug", settings: projectSettings) }
         project.addBuildConfig { id in ProjectModel.BuildConfig(id: id, name: "Release", settings: projectSettings) }
         
-        let targetKP = try! project.addAggregateTarget { _ in
+        let targetKeyPath = try! project.addAggregateTarget { _ in
             ProjectModel.AggregateTarget(id: "PACKAGE-PLACEHOLDER:\(id)", name: id)
         }
         let targetSettings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
 
-        project[keyPath: targetKP].common.addBuildConfig { id in
+        project[keyPath: targetKeyPath].common.addBuildConfig { id in
             ProjectModel.BuildConfig(id: id, name: "Debug", settings: targetSettings)
         }
-        project[keyPath: targetKP].common.addBuildConfig { id in
+        project[keyPath: targetKeyPath].common.addBuildConfig { id in
             ProjectModel.BuildConfig(id: id, name: "Release", settings: targetSettings)
         }
 
@@ -276,7 +276,7 @@ public final class PackagePIFBuilder {
             type: .placeholder,
             name: name,
             moduleName: name,
-            pifTarget: .aggregate(project[keyPath: targetKP]),
+            pifTarget: .aggregate(project[keyPath: targetKeyPath]),
             indexableFileURLs: [],
             headerFiles: [],
             linkedPackageBinaries: [],

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -371,7 +371,7 @@ public final class PackagePIFBuilder {
     /// Build the PIF.
     @discardableResult
     public func build() throws -> [ModuleOrProduct] {
-        self.log(.info, "building PIF for package \(self.package.identity)")
+        self.log(.info, "Building PIF for package \(self.package.identity)")
 
         var builder = PackagePIFProjectBuilder(createForPackage: package, builder: self)
         self.addProjectBuildSettings(&builder)

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -30,6 +30,8 @@ import struct PackageGraph.ModulesGraph
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
 
+#if canImport(SwiftBuild)
+
 import enum SwiftBuild.ProjectModel
 
 typealias GUID = SwiftBuild.ProjectModel.GUID
@@ -683,3 +685,5 @@ public struct SourceLocation: Sendable {
         self.line = line
     }
 }
+
+#endif

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -25,7 +25,6 @@ import class PackageModel.SystemLibraryModule
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
 
-#if canImport(SwiftBuild)
 import enum SwiftBuild.PIF
 
 /// Extension to create PIF **modules** for a given package.
@@ -815,4 +814,3 @@ extension PackagePIFProjectBuilder {
         self.builtModulesAndProducts.append(systemModule)
     }
 }
-#endif

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -25,25 +25,31 @@ import class PackageModel.SystemLibraryModule
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
 
-import enum SWBProjectModel.PIF
+import enum SwiftBuild.ProjectModel
 
 /// Extension to create PIF **modules** for a given package.
 extension PackagePIFProjectBuilder {
+    
     // MARK: - Plugin Modules
 
     mutating func makePluginModule(_ pluginModule: PackageGraph.ResolvedModule) throws {
         precondition(pluginModule.type == .plugin)
 
         // Create an executable PIF target in order to get specialization.
-        let pluginPifTarget = try self.pif.addTargetThrowing(
-            id: pluginModule.pifTargetGUID(),
-            productType: .executable,
-            name: pluginModule.name,
-            productName: pluginModule.name
-        )
-        log(.debug, "created \(type(of: pluginPifTarget)) '\(pluginPifTarget.id)' with name '\(pluginPifTarget.name)'")
+        let pluginPifTargetKP = try self.pif.addTarget { _ in
+            ProjectModel.Target(
+                id: pluginModule.pifTargetGUID(),
+                productType: .executable,
+                name: pluginModule.name,
+                productName: pluginModule.name
+            )
+        }
+        do {
+            let pluginPifTarget = self.pif[keyPath: pluginPifTargetKP]
+            log(.debug, "Created \(pluginPifTarget.productType) '\(pluginPifTarget.id)' with name '\(pluginPifTarget.name)'")
+        }
 
-        var buildSettings: SWBProjectModel.PIF.BuildSettings = self.package.underlying.packageBaseBuildSettings
+        var buildSettings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
 
         // Add the dependencies.
         pluginModule.recursivelyTraverseDependencies { dependency in
@@ -65,25 +71,25 @@ extension PackagePIFProjectBuilder {
                         .productRepresentingDependencyOfBuildPlugin(in: moduleProducts)
 
                     if let productDependency {
-                        pluginPifTarget.addDependency(
+                        self.pif[keyPath: pluginPifTargetKP].common.addDependency(
                             on: productDependency.pifTargetGUID(),
                             platformFilters: dependencyPlatformFilters
                         )
-                        log(.debug, ".. added dependency on product '\(productDependency.pifTargetGUID())'")
+                        log(.debug, "  Added dependency on product '\(productDependency.pifTargetGUID())'")
                     } else {
                         log(
                             .debug,
-                            ".. could not find a build plugin product to depend on for target '\(moduleDependency.pifTargetGUID())'"
+                            "  Could not find a build plugin product to depend on for target '\(moduleDependency.pifTargetGUID())'"
                         )
                     }
 
                 case .library, .systemModule, .test, .binary, .plugin, .macro:
                     let dependencyGUID = moduleDependency.pifTargetGUID()
-                    pluginPifTarget.addDependency(
+                    self.pif[keyPath: pluginPifTargetKP].common.addDependency(
                         on: dependencyGUID,
                         platformFilters: dependencyPlatformFilters
                     )
-                    log(.debug, ".. added dependency on target '\(dependencyGUID)'")
+                    log(.debug, "  Added dependency on target '\(dependencyGUID)'")
                 }
 
             case .product(let productDependency, let packageConditions):
@@ -100,26 +106,30 @@ extension PackagePIFProjectBuilder {
                     let dependencyPlatformFilters = packageConditions
                         .toPlatformFilter(toolsVersion: self.package.manifest.toolsVersion)
 
-                    pluginPifTarget.addDependency(
+                    self.pif[keyPath: pluginPifTargetKP].common.addDependency(
                         on: dependencyGUID,
                         platformFilters: dependencyPlatformFilters
                     )
-                    log(.debug, ".. added dependency on product '\(dependencyGUID)'")
+                    log(.debug, "  Added dependency on product '\(dependencyGUID)'")
                 }
             }
         }
 
         // Any dependencies of plugin targets need to be built for the host.
-        buildSettings.SUPPORTED_PLATFORMS = ["$(HOST_PLATFORM)"]
+        buildSettings[.SUPPORTED_PLATFORMS] = ["$(HOST_PLATFORM)"]
 
-        pluginPifTarget.addBuildConfig(name: "Debug", settings: buildSettings)
-        pluginPifTarget.addBuildConfig(name: "Release", settings: buildSettings)
+        self.pif[keyPath: pluginPifTargetKP].common.addBuildConfig { id in
+            BuildConfig(id: id, name: "Debug", settings: buildSettings)
+        }
+        self.pif[keyPath: pluginPifTargetKP].common.addBuildConfig { id in
+            BuildConfig(id: id, name: "Release", settings: buildSettings)
+        }
 
         let pluginModuleMetadata = PIFPackageBuilder.ModuleOrProduct(
             type: .plugin,
             name: pluginModule.name,
             moduleName: pluginModule.name,
-            pifTarget: pluginPifTarget,
+            pifTarget: .target(self.pif[keyPath: pluginPifTargetKP]),
             indexableFileURLs: [],
             headerFiles: [],
             linkedPackageBinaries: [],
@@ -166,11 +176,12 @@ extension PackagePIFProjectBuilder {
             )
             dynamicLibraryVariant.isDynamicLibraryVariant = true
             self.builtModulesAndProducts.append(dynamicLibraryVariant)
+            
+            // if case let .target(shows) = state, shows.isEmpty {
 
-            let pifTarget = staticLibrary.pifTarget as? SWBProjectModel.PIF.Target
-            let dynamicPifTarget = dynamicLibraryVariant.pifTarget as? SWBProjectModel.PIF.Target
-
-            guard let pifTarget, let dynamicPifTarget else {
+            guard let pifTarget = staticLibrary.pifTarget,
+                  let dynamicPifTarget = dynamicLibraryVariant.pifTarget
+            else {
                 fatalError("Could not assign dynamic PIF target")
             }
             pifTarget.dynamicTargetVariant = dynamicPifTarget
@@ -224,7 +235,7 @@ extension PackagePIFProjectBuilder {
 
         let pifTargetName: String
         let executableName: String
-        let productType: SWBProjectModel.PIF.Target.ProductType
+        let productType: SwiftBuild.ProjectModel.Target.ProductType
 
         switch desiredModuleType {
         case .dynamicLibrary:
@@ -321,10 +332,10 @@ extension PackagePIFProjectBuilder {
         }
 
         // Create a set of build settings that will be imparted to any target that depends on this one.
-        var impartedSettings = SWBProjectModel.PIF.BuildSettings()
+        var impartedSettings = SwiftBuild.ProjectModel.BuildSettings()
 
         // Configure the target-wide build settings. The details depend on the kind of product we're building.
-        var settings: SWBProjectModel.PIF.BuildSettings = self.package.underlying.packageBaseBuildSettings
+        var settings: SwiftBuild.ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
 
         if shouldGenerateBundleAccessor {
             settings.GENERATE_RESOURCE_ACCESSORS = "YES"
@@ -683,10 +694,10 @@ extension PackagePIFProjectBuilder {
         for (buildConfig, declarationsByPlatform) in allBuildSettings.targetSettings {
             for (platform, settingsByDeclaration) in declarationsByPlatform {
                 // A `nil` platform means that the declaration applies to *all* platforms.
-                let pifPlatform = platform.map { SWBProjectModel.PIF.BuildSettings.Platform(from: $0) }
+                let pifPlatform = platform.map { SwiftBuild.ProjectModel.BuildSettings.Platform(from: $0) }
 
                 for (declaration, stringValues) in settingsByDeclaration {
-                    let pifDeclaration = SWBProjectModel.PIF.BuildSettings.Declaration(from: declaration)
+                    let pifDeclaration = SwiftBuild.ProjectModel.BuildSettings.Declaration(from: declaration)
                     switch buildConfig {
                     case .debug:
                         debugSettings.append(values: stringValues, to: pifDeclaration, platform: pifPlatform)
@@ -700,10 +711,10 @@ extension PackagePIFProjectBuilder {
         // Impart the linker flags.
         for (platform, settingsByDeclaration) in sourceModule.allBuildSettings.impartedSettings {
             // A `nil` platform means that the declaration applies to *all* platforms.
-            let pifPlatform = platform.map { SWBProjectModel.PIF.BuildSettings.Platform(from: $0) }
+            let pifPlatform = platform.map { SwiftBuild.ProjectModel.BuildSettings.Platform(from: $0) }
 
             for (declaration, stringValues) in settingsByDeclaration {
-                let pifDeclaration = SWBProjectModel.PIF.BuildSettings.Declaration(from: declaration)
+                let pifDeclaration = SwiftBuild.ProjectModel.BuildSettings.Declaration(from: declaration)
                 impartedSettings.append(values: stringValues, to: pifDeclaration, platform: pifPlatform)
             }
         }
@@ -771,14 +782,14 @@ extension PackagePIFProjectBuilder {
             "created \(type(of: systemLibraryPifTarget)) '\(systemLibraryPifTarget.id)' with name '\(systemLibraryPifTarget.name)'"
         )
 
-        let settings: SWBProjectModel.PIF.BuildSettings = self.package.underlying.packageBaseBuildSettings
+        let settings: SwiftBuild.ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
         let pkgConfig = try systemLibrary.pkgConfig(
             package: self.package,
             observabilityScope: pifBuilder.observabilityScope
         )
 
         // Impart the header search path to all direct and indirect clients.
-        var impartedSettings = SWBProjectModel.PIF.BuildSettings()
+        var impartedSettings = SwiftBuild.ProjectModel.BuildSettings()
         impartedSettings.OTHER_CFLAGS = ["-fmodule-map-file=\(systemLibrary.modulemapFileAbsolutePath)"] + pkgConfig
             .cFlags.prepending("$(inherited)")
         impartedSettings.OTHER_LDFLAGS = pkgConfig.libs.prepending("$(inherited)")

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -25,7 +25,7 @@ import class PackageModel.SystemLibraryModule
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
 
-import enum SwiftBuild.PIF
+import enum SWBProjectModel.PIF
 
 /// Extension to create PIF **modules** for a given package.
 extension PackagePIFProjectBuilder {
@@ -43,7 +43,7 @@ extension PackagePIFProjectBuilder {
         )
         log(.debug, "created \(type(of: pluginPifTarget)) '\(pluginPifTarget.id)' with name '\(pluginPifTarget.name)'")
 
-        var buildSettings: SwiftBuild.PIF.BuildSettings = self.package.underlying.packageBaseBuildSettings
+        var buildSettings: SWBProjectModel.PIF.BuildSettings = self.package.underlying.packageBaseBuildSettings
 
         // Add the dependencies.
         pluginModule.recursivelyTraverseDependencies { dependency in
@@ -167,8 +167,8 @@ extension PackagePIFProjectBuilder {
             dynamicLibraryVariant.isDynamicLibraryVariant = true
             self.builtModulesAndProducts.append(dynamicLibraryVariant)
 
-            let pifTarget = staticLibrary.pifTarget as? SwiftBuild.PIF.Target
-            let dynamicPifTarget = dynamicLibraryVariant.pifTarget as? SwiftBuild.PIF.Target
+            let pifTarget = staticLibrary.pifTarget as? SWBProjectModel.PIF.Target
+            let dynamicPifTarget = dynamicLibraryVariant.pifTarget as? SWBProjectModel.PIF.Target
 
             guard let pifTarget, let dynamicPifTarget else {
                 fatalError("Could not assign dynamic PIF target")
@@ -224,7 +224,7 @@ extension PackagePIFProjectBuilder {
 
         let pifTargetName: String
         let executableName: String
-        let productType: SwiftBuild.PIF.Target.ProductType
+        let productType: SWBProjectModel.PIF.Target.ProductType
 
         switch desiredModuleType {
         case .dynamicLibrary:
@@ -321,10 +321,10 @@ extension PackagePIFProjectBuilder {
         }
 
         // Create a set of build settings that will be imparted to any target that depends on this one.
-        var impartedSettings = SwiftBuild.PIF.BuildSettings()
+        var impartedSettings = SWBProjectModel.PIF.BuildSettings()
 
         // Configure the target-wide build settings. The details depend on the kind of product we're building.
-        var settings: SwiftBuild.PIF.BuildSettings = self.package.underlying.packageBaseBuildSettings
+        var settings: SWBProjectModel.PIF.BuildSettings = self.package.underlying.packageBaseBuildSettings
 
         if shouldGenerateBundleAccessor {
             settings.GENERATE_RESOURCE_ACCESSORS = "YES"
@@ -683,10 +683,10 @@ extension PackagePIFProjectBuilder {
         for (buildConfig, declarationsByPlatform) in allBuildSettings.targetSettings {
             for (platform, settingsByDeclaration) in declarationsByPlatform {
                 // A `nil` platform means that the declaration applies to *all* platforms.
-                let pifPlatform = platform.map { SwiftBuild.PIF.BuildSettings.Platform(from: $0) }
+                let pifPlatform = platform.map { SWBProjectModel.PIF.BuildSettings.Platform(from: $0) }
 
                 for (declaration, stringValues) in settingsByDeclaration {
-                    let pifDeclaration = SwiftBuild.PIF.BuildSettings.Declaration(from: declaration)
+                    let pifDeclaration = SWBProjectModel.PIF.BuildSettings.Declaration(from: declaration)
                     switch buildConfig {
                     case .debug:
                         debugSettings.append(values: stringValues, to: pifDeclaration, platform: pifPlatform)
@@ -700,10 +700,10 @@ extension PackagePIFProjectBuilder {
         // Impart the linker flags.
         for (platform, settingsByDeclaration) in sourceModule.allBuildSettings.impartedSettings {
             // A `nil` platform means that the declaration applies to *all* platforms.
-            let pifPlatform = platform.map { SwiftBuild.PIF.BuildSettings.Platform(from: $0) }
+            let pifPlatform = platform.map { SWBProjectModel.PIF.BuildSettings.Platform(from: $0) }
 
             for (declaration, stringValues) in settingsByDeclaration {
-                let pifDeclaration = SwiftBuild.PIF.BuildSettings.Declaration(from: declaration)
+                let pifDeclaration = SWBProjectModel.PIF.BuildSettings.Declaration(from: declaration)
                 impartedSettings.append(values: stringValues, to: pifDeclaration, platform: pifPlatform)
             }
         }
@@ -771,14 +771,14 @@ extension PackagePIFProjectBuilder {
             "created \(type(of: systemLibraryPifTarget)) '\(systemLibraryPifTarget.id)' with name '\(systemLibraryPifTarget.name)'"
         )
 
-        let settings: SwiftBuild.PIF.BuildSettings = self.package.underlying.packageBaseBuildSettings
+        let settings: SWBProjectModel.PIF.BuildSettings = self.package.underlying.packageBaseBuildSettings
         let pkgConfig = try systemLibrary.pkgConfig(
             package: self.package,
             observabilityScope: pifBuilder.observabilityScope
         )
 
         // Impart the header search path to all direct and indirect clients.
-        var impartedSettings = SwiftBuild.PIF.BuildSettings()
+        var impartedSettings = SWBProjectModel.PIF.BuildSettings()
         impartedSettings.OTHER_CFLAGS = ["-fmodule-map-file=\(systemLibrary.modulemapFileAbsolutePath)"] + pkgConfig
             .cFlags.prepending("$(inherited)")
         impartedSettings.OTHER_LDFLAGS = pkgConfig.libs.prepending("$(inherited)")

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -36,7 +36,7 @@ extension PackagePIFProjectBuilder {
         precondition(pluginModule.type == .plugin)
 
         // Create an executable PIF target in order to get specialization.
-        let pluginPifTargetKP = try self.pif.addTarget { _ in
+        let pluginPifTargetKP = try self.project.addTarget { _ in
             ProjectModel.Target(
                 id: pluginModule.pifTargetGUID(),
                 productType: .executable,
@@ -45,7 +45,7 @@ extension PackagePIFProjectBuilder {
             )
         }
         do {
-            let pluginPifTarget = self.pif[keyPath: pluginPifTargetKP]
+            let pluginPifTarget = self.project[keyPath: pluginPifTargetKP]
             log(.debug, "Created \(pluginPifTarget.productType) '\(pluginPifTarget.id)' with name '\(pluginPifTarget.name)'")
         }
 
@@ -71,25 +71,26 @@ extension PackagePIFProjectBuilder {
                         .productRepresentingDependencyOfBuildPlugin(in: moduleProducts)
 
                     if let productDependency {
-                        self.pif[keyPath: pluginPifTargetKP].common.addDependency(
+                        self.project[keyPath: pluginPifTargetKP].common.addDependency(
                             on: productDependency.pifTargetGUID(),
                             platformFilters: dependencyPlatformFilters
                         )
-                        log(.debug, "  Added dependency on product '\(productDependency.pifTargetGUID())'")
+                        log(.debug, indent: 1, "Added dependency on product '\(productDependency.pifTargetGUID())'")
                     } else {
                         log(
                             .debug,
-                            "  Could not find a build plugin product to depend on for target '\(moduleDependency.pifTargetGUID())'"
+                            indent: 1,
+                            "Could not find a build plugin product to depend on for target '\(moduleDependency.pifTargetGUID())'"
                         )
                     }
 
                 case .library, .systemModule, .test, .binary, .plugin, .macro:
                     let dependencyGUID = moduleDependency.pifTargetGUID()
-                    self.pif[keyPath: pluginPifTargetKP].common.addDependency(
+                    self.project[keyPath: pluginPifTargetKP].common.addDependency(
                         on: dependencyGUID,
                         platformFilters: dependencyPlatformFilters
                     )
-                    log(.debug, "  Added dependency on target '\(dependencyGUID)'")
+                    log(.debug, indent: 1, "Added dependency on target '\(dependencyGUID)'")
                 }
 
             case .product(let productDependency, let packageConditions):
@@ -106,11 +107,11 @@ extension PackagePIFProjectBuilder {
                     let dependencyPlatformFilters = packageConditions
                         .toPlatformFilter(toolsVersion: self.package.manifest.toolsVersion)
 
-                    self.pif[keyPath: pluginPifTargetKP].common.addDependency(
+                    self.project[keyPath: pluginPifTargetKP].common.addDependency(
                         on: dependencyGUID,
                         platformFilters: dependencyPlatformFilters
                     )
-                    log(.debug, "  Added dependency on product '\(dependencyGUID)'")
+                    log(.debug, indent: 1, "Added dependency on product '\(dependencyGUID)'")
                 }
             }
         }
@@ -118,18 +119,18 @@ extension PackagePIFProjectBuilder {
         // Any dependencies of plugin targets need to be built for the host.
         buildSettings[.SUPPORTED_PLATFORMS] = ["$(HOST_PLATFORM)"]
 
-        self.pif[keyPath: pluginPifTargetKP].common.addBuildConfig { id in
+        self.project[keyPath: pluginPifTargetKP].common.addBuildConfig { id in
             BuildConfig(id: id, name: "Debug", settings: buildSettings)
         }
-        self.pif[keyPath: pluginPifTargetKP].common.addBuildConfig { id in
+        self.project[keyPath: pluginPifTargetKP].common.addBuildConfig { id in
             BuildConfig(id: id, name: "Release", settings: buildSettings)
         }
 
-        let pluginModuleMetadata = PIFPackageBuilder.ModuleOrProduct(
+        let pluginModuleMetadata = PackagePIFBuilder.ModuleOrProduct(
             type: .plugin,
             name: pluginModule.name,
             moduleName: pluginModule.name,
-            pifTarget: .target(self.pif[keyPath: pluginPifTargetKP]),
+            pifTarget: .target(self.project[keyPath: pluginPifTargetKP]),
             indexableFileURLs: [],
             headerFiles: [],
             linkedPackageBinaries: [],
@@ -178,12 +179,12 @@ extension PackagePIFProjectBuilder {
             self.builtModulesAndProducts.append(dynamicLibraryVariant)
             
             guard let pifTarget = staticLibrary.pifTarget,
-                  let pifTargetKP = self.pif.findTarget(id: pifTarget.id),
+                  let pifTargetKeyPath = self.project.findTarget(id: pifTarget.id),
                   let dynamicPifTarget = dynamicLibraryVariant.pifTarget
             else {
                 fatalError("Could not assign dynamic PIF target")
             }
-            self.pif[keyPath: pifTargetKP].dynamicTargetVariantId = dynamicPifTarget.id
+            self.project[keyPath: pifTargetKeyPath].dynamicTargetVariantId = dynamicPifTarget.id
         }
     }
 
@@ -229,7 +230,7 @@ extension PackagePIFProjectBuilder {
         targetSuffix: TargetGUIDSuffix? = nil,
         addBuildToolPluginCommands: Bool = true,
         inputResourceBundleName: String? = nil
-    ) throws -> (PIFPackageBuilder.ModuleOrProduct, resourceBundleName: String?) {
+    ) throws -> (PackagePIFBuilder.ModuleOrProduct, resourceBundleName: String?) {
         precondition(sourceModule.isSourceModule)
 
         let pifTargetName: String
@@ -270,7 +271,7 @@ extension PackagePIFProjectBuilder {
             true
         }
 
-        let sourceModulePifTargetKP = try self.pif.addTarget { _ in
+        let sourceModuleTargetKeyPath = try self.project.addTarget { _ in
             ProjectModel.Target(
                 id: sourceModule.pifTargetGUID(suffix: targetSuffix),
                 productType: productType,
@@ -280,7 +281,7 @@ extension PackagePIFProjectBuilder {
             )
         }
         do {
-            let sourceModulePifTarget = self.pif[keyPath: sourceModulePifTargetKP]
+            let sourceModulePifTarget = self.project[keyPath: sourceModuleTargetKeyPath]
             log(.debug,
                 "Created \(sourceModulePifTarget.productType) '\(sourceModulePifTarget.id)' " +
                 "with name '\(sourceModulePifTarget.name)' and product name '\(sourceModulePifTarget.productName)'"
@@ -290,7 +291,7 @@ extension PackagePIFProjectBuilder {
         // Deal with any generated source files or resource files.
         let (generatedSourceFiles, generatedResourceFiles) = computePluginGeneratedFiles(
             module: sourceModule,
-            pifTarget: &self.pif[keyPath: sourceModulePifTargetKP],
+            targetKeyPath: sourceModuleTargetKeyPath,
             addBuildToolPluginCommands: false
         )
 
@@ -301,7 +302,7 @@ extension PackagePIFProjectBuilder {
         if resourceBundleName == nil && desiredModuleType != .executable && desiredModuleType != .macro {
             let (result, resourceBundle) = try addResourceBundle(
                 for: sourceModule,
-                pifTargetKeyPath: sourceModulePifTargetKP,
+                targetKeyPath: sourceModuleTargetKeyPath,
                 generatedResourceFiles: generatedResourceFiles
             )
             if let resourceBundle { self.builtModulesAndProducts.append(resourceBundle) }
@@ -321,14 +322,14 @@ extension PackagePIFProjectBuilder {
         }
 
         // Find the PIF target for the resource bundle, if any. Otherwise fall back to the module.
-        let resourceBundlePifTargetKP = self.resourceBundleTargetKeyPath(forModuleName: sourceModule.name) ?? sourceModulePifTargetKP
+        let resourceBundlePifTargetKP = self.resourceBundleTargetKeyPath(forModuleName: sourceModule.name) ?? sourceModuleTargetKeyPath
 
         // Add build tool commands to the resource bundle target.
         if desiredModuleType != .executable && desiredModuleType != .macro && addBuildToolPluginCommands {
             addBuildToolCommands(
                 module: sourceModule,
-                sourceModulePifTarget: &self.pif[keyPath: sourceModulePifTargetKP],
-                resourceBundlePifTarget: &self.pif[keyPath: resourceBundlePifTargetKP],
+                sourceModuleTargetKeyPath: sourceModuleTargetKeyPath,
+                resourceBundleTargetKeyPath: resourceBundlePifTargetKP,
                 sourceFilePaths: generatedSourceFiles,
                 resourceFilePaths: generatedResourceFiles
             )
@@ -366,7 +367,7 @@ extension PackagePIFProjectBuilder {
             moduleMapFile = "\(generatedModuleMapDir)/\(sourceModule.name).modulemap"
 
             // We only need to impart this to C clients.
-            impartedSettings.OTHER_CFLAGS = ["-fmodule-map-file=\(moduleMapFile)", "$(inherited)"]
+            impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(moduleMapFile)", "$(inherited)"]
         } else if sourceModule.moduleMapFileRelativePath == nil {
             // Otherwise, this is a C library module and we generate a modulemap if one is already not provided.
             if case .umbrellaHeader(let path) = sourceModule.moduleMapType {
@@ -389,8 +390,8 @@ extension PackagePIFProjectBuilder {
             if moduleMapFileContents.hasContent {
                 // Pass the path of the module map up to all direct and indirect clients.
                 moduleMapFile = "\(generatedModuleMapDir)/\(sourceModule.name).modulemap"
-                impartedSettings.OTHER_CFLAGS = ["-fmodule-map-file=\(moduleMapFile)", "$(inherited)"]
-                impartedSettings.OTHER_SWIFT_FLAGS = ["-Xcc", "-fmodule-map-file=\(moduleMapFile)", "$(inherited)"]
+                impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(moduleMapFile)", "$(inherited)"]
+                impartedSettings[.OTHER_SWIFT_FLAGS] = ["-Xcc", "-fmodule-map-file=\(moduleMapFile)", "$(inherited)"]
             }
         }
 
@@ -406,28 +407,28 @@ extension PackagePIFProjectBuilder {
                 delegate: pifBuilder.delegate
             )
         } else {
-            settings.TARGET_NAME = sourceModule.name
-            settings.PRODUCT_NAME = "$(TARGET_NAME)"
-            settings.PRODUCT_MODULE_NAME = sourceModule.c99name
-            settings.PRODUCT_BUNDLE_IDENTIFIER = "\(self.package.identity).\(sourceModule.name)"
+            settings[.TARGET_NAME] = sourceModule.name
+            settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
+            settings[.PRODUCT_MODULE_NAME] = sourceModule.c99name
+            settings[.PRODUCT_BUNDLE_IDENTIFIER] = "\(self.package.identity).\(sourceModule.name)"
                 .spm_mangledToBundleIdentifier()
-            settings.EXECUTABLE_NAME = executableName
-            settings.CLANG_ENABLE_MODULES = "YES"
-            settings.GENERATE_MASTER_OBJECT_FILE = "NO"
-            settings.STRIP_INSTALLED_PRODUCT = "NO"
+            settings[.EXECUTABLE_NAME] = executableName
+            settings[.CLANG_ENABLE_MODULES] = "YES"
+            settings[.GENERATE_MASTER_OBJECT_FILE] = "NO"
+            settings[.STRIP_INSTALLED_PRODUCT] = "NO"
 
             // Macros build as executables, so they need slightly different
             // build settings from other module types which build a "*.o".
             if desiredModuleType == .macro {
-                settings.MACH_O_TYPE = "mh_execute"
+                settings[.MACH_O_TYPE] = "mh_execute"
             } else {
-                settings.MACH_O_TYPE = "mh_object"
+                settings[.MACH_O_TYPE] = "mh_object"
                 // Disable code coverage linker flags since we're producing .o files.
                 // Otherwise, we will run into duplicated symbols when there are more than one targets that produce .o
                 // as their product.
-                settings.CLANG_COVERAGE_MAPPING_LINKER_ARGS = "NO"
+                settings[.CLANG_COVERAGE_MAPPING_LINKER_ARGS] = "NO"
             }
-            settings.SWIFT_PACKAGE_NAME = sourceModule.packageName
+            settings[.SWIFT_PACKAGE_NAME] = sourceModule.packageName
 
             if desiredModuleType == .executable {
                 // Tell the Swift compiler to produce an alternate entry point rather than the standard `_main` entry
@@ -435,16 +436,16 @@ extension PackagePIFProjectBuilder {
                 // so that we can link one or more testable executable modules together into a single test bundle.
                 // This allows the test bundle to treat the executable as if it were any regular library module,
                 // and will have access to all symbols except the main entry point its.
-                settings.OTHER_SWIFT_FLAGS.lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
+                settings[.OTHER_SWIFT_FLAGS].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
                     $0.append(contentsOf: ["-Xfrontend", "-entry-point-function-name"])
                     $0.append(contentsOf: ["-Xfrontend", "\(sourceModule.c99name)_main"])
                 }
 
                 // We have to give each target a unique name.
-                settings.TARGET_NAME = sourceModule.name + targetSuffix.description(forName: sourceModule.name)
+                settings[.TARGET_NAME] = sourceModule.name + targetSuffix.description(forName: sourceModule.name)
 
                 // Redirect the built executable into a separate directory so it won't conflict with the real one.
-                settings.TARGET_BUILD_DIR = "$(TARGET_BUILD_DIR)/ExecutableModules"
+                settings[.TARGET_BUILD_DIR] = "$(TARGET_BUILD_DIR)/ExecutableModules"
 
                 // Don't install the Swift module of the testable side-built artifact, lest it conflict with the regular
                 // one.
@@ -452,45 +453,45 @@ extension PackagePIFProjectBuilder {
                 // different in the Swift module
                 // (the actual runtime artifact is of course very different, and that's why we're building a separate
                 // testable artifact).
-                settings.SWIFT_INSTALL_MODULE = "NO"
+                settings[.SWIFT_INSTALL_MODULE] = "NO"
             }
 
             if let aliases = sourceModule.moduleAliases {
                 // Format each entry as "original_name=alias"
                 let list = aliases.map { $0.0 + "=" + $0.1 }
-                settings.SWIFT_MODULE_ALIASES = list.isEmpty ? nil : list
+                settings[.SWIFT_MODULE_ALIASES] = list.isEmpty ? nil : list
             }
 
             // We mark in the PIF that we are intentionally not offering a dynamic target here,
             // so we can emit a diagnostic if it is being requested by Swift Build.
             if !self.shouldOfferDynamicTarget(sourceModule.name) {
-                settings.PACKAGE_TARGET_NAME_CONFLICTS_WITH_PRODUCT_NAME = "YES"
+                settings[.PACKAGE_TARGET_NAME_CONFLICTS_WITH_PRODUCT_NAME] = "YES"
             }
 
             // We are setting this instead of `LD_DYLIB_INSTALL_NAME` because `mh_object` files
             // don't actually have install names, so we should not pass an install name to the linker.
-            settings.TAPI_DYLIB_INSTALL_NAME = sourceModule.name
+            settings[.TAPI_DYLIB_INSTALL_NAME] = sourceModule.name
         }
 
-        settings.PACKAGE_RESOURCE_TARGET_KIND = "regular"
-        settings.MODULEMAP_FILE_CONTENTS = moduleMapFileContents
-        settings.MODULEMAP_PATH = moduleMapFile
-        settings.DEFINES_MODULE = "YES"
+        settings[.PACKAGE_RESOURCE_TARGET_KIND] = "regular"
+        settings[.MODULEMAP_FILE_CONTENTS] = moduleMapFileContents
+        settings[.MODULEMAP_PATH] = moduleMapFile
+        settings[.DEFINES_MODULE] = "YES"
 
         // Settings for text-based API.
         // Due to rdar://78331694 (Cannot use TAPI for packages in contexts where we need to code-sign (e.g. apps))
         // we are only enabling TAPI in `configureSourceModuleBuildSettings`, if desired.
-        settings.SUPPORTS_TEXT_BASED_API = "NO"
+        settings[.SUPPORTS_TEXT_BASED_API] = "NO"
 
         // If the module includes C headers, we set up the HEADER_SEARCH_PATHS setting appropriately.
         if let includeDirAbsPath = sourceModule.includeDirAbsolutePath {
             // Let the target itself find its own headers.
-            settings.HEADER_SEARCH_PATHS = [includeDirAbsPath.pathString, "$(inherited)"]
-            log(.debug, ".. added '\(includeDirAbsPath)' to HEADER_SEARCH_PATHS")
+            settings[.HEADER_SEARCH_PATHS] = [includeDirAbsPath.pathString, "$(inherited)"]
+            log(.debug, indent: 1, "Added '\(includeDirAbsPath)' to HEADER_SEARCH_PATHS")
 
             // Also propagate this search path to all direct and indirect clients.
-            impartedSettings.HEADER_SEARCH_PATHS = [includeDirAbsPath.pathString, "$(inherited)"]
-            log(.debug, ".. added '\(includeDirAbsPath)' to imparted HEADER_SEARCH_PATHS")
+            impartedSettings[.HEADER_SEARCH_PATHS] = [includeDirAbsPath.pathString, "$(inherited)"]
+            log(.debug, indent: 1, "Added '\(includeDirAbsPath)' to imparted HEADER_SEARCH_PATHS")
         }
 
         // Additional settings for the linker.
@@ -507,24 +508,25 @@ extension PackagePIFProjectBuilder {
         } else {
             baselineOTHER_LDFLAGS = ["$(inherited)"]
         }
-        impartedSettings.OTHER_LDFLAGS = (sourceModule.isCxx ? ["-lc++"] : []) + baselineOTHER_LDFLAGS
-        impartedSettings.OTHER_LDRFLAGS = []
-        log(.debug, ".. added '\(String(describing: impartedSettings.OTHER_LDFLAGS))' to imparted OTHER_LDFLAGS")
+        impartedSettings[.OTHER_LDFLAGS] = (sourceModule.isCxx ? ["-lc++"] : []) + baselineOTHER_LDFLAGS
+        impartedSettings[.OTHER_LDRFLAGS] = []
+        log(.debug, indent: 1, "Added '\(String(describing: impartedSettings[.OTHER_LDFLAGS]))' to imparted OTHER_LDFLAGS")
 
         // This should be only for dynamic targets, but that isn't possible today.
         // Improvement is tracked by rdar://77403529 (Only impart `PackageFrameworks` search paths to clients of dynamic
         // package targets and products).
-        impartedSettings.FRAMEWORK_SEARCH_PATHS = ["$(BUILT_PRODUCTS_DIR)/PackageFrameworks", "$(inherited)"]
+        impartedSettings[.FRAMEWORK_SEARCH_PATHS] = ["$(BUILT_PRODUCTS_DIR)/PackageFrameworks", "$(inherited)"]
         log(
             .debug,
-            ".. added '\(String(describing: impartedSettings.FRAMEWORK_SEARCH_PATHS))' to imparted FRAMEWORK_SEARCH_PATHS"
+            indent: 1,
+            "Added '\(String(describing: impartedSettings[.FRAMEWORK_SEARCH_PATHS]))' to imparted FRAMEWORK_SEARCH_PATHS"
         )
 
         // Set the appropriate language versions.
-        settings.SWIFT_VERSION = sourceModule.packageSwiftLanguageVersion(manifest: packageManifest)
-        settings.GCC_C_LANGUAGE_STANDARD = sourceModule.cLanguageStandard
-        settings.CLANG_CXX_LANGUAGE_STANDARD = sourceModule.cxxLanguageStandard
-        settings.SWIFT_ENABLE_BARE_SLASH_REGEX = "NO"
+        settings[.SWIFT_VERSION] = sourceModule.packageSwiftLanguageVersion(manifest: packageManifest)
+        settings[.GCC_C_LANGUAGE_STANDARD] = sourceModule.cLanguageStandard
+        settings[.CLANG_CXX_LANGUAGE_STANDARD] = sourceModule.cxxLanguageStandard
+        settings[.SWIFT_ENABLE_BARE_SLASH_REGEX] = "NO"
 
         // Create a group for the target's source files.
         //
@@ -533,11 +535,17 @@ extension PackagePIFProjectBuilder {
         // be a mismatch between the paths that the index service is using for Swift Build queries,
         // and what paths Swift Build uses in its build description; such a mismatch would result
         // in the index service failing to get compiler arguments for source files of the target.
-        let targetSourceFileGroup = self.pif.mainGroup.addGroup(
-            path: try! resolveSymlinks(sourceModule.sourceDirAbsolutePath).pathString,
-            pathBase: .absolute
-        )
-        log(.debug, ".. added source file group '\(targetSourceFileGroup.path)'")
+        let targetSourceFileGroupKeyPath = self.project.mainGroup.addGroup { id in
+            ProjectModel.Group(
+                id: id,
+                path: try! resolveSymlinks(sourceModule.sourceDirAbsolutePath).pathString,
+                pathBase: .absolute
+           )
+        }
+        do {
+            let targetSourceFileGroup = self.project.mainGroup[keyPath: targetSourceFileGroupKeyPath]
+            log(.debug, indent: 1, "Added source file group '\(targetSourceFileGroup.path)'")
+        }
 
         // Add a source file reference for each of the source files,
         // and also an indexable-file URL for each one.
@@ -545,16 +553,19 @@ extension PackagePIFProjectBuilder {
         // Symlinks should be resolved externally.
         var indexableFileURLs: [SourceControlURL] = []
         for sourcePath in sourceModule.sourceFileRelativePaths {
-            sourceModulePifTargetKP.addSourceFile(
-                ref: targetSourceFileGroup.addFileReference(path: sourcePath.pathString, pathBase: .groupDir)
-            )
-            log(.debug, ".. .. added source file '\(sourcePath)'")
+            let sourceFileRef = self.project.mainGroup[keyPath: targetSourceFileGroupKeyPath].addFileReference { id in
+                FileReference(id: id, path: sourcePath.pathString, pathBase: .groupDir)
+            }
+            self.project[keyPath: sourceModuleTargetKeyPath].addSourceFile { id in
+                BuildFile(id: id, fileRef: sourceFileRef)
+            }
             indexableFileURLs.append(
                 SourceControlURL(fileURLWithPath: sourceModule.sourceDirAbsolutePath.appending(sourcePath))
             )
+            log(.debug, indent: 2, "Added source file '\(sourcePath)'")
         }
         for resource in sourceModule.resources {
-            log(.debug, ".. .. added resource file '\(resource.path)'")
+            log(.debug, indent: 2, "Added resource file '\(resource.path)'")
             indexableFileURLs.append(SourceControlURL(fileURLWithPath: resource.path))
         }
 
@@ -562,24 +573,27 @@ extension PackagePIFProjectBuilder {
 
         // Add any additional source files emitted by custom build commands.
         for path in generatedSourceFiles {
-            sourceModulePifTarget.addSourceFile(
-                ref: targetSourceFileGroup.addFileReference(path: path.pathString, pathBase: .absolute)
-            )
-            log(.debug, ".. .. added generated source file '\(path)'")
+            let sourceFileRef = self.project.mainGroup[keyPath: targetSourceFileGroupKeyPath].addFileReference { id in
+                FileReference(id: id, path: path.pathString, pathBase: .absolute)
+            }
+            self.project[keyPath: sourceModuleTargetKeyPath].addSourceFile { id in
+                BuildFile(id: id, fileRef: sourceFileRef)
+            }
+            log(.debug, indent: 2, "Added generated source file '\(path)'")
         }
 
         if let resourceBundle = resourceBundleName {
-            impartedSettings.EMBED_PACKAGE_RESOURCE_BUNDLE_NAMES = ["$(inherited)", resourceBundle]
-            settings.PACKAGE_RESOURCE_BUNDLE_NAME = resourceBundle
-            settings.COREML_CODEGEN_LANGUAGE = sourceModule.usesSwift ? "Swift" : "Objective-C"
-            settings.COREML_COMPILER_CONTAINER = "swift-package"
+            impartedSettings[.EMBED_PACKAGE_RESOURCE_BUNDLE_NAMES] = ["$(inherited)", resourceBundle]
+            settings[.PACKAGE_RESOURCE_BUNDLE_NAME] = resourceBundle
+            settings[.COREML_CODEGEN_LANGUAGE] = sourceModule.usesSwift ? "Swift" : "Objective-C"
+            settings[.COREML_COMPILER_CONTAINER] = "swift-package"
         }
 
         if desiredModuleType == .macro {
-            settings.SWIFT_IMPLEMENTS_MACROS_FOR_MODULE_NAMES = [sourceModule.c99name]
+            settings[.SWIFT_IMPLEMENTS_MACROS_FOR_MODULE_NAMES] = [sourceModule.c99name]
         }
         if sourceModule.type == .macro {
-            settings.SKIP_BUILDING_DOCUMENTATION = "YES"
+            settings[.SKIP_BUILDING_DOCUMENTATION] = "YES"
         }
 
         // Handle the target's dependencies (but only link against them if needed).
@@ -602,56 +616,66 @@ extension PackagePIFProjectBuilder {
                     if let product = moduleDependency
                         .productRepresentingDependencyOfBuildPlugin(in: moduleMainProducts)
                     {
-                        sourceModulePifTargetKP.addDependency(
+                        self.project[keyPath: sourceModuleTargetKeyPath].common.addDependency(
                             on: product.pifTargetGUID(),
                             platformFilters: dependencyPlatformFilters,
                             linkProduct: false
                         )
-                        log(.debug, ".. added dependency on product '\(product.pifTargetGUID)'")
+                        log(.debug, indent: 1, "Added dependency on product '\(product.pifTargetGUID())'")
                     } else {
                         log(
                             .debug,
-                            ".. could not find a build plugin product to depend on for target '\(moduleDependency.pifTargetGUID())'"
+                            indent: 1,
+                            "Could not find a build plugin product to depend on for target '\(moduleDependency.pifTargetGUID())'"
                         )
                     }
 
                 case .binary:
-                    let binaryReference = self.binaryGroup.addFileReference(path: moduleDependency.path.pathString)
+                    let binaryReference = self.binaryGroup.addFileReference { id in
+                        FileReference(id: id, path: moduleDependency.path.pathString)
+                    }
                     if shouldLinkProduct {
-                        sourceModulePifTargetKP.addLibrary(
-                            ref: binaryReference,
-                            platformFilters: dependencyPlatformFilters,
-                            codeSignOnCopy: true,
-                            removeHeadersOnCopy: true
-                        )
+                        self.project[keyPath: sourceModuleTargetKeyPath].addLibrary { id in
+                            BuildFile(
+                                id: id,
+                                fileRef: binaryReference,
+                                platformFilters: dependencyPlatformFilters,
+                                codeSignOnCopy: true,
+                                removeHeadersOnCopy: true
+                            )
+                        }
                     } else {
                         // If we are producing a single ".o", don't link binaries since they
                         // could be static which would cause them to become part of the ".o".
-                        sourceModulePifTargetKP.addResourceFile(
-                            ref: binaryReference,
-                            platformFilters: dependencyPlatformFilters
-                        )
+                        self.project[keyPath: sourceModuleTargetKeyPath].addResourceFile { id in
+                            BuildFile(
+                                id: id,
+                                fileRef: binaryReference,
+                                platformFilters: dependencyPlatformFilters
+                            )
+                        }
                     }
-                    log(.debug, ".. added use of binary library '\(moduleDependency.path)'")
+                    log(.debug, indent: 1, "Added use of binary library '\(moduleDependency.path)'")
 
                 case .plugin:
                     let dependencyGUID = moduleDependency.pifTargetGUID()
-                    sourceModulePifTargetKP.addDependency(
+                    self.project[keyPath: sourceModuleTargetKeyPath].common.addDependency(
                         on: dependencyGUID,
                         platformFilters: dependencyPlatformFilters,
                         linkProduct: false
                     )
-                    log(.debug, ".. added use of plugin target '\(dependencyGUID)'")
+                    log(.debug, indent: 1, "Added use of plugin target '\(dependencyGUID)'")
 
                 case .library, .test, .macro, .systemModule:
-                    sourceModulePifTargetKP.addDependency(
+                    self.project[keyPath: sourceModuleTargetKeyPath].common.addDependency(
                         on: moduleDependency.pifTargetGUID(),
                         platformFilters: dependencyPlatformFilters,
                         linkProduct: shouldLinkProduct
                     )
                     log(
                         .debug,
-                        ".. added \(shouldLinkProduct ? "linked " : "")dependency on target '\(moduleDependency.pifTargetGUID())'"
+                        indent: 1,
+                        "Added \(shouldLinkProduct ? "linked " : "")dependency on target '\(moduleDependency.pifTargetGUID())'"
                     )
                 }
 
@@ -669,14 +693,15 @@ extension PackagePIFProjectBuilder {
                         .toPlatformFilter(toolsVersion: self.package.manifest.toolsVersion)
                     let shouldLinkProduct = shouldLinkProduct && productDependency.isLinkable
 
-                    sourceModulePifTargetKP.addDependency(
+                    self.project[keyPath: sourceModuleTargetKeyPath].common.addDependency(
                         on: productDependency.pifTargetGUID(),
                         platformFilters: dependencyPlatformFilters,
                         linkProduct: shouldLinkProduct
                     )
                     log(
                         .debug,
-                        ".. added \(shouldLinkProduct ? "linked " : "")dependency on product '\(productDependency.pifTargetGUID)'"
+                        indent: 1,
+                        "Added \(shouldLinkProduct ? "linked " : "")dependency on product '\(productDependency.pifTargetGUID)'"
                     )
                 }
             }
@@ -696,16 +721,13 @@ extension PackagePIFProjectBuilder {
         // Apply target-specific build settings defined in the manifest.
         for (buildConfig, declarationsByPlatform) in allBuildSettings.targetSettings {
             for (platform, settingsByDeclaration) in declarationsByPlatform {
-                // A `nil` platform means that the declaration applies to *all* platforms.
-                let pifPlatform = platform.map { SwiftBuild.ProjectModel.BuildSettings.Platform(from: $0) }
-
+                // Note: A `nil` platform means that the declaration applies to *all* platforms.
                 for (declaration, stringValues) in settingsByDeclaration {
-                    let pifDeclaration = SwiftBuild.ProjectModel.BuildSettings.Declaration(from: declaration)
                     switch buildConfig {
                     case .debug:
-                        debugSettings.append(values: stringValues, to: pifDeclaration, platform: pifPlatform)
+                        debugSettings.append(values: stringValues, to: declaration, platform: platform)
                     case .release:
-                        releaseSettings.append(values: stringValues, to: pifDeclaration, platform: pifPlatform)
+                        releaseSettings.append(values: stringValues, to: declaration, platform: platform)
                     }
                 }
             }
@@ -713,38 +735,41 @@ extension PackagePIFProjectBuilder {
 
         // Impart the linker flags.
         for (platform, settingsByDeclaration) in sourceModule.allBuildSettings.impartedSettings {
-            // A `nil` platform means that the declaration applies to *all* platforms.
-            let pifPlatform = platform.map { SwiftBuild.ProjectModel.BuildSettings.Platform(from: $0) }
-
+            // Note: A `nil` platform means that the declaration applies to *all* platforms.
             for (declaration, stringValues) in settingsByDeclaration {
-                let pifDeclaration = SwiftBuild.ProjectModel.BuildSettings.Declaration(from: declaration)
-                impartedSettings.append(values: stringValues, to: pifDeclaration, platform: pifPlatform)
+                impartedSettings.append(values: stringValues, to: declaration, platform: platform)
             }
         }
 
         // Set the imparted settings, which are ones that clients (both direct and indirect ones) use.
         var debugImpartedSettings = impartedSettings
-        debugImpartedSettings.LD_RUNPATH_SEARCH_PATHS =
+        debugImpartedSettings[.LD_RUNPATH_SEARCH_PATHS] =
             ["$(BUILT_PRODUCTS_DIR)/PackageFrameworks"] +
-            (debugImpartedSettings.LD_RUNPATH_SEARCH_PATHS ?? ["$(inherited)"])
+            (debugImpartedSettings[.LD_RUNPATH_SEARCH_PATHS] ?? ["$(inherited)"])
 
-        sourceModulePifTargetKP.addBuildConfig(
-            name: "Debug",
-            settings: debugSettings,
-            impartedBuildSettings: debugImpartedSettings
-        )
-        sourceModulePifTargetKP.addBuildConfig(
-            name: "Release",
-            settings: releaseSettings,
-            impartedBuildSettings: impartedSettings
-        )
-
-        // Collect linked binaries.
-        let linkedPackageBinaries: [PIFPackageBuilder.LinkedPackageBinary] = sourceModule.dependencies.compactMap {
-            PIFPackageBuilder.LinkedPackageBinary(dependency: $0, package: self.package)
+        self.project[keyPath: sourceModuleTargetKeyPath].common.addBuildConfig { id in
+            BuildConfig(
+                id: id,
+                name: "Debug",
+                settings: debugSettings,
+                impartedBuildSettings: debugImpartedSettings
+            )
+        }
+        self.project[keyPath: sourceModuleTargetKeyPath].common.addBuildConfig { id in
+            BuildConfig(
+                id: id,
+                name: "Release",
+                settings: releaseSettings,
+                impartedBuildSettings: impartedSettings
+            )
         }
 
-        let productOrModuleType: PIFPackageBuilder.ModuleOrProductType = if desiredModuleType == .dynamicLibrary {
+        // Collect linked binaries.
+        let linkedPackageBinaries: [PackagePIFBuilder.LinkedPackageBinary] = sourceModule.dependencies.compactMap {
+            PackagePIFBuilder.LinkedPackageBinary(dependency: $0, package: self.package)
+        }
+
+        let productOrModuleType: PackagePIFBuilder.ModuleOrProductType = if desiredModuleType == .dynamicLibrary {
             pifBuilder.createDylibForDynamicProducts ? .dynamicLibrary : .framework
         } else if desiredModuleType == .macro {
             .macro
@@ -752,11 +777,11 @@ extension PackagePIFProjectBuilder {
             .module
         }
 
-        let moduleOrProduct = PIFPackageBuilder.ModuleOrProduct(
+        let moduleOrProduct = PackagePIFBuilder.ModuleOrProduct(
             type: productOrModuleType,
             name: sourceModule.name,
             moduleName: sourceModule.c99name,
-            pifTarget: sourceModulePifTargetKP,
+            pifTarget: .target(self.project[keyPath: sourceModuleTargetKeyPath]),
             indexableFileURLs: indexableFileURLs,
             headerFiles: headerFiles,
             linkedPackageBinaries: linkedPackageBinaries,
@@ -772,18 +797,22 @@ extension PackagePIFProjectBuilder {
 
     mutating func makeSystemLibraryModule(_ resolvedSystemLibrary: PackageGraph.ResolvedModule) throws {
         precondition(resolvedSystemLibrary.type == .systemModule)
-
         let systemLibrary = resolvedSystemLibrary.underlying as! SystemLibraryModule
 
         // Create an aggregate PIF target (which doesn't have an actual product).
-        let systemLibraryPifTarget = self.pif.addAggregateTarget(
-            id: resolvedSystemLibrary.pifTargetGUID(),
-            name: resolvedSystemLibrary.name
-        )
-        log(
-            .debug,
-            "created \(type(of: systemLibraryPifTarget)) '\(systemLibraryPifTarget.id)' with name '\(systemLibraryPifTarget.name)'"
-        )
+        let systemLibraryTargetKeyPath = try self.project.addAggregateTarget { _ in
+            ProjectModel.AggregateTarget(
+                id: resolvedSystemLibrary.pifTargetGUID(),
+                name: resolvedSystemLibrary.name
+            )
+        }
+        do {
+            let systemLibraryTarget = self.project[keyPath: systemLibraryTargetKeyPath]
+            log(
+                .debug,
+                "Created \(type(of: systemLibraryTarget)) '\(systemLibraryTarget.id)' with name '\(systemLibraryTarget.name)'"
+            )
+        }
 
         let settings: SwiftBuild.ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
         let pkgConfig = try systemLibrary.pkgConfig(
@@ -793,31 +822,36 @@ extension PackagePIFProjectBuilder {
 
         // Impart the header search path to all direct and indirect clients.
         var impartedSettings = SwiftBuild.ProjectModel.BuildSettings()
-        impartedSettings.OTHER_CFLAGS = ["-fmodule-map-file=\(systemLibrary.modulemapFileAbsolutePath)"] + pkgConfig
-            .cFlags.prepending("$(inherited)")
-        impartedSettings.OTHER_LDFLAGS = pkgConfig.libs.prepending("$(inherited)")
-        impartedSettings.OTHER_LDRFLAGS = []
-        impartedSettings.OTHER_SWIFT_FLAGS = ["-Xcc"] + impartedSettings.OTHER_CFLAGS!
-        log(.debug, ".. added '\(systemLibrary.path.pathString)' to imparted HEADER_SEARCH_PATHS")
+        impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(systemLibrary.modulemapFileAbsolutePath)"] +
+            pkgConfig.cFlags.prepending("$(inherited)")
+        impartedSettings[.OTHER_LDFLAGS] = pkgConfig.libs.prepending("$(inherited)")
+        impartedSettings[.OTHER_LDRFLAGS] = []
+        impartedSettings[.OTHER_SWIFT_FLAGS] = ["-Xcc"] + impartedSettings[.OTHER_CFLAGS]!
+        log(.debug, indent: 1, "Added '\(systemLibrary.path.pathString)' to imparted HEADER_SEARCH_PATHS")
 
-        systemLibraryPifTarget.addBuildConfig(
-            name: "Debug",
-            settings: settings,
-            impartedBuildSettings: impartedSettings
-        )
-        systemLibraryPifTarget.addBuildConfig(
-            name: "Release",
-            settings: settings,
-            impartedBuildSettings: impartedSettings
-        )
-
+        self.project[keyPath: systemLibraryTargetKeyPath].common.addBuildConfig { id in
+            BuildConfig(
+                id: id,
+                name: "Debug",
+                settings: settings,
+                impartedBuildSettings: impartedSettings
+            )
+        }
+        self.project[keyPath: systemLibraryTargetKeyPath].common.addBuildConfig { id in
+            BuildConfig(
+                id: id,
+                name: "Release",
+                settings: settings,
+                impartedBuildSettings: impartedSettings
+            )
+        }
         // FIXME: Should we also impart linkage?
 
-        let systemModule = PIFPackageBuilder.ModuleOrProduct(
+        let systemModule = PackagePIFBuilder.ModuleOrProduct(
             type: .module,
             name: resolvedSystemLibrary.name,
             moduleName: resolvedSystemLibrary.c99name,
-            pifTarget: systemLibraryPifTarget,
+            pifTarget: .aggregate(self.project[keyPath: systemLibraryTargetKeyPath]),
             indexableFileURLs: [],
             headerFiles: [],
             linkedPackageBinaries: [],

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -235,7 +235,7 @@ extension PackagePIFProjectBuilder {
 
         let pifTargetName: String
         let executableName: String
-        let productType: SwiftBuild.ProjectModel.Target.ProductType
+        let productType: ProjectModel.Target.ProductType
 
         switch desiredModuleType {
         case .dynamicLibrary:
@@ -814,14 +814,14 @@ extension PackagePIFProjectBuilder {
             )
         }
 
-        let settings: SwiftBuild.ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
+        let settings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
         let pkgConfig = try systemLibrary.pkgConfig(
             package: self.package,
             observabilityScope: pifBuilder.observabilityScope
         )
 
         // Impart the header search path to all direct and indirect clients.
-        var impartedSettings = SwiftBuild.ProjectModel.BuildSettings()
+        var impartedSettings = ProjectModel.BuildSettings()
         impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(systemLibrary.modulemapFileAbsolutePath)"] +
             pkgConfig.cFlags.prepending("$(inherited)")
         impartedSettings[.OTHER_LDFLAGS] = pkgConfig.libs.prepending("$(inherited)")

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -36,7 +36,7 @@ extension PackagePIFProjectBuilder {
         precondition(pluginModule.type == .plugin)
 
         // Create an executable PIF target in order to get specialization.
-        let pluginPifTargetKP = try self.project.addTarget { _ in
+        let pluginTargetKeyPath = try self.project.addTarget { _ in
             ProjectModel.Target(
                 id: pluginModule.pifTargetGUID(),
                 productType: .executable,
@@ -45,8 +45,8 @@ extension PackagePIFProjectBuilder {
             )
         }
         do {
-            let pluginPifTarget = self.project[keyPath: pluginPifTargetKP]
-            log(.debug, "Created \(pluginPifTarget.productType) '\(pluginPifTarget.id)' with name '\(pluginPifTarget.name)'")
+            let pluginTarget = self.project[keyPath: pluginTargetKeyPath]
+            log(.debug, "Created \(pluginTarget.productType) '\(pluginTarget.id)' with name '\(pluginTarget.name)'")
         }
 
         var buildSettings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
@@ -71,7 +71,7 @@ extension PackagePIFProjectBuilder {
                         .productRepresentingDependencyOfBuildPlugin(in: moduleProducts)
 
                     if let productDependency {
-                        self.project[keyPath: pluginPifTargetKP].common.addDependency(
+                        self.project[keyPath: pluginTargetKeyPath].common.addDependency(
                             on: productDependency.pifTargetGUID(),
                             platformFilters: dependencyPlatformFilters
                         )
@@ -86,7 +86,7 @@ extension PackagePIFProjectBuilder {
 
                 case .library, .systemModule, .test, .binary, .plugin, .macro:
                     let dependencyGUID = moduleDependency.pifTargetGUID()
-                    self.project[keyPath: pluginPifTargetKP].common.addDependency(
+                    self.project[keyPath: pluginTargetKeyPath].common.addDependency(
                         on: dependencyGUID,
                         platformFilters: dependencyPlatformFilters
                     )
@@ -107,7 +107,7 @@ extension PackagePIFProjectBuilder {
                     let dependencyPlatformFilters = packageConditions
                         .toPlatformFilter(toolsVersion: self.package.manifest.toolsVersion)
 
-                    self.project[keyPath: pluginPifTargetKP].common.addDependency(
+                    self.project[keyPath: pluginTargetKeyPath].common.addDependency(
                         on: dependencyGUID,
                         platformFilters: dependencyPlatformFilters
                     )
@@ -119,10 +119,10 @@ extension PackagePIFProjectBuilder {
         // Any dependencies of plugin targets need to be built for the host.
         buildSettings[.SUPPORTED_PLATFORMS] = ["$(HOST_PLATFORM)"]
 
-        self.project[keyPath: pluginPifTargetKP].common.addBuildConfig { id in
+        self.project[keyPath: pluginTargetKeyPath].common.addBuildConfig { id in
             BuildConfig(id: id, name: "Debug", settings: buildSettings)
         }
-        self.project[keyPath: pluginPifTargetKP].common.addBuildConfig { id in
+        self.project[keyPath: pluginTargetKeyPath].common.addBuildConfig { id in
             BuildConfig(id: id, name: "Release", settings: buildSettings)
         }
 
@@ -130,7 +130,7 @@ extension PackagePIFProjectBuilder {
             type: .plugin,
             name: pluginModule.name,
             moduleName: pluginModule.name,
-            pifTarget: .target(self.project[keyPath: pluginPifTargetKP]),
+            pifTarget: .target(self.project[keyPath: pluginTargetKeyPath]),
             indexableFileURLs: [],
             headerFiles: [],
             linkedPackageBinaries: [],
@@ -281,10 +281,10 @@ extension PackagePIFProjectBuilder {
             )
         }
         do {
-            let sourceModulePifTarget = self.project[keyPath: sourceModuleTargetKeyPath]
+            let sourceModuleTarget = self.project[keyPath: sourceModuleTargetKeyPath]
             log(.debug,
-                "Created \(sourceModulePifTarget.productType) '\(sourceModulePifTarget.id)' " +
-                "with name '\(sourceModulePifTarget.name)' and product name '\(sourceModulePifTarget.productName)'"
+                "Created \(sourceModuleTarget.productType) '\(sourceModuleTarget.id)' " +
+                "with name '\(sourceModuleTarget.name)' and product name '\(sourceModuleTarget.productName)'"
             )
         }
 
@@ -322,14 +322,14 @@ extension PackagePIFProjectBuilder {
         }
 
         // Find the PIF target for the resource bundle, if any. Otherwise fall back to the module.
-        let resourceBundlePifTargetKP = self.resourceBundleTargetKeyPath(forModuleName: sourceModule.name) ?? sourceModuleTargetKeyPath
+        let resourceBundleTargetKeyPath = self.resourceBundleTargetKeyPath(forModuleName: sourceModule.name) ?? sourceModuleTargetKeyPath
 
         // Add build tool commands to the resource bundle target.
         if desiredModuleType != .executable && desiredModuleType != .macro && addBuildToolPluginCommands {
             addBuildToolCommands(
                 module: sourceModule,
                 sourceModuleTargetKeyPath: sourceModuleTargetKeyPath,
-                resourceBundleTargetKeyPath: resourceBundlePifTargetKP,
+                resourceBundleTargetKeyPath: resourceBundleTargetKeyPath,
                 sourceFilePaths: generatedSourceFiles,
                 resourceFilePaths: generatedResourceFiles
             )

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -31,7 +31,6 @@ import enum SwiftBuild.ProjectModel
 
 /// Extension to create PIF **modules** for a given package.
 extension PackagePIFProjectBuilder {
-    
     // MARK: - Plugin Modules
 
     mutating func makePluginModule(_ pluginModule: PackageGraph.ResolvedModule) throws {
@@ -60,7 +59,7 @@ extension PackagePIFProjectBuilder {
                 // This assertion is temporarily disabled since we may see targets from
                 // _other_ packages, but this should be resolved; see rdar://95467710.
                 /* assert(moduleDependency.packageName == self.package.name) */
-                
+
                 let dependencyPlatformFilters = packageConditions
                     .toPlatformFilter(toolsVersion: self.package.manifest.toolsVersion)
 
@@ -179,7 +178,7 @@ extension PackagePIFProjectBuilder {
             )
             dynamicLibraryVariant.isDynamicLibraryVariant = true
             self.builtModulesAndProducts.append(dynamicLibraryVariant)
-            
+
             guard let pifTarget = staticLibrary.pifTarget,
                   let pifTargetKeyPath = self.project.findTarget(id: pifTarget.id),
                   let dynamicPifTarget = dynamicLibraryVariant.pifTarget
@@ -284,9 +283,10 @@ extension PackagePIFProjectBuilder {
         }
         do {
             let sourceModuleTarget = self.project[keyPath: sourceModuleTargetKeyPath]
-            log(.debug,
+            log(
+                .debug,
                 "Created \(sourceModuleTarget.productType) '\(sourceModuleTarget.id)' " +
-                "with name '\(sourceModuleTarget.name)' and product name '\(sourceModuleTarget.productName)'"
+                    "with name '\(sourceModuleTarget.name)' and product name '\(sourceModuleTarget.productName)'"
             )
         }
 
@@ -324,7 +324,9 @@ extension PackagePIFProjectBuilder {
         }
 
         // Find the PIF target for the resource bundle, if any. Otherwise fall back to the module.
-        let resourceBundleTargetKeyPath = self.resourceBundleTargetKeyPath(forModuleName: sourceModule.name) ?? sourceModuleTargetKeyPath
+        let resourceBundleTargetKeyPath = self.resourceBundleTargetKeyPath(
+            forModuleName: sourceModule.name
+        ) ?? sourceModuleTargetKeyPath
 
         // Add build tool commands to the resource bundle target.
         if desiredModuleType != .executable && desiredModuleType != .macro && addBuildToolPluginCommands {
@@ -512,7 +514,11 @@ extension PackagePIFProjectBuilder {
         }
         impartedSettings[.OTHER_LDFLAGS] = (sourceModule.isCxx ? ["-lc++"] : []) + baselineOTHER_LDFLAGS
         impartedSettings[.OTHER_LDRFLAGS] = []
-        log(.debug, indent: 1, "Added '\(String(describing: impartedSettings[.OTHER_LDFLAGS]))' to imparted OTHER_LDFLAGS")
+        log(
+            .debug,
+            indent: 1,
+            "Added '\(String(describing: impartedSettings[.OTHER_LDFLAGS]))' to imparted OTHER_LDFLAGS"
+        )
 
         // This should be only for dynamic targets, but that isn't possible today.
         // Improvement is tracked by rdar://77403529 (Only impart `PackageFrameworks` search paths to clients of dynamic
@@ -542,7 +548,7 @@ extension PackagePIFProjectBuilder {
                 id: id,
                 path: try! resolveSymlinks(sourceModule.sourceDirAbsolutePath).pathString,
                 pathBase: .absolute
-           )
+            )
         }
         do {
             let targetSourceFileGroup = self.project.mainGroup[keyPath: targetSourceFileGroupKeyPath]
@@ -606,7 +612,7 @@ extension PackagePIFProjectBuilder {
                 // This assertion is temporarily disabled since we may see targets from
                 // _other_ packages, but this should be resolved; see rdar://95467710.
                 /* assert(moduleDependency.packageName == self.package.name) */
-                
+
                 let dependencyPlatformFilters = packageConditions
                     .toPlatformFilter(toolsVersion: self.package.manifest.toolsVersion)
 

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -25,6 +25,8 @@ import class PackageModel.SystemLibraryModule
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
 
+#if canImport(SwiftBuild)
+
 import enum SwiftBuild.ProjectModel
 
 /// Extension to create PIF **modules** for a given package.
@@ -862,3 +864,5 @@ extension PackagePIFProjectBuilder {
         self.builtModulesAndProducts.append(systemModule)
     }
 }
+
+#endif

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -27,7 +27,6 @@ import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
 import struct PackageGraph.ResolvedProduct
 
-#if canImport(SwiftBuild)
 import enum SwiftBuild.PIF
 
 /// Extension to create PIF **products** for a given package.
@@ -897,5 +896,3 @@ private struct PackageRegistrySignature: Encodable {
     let source: Source
     let formatVersion = 2
 }
-
-#endif

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -27,7 +27,7 @@ import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
 import struct PackageGraph.ResolvedProduct
 
-import enum SwiftBuild.PIF
+import enum SWBProjectModel.PIF
 
 /// Extension to create PIF **products** for a given package.
 extension PackagePIFProjectBuilder {
@@ -48,7 +48,7 @@ extension PackagePIFProjectBuilder {
         }
 
         // Determine the kind of PIF target *product type* to create for the package product.
-        let pifProductType: SwiftBuild.PIF.Target.ProductType
+        let pifProductType: SWBProjectModel.PIF.Target.ProductType
         let moduleOrProductType: PIFPackageBuilder.ModuleOrProductType
         let synthesizedResourceGeneratingPluginInvocationResults: [PIFPackageBuilder.BuildToolPluginInvocationResult] =
             []
@@ -100,7 +100,7 @@ extension PackagePIFProjectBuilder {
 
         // Configure the target-wide build settings. The details depend on the kind of product we're building,
         // but are in general the ones that are suitable for end-product artifacts such as executables and test bundles.
-        var settings: SwiftBuild.PIF.BuildSettings = package.underlying.packageBaseBuildSettings
+        var settings: SWBProjectModel.PIF.BuildSettings = package.underlying.packageBaseBuildSettings
         settings.TARGET_NAME = product.name
         settings.PACKAGE_RESOURCE_TARGET_KIND = "regular"
         settings.PRODUCT_NAME = "$(TARGET_NAME)"
@@ -406,16 +406,16 @@ extension PackagePIFProjectBuilder {
         // Until this point the build settings for the target have been the same between debug and release
         // configurations.
         // The custom manifest settings might cause them to diverge.
-        var debugSettings: SwiftBuild.PIF.BuildSettings = settings
-        var releaseSettings: SwiftBuild.PIF.BuildSettings = settings
+        var debugSettings: SWBProjectModel.PIF.BuildSettings = settings
+        var releaseSettings: SWBProjectModel.PIF.BuildSettings = settings
 
         // Apply target-specific build settings defined in the manifest.
         for (buildConfig, declarationsByPlatform) in mainModule.allBuildSettings.targetSettings {
             for (platform, declarations) in declarationsByPlatform {
                 // A `nil` platform means that the declaration applies to *all* platforms.
-                let pifPlatform = platform.map { SwiftBuild.PIF.BuildSettings.Platform(from: $0) }
+                let pifPlatform = platform.map { SWBProjectModel.PIF.BuildSettings.Platform(from: $0) }
                 for (declaration, stringValues) in declarations {
-                    let pifDeclaration = SwiftBuild.PIF.BuildSettings.Declaration(from: declaration)
+                    let pifDeclaration = SWBProjectModel.PIF.BuildSettings.Declaration(from: declaration)
                     switch buildConfig {
                     case .debug:
                         debugSettings.append(values: stringValues, to: pifDeclaration, platform: pifPlatform)
@@ -452,8 +452,8 @@ extension PackagePIFProjectBuilder {
         _ product: PackageGraph.ResolvedProduct,
         with packageConditions: [PackageModel.PackageCondition],
         isLinkable: Bool,
-        pifTarget: SwiftBuild.PIF.Target,
-        settings: inout SwiftBuild.PIF.BuildSettings
+        pifTarget: SWBProjectModel.PIF.Target,
+        settings: inout SWBProjectModel.PIF.BuildSettings
     ) {
         // Do not add a dependency for binary-only executable products since they are not part of the build.
         if product.isBinaryOnlyExecutableProduct {
@@ -502,8 +502,8 @@ extension PackagePIFProjectBuilder {
             dynamicLibraryVariant.isDynamicLibraryVariant = true
             self.builtModulesAndProducts.append(dynamicLibraryVariant)
 
-            let pifTarget = library.pifTarget as? SwiftBuild.PIF.Target
-            let dynamicPifTarget = dynamicLibraryVariant.pifTarget as? SwiftBuild.PIF.Target
+            let pifTarget = library.pifTarget as? SWBProjectModel.PIF.Target
+            let dynamicPifTarget = dynamicLibraryVariant.pifTarget as? SWBProjectModel.PIF.Target
 
             if let pifTarget, let dynamicPifTarget {
                 pifTarget.dynamicTargetVariant = dynamicPifTarget
@@ -531,7 +531,7 @@ extension PackagePIFProjectBuilder {
 
         let pifTargetProductName: String
         let executableName: String
-        let productType: SwiftBuild.PIF.Target.ProductType
+        let productType: SWBProjectModel.PIF.Target.ProductType
 
         if desiredProductType == .dynamic {
             if pifBuilder.createDylibForDynamicProducts {
@@ -606,7 +606,7 @@ extension PackagePIFProjectBuilder {
             }
         }
 
-        var settings: SwiftBuild.PIF.BuildSettings = package.underlying.packageBaseBuildSettings
+        var settings: SWBProjectModel.PIF.BuildSettings = package.underlying.packageBaseBuildSettings
 
         // Add other build settings when we're building an actual dylib.
         if desiredProductType == .dynamic {
@@ -839,7 +839,7 @@ extension PackagePIFProjectBuilder {
         )
         log(.debug, "created \(type(of: pluginPifTarget)) '\(pluginPifTarget.id)' with name '\(pluginPifTarget.name)'")
 
-        let buildSettings: SwiftBuild.PIF.BuildSettings = package.underlying.packageBaseBuildSettings
+        let buildSettings: SWBProjectModel.PIF.BuildSettings = package.underlying.packageBaseBuildSettings
         pluginPifTarget.addBuildConfig(name: "Debug", settings: buildSettings)
         pluginPifTarget.addBuildConfig(name: "Release", settings: buildSettings)
 

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -27,7 +27,7 @@ import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
 import struct PackageGraph.ResolvedProduct
 
-import enum SWBProjectModel.PIF
+import enum SwiftBuild.ProjectModel
 
 /// Extension to create PIF **products** for a given package.
 extension PackagePIFProjectBuilder {
@@ -48,7 +48,7 @@ extension PackagePIFProjectBuilder {
         }
 
         // Determine the kind of PIF target *product type* to create for the package product.
-        let pifProductType: SWBProjectModel.PIF.Target.ProductType
+        let pifProductType: SwiftBuild.ProjectModel.Target.ProductType
         let moduleOrProductType: PIFPackageBuilder.ModuleOrProductType
         let synthesizedResourceGeneratingPluginInvocationResults: [PIFPackageBuilder.BuildToolPluginInvocationResult] =
             []
@@ -100,7 +100,7 @@ extension PackagePIFProjectBuilder {
 
         // Configure the target-wide build settings. The details depend on the kind of product we're building,
         // but are in general the ones that are suitable for end-product artifacts such as executables and test bundles.
-        var settings: SWBProjectModel.PIF.BuildSettings = package.underlying.packageBaseBuildSettings
+        var settings: SwiftBuild.ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
         settings.TARGET_NAME = product.name
         settings.PACKAGE_RESOURCE_TARGET_KIND = "regular"
         settings.PRODUCT_NAME = "$(TARGET_NAME)"
@@ -406,16 +406,16 @@ extension PackagePIFProjectBuilder {
         // Until this point the build settings for the target have been the same between debug and release
         // configurations.
         // The custom manifest settings might cause them to diverge.
-        var debugSettings: SWBProjectModel.PIF.BuildSettings = settings
-        var releaseSettings: SWBProjectModel.PIF.BuildSettings = settings
+        var debugSettings: SwiftBuild.ProjectModel.BuildSettings = settings
+        var releaseSettings: SwiftBuild.ProjectModel.BuildSettings = settings
 
         // Apply target-specific build settings defined in the manifest.
         for (buildConfig, declarationsByPlatform) in mainModule.allBuildSettings.targetSettings {
             for (platform, declarations) in declarationsByPlatform {
                 // A `nil` platform means that the declaration applies to *all* platforms.
-                let pifPlatform = platform.map { SWBProjectModel.PIF.BuildSettings.Platform(from: $0) }
+                let pifPlatform = platform.map { SwiftBuild.ProjectModel.BuildSettings.Platform(from: $0) }
                 for (declaration, stringValues) in declarations {
-                    let pifDeclaration = SWBProjectModel.PIF.BuildSettings.Declaration(from: declaration)
+                    let pifDeclaration = SwiftBuild.ProjectModel.BuildSettings.Declaration(from: declaration)
                     switch buildConfig {
                     case .debug:
                         debugSettings.append(values: stringValues, to: pifDeclaration, platform: pifPlatform)
@@ -452,8 +452,8 @@ extension PackagePIFProjectBuilder {
         _ product: PackageGraph.ResolvedProduct,
         with packageConditions: [PackageModel.PackageCondition],
         isLinkable: Bool,
-        pifTarget: SWBProjectModel.PIF.Target,
-        settings: inout SWBProjectModel.PIF.BuildSettings
+        pifTarget: SwiftBuild.ProjectModel.Target,
+        settings: inout SwiftBuild.ProjectModel.BuildSettings
     ) {
         // Do not add a dependency for binary-only executable products since they are not part of the build.
         if product.isBinaryOnlyExecutableProduct {
@@ -502,8 +502,8 @@ extension PackagePIFProjectBuilder {
             dynamicLibraryVariant.isDynamicLibraryVariant = true
             self.builtModulesAndProducts.append(dynamicLibraryVariant)
 
-            let pifTarget = library.pifTarget as? SWBProjectModel.PIF.Target
-            let dynamicPifTarget = dynamicLibraryVariant.pifTarget as? SWBProjectModel.PIF.Target
+            let pifTarget = library.pifTarget as? SwiftBuild.ProjectModel.Target
+            let dynamicPifTarget = dynamicLibraryVariant.pifTarget as? SwiftBuild.ProjectModel.Target
 
             if let pifTarget, let dynamicPifTarget {
                 pifTarget.dynamicTargetVariant = dynamicPifTarget
@@ -531,7 +531,7 @@ extension PackagePIFProjectBuilder {
 
         let pifTargetProductName: String
         let executableName: String
-        let productType: SWBProjectModel.PIF.Target.ProductType
+        let productType: SwiftBuild.ProjectModel.Target.ProductType
 
         if desiredProductType == .dynamic {
             if pifBuilder.createDylibForDynamicProducts {
@@ -606,7 +606,7 @@ extension PackagePIFProjectBuilder {
             }
         }
 
-        var settings: SWBProjectModel.PIF.BuildSettings = package.underlying.packageBaseBuildSettings
+        var settings: SwiftBuild.ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
 
         // Add other build settings when we're building an actual dylib.
         if desiredProductType == .dynamic {
@@ -839,7 +839,7 @@ extension PackagePIFProjectBuilder {
         )
         log(.debug, "created \(type(of: pluginPifTarget)) '\(pluginPifTarget.id)' with name '\(pluginPifTarget.name)'")
 
-        let buildSettings: SWBProjectModel.PIF.BuildSettings = package.underlying.packageBaseBuildSettings
+        let buildSettings: SwiftBuild.ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
         pluginPifTarget.addBuildConfig(name: "Debug", settings: buildSettings)
         pluginPifTarget.addBuildConfig(name: "Release", settings: buildSettings)
 

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -27,6 +27,8 @@ import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
 import struct PackageGraph.ResolvedProduct
 
+#if canImport(SwiftBuild)
+
 import enum SwiftBuild.ProjectModel
 
 /// Extension to create PIF **products** for a given package.
@@ -984,3 +986,5 @@ private struct PackageRegistrySignature: Encodable {
     let source: Source
     let formatVersion = 2
 }
+
+#endif

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -49,7 +49,7 @@ extension PackagePIFProjectBuilder {
         }
 
         // Determine the kind of PIF target *product type* to create for the package product.
-        let pifProductType: SwiftBuild.ProjectModel.Target.ProductType
+        let pifProductType: ProjectModel.Target.ProductType
         let moduleOrProductType: PackagePIFBuilder.ModuleOrProductType
         let synthesizedResourceGeneratingPluginInvocationResults: [PackagePIFBuilder.BuildToolPluginInvocationResult] =
             []
@@ -107,7 +107,7 @@ extension PackagePIFProjectBuilder {
 
         // Configure the target-wide build settings. The details depend on the kind of product we're building,
         // but are in general the ones that are suitable for end-product artifacts such as executables and test bundles.
-        var settings: SwiftBuild.ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
+        var settings: ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
         settings[.TARGET_NAME] = product.name
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "regular"
         settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
@@ -444,8 +444,8 @@ extension PackagePIFProjectBuilder {
         // Until this point the build settings for the target have been the same between debug and release
         // configurations.
         // The custom manifest settings might cause them to diverge.
-        var debugSettings: SwiftBuild.ProjectModel.BuildSettings = settings
-        var releaseSettings: SwiftBuild.ProjectModel.BuildSettings = settings
+        var debugSettings: ProjectModel.BuildSettings = settings
+        var releaseSettings: ProjectModel.BuildSettings = settings
 
         // Apply target-specific build settings defined in the manifest.
         for (buildConfig, declarationsByPlatform) in mainModule.allBuildSettings.targetSettings {
@@ -493,7 +493,7 @@ extension PackagePIFProjectBuilder {
         with packageConditions: [PackageModel.PackageCondition],
         isLinkable: Bool,
         targetKeyPath: WritableKeyPath<ProjectModel.Project, ProjectModel.Target>,
-        settings: inout SwiftBuild.ProjectModel.BuildSettings
+        settings: inout ProjectModel.BuildSettings
     ) {
         // Do not add a dependency for binary-only executable products since they are not part of the build.
         if product.isBinaryOnlyExecutableProduct {
@@ -571,7 +571,7 @@ extension PackagePIFProjectBuilder {
 
         let pifTargetProductName: String
         let executableName: String
-        let productType: SwiftBuild.ProjectModel.Target.ProductType
+        let productType: ProjectModel.Target.ProductType
 
         if desiredProductType == .dynamic {
             if pifBuilder.createDylibForDynamicProducts {
@@ -665,7 +665,7 @@ extension PackagePIFProjectBuilder {
             }
         }
 
-        var settings: SwiftBuild.ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
+        var settings: ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
 
         // Add other build settings when we're building an actual dylib.
         if desiredProductType == .dynamic {
@@ -923,7 +923,7 @@ extension PackagePIFProjectBuilder {
             log(.debug, "Created aggregate target '\(pluginTarget.id)' with name '\(pluginTarget.name)'")
         }
 
-        let buildSettings: SwiftBuild.ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
+        let buildSettings: ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
         self.project[keyPath: pluginTargetKeyPath].common.addBuildConfig { id in
             BuildConfig(id: id, name: "Debug", settings: buildSettings)
         }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -31,6 +31,7 @@ import enum SwiftBuild.ProjectModel
 
 /// Extension to create PIF **products** for a given package.
 extension PackagePIFProjectBuilder {
+
     // MARK: - Main Module Products
 
     mutating func makeMainModuleProduct(_ product: PackageGraph.ResolvedProduct) throws {
@@ -49,14 +50,14 @@ extension PackagePIFProjectBuilder {
 
         // Determine the kind of PIF target *product type* to create for the package product.
         let pifProductType: SwiftBuild.ProjectModel.Target.ProductType
-        let moduleOrProductType: PIFPackageBuilder.ModuleOrProductType
-        let synthesizedResourceGeneratingPluginInvocationResults: [PIFPackageBuilder.BuildToolPluginInvocationResult] =
+        let moduleOrProductType: PackagePIFBuilder.ModuleOrProductType
+        let synthesizedResourceGeneratingPluginInvocationResults: [PackagePIFBuilder.BuildToolPluginInvocationResult] =
             []
 
         if product.type == .executable {
             if let customPIFProductType = pifBuilder.delegate.customProductType(forExecutable: product.underlying) {
                 pifProductType = customPIFProductType
-                moduleOrProductType = PIFPackageBuilder.ModuleOrProductType(from: customPIFProductType)
+                moduleOrProductType = PackagePIFBuilder.ModuleOrProductType(from: customPIFProductType)
             } else {
                 // No custom type provider. Current behavior is to fall back on regular executable.
                 pifProductType = .executable
@@ -70,16 +71,22 @@ extension PackagePIFProjectBuilder {
         }
 
         // It's not a library product, so create a regular PIF target of the appropriate product type.
-        let mainModulePifTarget = try self.pif.addTargetThrowing(
-            id: product.pifTargetGUID(),
-            productType: pifProductType,
-            name: product.name,
-            productName: product.name
-        )
-        log(
-            .debug,
-            "created \(type(of: mainModulePifTarget)) '\(mainModulePifTarget.id)' of type '\(mainModulePifTarget.productType.asString)' with name '\(mainModulePifTarget.name)' and product name '\(mainModulePifTarget.productName)'"
-        )
+        let mainModuleTargetKeyPath = try self.project.addTarget { _ in
+            ProjectModel.Target(
+                id: product.pifTargetGUID(),
+                productType: pifProductType,
+                name: product.name,
+                productName: product.name
+            )
+        }
+        do {
+            let mainModuleTarget = self.project[keyPath: mainModuleTargetKeyPath]
+            log(
+                .debug,
+                "Created \(mainModuleTarget.productType)) '\(mainModuleTarget.id)' " +
+                "with name '\(mainModuleTarget.name)' and product name '\(mainModuleTarget.productName)'"
+            )
+        }
 
         // We're currently *not* handling other module targets (and SwiftPM should never return them) for
         // a main-module product but, for diagnostic purposes, we warn about any that we do come across.
@@ -91,7 +98,7 @@ extension PackagePIFProjectBuilder {
         // Deal with any generated source files or resource files.
         let (generatedSourceFiles, pluginGeneratedResourceFiles) = computePluginGeneratedFiles(
             module: mainModule,
-            pifTarget: mainModulePifTarget,
+            targetKeyPath: mainModuleTargetKeyPath,
             addBuildToolPluginCommands: pifProductType == .application
         )
         if mainModule.resources.hasContent || pluginGeneratedResourceFiles.hasContent {
@@ -101,86 +108,106 @@ extension PackagePIFProjectBuilder {
         // Configure the target-wide build settings. The details depend on the kind of product we're building,
         // but are in general the ones that are suitable for end-product artifacts such as executables and test bundles.
         var settings: SwiftBuild.ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
-        settings.TARGET_NAME = product.name
-        settings.PACKAGE_RESOURCE_TARGET_KIND = "regular"
-        settings.PRODUCT_NAME = "$(TARGET_NAME)"
-        settings.PRODUCT_MODULE_NAME = product.c99name
-        settings.PRODUCT_BUNDLE_IDENTIFIER = "\(self.package.identity).\(product.name)"
-            .spm_mangledToBundleIdentifier()
-        settings.EXECUTABLE_NAME = product.name
-        settings.CLANG_ENABLE_MODULES = "YES"
-        settings.SWIFT_PACKAGE_NAME = mainModule.packageName
+        settings[.TARGET_NAME] = product.name
+        settings[.PACKAGE_RESOURCE_TARGET_KIND] = "regular"
+        settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
+        settings[.PRODUCT_MODULE_NAME] = product.c99name
+        settings[.PRODUCT_BUNDLE_IDENTIFIER] = "\(self.package.identity).\(product.name)".spm_mangledToBundleIdentifier()
+        settings[.EXECUTABLE_NAME] = product.name
+        settings[.CLANG_ENABLE_MODULES] = "YES"
+        settings[.SWIFT_PACKAGE_NAME] = mainModule.packageName
 
         if mainModule.type == .test {
             // FIXME: we shouldn't always include both the deep and shallow bundle paths here, but for that we'll need rdar://31867023
-            settings.LD_RUNPATH_SEARCH_PATHS = ["@loader_path/Frameworks", "@loader_path/../Frameworks", "$(inherited)"]
-            settings.GENERATE_INFOPLIST_FILE = "YES"
-            settings.SKIP_INSTALL = "NO"
-            settings.SWIFT_ACTIVE_COMPILATION_CONDITIONS.lazilyInitialize { ["$(inherited)"] }
+            settings[.LD_RUNPATH_SEARCH_PATHS] = ["@loader_path/Frameworks", "@loader_path/../Frameworks", "$(inherited)"]
+            settings[.GENERATE_INFOPLIST_FILE] = "YES"
+            settings[.SKIP_INSTALL] = "NO"
+            settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS].lazilyInitialize { ["$(inherited)"] }
         } else if mainModule.type == .executable {
             // Setup install path for executables if it's in root of a pure Swift package.
             if pifBuilder.delegate.hostsOnlyPackages && pifBuilder.delegate.isRootPackage {
-                settings.SKIP_INSTALL = "NO"
-                settings.INSTALL_PATH = "/usr/local/bin"
-                settings.LD_RUNPATH_SEARCH_PATHS = ["$(inherited)", "@executable_path/../lib"]
+                settings[.SKIP_INSTALL] = "NO"
+                settings[.INSTALL_PATH] = "/usr/local/bin"
+                settings[.LD_RUNPATH_SEARCH_PATHS] = ["$(inherited)", "@executable_path/../lib"]
             }
         }
 
         let mainTargetDeploymentTargets = mainModule.deploymentTargets(using: pifBuilder.delegate)
 
-        settings.MACOSX_DEPLOYMENT_TARGET = mainTargetDeploymentTargets[.macOS] ?? nil
-        settings.IPHONEOS_DEPLOYMENT_TARGET = mainTargetDeploymentTargets[.iOS] ?? nil
+        settings[.MACOSX_DEPLOYMENT_TARGET] = mainTargetDeploymentTargets[.macOS] ?? nil
+        settings[.IPHONEOS_DEPLOYMENT_TARGET] = mainTargetDeploymentTargets[.iOS] ?? nil
         if let deploymentTarget_macCatalyst = mainTargetDeploymentTargets[.macCatalyst] {
             settings
                 .platformSpecificSettings[.macCatalyst]![.IPHONEOS_DEPLOYMENT_TARGET] = [deploymentTarget_macCatalyst]
         }
-        settings.TVOS_DEPLOYMENT_TARGET = mainTargetDeploymentTargets[.tvOS] ?? nil
-        settings.WATCHOS_DEPLOYMENT_TARGET = mainTargetDeploymentTargets[.watchOS] ?? nil
-        settings.DRIVERKIT_DEPLOYMENT_TARGET = mainTargetDeploymentTargets[.driverKit] ?? nil
-        settings.XROS_DEPLOYMENT_TARGET = mainTargetDeploymentTargets[.visionOS] ?? nil
+        settings[.TVOS_DEPLOYMENT_TARGET] = mainTargetDeploymentTargets[.tvOS] ?? nil
+        settings[.WATCHOS_DEPLOYMENT_TARGET] = mainTargetDeploymentTargets[.watchOS] ?? nil
+        settings[.DRIVERKIT_DEPLOYMENT_TARGET] = mainTargetDeploymentTargets[.driverKit] ?? nil
+        settings[.XROS_DEPLOYMENT_TARGET] = mainTargetDeploymentTargets[.visionOS] ?? nil
 
         // If the main module includes C headers, then we need to set up the HEADER_SEARCH_PATHS setting appropriately.
         if let includeDirAbsolutePath = mainModule.includeDirAbsolutePath {
             // Let the main module itself find its own headers.
-            settings.HEADER_SEARCH_PATHS = [includeDirAbsolutePath.pathString, "$(inherited)"]
-            log(.debug, ".. added '\(includeDirAbsolutePath)' to HEADER_SEARCH_PATHS")
+            settings[.HEADER_SEARCH_PATHS] = [includeDirAbsolutePath.pathString, "$(inherited)"]
+            log(.debug, indent: 1, "Added '\(includeDirAbsolutePath)' to HEADER_SEARCH_PATHS")
         }
 
         // Set the appropriate language versions.
-        settings.SWIFT_VERSION = mainModule.packageSwiftLanguageVersion(manifest: packageManifest)
-        settings.GCC_C_LANGUAGE_STANDARD = mainModule.cLanguageStandard
-        settings.CLANG_CXX_LANGUAGE_STANDARD = mainModule.cxxLanguageStandard
-        settings.SWIFT_ENABLE_BARE_SLASH_REGEX = "NO"
+        settings[.SWIFT_VERSION] = mainModule.packageSwiftLanguageVersion(manifest: packageManifest)
+        settings[.GCC_C_LANGUAGE_STANDARD] = mainModule.cLanguageStandard
+        settings[.CLANG_CXX_LANGUAGE_STANDARD] = mainModule.cxxLanguageStandard
+        settings[.SWIFT_ENABLE_BARE_SLASH_REGEX] = "NO"
 
         // Create a group for the source files of the main module
         // For now we use an absolute path for it, but we should really make it
         // container-relative, since it's always inside the package directory.
-        let mainTargetSourceFileGroup = self.pif.mainGroup.addGroup(
-            path: mainModule.sourceDirAbsolutePath.pathString,
-            pathBase: .absolute
-        )
-        log(.debug, ".. added source file group '\(mainTargetSourceFileGroup.path)'")
+        let mainTargetSourceFileGroupKeyPath = self.project.mainGroup.addGroup { id in
+            ProjectModel.Group(
+                id: id,
+                path: mainModule.sourceDirAbsolutePath.pathString,
+                pathBase: .absolute
+            )
+        }
+        do {
+            let mainTargetSourceFileGroup = self.project.mainGroup[keyPath: mainTargetSourceFileGroupKeyPath]
+            log(.debug, indent: 1, "Added source file group '\(mainTargetSourceFileGroup.path)'")
+        }
 
         // Add a source file reference for each of the source files, and also an indexable-file URL for each one.
         // Note that the indexer requires them to have any symbolic links resolved.
         var indexableFileURLs: [SourceControlURL] = []
         for sourcePath in mainModule.sourceFileRelativePaths {
-            mainModulePifTarget.addSourceFile(
-                ref: mainTargetSourceFileGroup.addFileReference(path: sourcePath.pathString, pathBase: .groupDir)
+            let sourceFileRef = self.project.mainGroup[keyPath: mainTargetSourceFileGroupKeyPath].addFileReference { id in
+                FileReference(
+                    id: id,
+                    path: sourcePath.pathString,
+                    pathBase: .groupDir
+                )
+            }
+            self.project[keyPath: mainModuleTargetKeyPath].addSourceFile { id in
+                BuildFile(id: id, fileRef: sourceFileRef)
+            }
+            log(.debug, indent: 2, "Added source file '\(sourcePath)'")
+            indexableFileURLs.append(
+                SourceControlURL(fileURLWithPath: mainModule.sourceDirAbsolutePath.appending(sourcePath))
             )
-            log(.debug, ".. .. added source file '\(sourcePath)'")
-            indexableFileURLs
-                .append(SourceControlURL(fileURLWithPath: mainModule.sourceDirAbsolutePath.appending(sourcePath)))
         }
 
         let headerFiles = Set(mainModule.headerFileAbsolutePaths)
 
         // Add any additional source files emitted by custom build commands.
         for path in generatedSourceFiles {
-            mainModulePifTarget.addSourceFile(
-                ref: mainTargetSourceFileGroup.addFileReference(path: path.pathString, pathBase: .absolute)
-            )
-            log(.debug, ".. .. added generated source file '\(path)'")
+            let sourceFileRef = self.project.mainGroup[keyPath: mainTargetSourceFileGroupKeyPath].addFileReference { id in
+                FileReference(
+                    id: id,
+                    path: path.pathString,
+                    pathBase: .absolute
+                )
+            }
+            self.project[keyPath: mainModuleTargetKeyPath].addSourceFile { id in
+                BuildFile(id: id, fileRef: sourceFileRef)
+            }
+            log(.debug, indent: 2, "Added generated source file '\(path)'")
         }
 
         // Add any additional resource files emitted by synthesized build commands
@@ -189,7 +216,7 @@ extension PackagePIFProjectBuilder {
             generatedResourceFiles.append(
                 contentsOf: addBuildToolCommands(
                     from: synthesizedResourceGeneratingPluginInvocationResults,
-                    pifTarget: mainModulePifTarget,
+                    targetKeyPath: mainModuleTargetKeyPath,
                     addBuildToolPluginCommands: pifProductType == .application
                 )
             )
@@ -201,76 +228,80 @@ extension PackagePIFProjectBuilder {
         if pifProductType == .application {
             let result = processResources(
                 for: mainModule,
-                sourceModulePifTarget: mainModulePifTarget,
+                sourceModuleTargetKeyPath: mainModuleTargetKeyPath,
                 // For application products we embed the resources directly into the PIF target.
-                resourceBundlePifTarget: nil,
+                resourceBundleTargetKeyPath: nil,
                 generatedResourceFiles: generatedResourceFiles
             )
 
             if result.shouldGenerateBundleAccessor {
-                settings.GENERATE_RESOURCE_ACCESSORS = "YES"
+                settings[.GENERATE_RESOURCE_ACCESSORS] = "YES"
             }
             if result.shouldGenerateEmbedInCodeAccessor {
-                settings.GENERATE_EMBED_IN_CODE_ACCESSORS = "YES"
+                settings[.GENERATE_EMBED_IN_CODE_ACCESSORS] = "YES"
             }
-
             // FIXME: We should also adjust the generated module bundle glue so that `Bundle.module` is a synonym for `Bundle.main` in this case.
         } else {
             let (result, resourceBundle) = try addResourceBundle(
                 for: mainModule,
-                pifTarget: mainModulePifTarget,
+                targetKeyPath: mainModuleTargetKeyPath,
                 generatedResourceFiles: generatedResourceFiles
             )
             if let resourceBundle { self.builtModulesAndProducts.append(resourceBundle) }
 
             if let resourceBundle = result.bundleName {
                 // Associate the resource bundle with the target.
-                settings.PACKAGE_RESOURCE_BUNDLE_NAME = resourceBundle
+                settings[.PACKAGE_RESOURCE_BUNDLE_NAME] = resourceBundle
 
                 if result.shouldGenerateBundleAccessor {
-                    settings.GENERATE_RESOURCE_ACCESSORS = "YES"
+                    settings[.GENERATE_RESOURCE_ACCESSORS] = "YES"
                 }
                 if result.shouldGenerateEmbedInCodeAccessor {
-                    settings.GENERATE_EMBED_IN_CODE_ACCESSORS = "YES"
+                    settings[.GENERATE_EMBED_IN_CODE_ACCESSORS] = "YES"
                 }
 
                 // If it's a kind of product that can contain resources, we also add a use of it.
-                let ref = self.pif.mainGroup
-                    .addFileReference(path: "$(CONFIGURATION_BUILD_DIR)/\(resourceBundle).bundle")
+                let resourceBundleRef = self.project.mainGroup.addFileReference { id in
+                    FileReference(id: id, path: "$(CONFIGURATION_BUILD_DIR)/\(resourceBundle).bundle")
+                }
                 if pifProductType == .bundle || pifProductType == .unitTest {
-                    settings.COREML_CODEGEN_LANGUAGE = mainModule.usesSwift ? "Swift" : "Objective-C"
-                    settings.COREML_COMPILER_CONTAINER = "swift-package"
+                    settings[.COREML_CODEGEN_LANGUAGE] = mainModule.usesSwift ? "Swift" : "Objective-C"
+                    settings[.COREML_COMPILER_CONTAINER] = "swift-package"
 
-                    mainModulePifTarget.addResourceFile(ref: ref)
-                    log(.debug, ".. added use of resource bundle '\(ref.path)'")
+                    self.project[keyPath: mainModuleTargetKeyPath].addResourceFile { id in
+                        BuildFile(id: id, fileRef: resourceBundleRef)
+                    }
+                    log(.debug, indent: 2, "Added use of resource bundle '\(resourceBundleRef.path)'")
                 } else {
                     log(
                         .debug,
-                        ".. ignored resource bundle '\(ref.path)' for main module of type \(type(of: mainModule))"
+                        indent: 2,
+                        "Ignored resource bundle '\(resourceBundleRef.path)' for main module of type \(type(of: mainModule))"
                     )
                 }
 
                 // Add build tool commands to the resource bundle target.
-                let resourceBundlePifTarget = self
-                    .resourceBundleTarget(forModuleName: mainModule.name) ?? mainModulePifTarget
+                let mainResourceBundleTargetKeyPath = self.resourceBundleTargetKeyPath(forModuleName: mainModule.name)
+                let resourceBundleTargetKeyPath = mainResourceBundleTargetKeyPath ?? mainModuleTargetKeyPath
+                
                 addBuildToolCommands(
                     module: mainModule,
-                    sourceModulePifTarget: mainModulePifTarget,
-                    resourceBundlePifTarget: resourceBundlePifTarget,
+                    sourceModuleTargetKeyPath: mainModuleTargetKeyPath,
+                    resourceBundleTargetKeyPath: resourceBundleTargetKeyPath,
                     sourceFilePaths: generatedSourceFiles,
                     resourceFilePaths: generatedResourceFiles
                 )
             } else {
                 // Generated resources always trigger the creation of a bundle accessor.
-                settings.GENERATE_RESOURCE_ACCESSORS = "YES"
-                settings.GENERATE_EMBED_IN_CODE_ACCESSORS = "NO"
+                settings[.GENERATE_RESOURCE_ACCESSORS] = "YES"
+                settings[.GENERATE_EMBED_IN_CODE_ACCESSORS] = "NO"
 
-                // If we did not create a resource bundle target, we still need to add build tool commands for any
-                // generated files.
+                // If we did not create a resource bundle target,
+                // we still need to add build tool commands for any generated files.
                 addBuildToolCommands(
                     module: mainModule,
-                    sourceModulePifTarget: mainModulePifTarget,
-                    resourceBundlePifTarget: mainModulePifTarget,
+                    sourceModuleTargetKeyPath: mainModuleTargetKeyPath,
+                    resourceBundleTargetKeyPath: mainModuleTargetKeyPath,
                     sourceFilePaths: generatedSourceFiles,
                     resourceFilePaths: generatedResourceFiles
                 )
@@ -287,39 +318,44 @@ extension PackagePIFProjectBuilder {
 
                 switch moduleDependency.type {
                 case .binary:
-                    let binaryReference = self.binaryGroup.addFileReference(path: moduleDependency.path.pathString)
-                    mainModulePifTarget.addLibrary(
-                        ref: binaryReference,
-                        platformFilters: packageConditions
-                            .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
-                        codeSignOnCopy: true,
-                        removeHeadersOnCopy: true
-                    )
-                    log(.debug, ".. added use of binary library '\(moduleDependency.path)'")
+                    let binaryFileRef = self.binaryGroup.addFileReference { id in
+                        FileReference(id: id, path: moduleDependency.path.pathString)
+                    }
+                    let toolsVersion = self.package.manifest.toolsVersion
+                    self.project[keyPath: mainModuleTargetKeyPath].addLibrary { id in
+                        BuildFile(
+                            id: id,
+                            fileRef: binaryFileRef,
+                            platformFilters: packageConditions.toPlatformFilter(toolsVersion: toolsVersion),
+                            codeSignOnCopy: true,
+                            removeHeadersOnCopy: true
+                        )
+                    }
+                    log(.debug, indent: 1, "Added use of binary library '\(moduleDependency.path)'")
 
                 case .plugin:
                     let dependencyId = moduleDependency.pifTargetGUID()
-                    mainModulePifTarget.addDependency(
+                    self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(
                         on: dependencyId,
                         platformFilters: packageConditions
                             .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
                         linkProduct: false
                     )
-                    log(.debug, ".. added use of plugin target '\(dependencyId)'")
+                    log(.debug, indent: 1, "Added use of plugin target '\(dependencyId)'")
 
                 case .macro:
                     let dependencyId = moduleDependency.pifTargetGUID()
-                    mainModulePifTarget.addDependency(
+                    self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(
                         on: dependencyId,
                         platformFilters: packageConditions
                             .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
                         linkProduct: false
                     )
-                    log(.debug, ".. added dependency on product '\(dependencyId)'")
+                    log(.debug, indent: 1, "Added dependency on product '\(dependencyId)'")
 
                     // Link with a testable version of the macro if appropriate.
                     if product.type == .test {
-                        mainModulePifTarget.addDependency(
+                        self.project[keyPath:mainModuleTargetKeyPath].common.addDependency(
                             on: moduleDependency.pifTargetGUID(suffix: .testable),
                             platformFilters: packageConditions
                                 .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
@@ -327,7 +363,8 @@ extension PackagePIFProjectBuilder {
                         )
                         log(
                             .debug,
-                            ".. added linked dependency on target '\(moduleDependency.pifTargetGUID(suffix: .testable))'"
+                            indent: 1,
+                            "Added linked dependency on target '\(moduleDependency.pifTargetGUID(suffix: .testable))'"
                         )
 
                         // FIXME: Manually propagate product dependencies of macros but the build system should really handle this.
@@ -339,7 +376,7 @@ extension PackagePIFProjectBuilder {
                                     productDependency,
                                     with: packageConditions,
                                     isLinkable: isLinkable,
-                                    pifTarget: mainModulePifTarget,
+                                    targetKeyPath: mainModuleTargetKeyPath,
                                     settings: &settings
                                 )
                             case .module:
@@ -354,32 +391,32 @@ extension PackagePIFProjectBuilder {
                     let productDependency = modulesGraph.allProducts.only { $0.name == moduleDependency.name }
                     if let productDependency {
                         let productDependencyGUID = productDependency.pifTargetGUID()
-                        mainModulePifTarget.addDependency(
+                        self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(
                             on: productDependencyGUID,
                             platformFilters: packageConditions
                                 .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
                             linkProduct: false
                         )
-                        log(.debug, ".. added dependency on product '\(productDependencyGUID)'")
+                        log(.debug, indent: 1, "Added dependency on product '\(productDependencyGUID)'")
                     }
 
                     // If we're linking against an executable and the tools version is new enough,
                     // we also link against a testable version of the executable.
                     if product.type == .test, self.package.manifest.toolsVersion >= .v5_5 {
                         let moduleDependencyGUID = moduleDependency.pifTargetGUID(suffix: .testable)
-                        mainModulePifTarget.addDependency(
+                        self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(
                             on: moduleDependencyGUID,
                             platformFilters: packageConditions
                                 .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
                             linkProduct: true
                         )
-                        log(.debug, ".. added linked dependency on target '\(moduleDependencyGUID)'")
+                        log(.debug, indent: 1, "Added linked dependency on target '\(moduleDependencyGUID)'")
                     }
 
                 case .library, .systemModule, .test:
                     let shouldLinkProduct = moduleDependency.type != .systemModule
                     let dependencyGUID = moduleDependency.pifTargetGUID()
-                    mainModulePifTarget.addDependency(
+                    self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(
                         on: dependencyGUID,
                         platformFilters: packageConditions
                             .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
@@ -387,7 +424,8 @@ extension PackagePIFProjectBuilder {
                     )
                     log(
                         .debug,
-                        ".. added \(shouldLinkProduct ? "linked " : "")dependency on target '\(dependencyGUID)'"
+                        indent: 1,
+                        "Added \(shouldLinkProduct ? "linked " : "")dependency on target '\(dependencyGUID)'"
                     )
                 }
 
@@ -397,7 +435,7 @@ extension PackagePIFProjectBuilder {
                     productDependency,
                     with: packageConditions,
                     isLinkable: isLinkable,
-                    pifTarget: mainModulePifTarget,
+                    targetKeyPath: mainModuleTargetKeyPath,
                     settings: &settings
                 )
             }
@@ -413,31 +451,33 @@ extension PackagePIFProjectBuilder {
         for (buildConfig, declarationsByPlatform) in mainModule.allBuildSettings.targetSettings {
             for (platform, declarations) in declarationsByPlatform {
                 // A `nil` platform means that the declaration applies to *all* platforms.
-                let pifPlatform = platform.map { SwiftBuild.ProjectModel.BuildSettings.Platform(from: $0) }
                 for (declaration, stringValues) in declarations {
-                    let pifDeclaration = SwiftBuild.ProjectModel.BuildSettings.Declaration(from: declaration)
                     switch buildConfig {
                     case .debug:
-                        debugSettings.append(values: stringValues, to: pifDeclaration, platform: pifPlatform)
+                        debugSettings.append(values: stringValues, to: declaration, platform: platform)
                     case .release:
-                        releaseSettings.append(values: stringValues, to: pifDeclaration, platform: pifPlatform)
+                        releaseSettings.append(values: stringValues, to: declaration, platform: platform)
                     }
                 }
             }
         }
-        mainModulePifTarget.addBuildConfig(name: "Debug", settings: debugSettings)
-        mainModulePifTarget.addBuildConfig(name: "Release", settings: releaseSettings)
-
-        // Collect linked binaries.
-        let linkedPackageBinaries: [PIFPackageBuilder.LinkedPackageBinary] = mainModule.dependencies.compactMap {
-            PIFPackageBuilder.LinkedPackageBinary(dependency: $0, package: self.package)
+        self.project[keyPath: mainModuleTargetKeyPath].common.addBuildConfig { id in
+            BuildConfig(id: id, name: "Debug", settings: debugSettings)
+        }
+        self.project[keyPath: mainModuleTargetKeyPath].common.addBuildConfig { id in
+            BuildConfig(id: id, name: "Release", settings: releaseSettings)
         }
 
-        let moduleOrProduct = PIFPackageBuilder.ModuleOrProduct(
+        // Collect linked binaries.
+        let linkedPackageBinaries: [PackagePIFBuilder.LinkedPackageBinary] = mainModule.dependencies.compactMap {
+            PackagePIFBuilder.LinkedPackageBinary(dependency: $0, package: self.package)
+        }
+
+        let moduleOrProduct = PackagePIFBuilder.ModuleOrProduct(
             type: moduleOrProductType,
             name: product.name,
             moduleName: product.c99name,
-            pifTarget: mainModulePifTarget,
+            pifTarget: .target(self.project[keyPath: mainModuleTargetKeyPath]),
             indexableFileURLs: indexableFileURLs,
             headerFiles: headerFiles,
             linkedPackageBinaries: linkedPackageBinaries,
@@ -448,11 +488,11 @@ extension PackagePIFProjectBuilder {
         self.builtModulesAndProducts.append(moduleOrProduct)
     }
 
-    private func handleProduct(
+    private mutating func handleProduct(
         _ product: PackageGraph.ResolvedProduct,
         with packageConditions: [PackageModel.PackageCondition],
         isLinkable: Bool,
-        pifTarget: SwiftBuild.ProjectModel.Target,
+        targetKeyPath: WritableKeyPath<ProjectModel.Project, ProjectModel.Target>,
         settings: inout SwiftBuild.ProjectModel.BuildSettings
     ) {
         // Do not add a dependency for binary-only executable products since they are not part of the build.
@@ -462,14 +502,15 @@ extension PackagePIFProjectBuilder {
 
         if !pifBuilder.delegate.shouldSuppressProductDependency(product: product.underlying, buildSettings: &settings) {
             let shouldLinkProduct = isLinkable
-            pifTarget.addDependency(
+            self.project[keyPath: targetKeyPath].common.addDependency(
                 on: product.pifTargetGUID(),
                 platformFilters: packageConditions.toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
                 linkProduct: shouldLinkProduct
             )
             log(
                 .debug,
-                ".. added \(shouldLinkProduct ? "linked " : "")dependency on product '\(product.pifTargetGUID()))'"
+                indent: 1,
+                "Added \(shouldLinkProduct ? "linked " : "")dependency on product '\(product.pifTargetGUID()))'"
             )
         }
     }
@@ -502,14 +543,13 @@ extension PackagePIFProjectBuilder {
             dynamicLibraryVariant.isDynamicLibraryVariant = true
             self.builtModulesAndProducts.append(dynamicLibraryVariant)
 
-            let pifTarget = library.pifTarget as? SwiftBuild.ProjectModel.Target
-            let dynamicPifTarget = dynamicLibraryVariant.pifTarget as? SwiftBuild.ProjectModel.Target
-
-            if let pifTarget, let dynamicPifTarget {
-                pifTarget.dynamicTargetVariant = dynamicPifTarget
-            } else {
-                assertionFailure("Could not assign dynamic PIF target")
+            guard let pifTarget = library.pifTarget,
+                  let pifTargetKeyPath = self.project.findTarget(id: pifTarget.id),
+                  let dynamicPifTarget = dynamicLibraryVariant.pifTarget
+            else {
+                fatalError("Could not assign dynamic PIF target")
             }
+            self.project[keyPath: pifTargetKeyPath].dynamicTargetVariantId = dynamicPifTarget.id
         }
     }
 
@@ -519,12 +559,12 @@ extension PackagePIFProjectBuilder {
     /// all SwiftPM library products are represented by two PIF targets:
     /// one of the "native" manifestation that gets linked into the client,
     /// and another for a dynamic framework specifically for use by the development-time features.
-    private func buildLibraryProduct(
+    private mutating func buildLibraryProduct(
         _ product: PackageGraph.ResolvedProduct,
         type desiredProductType: ProductType.LibraryType,
         targetSuffix: TargetGUIDSuffix? = nil,
         embedResources: Bool
-    ) throws -> PIFPackageBuilder.ModuleOrProduct {
+    ) throws -> PackagePIFBuilder.ModuleOrProduct {
         precondition(product.type.isLibrary)
 
         // FIXME: Cleanup this mess with <rdar://56889224>
@@ -539,8 +579,8 @@ extension PackagePIFProjectBuilder {
                 executableName = pifTargetProductName
                 productType = .dynamicLibrary
             } else {
-                // If a product is explicitly declared dynamic, we preserve its name, otherwise we will compute an
-                // automatic one.
+                // If a product is explicitly declared dynamic, we preserve its name,
+                // otherwise we will compute an automatic one.
                 if product.libraryType == .dynamic {
                     if let customExecutableName = pifBuilder.delegate
                         .customExecutableName(product: product.underlying)
@@ -550,7 +590,7 @@ extension PackagePIFProjectBuilder {
                         executableName = product.name
                     }
                 } else {
-                    executableName = PIFPackageBuilder.computePackageProductFrameworkName(productName: product.name)
+                    executableName = PackagePIFBuilder.computePackageProductFrameworkName(productName: product.name)
                 }
                 pifTargetProductName = "\(executableName).framework"
                 productType = .framework
@@ -562,47 +602,66 @@ extension PackagePIFProjectBuilder {
         }
 
         // Create a special kind of PIF target that just "groups" a set of targets for clients to depend on.
-        // SwiftBuild will *not* produce a separate artifact for a package product, but will instead consider any
-        // dependency on
-        // the package product to be a dependency on the whole set of targets on which the package product depends.
-        let pifTarget = try self.pif.addTargetThrowing(
-            id: product.pifTargetGUID(suffix: targetSuffix),
-            productType: productType,
-            name: product.name,
-            productName: pifTargetProductName
-        )
-        log(
-            .debug,
-            "created \(type(of: pifTarget)) '\(pifTarget.id)' of type '\(pifTarget.productType.asString)' with name '\(pifTarget.name)' and product name '\(pifTarget.productName)'"
-        )
+        // Swift Build will *not* produce a separate artifact for a package product, but will instead consider any
+        // dependency on the package product to be a dependency on the whole set of targets
+        // on which the package product depends.
+        let librayUmbrellaTargetKeyPath = try self.project.addTarget { _ in
+            ProjectModel.Target(
+                id: product.pifTargetGUID(suffix: targetSuffix),
+                productType: productType,
+                name: product.name,
+                productName: pifTargetProductName
+            )
+        }
+        do {
+            let librayTarget = self.project[keyPath: librayUmbrellaTargetKeyPath]
+            log(
+                .debug,
+                "Created target '\(librayTarget.id)' of type '\(librayTarget.productType)' with " +
+                "name '\(librayTarget.name)' and product name '\(librayTarget.productName)'"
+            )
+        }
 
         // Add linked dependencies on the *targets* that comprise the product.
         for module in product.modules {
             // Binary targets are special in that they are just linked, not built.
             if let binaryTarget = module.underlying as? BinaryModule {
-                let binaryReference = self.binaryGroup.addFileReference(path: binaryTarget.artifactPath.pathString)
-                pifTarget.addLibrary(ref: binaryReference, codeSignOnCopy: true, removeHeadersOnCopy: true)
-                log(.debug, ".. added use of binary library '\(binaryTarget.artifactPath.pathString)'")
+                let binaryFileRef = self.binaryGroup.addFileReference { id in
+                    FileReference(id: id, path: binaryTarget.artifactPath.pathString)
+                }
+                self.project[keyPath: librayUmbrellaTargetKeyPath].addLibrary { id in
+                    BuildFile(id: id, fileRef: binaryFileRef, codeSignOnCopy: true, removeHeadersOnCopy: true)
+                }
+                log(.debug, indent: 1, "Added use of binary library '\(binaryTarget.artifactPath)'")
                 continue
             }
             // We add these as linked dependencies; because the product type is `.packageProduct`,
             // SwiftBuild won't actually link them, but will instead impart linkage to any clients that
             // link against the package product.
-            pifTarget.addDependency(on: module.pifTargetGUID(), platformFilters: [], linkProduct: true)
-            log(.debug, ".. added linked dependency on target '\(module.pifTargetGUID())'")
+            self.project[keyPath: librayUmbrellaTargetKeyPath].common.addDependency(
+                on: module.pifTargetGUID(),
+                platformFilters: [],
+                linkProduct: true
+            )
+            log(.debug, indent: 1, "Added linked dependency on target '\(module.pifTargetGUID())'")
         }
 
         for module in product.modules where module.underlying.isSourceModule && module.resources.hasContent {
-            // FIXME: Find a way to determine whether a module has generated resources here so that we can embed resources into dynamic targets.
-            pifTarget.addDependency(on: pifTargetIdForResourceBundle(module.name), platformFilters: [])
+            // FIXME: Find a way to determine whether a module has generated resources
+            // here so that we can embed resources into dynamic targets.
+            self.project[keyPath: librayUmbrellaTargetKeyPath].common.addDependency(on: pifTargetIdForResourceBundle(module.name), platformFilters: [])
 
-            let filreRef = self.pif.mainGroup
-                .addFileReference(path: "$(CONFIGURATION_BUILD_DIR)/\(package.name)_\(module.name).bundle")
+            let packageName = self.package.name
+            let fileRef = self.project.mainGroup.addFileReference { id in
+                FileReference(id: id, path: "$(CONFIGURATION_BUILD_DIR)/\(packageName)_\(module.name).bundle")
+            }
             if embedResources {
-                pifTarget.addResourceFile(ref: filreRef)
-                log(.debug, ".. added use of resource bundle '\(filreRef.path)'")
+                self.project[keyPath: librayUmbrellaTargetKeyPath].addResourceFile { id in
+                    BuildFile(id: id, fileRef: fileRef)
+                }
+                log(.debug, indent: 1, "Added use of resource bundle '\(fileRef.path)'")
             } else {
-                log(.debug, ".. ignored resource bundle '\(filreRef.path)' because resource embedding is disabled")
+                log(.debug, indent: 1, "Ignored resource bundle '\(fileRef.path)' because resource embedding is disabled")
             }
         }
 
@@ -620,22 +679,23 @@ extension PackagePIFProjectBuilder {
                 installPath: installPath(for: product.underlying),
                 delegate: pifBuilder.delegate
             )
-
-            pifTarget.addSourcesBuildPhase()
+            self.project[keyPath: librayUmbrellaTargetKeyPath].common.addSourcesBuildPhase { id in
+                ProjectModel.SourcesBuildPhase(id: id)
+            }
         }
 
         // Additional configuration and files for this library product.
         pifBuilder.delegate.configureLibraryProduct(
             product: product.underlying,
-            pifTarget: pifTarget,
-            additionalFiles: self.additionalFilesGroup
+            target: librayUmbrellaTargetKeyPath,
+            additionalFiles: additionalFilesGroupKeyPath
         )
 
         // If the given package is a root package or it is used via a branch/revision, we allow unsafe flags.
-        let implicitlyAllowAllUnsafeFlags = pifBuilder.delegate.isBranchOrRevisionBased || pifBuilder.delegate
-            .isUserManaged
+        let implicitlyAllowAllUnsafeFlags = pifBuilder.delegate.isBranchOrRevisionBased ||
+            pifBuilder.delegate.isUserManaged
         let recordUsesUnsafeFlags = try !implicitlyAllowAllUnsafeFlags && product.usesUnsafeFlags
-        settings.USES_SWIFTPM_UNSAFE_FLAGS = recordUsesUnsafeFlags ? "YES" : "NO"
+        settings[.USES_SWIFTPM_UNSAFE_FLAGS] = recordUsesUnsafeFlags ? "YES" : "NO"
 
         // Handle the dependencies of the targets in the product
         // (and link against them, which in the case of a package product, really just means that clients should link
@@ -648,32 +708,37 @@ extension PackagePIFProjectBuilder {
                 /* assert(moduleDependency.packageName == self.package.name) */
                 
                 if moduleDependency.type == .systemModule {
-                    log(.debug, ".. noted use of system module '\(moduleDependency.name)'")
+                    log(.debug, indent: 1, "Noted use of system module '\(moduleDependency.name)'")
                     return
                 }
 
                 if let binaryTarget = moduleDependency.underlying as? BinaryModule {
-                    let binaryReference = self.binaryGroup.addFileReference(path: binaryTarget.path.pathString)
-                    pifTarget.addLibrary(
-                        ref: binaryReference,
-                        platformFilters: packageConditions
-                            .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
-                        codeSignOnCopy: true,
-                        removeHeadersOnCopy: true
-                    )
-                    log(.debug, ".. added use of binary library '\(binaryTarget.path)'")
+                    let binaryFileRef = self.binaryGroup.addFileReference { id in
+                        FileReference(id: id, path: binaryTarget.path.pathString)
+                    }
+                    let toolsVersion = package.manifest.toolsVersion
+                    self.project[keyPath: librayUmbrellaTargetKeyPath].addLibrary { id in
+                        BuildFile(
+                            id: id,
+                            fileRef: binaryFileRef,
+                            platformFilters: packageConditions.toPlatformFilter(toolsVersion: toolsVersion),
+                            codeSignOnCopy: true,
+                            removeHeadersOnCopy: true
+                        )
+                    }
+                    log(.debug, indent: 1, "Added use of binary library '\(binaryTarget.path)'")
                     return
                 }
 
                 if moduleDependency.type == .plugin {
                     let dependencyId = moduleDependency.pifTargetGUID()
-                    pifTarget.addDependency(
+                    self.project[keyPath: librayUmbrellaTargetKeyPath].common.addDependency(
                         on: dependencyId,
                         platformFilters: packageConditions
                             .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
                         linkProduct: false
                     )
-                    log(.debug, ".. added use of plugin target '\(dependencyId)'")
+                    log(.debug, indent: 1, "Added use of plugin target '\(dependencyId)'")
                     return
                 }
 
@@ -688,28 +753,29 @@ extension PackagePIFProjectBuilder {
                     if let product = moduleDependency
                         .productRepresentingDependencyOfBuildPlugin(in: mainModuleProducts)
                     {
-                        pifTarget.addDependency(
+                        self.project[keyPath: librayUmbrellaTargetKeyPath].common.addDependency(
                             on: product.pifTargetGUID(),
                             platformFilters: packageConditions
                                 .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
                             linkProduct: false
                         )
-                        log(.debug, ".. added dependency on product '\(product.pifTargetGUID())'")
+                        log(.debug, indent: 1, "Added dependency on product '\(product.pifTargetGUID())'")
                         return
                     } else {
                         log(
                             .debug,
-                            ".. could not find a build plugin product to depend on for target '\(product.pifTargetGUID()))'"
+                            indent: 1,
+                            "Could not find a build plugin product to depend on for target '\(product.pifTargetGUID()))'"
                         )
                     }
                 }
 
-                pifTarget.addDependency(
+                self.project[keyPath: librayUmbrellaTargetKeyPath].common.addDependency(
                     on: moduleDependency.pifTargetGUID(),
                     platformFilters: packageConditions.toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
                     linkProduct: true
                 )
-                log(.debug, ".. added linked dependency on target '\(moduleDependency.pifTargetGUID()))'")
+                log(.debug, indent: 1, "Added linked dependency on target '\(moduleDependency.pifTargetGUID()))'")
 
             case .product(let productDependency, let packageConditions):
                 // Do not add a dependency for binary-only executable products since they are not part of the build.
@@ -722,7 +788,7 @@ extension PackagePIFProjectBuilder {
                     buildSettings: &settings
                 ) {
                     let shouldLinkProduct = productDependency.isLinkable
-                    pifTarget.addDependency(
+                    self.project[keyPath: librayUmbrellaTargetKeyPath].common.addDependency(
                         on: productDependency.pifTargetGUID(),
                         platformFilters: packageConditions
                             .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
@@ -730,7 +796,8 @@ extension PackagePIFProjectBuilder {
                     )
                     log(
                         .debug,
-                        ".. added \(shouldLinkProduct ? "linked" : "") dependency on product '\(productDependency.pifTargetGUID()))'"
+                        indent: 1,
+                        "Added \(shouldLinkProduct ? "linked" : "") dependency on product '\(productDependency.pifTargetGUID()))'"
                     )
                 }
             }
@@ -753,29 +820,33 @@ extension PackagePIFProjectBuilder {
             let encoder = PropertyListEncoder()
             encoder.outputFormat = .xml
             let data = try encoder.encode(signatureData)
-            settings.PACKAGE_REGISTRY_SIGNATURE = String(data: data, encoding: .utf8)
+            settings[.PACKAGE_REGISTRY_SIGNATURE] = String(data: data, encoding: .utf8)
         }
 
-        pifTarget.addBuildConfig(name: "Debug", settings: settings)
-        pifTarget.addBuildConfig(name: "Release", settings: settings)
+        self.project[keyPath: librayUmbrellaTargetKeyPath].common.addBuildConfig { id in
+            BuildConfig(id: id, name: "Debug", settings: settings)
+        }
+        self.project[keyPath: librayUmbrellaTargetKeyPath].common.addBuildConfig { id in
+            BuildConfig(id: id, name: "Release", settings: settings)
+        }
 
         // Collect linked binaries.
         let linkedPackageBinaries = product.modules.compactMap {
-            PIFPackageBuilder.LinkedPackageBinary(module: $0, package: self.package)
+            PackagePIFBuilder.LinkedPackageBinary(module: $0, package: self.package)
         }
 
-        let moduleOrProductType: PIFPackageBuilder.ModuleOrProductType = switch product.libraryType {
+        let moduleOrProductType: PackagePIFBuilder.ModuleOrProductType = switch product.libraryType {
         case .dynamic:
             pifBuilder.createDylibForDynamicProducts ? .dynamicLibrary : .framework
         default:
             .staticArchive
         }
 
-        return PIFPackageBuilder.ModuleOrProduct(
+        return PackagePIFBuilder.ModuleOrProduct(
             type: moduleOrProductType,
             name: product.name,
             moduleName: product.c99name,
-            pifTarget: pifTarget,
+            pifTarget: .target(self.project[keyPath: librayUmbrellaTargetKeyPath]),
             indexableFileURLs: [],
             headerFiles: [],
             linkedPackageBinaries: linkedPackageBinaries,
@@ -790,34 +861,42 @@ extension PackagePIFProjectBuilder {
     mutating func makeSystemLibraryProduct(_ product: PackageGraph.ResolvedProduct) throws {
         precondition(product.type == .library(.automatic))
 
-        let pifTarget = try self.pif.addTargetThrowing(
-            id: product.pifTargetGUID(),
-            productType: .packageProduct,
-            name: product.name,
-            productName: product.name
-        )
-
-        log(
-            .debug,
-            "created \(type(of: pifTarget)) '\(pifTarget.id)' of type '\(pifTarget.productType.asString)' " +
-                "with name '\(pifTarget.name)' and product name '\(pifTarget.productName)'"
-        )
+        let systemLibraryTargetKeyPath = try self.project.addTarget { _ in
+            ProjectModel.Target(
+                id: product.pifTargetGUID(),
+                productType: .packageProduct,
+                name: product.name,
+                productName: product.name
+            )
+        }
+        do {
+            let systemLibraryTarget = self.project[keyPath: systemLibraryTargetKeyPath]
+            log(
+                .debug,
+                "Created target '\(systemLibraryTarget.id)' of type '\(systemLibraryTarget.productType)' " +
+                    "with name '\(systemLibraryTarget.name)' and product name '\(systemLibraryTarget.productName)'"
+            )
+        }
 
         let buildSettings = self.package.underlying.packageBaseBuildSettings
-        pifTarget.addBuildConfig(name: "Debug", settings: buildSettings)
-        pifTarget.addBuildConfig(name: "Release", settings: buildSettings)
+        self.project[keyPath: systemLibraryTargetKeyPath].common.addBuildConfig { id in
+            BuildConfig(id: id, name: "Debug", settings: buildSettings)
+        }
+        self.project[keyPath: systemLibraryTargetKeyPath].common.addBuildConfig { id in
+            BuildConfig(id: id, name: "Release", settings: buildSettings)
+        }
 
-        pifTarget.addDependency(
+        self.project[keyPath: systemLibraryTargetKeyPath].common.addDependency(
             on: product.systemModule!.pifTargetGUID(),
             platformFilters: [],
             linkProduct: false
         )
 
-        let systemLibrary = PIFPackageBuilder.ModuleOrProduct(
+        let systemLibrary = PackagePIFBuilder.ModuleOrProduct(
             type: .staticArchive,
             name: product.name,
             moduleName: product.c99name,
-            pifTarget: pifTarget,
+            pifTarget: .target(self.project[keyPath: systemLibraryTargetKeyPath]),
             indexableFileURLs: [],
             headerFiles: [],
             linkedPackageBinaries: [],
@@ -833,24 +912,33 @@ extension PackagePIFProjectBuilder {
     mutating func makePluginProduct(_ pluginProduct: PackageGraph.ResolvedProduct) throws {
         precondition(pluginProduct.type == .plugin)
 
-        let pluginPifTarget = self.pif.addAggregateTarget(
-            id: pluginProduct.pifTargetGUID(),
-            name: pluginProduct.name
-        )
-        log(.debug, "created \(type(of: pluginPifTarget)) '\(pluginPifTarget.id)' with name '\(pluginPifTarget.name)'")
+        let pluginTargetKeyPath = try self.project.addAggregateTarget { _ in
+            ProjectModel.AggregateTarget(
+                id: pluginProduct.pifTargetGUID(),
+                name: pluginProduct.name
+            )
+        }
+        do  {
+            let pluginTarget = self.project[keyPath: pluginTargetKeyPath]
+            log(.debug, "Created aggregate target '\(pluginTarget.id)' with name '\(pluginTarget.name)'")
+        }
 
         let buildSettings: SwiftBuild.ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
-        pluginPifTarget.addBuildConfig(name: "Debug", settings: buildSettings)
-        pluginPifTarget.addBuildConfig(name: "Release", settings: buildSettings)
+        self.project[keyPath: pluginTargetKeyPath].common.addBuildConfig { id in
+            BuildConfig(id: id, name: "Debug", settings: buildSettings)
+        }
+        self.project[keyPath: pluginTargetKeyPath].common.addBuildConfig { id in
+            BuildConfig(id: id, name: "Release", settings: buildSettings)
+        }
 
         for pluginModule in pluginProduct.pluginModules! {
-            pluginPifTarget.addDependency(
+            self.project[keyPath: pluginTargetKeyPath].common.addDependency(
                 on: pluginModule.pifTargetGUID(),
                 platformFilters: []
             )
         }
 
-        let pluginType: PIFPackageBuilder.ModuleOrProductType = {
+        let pluginType: PackagePIFBuilder.ModuleOrProductType = {
             if let pluginTarget = pluginProduct.pluginModules!.only {
                 switch pluginTarget.capability {
                 case .buildTool:
@@ -866,11 +954,11 @@ extension PackagePIFProjectBuilder {
             }
         }()
 
-        let pluginProductMetadata = PIFPackageBuilder.ModuleOrProduct(
+        let pluginProductMetadata = PackagePIFBuilder.ModuleOrProduct(
             type: pluginType,
             name: pluginProduct.name,
             moduleName: pluginProduct.c99name,
-            pifTarget: pluginPifTarget,
+            pifTarget: .aggregate(self.project[keyPath: pluginTargetKeyPath]),
             indexableFileURLs: [],
             headerFiles: [],
             linkedPackageBinaries: [],

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -41,7 +41,7 @@ struct PackagePIFProjectBuilder {
     let packageManifest: PackageModel.Manifest
     let modulesGraph: PackageGraph.ModulesGraph
 
-    var pif: ProjectModel.Project
+    var pif: ProjectModel.Project // TODO: Let's rename to `project` instead?
     let binaryGroup: ProjectModel.Group
     let additionalFilesGroup: ProjectModel.Group
 
@@ -142,7 +142,7 @@ struct PackagePIFProjectBuilder {
 
     mutating func addResourceBundle(
         for module: PackageGraph.ResolvedModule,
-        pifTargetKP: WritableKeyPath<ProjectModel.Project, ProjectModel.Target>,
+        pifTargetKeyPath pifTargetKP: WritableKeyPath<ProjectModel.Project, ProjectModel.Target>,
         generatedResourceFiles: [String]
     ) throws -> (PIFPackageBuilder.EmbedResourcesResult, PIFPackageBuilder.ModuleOrProduct?) {
         if module.resources.isEmpty && generatedResourceFiles.isEmpty {
@@ -328,15 +328,10 @@ struct PackagePIFProjectBuilder {
         )
     }
 
-    func resourceBundleTarget(forModuleName name: String) -> ProjectModel.Target? {
+    func resourceBundleTargetKeyPath(forModuleName name: String) -> WritableKeyPath<ProjectModel.Project, ProjectModel.Target>? {
         let resourceBundleGUID = self.pifTargetIdForResourceBundle(name)
-        let target = self.pif.targets.only { $0.id == resourceBundleGUID }
-        guard let target else { return nil }
-
-        return switch target {
-        case .target(let target): target
-        case .aggregate: nil
-        }
+        let targetKP = self.pif.findTarget(id: resourceBundleGUID)
+        return targetKP
     }
 
     func pifTargetIdForResourceBundle(_ name: String) -> GUID {

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -30,7 +30,6 @@ import struct PackageGraph.ResolvedPackage
 import struct PackageLoading.FileRuleDescription
 import struct PackageLoading.TargetSourcesBuilder
 
-#if canImport(SwiftBuild)
 import enum SwiftBuild.PIF
 import struct SwiftBuild.SwiftBuildFileType
 
@@ -478,5 +477,3 @@ struct PackagePIFProjectBuilder {
         !self.dynamicLibraryProductNames.contains(targetName)
     }
 }
-
-#endif

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -278,7 +278,7 @@ struct PackagePIFProjectBuilder {
             // CoreData files should also be in the actual target because they
             // can end up generating code during the build.
             // The build system will only perform codegen tasks for the main target in this case.
-            let isCoreDataFile = [SWBProjectModel.SwiftBuildFileType.xcdatamodeld, .xcdatamodel]
+            let isCoreDataFile = [SwiftBuild.SwiftBuildFileType.xcdatamodeld, .xcdatamodel]
                 .contains { $0.fileTypes.contains(resourcePath.pathExtension) }
 
             if isCoreDataFile {
@@ -289,7 +289,7 @@ struct PackagePIFProjectBuilder {
             }
 
             // Core ML files need to be included in the source module as well, because there is code generation.
-            let coreMLFileTypes: [SWBProjectModel.SwiftBuildFileType] = [.mlmodel, .mlpackage]
+            let coreMLFileTypes: [SwiftBuild.SwiftBuildFileType] = [.mlmodel, .mlpackage]
             let isCoreMLFile = coreMLFileTypes.contains { $0.fileTypes.contains(resourcePath.pathExtension) }
 
             if isCoreMLFile {
@@ -300,7 +300,7 @@ struct PackagePIFProjectBuilder {
             }
             
             // Metal source code needs to be added to the source build phase.
-            let isMetalFile = SWBProjectModel.SwiftBuildFileType.metal.fileTypes.contains(resourcePath.pathExtension)
+            let isMetalFile = SwiftBuild.SwiftBuildFileType.metal.fileTypes.contains(resourcePath.pathExtension)
 
             if isMetalFile {
                 self.project[keyPath: pifTargetForResourcesKP].addSourceFile { id in

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -258,8 +258,9 @@ struct PackagePIFProjectBuilder {
             )
         }
         // If resourceBundleTarget is nil, we add resources to the sourceModuleTarget instead.
-        let targetForResourcesKeyPath = resourceBundleTargetKeyPath ?? sourceModuleTargetKeyPath
-
+        let targetForResourcesKeyPath: WritableKeyPath<ProjectModel.Project, ProjectModel.Target> =
+            resourceBundleTargetKeyPath ?? sourceModuleTargetKeyPath
+        
         // Generated resources get a default treatment for rule and localization.
         let generatedResources = generatedResourceFiles.compactMap {
             PackagePIFBuilder.Resource(path: $0, rule: .process(localization: nil))
@@ -332,11 +333,14 @@ struct PackagePIFProjectBuilder {
             self.log(.debug, indent: 2, "Added resource file '\(resourcePath)'")
         }
 
-        let resourceBundleTargetName: String? = if let resourceBundleTargetKeyPath {
-            self.project[keyPath: resourceBundleTargetKeyPath].name
+        let resourceBundleTargetName: String?
+        if let resourceBundleTargetKeyPath {
+            let resourceBundleTarget = self.project[keyPath: resourceBundleTargetKeyPath]
+            resourceBundleTargetName = resourceBundleTarget.name
         } else {
-            nil
+            resourceBundleTargetName = nil
         }
+        
         return PackagePIFBuilder.EmbedResourcesResult(
             bundleName: resourceBundleTargetName,
             shouldGenerateBundleAccessor: shouldGenerateBundleAccessor,

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -30,6 +30,8 @@ import struct PackageGraph.ResolvedPackage
 import struct PackageLoading.FileRuleDescription
 import struct PackageLoading.TargetSourcesBuilder
 
+#if canImport(SwiftBuild)
+
 import enum SwiftBuild.ProjectModel
 import struct SwiftBuild.SwiftBuildFileType
 import struct SwiftBuild.Pair
@@ -534,3 +536,5 @@ struct PackagePIFProjectBuilder {
         !self.dynamicLibraryProductNames.contains(targetName)
     }
 }
+
+#endif

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -182,7 +182,7 @@ struct PackagePIFProjectBuilder {
             platformFilters: [],
             linkProduct: false
         )
-        self.log(.debug, ".. added dependency on resource target '\(resourcesTarget.id)'")
+        self.log(.debug, indent: 1, "Added dependency on resource target '\(resourcesTarget.id)'")
 
         for pluginModule in module.pluginsAppliedToModule {
             self.project[keyPath: resourcesTargetKP].common.addDependency(
@@ -194,7 +194,9 @@ struct PackagePIFProjectBuilder {
 
         self.log(
             .debug,
-            ".. created \(type(of: resourcesTarget)) '\(resourcesTarget.id)' of type '\(resourcesTarget.productType)' with name '\(resourcesTarget.name)' and product name '\(resourcesTarget.productName)'"
+            indent: 1,
+            "Created \(type(of: resourcesTarget)) '\(resourcesTarget.id)' of type '\(resourcesTarget.productType)' " +
+            "with name '\(resourcesTarget.name)' and product name '\(resourcesTarget.productName)'"
         )
 
         var settings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
@@ -283,7 +285,7 @@ struct PackagePIFProjectBuilder {
                 self.project[keyPath: sourceModuleTargetKeyPath].addSourceFile { id in
                     BuildFile(id: id, fileRef: ref)
                 }
-                self.log(.debug, ".. .. added core data resource as source file '\(resourcePath)'")
+                self.log(.debug, indent: 2, "Added core data resource as source file '\(resourcePath)'")
             }
 
             // Core ML files need to be included in the source module as well, because there is code generation.
@@ -294,7 +296,7 @@ struct PackagePIFProjectBuilder {
                 self.project[keyPath: sourceModuleTargetKeyPath].addSourceFile { id in
                     BuildFile(id: id, fileRef: ref, generatedCodeVisibility: .public)
                 }
-                self.log(.debug, ".. .. added coreml resource as source file '\(resourcePath)'")
+                self.log(.debug, indent: 2, "Added coreml resource as source file '\(resourcePath)'")
             }
             
             // Metal source code needs to be added to the source build phase.
@@ -322,10 +324,10 @@ struct PackagePIFProjectBuilder {
                 self.project[keyPath: sourceModuleTargetKeyPath].addSourceFile { id in
                     BuildFile(id: id, fileRef: ref)
                 }
-                self.log(.debug, ".. .. added asset catalog as source file '\(resourcePath)'")
+                self.log(.debug, indent: 2, "Added asset catalog as source file '\(resourcePath)'")
             }
 
-            self.log(.debug, ".. .. added resource file '\(resourcePath)'")
+            self.log(.debug, indent: 2, "Added resource file '\(resourcePath)'")
         }
         
         let resourceBundlePifTargetName: String? = if let resourceBundleTargetKeyPath {


### PR DESCRIPTION
### Motivation:

The goal is to adopt the new `SwiftBuild.ProjectModel` API. This new API provides a *typesafer* and *modern* way of building PIFs programmatically.

This continues the work I started in PR #8405, introducing now our new PIF builder for packages.

### Modifications:

Replaces all `SwiftBuild.PIF` (aka, `SWBProjectModel.PIF`) API usage, in `PackagePIFBuilder`, with the new `SwiftBuild.ProjectModel` API instead.

PS. I did run `swiftformat` in all new/changed code, as indicated by the *contributors* guide.

### Result:

`PackagePIFBuilder` is now modernized... but still not actually used. This will come in my next pull request.

Tracked by rdar://147526957.