### PR TITLE
Add executorFactory option to package manifest.

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -501,7 +501,7 @@ public struct SwiftSetting: Sendable {
       _ condition: BuildSettingCondition? = nil
     ) -> SwiftSetting {
         return SwiftSetting(
-          name: "swiftExecutorFactory", value: [name], condition: condition)
+          name: "executorFactory", value: [factory], condition: condition)
     }
 }
 

--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -486,6 +486,23 @@ public struct SwiftSetting: Sendable {
         return SwiftSetting(
             name: "defaultIsolation", value: [isolationString], condition: condition)
     }
+
+    /// Defines an `-executor-factory` to pass to the
+    /// corresponding build tool.
+    ///
+    /// - Since: First available in PackageDescription 6.2
+    ///
+    /// - Parameters:
+    ///   - factory: The type name of the executor factory that should be used.
+    ///   - condition: A condition that restricts the application of the build setting.
+    @available(_PackageDescription, introduced: 6.2)
+    public static func executorFactory(
+      _ factory: String,
+      _ condition: BuildSettingCondition? = nil
+    ) -> SwiftSetting {
+        return SwiftSetting(
+          name: "swiftExecutorFactory", value: [name], condition: condition)
+    }
 }
 
 /// A linker build setting.

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -758,11 +758,11 @@ extension TargetBuildSettingDescription.Kind {
             }
 
             return .defaultIsolation(isolation)
-        case "swiftExecutorFactory":
+        case "executorFactory":
             guard let value = values.first else {
                 throw InternalError("invalid (empty) build settings value")
             }
-            return .swiftExecutorFactory(value)
+            return .executorFactory(value)
         default:
             throw InternalError("invalid build setting \(name)")
         }

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -758,6 +758,11 @@ extension TargetBuildSettingDescription.Kind {
             }
 
             return .defaultIsolation(isolation)
+        case "swiftExecutorFactory":
+            guard let value = values.first else {
+                throw InternalError("invalid (empty) build settings value")
+            }
+            return .swiftExecutorFactory(value)
         default:
             throw InternalError("invalid build setting \(name)")
         }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1264,7 +1264,7 @@ public final class PackageBuilder {
 
                 values = ["-default-isolation", isolation.rawValue]
 
-            case .swiftExecutorFactory(let factory):
+            case .executorFactory(let factory):
                 switch setting.tool {
                 case .c, .cxx, .linker:
                     throw InternalError("only Swift supports executor factory")

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1263,6 +1263,17 @@ public final class PackageBuilder {
                 }
 
                 values = ["-default-isolation", isolation.rawValue]
+
+            case .swiftExecutorFactory(let factory):
+                switch setting.tool {
+                case .c, .cxx, .linker:
+                    throw InternalError("only Swift supports executor factory")
+
+                case .swift:
+                  decl = .OTHER_SWIFT_FLAGS
+                }
+
+                values = ["-executor-factory ", factory]
             }
 
             // Create an assignment for this setting.

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -58,7 +58,7 @@ public enum TargetBuildSettingDescription {
                 return !flags.isEmpty
             case .headerSearchPath, .define, .linkedLibrary, .linkedFramework, .interoperabilityMode,
                  .enableUpcomingFeature, .enableExperimentalFeature, .strictMemorySafety, .swiftLanguageMode,
-                 .defaultIsolation, executorFactory:
+                 .defaultIsolation, .executorFactory:
                 return false
             }
         }

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -49,6 +49,8 @@ public enum TargetBuildSettingDescription {
 
         case defaultIsolation(DefaultIsolation)
 
+        case executorFactory(String)
+
         public var isUnsafeFlags: Bool {
             switch self {
             case .unsafeFlags(let flags):
@@ -56,7 +58,7 @@ public enum TargetBuildSettingDescription {
                 return !flags.isEmpty
             case .headerSearchPath, .define, .linkedLibrary, .linkedFramework, .interoperabilityMode,
                  .enableUpcomingFeature, .enableExperimentalFeature, .strictMemorySafety, .swiftLanguageMode,
-                 .defaultIsolation:
+                 .defaultIsolation, executorFactory:
                 return false
             }
         }

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -584,7 +584,7 @@ fileprivate extension SourceCodeFragment {
                 params.append(SourceCodeFragment(from: condition))
             }
             self.init(enum: setting.kind.name, subnodes: params)
-        case .swiftExecutorFactory(let factory):
+        case .executorFactory(let factory):
             params.append(SourceCodeFragment(string: factory))
             self.init(enum: setting.kind.name, subnodes: params)
         }
@@ -1026,6 +1026,8 @@ extension TargetBuildSettingDescription.Kind {
             return "swiftLanguageMode"
         case .defaultIsolation:
             return "defaultIsolation"
+        case .executorFactory:
+            return "executorFactory"
         }
     }
 }

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -584,6 +584,9 @@ fileprivate extension SourceCodeFragment {
                 params.append(SourceCodeFragment(from: condition))
             }
             self.init(enum: setting.kind.name, subnodes: params)
+        case .swiftExecutorFactory(let factory):
+            params.append(SourceCodeFragment(string: factory))
+            self.init(enum: setting.kind.name, subnodes: params)
         }
     }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4308,6 +4308,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                         ),
                         .init(tool: .swift, kind: .strictMemorySafety),
                         .init(tool: .swift, kind: .defaultIsolation(.MainActor)),
+                        .init(tool: .swift, kind: .executorFactory("Foo.Bar")),
                     ]
                 ),
                 TargetDescription(

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -898,4 +898,23 @@ final class ManifestSourceGenerationTests: XCTestCase {
         let contents = try manifest.generateManifestFileContents(packageDirectory: manifest.path.parentDirectory)
         try await testManifestWritingRoundTrip(manifestContents: contents, toolsVersion: .v6_2)
     }
+
+    func testExecutorFactory() async throws {
+        let manifest = Manifest.createRootManifest(
+          displayName: "pkg",
+          path: "/pkg",
+          toolsVersion: .v6_2,
+          dependencies: [],
+          targets: [
+            try TargetDescription(
+              name: "A",
+              type: .executable,
+              settings: [
+                .init(tool: .swift, kind: .executorFactory("Foo.Bar"))
+              ]
+            )
+          ])
+        let contents = try manifest.generateManifestFileContents(packageDirectory: manifest.path.parentDirectory)
+        try await testManifestWritingRoundTrip(manifestContents: contents, toolsVersion: .v6_2)
+    }
 }


### PR DESCRIPTION
This lets you specify which executor factory to use in the `Package.swift`.

rdar://148430450
