### PR TITLE
Bootstrap: update logic to support pre-and post python 3.8

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -592,7 +592,8 @@ def install_file(args, src, destination, destination_is_directory=True, ignored_
 
     logging.info("Installing %s to %s", src, dest)
     if os.path.isdir(src):
-        shutil.copytree(src, dest, ignore=shutil.ignore_patterns(*ignored_patterns), dirs_exist_ok=True)
+        additional_kwargs = { "dirs_exist_ok": True } if sys.version_info.major >=3 and sys.version_info.minor >= 8 else {}
+        shutil.copytree(src, dest, ignore=shutil.ignore_patterns(*ignored_patterns), **additional_kwargs)
     else:
         shutil.copy2(src, dest)
 


### PR DESCRIPTION
PR #8373 (commit ID: 0193d5fb8) updated a `shutil.copytree(...)` command to pass in the `dirs_exists_ok=True` argument.  However, Python added support for the `dirs_exists_ok` argument to `shutil.copytree` in 3.8.

Update the function call to inspect the python version, and only add the argument if the script is running in a Python version equal, or higher than 3.8.

- Python 3.7 documentation: https://docs.python.org/3.7/library/shutil.html#shutil.copytree
- Python 3.8 documentation: https://docs.python.org/3.8/library/shutil.html#shutil.copytree

rdar://147297864
