### PR TITLE
Tests: Enable BasicsTests/FileSystem/* Tests on Windows (Swift Testing)

### DIFF
--- a/Tests/BasicsTests/FileSystem/FileSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/FileSystemTests.swift
@@ -9,77 +9,84 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
+import TSCTestSupport
+import Testing
 
 @testable import Basics
-import TSCTestSupport
-import XCTest
 
-final class FileSystemTests: XCTestCase {
-    func testStripFirstLevelComponent() throws {
+struct FileSystemTests {
+    @Test
+    func stripFirstLevelComponent() throws {
         let fileSystem = InMemoryFileSystem()
 
         let rootPath = AbsolutePath("/root")
         try fileSystem.createDirectory(rootPath)
 
-        let totalDirectories = Int.random(in: 0 ..< 100)
-        for index in 0 ..< totalDirectories {
+        let totalDirectories = Int.random(in: 0..<100)
+        for index in 0..<totalDirectories {
             let path = rootPath.appending("dir\(index)")
             try fileSystem.createDirectory(path, recursive: false)
         }
 
-        let totalFiles = Int.random(in: 0 ..< 100)
-        for index in 0 ..< totalFiles {
+        let totalFiles = Int.random(in: 0..<100)
+        for index in 0..<totalFiles {
             let path = rootPath.appending("file\(index)")
             try fileSystem.writeFileContents(path, string: "\(index)")
         }
 
         do {
             let contents = try fileSystem.getDirectoryContents(.root)
-            XCTAssertEqual(contents.count, 1)
+            #expect(contents.count == 1)
         }
 
         try fileSystem.stripFirstLevel(of: .root)
 
         do {
             let contents = Set(try fileSystem.getDirectoryContents(.root))
-            XCTAssertEqual(contents.count, totalDirectories + totalFiles)
+            #expect(contents.count == totalDirectories + totalFiles)
 
-            for index in 0 ..< totalDirectories {
-                XCTAssertTrue(contents.contains("dir\(index)"))
+            for index in 0..<totalDirectories {
+                #expect(contents.contains("dir\(index)"))
             }
-            for index in 0 ..< totalFiles {
-                XCTAssertTrue(contents.contains("file\(index)"))
+            for index in 0..<totalFiles {
+                #expect(contents.contains("file\(index)"))
             }
         }
     }
 
-    func testStripFirstLevelComponentErrors() throws {
+    @Test
+    func stripFirstLevelComponentErrors() throws {
+        let functionUnderTest = "stripFirstLevel"
         do {
             let fileSystem = InMemoryFileSystem()
-            XCTAssertThrowsError(try fileSystem.stripFirstLevel(of: .root), "expected error") { error in
-                XCTAssertMatch((error as? StringError)?.description, .contains("requires single top level directory"))
+            #expect(throws: StringError("\(functionUnderTest) requires single top level directory"))
+            {
+                try fileSystem.stripFirstLevel(of: .root)
             }
         }
 
         do {
             let fileSystem = InMemoryFileSystem()
-            for index in 0 ..< 3 {
+            for index in 0..<3 {
                 let path = AbsolutePath.root.appending("dir\(index)")
                 try fileSystem.createDirectory(path, recursive: false)
             }
-            XCTAssertThrowsError(try fileSystem.stripFirstLevel(of: .root), "expected error") { error in
-                XCTAssertMatch((error as? StringError)?.description, .contains("requires single top level directory"))
+            #expect(throws: StringError("\(functionUnderTest) requires single top level directory"))
+            {
+                try fileSystem.stripFirstLevel(of: .root)
             }
         }
 
         do {
             let fileSystem = InMemoryFileSystem()
-            for index in 0 ..< 3 {
+            for index in 0..<3 {
                 let path = AbsolutePath.root.appending("file\(index)")
                 try fileSystem.writeFileContents(path, string: "\(index)")
             }
-            XCTAssertThrowsError(try fileSystem.stripFirstLevel(of: .root), "expected error") { error in
-                XCTAssertMatch((error as? StringError)?.description, .contains("requires single top level directory"))
+            #expect(throws: StringError("\(functionUnderTest) requires single top level directory"))
+            {
+                try fileSystem.stripFirstLevel(of: .root)
             }
         }
 
@@ -87,8 +94,9 @@ final class FileSystemTests: XCTestCase {
             let fileSystem = InMemoryFileSystem()
             let path = AbsolutePath.root.appending("file")
             try fileSystem.writeFileContents(path, string: "")
-            XCTAssertThrowsError(try fileSystem.stripFirstLevel(of: .root), "expected error") { error in
-                XCTAssertMatch((error as? StringError)?.description, .contains("requires single top level directory"))
+            #expect(throws: StringError("\(functionUnderTest) requires single top level directory"))
+            {
+                try fileSystem.stripFirstLevel(of: .root)
             }
         }
     }

--- a/Tests/BasicsTests/FileSystem/InMemoryFilesSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/InMemoryFilesSystemTests.swift
@@ -21,216 +21,221 @@ let isLinux = true
 let isLinux = false
 #endif
 
-// Comment out the Swift Testing test until we figure out why the Linux Smoke Test
-// is crashing
-// struct InMemoryFileSystemTests {
-//     @Test(
-//         arguments: [
-//             (
-//                 path: "/",
-//                 recurvise: true,
-//                 expectedFiles: [
-//                     (p: "/", shouldExist: true),
-//                 ],
-//                 expectError: false
-//             ),
-//             (
-//                 path: "/tmp",
-//                 recurvise: true,
-//                 expectedFiles: [
-//                     (p: "/", shouldExist: true),
-//                     (p: "/tmp", shouldExist: true),
-//                 ],
-//                 expectError: false
-//             ),
-//             (
-//                 path: "/tmp/ws",
-//                 recurvise: true,
-//                 expectedFiles: [
-//                     (p: "/", shouldExist: true),
-//                     (p: "/tmp", shouldExist: true),
-//                     (p: "/tmp/ws", shouldExist: true),
-//                 ],
-//                 expectError: false
-//             ),
-//             (
-//                 path: "/tmp/ws",
-//                 recurvise: false,
-//                 expectedFiles: [
-//                     (p: "/", shouldExist: true),
-//                     (p: "/tmp", shouldExist: true),
-//                     (p: "/tmp/ws", shouldExist: true),
-//                 ],
-//                 expectError: true
-//             ),
-//         ]
-//     )
-//     func creatingDirectoryCreatesInternalFiles(
-//         path: String,
-//         recursive: Bool,
-//         expectedFiles: [(String, Bool) ],
-//         expectError: Bool
-//     ) async throws {
-//         let fs = InMemoryFileSystem()
-//         let pathUnderTest = AbsolutePath(path)
+struct InMemoryFileSystemTests {
+    @Test(
+        arguments: [
+            (
+                path: "/",
+                recurvise: true,
+                expectedFiles: [
+                    (p: "/", shouldExist: true)
+                ],
+                expectError: false
+            ),
+            (
+                path: "/tmp",
+                recurvise: true,
+                expectedFiles: [
+                    (p: "/", shouldExist: true),
+                    (p: "/tmp", shouldExist: true),
+                ],
+                expectError: false
+            ),
+            (
+                path: "/tmp/ws",
+                recurvise: true,
+                expectedFiles: [
+                    (p: "/", shouldExist: true),
+                    (p: "/tmp", shouldExist: true),
+                    (p: "/tmp/ws", shouldExist: true),
+                ],
+                expectError: false
+            ),
+            (
+                path: "/tmp/ws",
+                recurvise: false,
+                expectedFiles: [
+                    (p: "/", shouldExist: true),
+                    (p: "/tmp", shouldExist: true),
+                    (p: "/tmp/ws", shouldExist: true),
+                ],
+                expectError: true
+            ),
+        ]
+    )
+    func creatingDirectoryCreatesInternalFiles(
+        path: String,
+        recursive: Bool,
+        expectedFiles: [(String, Bool)],
+        expectError: Bool
+    ) async throws {
+        let fs = InMemoryFileSystem()
+        let pathUnderTest = AbsolutePath(path)
 
-//         func errorMessage(_ pa: AbsolutePath, _ exists: Bool) -> String {
-//             return "Path '\(pa) \(exists ? "should exists, but doesn't" : "should not exist, but does.")"
-//         }
+        func errorMessage(_ pa: AbsolutePath, _ exists: Bool) -> String {
+            return
+                "Path '\(pa) \(exists ? "should exists, but doesn't" : "should not exist, but does.")"
+        }
 
-//         try withKnownIssue {
-//             try fs.createDirectory(pathUnderTest, recursive: recursive)
+        try withKnownIssue {
+            try fs.createDirectory(pathUnderTest, recursive: recursive)
 
-//             for (p, shouldExist) in expectedFiles {
-//                 let expectedPath = AbsolutePath(p)
-//                 #expect(fs.exists(expectedPath) == shouldExist, "\(errorMessage(expectedPath, shouldExist))")
-//             }
-//         } when: {
-//             expectError
-//         }
-//     }
-
-
-//     @Test(
-//         arguments: [
-//             "/",
-//             "/tmp",
-//             "/tmp/",
-//             "/something/ws",
-//             "/something/ws/",
-//             "/what/is/this",
-//             "/what/is/this/",
-//         ]
-//     )
-//     func callingCreateDirectoryOnAnExistingDirectoryIsSuccessful(path: String) async throws {
-//         let root = AbsolutePath(path)
-//         let fs = InMemoryFileSystem()
-
-//         #expect(throws: Never.self) {
-//             try fs.createDirectory(root, recursive: true)
-//         }
-
-//         #expect(throws: Never.self) {
-//             try fs.createDirectory(root.appending("more"), recursive: true)
-//         }
-//     }
-
-//     struct writeFileContentsTests {
-
-//         @Test
-//         func testWriteFileContentsSuccessful() async throws {
-//             // GIVEN we have a filesytstem
-//             let fs = InMemoryFileSystem()
-//             // and a path
-//             let pathUnderTest = AbsolutePath("/myFile.zip")
-//             let expectedContents = ByteString([0xAA, 0xBB, 0xCC])
-
-//             // WHEN we write contents to the file
-//             try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
-
-//             // THEN we expect the file to exist
-//             #expect(fs.exists(pathUnderTest), "Path \(pathUnderTest.pathString) does not exists when it should")
-//         }
-
-//         @Test
-//         func testWritingAFileWithANonExistingParentDirectoryFails() async throws {
-//             // GIVEN we have a filesytstem
-//             let fs = InMemoryFileSystem()
-//             // and a path
-//             let pathUnderTest = AbsolutePath("/tmp/myFile.zip")
-//             let expectedContents = ByteString([0xAA, 0xBB, 0xCC])
-
-//             // WHEN we write contents to the file
-//             // THEn we expect an error to occus
-//             try withKnownIssue {
-//                 try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
-//             }
-
-//             // AND we expect the file to not exist
-//             #expect(!fs.exists(pathUnderTest), "Path \(pathUnderTest.pathString) does exists when it should not")
-//         }
-
-//         @Test
-//         func errorOccursWhenWritingToRootDirectory() async throws {
-//             // GIVEN we have a filesytstem
-//             let fs = InMemoryFileSystem()
-//             // and a path
-//             let pathUnderTest = AbsolutePath("/")
-//             let expectedContents = ByteString([0xAA, 0xBB, 0xCC])
-
-//             // WHEN we write contents to the file
-//             // THEN we expect an error to occur
-//             try withKnownIssue {
-//                 try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
-//             }
-
-//         }
-
-//         @Test
-//         func testErrorOccursIfParentIsNotADirectory() async throws {
-//             // GIVEN we have a filesytstem
-//             let fs = InMemoryFileSystem()
-//             // AND an existing file
-//             let aFile = AbsolutePath("/foo")
-//             try fs.writeFileContents(aFile, bytes: "")
-
-//             // AND a the path under test that has an existing file as a parent
-//             let pathUnderTest = aFile.appending("myFile")
-//             let expectedContents = ByteString([0xAA, 0xBB, 0xCC])
-
-//             // WHEN we write contents to the file
-//             // THEN we expect an error to occur
-//             withKnownIssue {
-//                 try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
-//             }
-
-//         }
-//     }
+            for (p, shouldExist) in expectedFiles {
+                let expectedPath = AbsolutePath(p)
+                #expect(
+                    fs.exists(expectedPath) == shouldExist,
+                    "\(errorMessage(expectedPath, shouldExist))")
+            }
+        } when: {
+            expectError
+        }
+    }
 
 
-//     struct testReadFileContentsTests {
-//         @Test
-//         func readingAFileThatDoesNotExistsRaisesAnError()async throws {
-//             // GIVEN we have a filesystem
-//             let fs = InMemoryFileSystem()
+    @Test(
+        arguments: [
+            "/",
+            "/tmp",
+            "/tmp/",
+            "/something/ws",
+            "/something/ws/",
+            "/what/is/this",
+            "/what/is/this/",
+        ]
+    )
+    func callingCreateDirectoryOnAnExistingDirectoryIsSuccessful(path: String) async throws {
+        let root = AbsolutePath(path)
+        let fs = InMemoryFileSystem()
 
-//             // WHEN we read a non-existing file
-//             // THEN an error occurs
-//             try withKnownIssue {
-//                 let _ = try fs.readFileContents("/file/does/not/exists")
-//             }
-//         }
+        #expect(throws: Never.self) {
+            try fs.createDirectory(root, recursive: true)
+        }
 
-//         @Test
-//         func readingExistingFileReturnsExpectedContents() async throws {
-//             // GIVEN we have a filesytstem
-//             let fs = InMemoryFileSystem()
-//             // AND a file a path
-//             let pathUnderTest = AbsolutePath("/myFile.zip")
-//             let expectedContents = ByteString([0xAA, 0xBB, 0xCC])
-//             try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
+        #expect(throws: Never.self) {
+            try fs.createDirectory(root.appending("more"), recursive: true)
+        }
+    }
 
-//             // WHEN we read contents if the file
-//             let actualContents = try fs.readFileContents(pathUnderTest)
+    struct writeFileContentsTests {
 
-//             // THEN the actual contents should match the expected to match the
-//             #expect(actualContents == expectedContents, "Actual is not as expected")
-//         }
+        @Test
+        func testWriteFileContentsSuccessful() async throws {
+            // GIVEN we have a filesytstem
+            let fs = InMemoryFileSystem()
+            // and a path
+            let pathUnderTest = AbsolutePath("/myFile.zip")
+            let expectedContents = ByteString([0xAA, 0xBB, 0xCC])
 
-//         @Test
-//         func readingADirectoryFailsWithAnError() async throws {
-//             // GIVEN we have a filesytstem
-//             let fs = InMemoryFileSystem()
-//             // AND a file a path
-//             let pathUnderTest = AbsolutePath("/myFile.zip")
-//             let expectedContents = ByteString([0xAA, 0xBB, 0xCC])
-//             try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
+            // WHEN we write contents to the file
+            try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
 
-//             // WHEN we read the contents of a directory
-//             // THEN we expect a failure to occur
-//             withKnownIssue {
-//                 let _ = try fs.readFileContents(pathUnderTest.parentDirectory)
-//             }
-//         }
-//     }
-// }
+            // THEN we expect the file to exist
+            #expect(
+                fs.exists(pathUnderTest),
+                "Path \(pathUnderTest.pathString) does not exists when it should")
+        }
+
+        @Test
+        func testWritingAFileWithANonExistingParentDirectoryFails() async throws {
+            // GIVEN we have a filesytstem
+            let fs = InMemoryFileSystem()
+            // and a path
+            let pathUnderTest = AbsolutePath("/tmp/myFile.zip")
+            let expectedContents = ByteString([0xAA, 0xBB, 0xCC])
+
+            // WHEN we write contents to the file
+            // THEn we expect an error to occus
+            try withKnownIssue {
+                try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
+            }
+
+            // AND we expect the file to not exist
+            #expect(
+                !fs.exists(pathUnderTest),
+                "Path \(pathUnderTest.pathString) does exists when it should not")
+        }
+
+        @Test
+        func errorOccursWhenWritingToRootDirectory() async throws {
+            // GIVEN we have a filesytstem
+            let fs = InMemoryFileSystem()
+            // and a path
+            let pathUnderTest = AbsolutePath("/")
+            let expectedContents = ByteString([0xAA, 0xBB, 0xCC])
+
+            // WHEN we write contents to the file
+            // THEN we expect an error to occur
+            try withKnownIssue {
+                try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
+            }
+
+        }
+
+        @Test
+        func testErrorOccursIfParentIsNotADirectory() async throws {
+            // GIVEN we have a filesytstem
+            let fs = InMemoryFileSystem()
+            // AND an existing file
+            let aFile = AbsolutePath("/foo")
+            try fs.writeFileContents(aFile, bytes: "")
+
+            // AND a the path under test that has an existing file as a parent
+            let pathUnderTest = aFile.appending("myFile")
+            let expectedContents = ByteString([0xAA, 0xBB, 0xCC])
+
+            // WHEN we write contents to the file
+            // THEN we expect an error to occur
+            withKnownIssue {
+                try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
+            }
+
+        }
+    }
+
+
+    struct testReadFileContentsTests {
+        @Test
+        func readingAFileThatDoesNotExistsRaisesAnError() async throws {
+            // GIVEN we have a filesystem
+            let fs = InMemoryFileSystem()
+
+            // WHEN we read a non-existing file
+            // THEN an error occurs
+            try withKnownIssue {
+                let _ = try fs.readFileContents("/file/does/not/exists")
+            }
+        }
+
+        @Test
+        func readingExistingFileReturnsExpectedContents() async throws {
+            // GIVEN we have a filesytstem
+            let fs = InMemoryFileSystem()
+            // AND a file a path
+            let pathUnderTest = AbsolutePath("/myFile.zip")
+            let expectedContents = ByteString([0xAA, 0xBB, 0xCC])
+            try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
+
+            // WHEN we read contents if the file
+            let actualContents = try fs.readFileContents(pathUnderTest)
+
+            // THEN the actual contents should match the expected to match the
+            #expect(actualContents == expectedContents, "Actual is not as expected")
+        }
+
+        @Test
+        func readingADirectoryFailsWithAnError() async throws {
+            // GIVEN we have a filesytstem
+            let fs = InMemoryFileSystem()
+            // AND a file a path
+            let pathUnderTest = AbsolutePath("/myFile.zip")
+            let expectedContents = ByteString([0xAA, 0xBB, 0xCC])
+            try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
+
+            // WHEN we read the contents of a directory
+            // THEN we expect a failure to occur
+            withKnownIssue {
+                let _ = try fs.readFileContents(pathUnderTest.parentDirectory)
+            }
+        }
+    }
+}

--- a/Tests/BasicsTests/FileSystem/PathTests.swift
+++ b/Tests/BasicsTests/FileSystem/PathTests.swift
@@ -6,13 +6,11 @@
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import Basics
 import Foundation
-import XCTest
-
-import _InternalTestSupport // for XCTSkipOnWindows()
+import Testing
 
 #if os(Windows)
 private var windows: Bool { true }
@@ -20,362 +18,530 @@ private var windows: Bool { true }
 private var windows: Bool { false }
 #endif
 
-class PathTests: XCTestCase {
-    func testBasics() {
-        XCTAssertEqual(AbsolutePath("/").pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/a").pathString, windows ? #"\a"# : "/a")
-        XCTAssertEqual(AbsolutePath("/a/b/c").pathString, windows ? #"\a\b\c"# : "/a/b/c")
-        XCTAssertEqual(RelativePath(".").pathString, ".")
-        XCTAssertEqual(RelativePath("a").pathString, "a")
-        XCTAssertEqual(RelativePath("a/b/c").pathString, windows ? #"a\b\c"# : "a/b/c")
-        XCTAssertEqual(RelativePath("~").pathString, "~")  // `~` is not special
+
+struct PathTests {
+    struct AbsolutePathTests {
+        private func pathStringIsSetCorrectlyTestImplementation(path: String, expected: String, label: String) {
+            let actual = AbsolutePath(path).pathString
+
+            #expect(actual == expected, "\(label): Actual is not as expected.")
+        }
+
+        @Test(
+            arguments: [
+                (path: "/", expected: (windows ? #"\"# : "/"), label: "Basics"),
+                (path: "/a", expected: (windows ? #"\a"# : "/a"), label: "Basics"),
+                (path: "/a/b/c", expected: (windows ? #"\a\b\c"# : "/a/b/c"), label: "Basics"),
+
+
+                (path: "/ab/cd/ef/", expected: (windows ? #"\ab\cd\ef"# : "/ab/cd/ef"), label: "Trailing path seperator"),
+                (path: "/ab/cd/ef//", expected: (windows ? #"\ab\cd\ef"# : "/ab/cd/ef"), label: "Trailing path seperator"),
+                (path: "/ab/cd/ef///", expected: (windows ? #"\ab\cd\ef"# : "/ab/cd/ef"), label: "Trailing path seperator"),
+
+
+            ]
+        )
+        func pathStringIsSetCorrectly(path: String, expected: String, label: String) {
+            pathStringIsSetCorrectlyTestImplementation(
+                path: path,
+                expected: expected,
+                label: label
+            )
+        }
+
+        @Test(
+            .skipHostOS(.windows),
+            arguments: [
+                (path: "/ab//cd//ef", expected: (windows ? #"\ab\cd\ef"# : "/ab/cd/ef"), label: "repeated path seperators"), // skip on windows
+                (path: "/ab///cd//ef", expected: (windows ? #"\ab\cd\ef"# : "/ab/cd/ef"), label: "repeated path seperators"), // skip on windows
+
+                (path: "/ab/././cd//ef", expected: "/ab/cd/ef", label: "dot path component"),
+                (path: "/ab/./cd//ef/.", expected:  "/ab/cd/ef", label: "dot path component"),
+
+
+                (path: "/..", expected: (windows ? #"\"# : "/"), label: "dot dot path component"),
+                (path: "/../../../../..", expected: (windows ? #"\"# : "/"), label: "dot dot path component"),
+                (path: "/abc/..", expected: (windows ? #"\"# : "/"), label: "dot dot path component"),
+                (path: "/abc/../..", expected: (windows ? #"\"# : "/"), label: "dot dot path component"),
+                (path: "/../abc", expected: (windows ? #"\abc"# : "/abc"), label: "dot dot path component"),
+                (path: "/../abc/..", expected: (windows ? #"\"# : "/"), label: "dot dot path component"),
+                (path: "/../abc/../def", expected: (windows ? #"\def"# : "/def"), label: "dot dot path component"),
+
+                (path: "///", expected: (windows ? #"\"# : "/"), label: "combinations and edge cases"),
+                (path: "/./", expected: (windows ? #"\"# : "/"), label: "combinations and edge cases"),
+
+            ]
+        )
+        func pathStringIsSetCorrectlySkipOnWindows(path: String, expected: String, label: String) {
+            pathStringIsSetCorrectlyTestImplementation(
+                path: path,
+                expected: expected,
+                label: label
+            )
+        }
+
+        @Test
+        func stringInitialization() throws {
+            let abs1 = AbsolutePath("/")
+            let abs2 = AbsolutePath(abs1, ".")
+            #expect(abs1 == abs2)
+            let rel3 = "."
+            let abs3 = try AbsolutePath(abs2, validating: rel3)
+            #expect(abs2 == abs3)
+            let base = AbsolutePath("/base/path")
+            let abs4 = AbsolutePath("/a/b/c", relativeTo: base)
+            #expect(abs4 == AbsolutePath("/a/b/c"))
+            let abs5 = AbsolutePath("./a/b/c", relativeTo: base)
+            #expect(abs5 == AbsolutePath("/base/path/a/b/c"))
+            let abs6 = AbsolutePath("~/bla", relativeTo: base)  // `~` isn't special
+            #expect(abs6 == AbsolutePath("/base/path/~/bla"))
+        }
+
+        @Test(
+            .skipHostOS(.windows),
+            arguments: [
+                (path: "/", expected: (windows ? #"\"# : "/")),
+                (path: "/a", expected: (windows ? #"\"# : "/")),
+                (path: "/./a", expected: (windows ? #"\"# : "/")),
+                (path: "/../..", expected: (windows ? #"\"# : "/")),
+                (path: "/ab/c//d/", expected: (windows ? #"\ab\c"# : "/ab/c")),
+            ]
+        )
+        func directoryNameExtraction(path: String, expected: String) throws {
+            let actual = AbsolutePath(path).dirname
+
+            #expect(actual == expected, "Actual is not as expected")
+        }
+
+        @Test(
+            .skipHostOS(.windows),
+            arguments: [
+                (path: "/", expected: (windows ? #"\"# : "/")),
+                (path: "/a", expected: "a"),
+                (path: "/./a", expected: "a"),
+                (path: "/../..", expected: "/"),
+            ]
+        )
+        func baseNameExtraction(path: String, expected: String) throws {
+            let actual = AbsolutePath(path).basename
+
+            #expect(actual == expected, "Actual is not as expected")
+        }
+
+        @Test(
+            .skipHostOS(.windows),
+            arguments: [
+                (path: "/", expected:  (windows ? #"\"# : "/")),
+                (path: "/a", expected:  "a"),
+                (path: "/./a", expected:  "a"),
+                (path: "/../..", expected:  "/"),
+                (path: "/a.txt", expected:  "a"),
+                (path: "/./a.txt", expected:  "a"),
+            ]
+        )
+        func baseNameWithoutExt(path: String, expected: String) throws {
+            let actual = AbsolutePath(path).basenameWithoutExt
+
+            #expect(actual == expected, "Actual is not as expected")
+            
+        }
+
+        @Test(
+            arguments: [
+                (path: "/", numParentDirectoryCalls: 1, expected: "/"),
+                (path: "/", numParentDirectoryCalls: 2, expected: "/"),
+                (path: "/bar", numParentDirectoryCalls: 1, expected: "/"),
+                (path: "/bar/../foo/..//", numParentDirectoryCalls: 2, expected: "/"),
+                (path: "/bar/../foo/..//yabba/a/b", numParentDirectoryCalls: 2, expected: "/yabba")
+            ]
+        )
+        func parentDirectoryAttributeReturnsAsExpected(path: String, numParentDirectoryCalls: Int, expected: String) throws {
+            let pathUnderTest = AbsolutePath(path)
+            let expectedPath = AbsolutePath(expected)
+            try #require(numParentDirectoryCalls >= 1, "Test configuration Error.")
+
+            var actual = pathUnderTest
+            for _ in 0 ..< numParentDirectoryCalls {
+                actual = actual.parentDirectory
+            }
+            #expect(actual == expectedPath)
+        }
+
+        @Test(
+            .skipHostOS(.windows),
+            arguments: [
+                (path: "/", expected: ["/"]),
+                (path: "/.", expected: ["/"]),
+                (path: "/..", expected: ["/"]),
+                (path: "/bar", expected: ["/", "bar"]),
+                (path: "/foo/bar/..", expected: ["/", "foo"]),
+                (path: "/bar/../foo", expected: ["/", "foo"]),
+                (path: "/bar/../foo/..//", expected: ["/"]),
+                (path: "/bar/../foo/..//yabba/a/b/", expected: ["/", "yabba", "a", "b"]),
+            ]
+        )
+        func componentsAttributeReturnsExpectedValue(path: String, expected: [String]) throws {
+            let actual = AbsolutePath(path).components
+
+            #expect(actual == expected, "Actual is not as expected")
+        }
+
+        struct AncestryTest {
+            @Test(
+                arguments: [
+                    (path: "/a/b/c/d/e/f", descendentOfOrEqualTo: "/a/b/c/d", expected: true),
+                    (path: "/a/b/c/d/e/f.swift", descendentOfOrEqualTo: "/a/b/c", expected: true),
+                    (path: "/", descendentOfOrEqualTo: "/", expected: true),
+                    (path: "/foo/bar", descendentOfOrEqualTo: "/", expected: true),
+                    (path: "/foo/bar", descendentOfOrEqualTo: "/foo/bar/baz", expected: false),
+                    (path: "/foo/bar", descendentOfOrEqualTo: "/bar", expected: false)
+                ]
+            )
+            func isDescendantOfOrEqual(path: String, descendentOfOrEqualTo: String, expected: Bool) {
+                let actual = AbsolutePath(path).isDescendantOfOrEqual(to: AbsolutePath(descendentOfOrEqualTo))
+
+                #expect(actual == expected, "Actual is not as expected")
+            }
+
+            @Test(
+                arguments: [
+                    (path: "/foo/bar", descendentOf: "/foo/bar", expected: false),
+                    (path: "/foo/bar", descendentOf: "/foo", expected: true)
+                ]
+            )
+            func isDescendant(path: String, ancesterOf: String, expected: Bool) {
+                let actual = AbsolutePath(path).isDescendant(of: AbsolutePath(ancesterOf))
+
+                #expect(actual == expected, "Actual is not as expected")
+            }
+
+            @Test(
+                arguments: [
+                    (path: "/a/b/c/d", ancestorOfOrEqualTo: "/a/b/c/d/e/f", expected: true),
+                    (path: "/a/b/c", ancestorOfOrEqualTo: "/a/b/c/d/e/f.swift", expected: true),
+                    (path: "/", ancestorOfOrEqualTo: "/", expected: true),
+                    (path: "/", ancestorOfOrEqualTo: "/foo/bar", expected: true),
+                    (path: "/foo/bar/baz", ancestorOfOrEqualTo: "/foo/bar", expected: false),
+                    (path: "/bar", ancestorOfOrEqualTo: "/foo/bar", expected: false),
+                ]
+            )
+            func isAncestorOfOrEqual(path: String, ancestorOfOrEqualTo: String, expected: Bool) {
+                let actual = AbsolutePath(path).isAncestorOfOrEqual(to: AbsolutePath(ancestorOfOrEqualTo))
+
+                #expect(actual == expected, "Actual is not as expected")
+            }
+
+            @Test(
+                arguments: [
+                    (path: "/foo/bar", ancesterOf: "/foo/bar", expected: false),
+                    (path: "/foo", ancesterOf: "/foo/bar", expected: true),
+                ]
+            )
+            func isAncestor(path: String, ancesterOf: String, expected: Bool) {
+                let actual = AbsolutePath(path).isAncestor(of: AbsolutePath(ancesterOf))
+
+                #expect(actual == expected, "Actual is not as expected")
+            }
+        }
+
+        @Test(
+            .skipHostOS(.windows)
+        )
+        func absolutePathValidation() throws {
+            #expect(throws: Never.self) { 
+                try AbsolutePath(validating: "/a/b/c/d")
+            }
+
+            #expect {try AbsolutePath(validating: "~/a/b/d")} throws: { error in
+                ("\(error)" == "invalid absolute path '~/a/b/d'; absolute path must begin with '/'")
+            }
+
+            #expect {try AbsolutePath(validating: "a/b/d") } throws: { error in
+                ("\(error)" == "invalid absolute path 'a/b/d'")
+            }
+        }
+
+        @Test(
+            .skipHostOS(.windows)
+        )
+        func comparison() {
+            #expect(AbsolutePath("/") <= AbsolutePath("/"));
+            #expect(AbsolutePath("/abc") < AbsolutePath("/def"));
+            #expect(AbsolutePath("/2") <= AbsolutePath("/2.1"));
+            #expect(AbsolutePath("/3.1") > AbsolutePath("/2"));
+            #expect(AbsolutePath("/2") >= AbsolutePath("/2"));
+            #expect(AbsolutePath("/2.1") >= AbsolutePath("/2"));
+        }
+
+    }
+    struct RelativePathTests {
+        private func pathStringIsSetCorrectlyTestImplementation(path: String, expected: String, label: String) {
+            let actual = RelativePath(path).pathString
+
+            #expect(actual == expected, "\(label): Actual is not as expected.")
+        }
+
+        @Test(
+            arguments: [
+                (path: ".", expected: ".", label: "Basics"),
+                (path: "a", expected: "a", label: "Basics"),
+                (path: "a/b/c", expected: (windows ? #"a\b\c"# : "a/b/c"), label: "Basics"),
+                (path: "~", expected: "~", label: "Basics"),
+
+
+            ]
+        )
+        func pathStringIsSetCorrectly(path: String, expected: String, label: String) {
+            pathStringIsSetCorrectlyTestImplementation(
+                path: path,
+                expected: expected,
+                label: label
+            )
+        }
+
+        @Test(
+            .skipHostOS(.windows),
+            arguments: [
+                (path: "ab//cd//ef", expected: (windows ? #"ab\cd\ef"# : "ab/cd/ef"), label: "repeated path seperators"),
+                (path: "ab//cd///ef", expected: (windows ? #"ab\cd\ef"# : "ab/cd/ef"), label: "repeated path seperators"),
+
+                (path: "ab/cd/ef/", expected: (windows ? #"ab\cd\ef"# : "ab/cd/ef"), label: "Trailing path seperator"),
+                (path: "ab/cd/ef//", expected: (windows ? #"ab\cd\ef"# : "ab/cd/ef"), label: "Trailing path seperator"),
+                (path: "ab/cd/ef///", expected: (windows ? #"ab\cd\ef"# : "ab/cd/ef"), label: "Trailing path seperator"),
+
+                (path: "ab/./cd/././ef", expected: "ab/cd/ef", label: "dot path component"),
+                (path: "ab/./cd/ef/.", expected: "ab/cd/ef", label: "dot path component"),
+
+                (path: "..", expected: "..", label: "dot dot path component"),
+                (path: "../..", expected: "../..", label: "dot dot path component"),
+                (path: ".././..", expected: "../..", label: "dot dot path component"),
+                (path: "../abc/..", expected: "..", label: "dot dot path component"),
+                (path: "../abc/.././", expected: "..", label: "dot dot path component"),
+                (path: "abc/..", expected: ".", label: "dot dot path component"),
+
+                (path: "", expected:  ".", label: "combinations and edge cases"),
+                (path: ".", expected:  ".", label: "combinations and edge cases"),
+                (path: "./abc", expected:  "abc", label: "combinations and edge cases"),
+                (path: "./abc/", expected:  "abc", label: "combinations and edge cases"),
+                (path: "./abc/../bar", expected:  "bar", label: "combinations and edge cases"),
+                (path: "foo/../bar", expected:  "bar", label: "combinations and edge cases"),
+                (path: "foo///..///bar///baz", expected:  "bar/baz", label: "combinations and edge cases"),
+                (path: "foo/../bar/./", expected:  "bar", label: "combinations and edge cases"),
+                (path: "../abc/def/", expected:  "../abc/def", label: "combinations and edge cases"),
+                (path: "././././.", expected:  ".", label: "combinations and edge cases"),
+                (path: "./././../.", expected:  "..", label: "combinations and edge cases"),
+                (path: "./", expected:  ".", label: "combinations and edge cases"),
+                (path: ".//", expected:  ".", label: "combinations and edge cases"),
+                (path: "./.", expected:  ".", label: "combinations and edge cases"),
+                (path: "././", expected:  ".", label: "combinations and edge cases"),
+                (path: "../", expected:  "..", label: "combinations and edge cases"),
+                (path: "../.", expected:  "..", label: "combinations and edge cases"),
+                (path: "./..", expected:  "..", label: "combinations and edge cases"),
+                (path: "./../.", expected:  "..", label: "combinations and edge cases"),
+                (path: "./////../////./////", expected:  "..", label: "combinations and edge cases"),
+                (path: "../a", expected:  (windows ? #"..\a"# : "../a"), label: "combinations and edge cases"),
+                (path: "../a/..", expected:  "..", label: "combinations and edge cases"),
+                (path: "a/..", expected:  ".", label: "combinations and edge cases"),
+                (path: "a/../////../////./////", expected:  "..", label: "combinations and edge cases"),
+
+            ]
+        )
+        func pathStringIsSetCorrectlySkipOnWindows(path: String, expected: String, label: String) {
+            pathStringIsSetCorrectlyTestImplementation(
+                path: path,
+                expected: expected,
+                label: label
+            )
+        }
+
+        @Test(
+            .skipHostOS(.windows),
+            arguments: [
+                (path: "ab/c//d/", expected: (windows ? #"ab\c"# : "ab/c")),
+                (path: "../a", expected: ".."),
+                (path: "../a/..", expected: "."),
+                (path: "a/..", expected: "."),
+                (path: "./..", expected: "."),
+                (path: "a/../////../////./////", expected: "."),
+                (path: "abc", expected: "."),
+                (path: "", expected: "."),
+                (path: ".", expected: "."),
+            ]
+        )
+        func directoryNameExtraction(path: String, expected: String) throws {
+            let actual = RelativePath(path).dirname
+
+            #expect(actual == expected, "Actual is not as expected")
+        }
+
+        @Test(
+            .skipHostOS(.windows),
+            arguments: [
+                (path: "../..", expected:  ".."),
+                (path: "../a", expected:  "a"),
+                (path: "../a/..", expected:  ".."),
+                (path: "a/..", expected:  "."),
+                (path: "./..", expected:  ".."),
+                (path: "a/../////../////./////", expected:  ".."),
+                (path: "abc", expected:  "abc"),
+                (path: "", expected:  "."),
+                (path: ".", expected:  "."),
+            ]
+        )
+        func baseNameExtraction(path: String, expected: String) throws {
+            let actual = RelativePath(path).basename
+
+            #expect(actual == expected, "Actual is not as expected")
+        }
+
+        @Test(
+            .skipHostOS(.windows),
+            arguments: [
+                (path: "../..", expected:  ".."),
+                (path: "../a", expected:  "a"),
+                (path: "../a/..", expected:  ".."),
+                (path: "a/..", expected:  "."),
+                (path: "./..", expected:  ".."),
+                (path: "a/../////../////./////", expected:  ".."),
+                (path: "abc", expected:  "abc"),
+                (path: "", expected:  "."),
+                (path: ".", expected:  "."),
+                (path: "../a.bc", expected:  "a"),
+                (path: "abc.swift", expected:  "abc"),
+                (path: "../a.b.c", expected:  "a.b"),
+                (path: "abc.xyz.123", expected:  "abc.xyz"),
+
+            ]
+        )
+        func baseNameWithoutExt(path: String, expected: String) throws {
+            let actual: String = RelativePath(path).basenameWithoutExt
+
+            #expect(actual == expected, "Actual is not as expected")
+        }
+
+        @Test(
+            .skipHostOS(.windows, "expected nil is is not the actual"),
+            arguments: [
+                (path: "a", expectedSuffix: nil, expectedExtension: nil),
+                (path: "a.", expectedSuffix: nil, expectedExtension: nil),
+                (path: ".a", expectedSuffix: nil, expectedExtension: nil),
+                (path: "", expectedSuffix: nil, expectedExtension: nil),
+                (path: ".", expectedSuffix: nil, expectedExtension: nil),
+                (path: "..", expectedSuffix: nil, expectedExtension: nil),
+                (path: "a.foo", expectedSuffix: ".foo", expectedExtension: "foo"),
+                (path: ".a.foo", expectedSuffix: ".foo", expectedExtension: "foo"),
+                (path: "a.foo.bar", expectedSuffix: ".bar", expectedExtension: "bar"),
+                (path: ".a.foo.bar", expectedSuffix: ".bar", expectedExtension: "bar"),
+                (path: ".a.foo.bar.baz", expectedSuffix: ".baz", expectedExtension: "baz"),
+            ]
+        )
+        func suffixExtraction(path: String, expectedSuffix: String?, expectedExtension: String?) throws {
+            let pathUnderTest = RelativePath(path)
+
+            #expect(pathUnderTest.suffix == expectedSuffix, "Actual suffix is not as expected")
+            #expect(pathUnderTest.extension == expectedExtension, "Actual extension is not as expected")
+        }
+
+        @Test(
+            .skipHostOS(.windows),
+            arguments: [
+                (path: "", expected: ["."]),
+                (path: ".", expected: ["."]),
+                (path: "..", expected: [".."]),
+                (path: "bar", expected: ["bar"]),
+                (path: "foo/bar/..", expected: ["foo"]),
+                (path: "bar/../foo", expected: ["foo"]),
+                (path: "bar/../foo/..//", expected: ["."]),
+                (path: "bar/../foo/..//yabba/a/b/", expected: ["yabba", "a", "b"]),
+                (path: "../..", expected: ["..", ".."]),
+                (path: ".././/..", expected: ["..", ".."]),
+                (path: "../a", expected: ["..", "a"]),
+                (path: "../a/..", expected: [".."]),
+                (path: "a/..", expected: ["."]),
+                (path: "./..", expected: [".."]),
+                (path: "a/../////../////./////", expected: [".."]),
+                (path: "abc", expected: ["abc"])
+            ] as [(String, [String])]
+        )
+        func componentsAttributeReturnsExpectedValue(path: String, expected: [String]) {
+            let actual = RelativePath(path).components
+
+            #expect(actual == expected)
+        }
+        
+        @Test(
+            .skipHostOS(.windows)
+        )
+        func relativePathValidation() throws {
+            #expect(throws: Never.self) { 
+                try RelativePath(validating: "a/b/c/d")
+            }
+
+            #expect {try RelativePath(validating: "/a/b/d")} throws: { error in
+                ("\(error)" == "invalid relative path '/a/b/d'; relative path should not begin with '/'")
+            }
+        }
+
     }
 
-    func testStringInitialization() throws {
-        let abs1 = AbsolutePath("/")
-        let abs2 = AbsolutePath(abs1, ".")
-        XCTAssertEqual(abs1, abs2)
-        let rel3 = "."
-        let abs3 = try AbsolutePath(abs2, validating: rel3)
-        XCTAssertEqual(abs2, abs3)
-        let base = AbsolutePath("/base/path")
-        let abs4 = AbsolutePath("/a/b/c", relativeTo: base)
-        XCTAssertEqual(abs4, AbsolutePath("/a/b/c"))
-        let abs5 = AbsolutePath("./a/b/c", relativeTo: base)
-        XCTAssertEqual(abs5, AbsolutePath("/base/path/a/b/c"))
-        let abs6 = AbsolutePath("~/bla", relativeTo: base)  // `~` isn't special
-        XCTAssertEqual(abs6, AbsolutePath("/base/path/~/bla"))
-    }
-
-    func testStringLiteralInitialization() {
-        let abs = AbsolutePath("/")
-        XCTAssertEqual(abs.pathString, windows ? #"\"# : "/")
-        let rel1 = RelativePath(".")
-        XCTAssertEqual(rel1.pathString, ".")
-        let rel2 = RelativePath("~")
-        XCTAssertEqual(rel2.pathString, "~")  // `~` is not special
-    }
-
-    func testRepeatedPathSeparators() throws {
-        try XCTSkipOnWindows(because: "all assertions fail")
-
-        XCTAssertEqual(AbsolutePath("/ab//cd//ef").pathString, windows ? #"\ab\cd\ef"# : "/ab/cd/ef")
-        XCTAssertEqual(AbsolutePath("/ab///cd//ef").pathString, windows ? #"\ab\cd\ef"# : "/ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab//cd//ef").pathString, windows ? #"ab\cd\ef"# : "ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab//cd///ef").pathString, windows ? #"ab\cd\ef"# : "ab/cd/ef")
-    }
-
-    func testTrailingPathSeparators() throws {
-        try XCTSkipOnWindows(because: "trailing path seperator is not removed from pathString")
-
-        XCTAssertEqual(AbsolutePath("/ab/cd/ef/").pathString, windows ? #"\ab\cd\ef"# : "/ab/cd/ef")
-        XCTAssertEqual(AbsolutePath("/ab/cd/ef//").pathString, windows ? #"\ab\cd\ef"# : "/ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab/cd/ef/").pathString, windows ? #"ab\cd\ef"# : "ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab/cd/ef//").pathString, windows ? #"ab\cd\ef"# : "ab/cd/ef")
-    }
-
-    func testDotPathComponents() throws {
-        try XCTSkipOnWindows()
-
-        XCTAssertEqual(AbsolutePath("/ab/././cd//ef").pathString, "/ab/cd/ef")
-        XCTAssertEqual(AbsolutePath("/ab/./cd//ef/.").pathString, "/ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab/./cd/././ef").pathString, "ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab/./cd/ef/.").pathString, "ab/cd/ef")
-    }
-
-    func testDotDotPathComponents() throws {
-        try XCTSkipOnWindows()
-
-        XCTAssertEqual(AbsolutePath("/..").pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/../../../../..").pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/abc/..").pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/abc/../..").pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/../abc").pathString, windows ? #"\abc"# : "/abc")
-        XCTAssertEqual(AbsolutePath("/../abc/..").pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/../abc/../def").pathString, windows ? #"\def"# : "/def")
-        XCTAssertEqual(RelativePath("..").pathString, "..")
-        XCTAssertEqual(RelativePath("../..").pathString, "../..")
-        XCTAssertEqual(RelativePath(".././..").pathString, "../..")
-        XCTAssertEqual(RelativePath("../abc/..").pathString, "..")
-        XCTAssertEqual(RelativePath("../abc/.././").pathString, "..")
-        XCTAssertEqual(RelativePath("abc/..").pathString, ".")
-    }
-
-    func testCombinationsAndEdgeCases() throws {
-        try XCTSkipOnWindows()
-
-        XCTAssertEqual(AbsolutePath("///").pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/./").pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(RelativePath("").pathString, ".")
-        XCTAssertEqual(RelativePath(".").pathString, ".")
-        XCTAssertEqual(RelativePath("./abc").pathString, "abc")
-        XCTAssertEqual(RelativePath("./abc/").pathString, "abc")
-        XCTAssertEqual(RelativePath("./abc/../bar").pathString, "bar")
-        XCTAssertEqual(RelativePath("foo/../bar").pathString, "bar")
-        XCTAssertEqual(RelativePath("foo///..///bar///baz").pathString, "bar/baz")
-        XCTAssertEqual(RelativePath("foo/../bar/./").pathString, "bar")
-        XCTAssertEqual(RelativePath("../abc/def/").pathString, "../abc/def")
-        XCTAssertEqual(RelativePath("././././.").pathString, ".")
-        XCTAssertEqual(RelativePath("./././../.").pathString, "..")
-        XCTAssertEqual(RelativePath("./").pathString, ".")
-        XCTAssertEqual(RelativePath(".//").pathString, ".")
-        XCTAssertEqual(RelativePath("./.").pathString, ".")
-        XCTAssertEqual(RelativePath("././").pathString, ".")
-        XCTAssertEqual(RelativePath("../").pathString, "..")
-        XCTAssertEqual(RelativePath("../.").pathString, "..")
-        XCTAssertEqual(RelativePath("./..").pathString, "..")
-        XCTAssertEqual(RelativePath("./../.").pathString, "..")
-        XCTAssertEqual(RelativePath("./////../////./////").pathString, "..")
-        XCTAssertEqual(RelativePath("../a").pathString, windows ? #"..\a"# : "../a")
-        XCTAssertEqual(RelativePath("../a/..").pathString, "..")
-        XCTAssertEqual(RelativePath("a/..").pathString, ".")
-        XCTAssertEqual(RelativePath("a/../////../////./////").pathString, "..")
-    }
-
-    func testDirectoryNameExtraction() throws {
-        try XCTSkipOnWindows()
-
-        XCTAssertEqual(AbsolutePath("/").dirname, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/a").dirname, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/./a").dirname, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/../..").dirname, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/ab/c//d/").dirname, windows ? #"\ab\c"# : "/ab/c")
-        XCTAssertEqual(RelativePath("ab/c//d/").dirname, windows ? #"ab\c"# : "ab/c")
-        XCTAssertEqual(RelativePath("../a").dirname, "..")
-        XCTAssertEqual(RelativePath("../a/..").dirname, ".")
-        XCTAssertEqual(RelativePath("a/..").dirname, ".")
-        XCTAssertEqual(RelativePath("./..").dirname, ".")
-        XCTAssertEqual(RelativePath("a/../////../////./////").dirname, ".")
-        XCTAssertEqual(RelativePath("abc").dirname, ".")
-        XCTAssertEqual(RelativePath("").dirname, ".")
-        XCTAssertEqual(RelativePath(".").dirname, ".")
-    }
-
-    func testBaseNameExtraction() throws {
-        try XCTSkipOnWindows()
-
-        XCTAssertEqual(AbsolutePath("/").basename, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/a").basename, "a")
-        XCTAssertEqual(AbsolutePath("/./a").basename, "a")
-        XCTAssertEqual(AbsolutePath("/../..").basename, "/")
-        XCTAssertEqual(RelativePath("../..").basename, "..")
-        XCTAssertEqual(RelativePath("../a").basename, "a")
-        XCTAssertEqual(RelativePath("../a/..").basename, "..")
-        XCTAssertEqual(RelativePath("a/..").basename, ".")
-        XCTAssertEqual(RelativePath("./..").basename, "..")
-        XCTAssertEqual(RelativePath("a/../////../////./////").basename, "..")
-        XCTAssertEqual(RelativePath("abc").basename, "abc")
-        XCTAssertEqual(RelativePath("").basename, ".")
-        XCTAssertEqual(RelativePath(".").basename, ".")
-    }
-
-    func testBaseNameWithoutExt() throws{
-        try XCTSkipOnWindows()
-
-        XCTAssertEqual(AbsolutePath("/").basenameWithoutExt, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/a").basenameWithoutExt, "a")
-        XCTAssertEqual(AbsolutePath("/./a").basenameWithoutExt, "a")
-        XCTAssertEqual(AbsolutePath("/../..").basenameWithoutExt, "/")
-        XCTAssertEqual(RelativePath("../..").basenameWithoutExt, "..")
-        XCTAssertEqual(RelativePath("../a").basenameWithoutExt, "a")
-        XCTAssertEqual(RelativePath("../a/..").basenameWithoutExt, "..")
-        XCTAssertEqual(RelativePath("a/..").basenameWithoutExt, ".")
-        XCTAssertEqual(RelativePath("./..").basenameWithoutExt, "..")
-        XCTAssertEqual(RelativePath("a/../////../////./////").basenameWithoutExt, "..")
-        XCTAssertEqual(RelativePath("abc").basenameWithoutExt, "abc")
-        XCTAssertEqual(RelativePath("").basenameWithoutExt, ".")
-        XCTAssertEqual(RelativePath(".").basenameWithoutExt, ".")
-
-        XCTAssertEqual(AbsolutePath("/a.txt").basenameWithoutExt, "a")
-        XCTAssertEqual(AbsolutePath("/./a.txt").basenameWithoutExt, "a")
-        XCTAssertEqual(RelativePath("../a.bc").basenameWithoutExt, "a")
-        XCTAssertEqual(RelativePath("abc.swift").basenameWithoutExt, "abc")
-        XCTAssertEqual(RelativePath("../a.b.c").basenameWithoutExt, "a.b")
-        XCTAssertEqual(RelativePath("abc.xyz.123").basenameWithoutExt, "abc.xyz")
-    }
-
-    func testSuffixExtraction() throws {
-        try XCTSkipOnWindows(because: "expected nil is not the actual")
-
-        XCTAssertEqual(RelativePath("a").suffix, nil)
-        XCTAssertEqual(RelativePath("a").extension, nil)
-        XCTAssertEqual(RelativePath("a.").suffix, nil)
-        XCTAssertEqual(RelativePath("a.").extension, nil)
-        XCTAssertEqual(RelativePath(".a").suffix, nil)
-        XCTAssertEqual(RelativePath(".a").extension, nil)
-        XCTAssertEqual(RelativePath("").suffix, nil)
-        XCTAssertEqual(RelativePath("").extension, nil)
-        XCTAssertEqual(RelativePath(".").suffix, nil)
-        XCTAssertEqual(RelativePath(".").extension, nil)
-        XCTAssertEqual(RelativePath("..").suffix, nil)
-        XCTAssertEqual(RelativePath("..").extension, nil)
-        XCTAssertEqual(RelativePath("a.foo").suffix, ".foo")
-        XCTAssertEqual(RelativePath("a.foo").extension, "foo")
-        XCTAssertEqual(RelativePath(".a.foo").suffix, ".foo")
-        XCTAssertEqual(RelativePath(".a.foo").extension, "foo")
-        XCTAssertEqual(RelativePath(".a.foo.bar").suffix, ".bar")
-        XCTAssertEqual(RelativePath(".a.foo.bar").extension, "bar")
-        XCTAssertEqual(RelativePath("a.foo.bar").suffix, ".bar")
-        XCTAssertEqual(RelativePath("a.foo.bar").extension, "bar")
-        XCTAssertEqual(RelativePath(".a.foo.bar.baz").suffix, ".baz")
-        XCTAssertEqual(RelativePath(".a.foo.bar.baz").extension, "baz")
-    }
-
-    func testParentDirectory() throws {
-        try XCTSkipOnWindows()
-
-        XCTAssertEqual(AbsolutePath("/").parentDirectory, AbsolutePath("/"))
-        XCTAssertEqual(AbsolutePath("/").parentDirectory.parentDirectory, AbsolutePath("/"))
-        XCTAssertEqual(AbsolutePath("/bar").parentDirectory, AbsolutePath("/"))
-        XCTAssertEqual(AbsolutePath("/bar/../foo/..//").parentDirectory.parentDirectory, AbsolutePath("/"))
-        XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/a/b").parentDirectory.parentDirectory, AbsolutePath("/yabba"))
-    }
-
+    @Test(
+        .skipHostOS(.windows)
+    )
     @available(*, deprecated)
-    func testConcatenation() throws {
-        try XCTSkipOnWindows()
+    func concatenation() throws {
+        #expect(AbsolutePath(AbsolutePath("/"), RelativePath("")).pathString == (windows ? #"\"# : "/"))
+        #expect(AbsolutePath(AbsolutePath("/"), RelativePath(".")).pathString == (windows ? #"\"# : "/"))
+        #expect(AbsolutePath(AbsolutePath("/"), RelativePath("..")).pathString == (windows ? #"\"# : "/"))
+        #expect(AbsolutePath(AbsolutePath("/"), RelativePath("bar")).pathString == (windows ? #"\bar"# : "/bar"))
+        #expect(AbsolutePath(AbsolutePath("/foo/bar"), RelativePath("..")).pathString == (windows ? #"\foo"# : "/foo"))
+        #expect(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo")).pathString == (windows ? #"\foo"# : "/foo"))
+        #expect(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo/..//")).pathString == (windows ? #"\"# : "/"))
+        #expect(AbsolutePath(AbsolutePath("/bar/../foo/..//yabba/"), RelativePath("a/b")).pathString == (windows ? #"\yabba\a\b"# : "/yabba/a/b"))
 
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("")).pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath(".")).pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("..")).pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("bar")).pathString, windows ? #"\bar"# : "/bar")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/foo/bar"), RelativePath("..")).pathString, windows ? #"\foo"# : "/foo")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo")).pathString, windows ? #"\foo"# : "/foo")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo/..//")).pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar/../foo/..//yabba/"), RelativePath("a/b")).pathString, windows ? #"\yabba\a\b"# : "/yabba/a/b")
+        #expect(AbsolutePath("/").appending(RelativePath("")).pathString == (windows ? #"\"# : "/"))
+        #expect(AbsolutePath("/").appending(RelativePath(".")).pathString == (windows ? #"\"# : "/"))
+        #expect(AbsolutePath("/").appending(RelativePath("..")).pathString == (windows ? #"\"# : "/"))
+        #expect(AbsolutePath("/").appending(RelativePath("bar")).pathString == (windows ? #"\bar"# : "/bar"))
+        #expect(AbsolutePath("/foo/bar").appending(RelativePath("..")).pathString == (windows ? #"\foo"# : "/foo"))
+        #expect(AbsolutePath("/bar").appending(RelativePath("../foo")).pathString == (windows ? #"\foo"# : "/foo"))
+        #expect(AbsolutePath("/bar").appending(RelativePath("../foo/..//")).pathString == (windows ? #"\"# : "/"))
+        #expect(AbsolutePath("/bar/../foo/..//yabba/").appending(RelativePath("a/b")).pathString == (windows ? #"\yabba\a\b"# : "/yabba/a/b"))
 
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("")).pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath(".")).pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("..")).pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("bar")).pathString, windows ? #"\bar"# : "/bar")
-        XCTAssertEqual(AbsolutePath("/foo/bar").appending(RelativePath("..")).pathString, windows ? #"\foo"# : "/foo")
-        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo")).pathString, windows ? #"\foo"# : "/foo")
-        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo/..//")).pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/").appending(RelativePath("a/b")).pathString, windows ? #"\yabba\a\b"# : "/yabba/a/b")
+        #expect(AbsolutePath("/").appending(component: "a").pathString == (windows ? #"\a"# : "/a"))
+        #expect(AbsolutePath("/a").appending(component: "b").pathString == (windows ? #"\a\b"# : "/a/b"))
+        #expect(AbsolutePath("/").appending(components: "a", "b").pathString == (windows ? #"\a\b"# : "/a/b"))
+        #expect(AbsolutePath("/a").appending(components: "b", "c").pathString == (windows ? #"\a\b\c"# : "/a/b/c"))
 
-        XCTAssertEqual(AbsolutePath("/").appending(component: "a").pathString, windows ? #"\a"# : "/a")
-        XCTAssertEqual(AbsolutePath("/a").appending(component: "b").pathString, windows ? #"\a\b"# : "/a/b")
-        XCTAssertEqual(AbsolutePath("/").appending(components: "a", "b").pathString, windows ? #"\a\b"# : "/a/b")
-        XCTAssertEqual(AbsolutePath("/a").appending(components: "b", "c").pathString, windows ? #"\a\b\c"# : "/a/b/c")
+        #expect(AbsolutePath("/a/b/c").appending(components: "", "c").pathString == (windows ? #"\a\b\c\c"# : "/a/b/c/c"))
+        #expect(AbsolutePath("/a/b/c").appending(components: "").pathString == (windows ? #"\a\b\c"# : "/a/b/c"))
+        #expect(AbsolutePath("/a/b/c").appending(components: ".").pathString == (windows ? #"\a\b\c"# : "/a/b/c"))
+        #expect(AbsolutePath("/a/b/c").appending(components: "..").pathString == (windows ? #"\a\b"# : "/a/b"))
+        #expect(AbsolutePath("/a/b/c").appending(components: "..", "d").pathString == (windows ? #"\a\b\d"# : "/a/b/d"))
+        #expect(AbsolutePath("/").appending(components: "..").pathString == (windows ? #"\"# : "/"))
+        #expect(AbsolutePath("/").appending(components: ".").pathString == (windows ? #"\"# : "/"))
+        #expect(AbsolutePath("/").appending(components: "..", "a").pathString == (windows ? #"\a"# : "/a"))
 
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "", "c").pathString, windows ? #"\a\b\c\c"# : "/a/b/c/c")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "").pathString, windows ? #"\a\b\c"# : "/a/b/c")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: ".").pathString, windows ? #"\a\b\c"# : "/a/b/c")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "..").pathString, windows ? #"\a\b"# : "/a/b")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "..", "d").pathString, windows ? #"\a\b\d"# : "/a/b/d")
-        XCTAssertEqual(AbsolutePath("/").appending(components: "..").pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/").appending(components: ".").pathString, windows ? #"\"# : "/")
-        XCTAssertEqual(AbsolutePath("/").appending(components: "..", "a").pathString, windows ? #"\a"# : "/a")
-
-        XCTAssertEqual(RelativePath("hello").appending(components: "a", "b", "c", "..").pathString, windows ? #"hello\a\b"# : "hello/a/b")
-        XCTAssertEqual(RelativePath("hello").appending(RelativePath("a/b/../c/d")).pathString, windows ? #"hello\a\c\d"# : "hello/a/c/d")
+        #expect(RelativePath("hello").appending(components: "a", "b", "c", "..").pathString == (windows ? #"hello\a\b"# : "hello/a/b"))
+        #expect(RelativePath("hello").appending(RelativePath("a/b/../c/d")).pathString == (windows ? #"hello\a\c\d"# : "hello/a/c/d"))
     }
 
-    func testPathComponents() throws {
-        try XCTSkipOnWindows()
-
-        XCTAssertEqual(AbsolutePath("/").components, ["/"])
-        XCTAssertEqual(AbsolutePath("/.").components, ["/"])
-        XCTAssertEqual(AbsolutePath("/..").components, ["/"])
-        XCTAssertEqual(AbsolutePath("/bar").components, ["/", "bar"])
-        XCTAssertEqual(AbsolutePath("/foo/bar/..").components, ["/", "foo"])
-        XCTAssertEqual(AbsolutePath("/bar/../foo").components, ["/", "foo"])
-        XCTAssertEqual(AbsolutePath("/bar/../foo/..//").components, ["/"])
-        XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/a/b/").components, ["/", "yabba", "a", "b"])
-
-        XCTAssertEqual(RelativePath("").components, ["."])
-        XCTAssertEqual(RelativePath(".").components, ["."])
-        XCTAssertEqual(RelativePath("..").components, [".."])
-        XCTAssertEqual(RelativePath("bar").components, ["bar"])
-        XCTAssertEqual(RelativePath("foo/bar/..").components, ["foo"])
-        XCTAssertEqual(RelativePath("bar/../foo").components, ["foo"])
-        XCTAssertEqual(RelativePath("bar/../foo/..//").components, ["."])
-        XCTAssertEqual(RelativePath("bar/../foo/..//yabba/a/b/").components, ["yabba", "a", "b"])
-        XCTAssertEqual(RelativePath("../..").components, ["..", ".."])
-        XCTAssertEqual(RelativePath(".././/..").components, ["..", ".."])
-        XCTAssertEqual(RelativePath("../a").components, ["..", "a"])
-        XCTAssertEqual(RelativePath("../a/..").components, [".."])
-        XCTAssertEqual(RelativePath("a/..").components, ["."])
-        XCTAssertEqual(RelativePath("./..").components, [".."])
-        XCTAssertEqual(RelativePath("a/../////../////./////").components, [".."])
-        XCTAssertEqual(RelativePath("abc").components, ["abc"])
+    @Test(
+        .skipHostOS(.windows)
+    )
+    func relativePathFromAbsolutePaths() throws {
+        #expect(AbsolutePath("/").relative(to: AbsolutePath("/")) == RelativePath("."));
+        #expect(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/")) == RelativePath("a/b/c/d"));
+        #expect(AbsolutePath("/").relative(to: AbsolutePath("/a/b/c")) == RelativePath("../../.."));
+        #expect(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/b")) == RelativePath("c/d"));
+        #expect(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/b/c")) == RelativePath("d"));
+        #expect(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/c/d")) == RelativePath("../../b/c/d"));
+        #expect(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/b/c/d")) == RelativePath("../../../a/b/c/d"));
     }
 
-    func testRelativePathFromAbsolutePaths() throws {
-        try XCTSkipOnWindows()
-
-        XCTAssertEqual(AbsolutePath("/").relative(to: AbsolutePath("/")), RelativePath("."));
-        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/")), RelativePath("a/b/c/d"));
-        XCTAssertEqual(AbsolutePath("/").relative(to: AbsolutePath("/a/b/c")), RelativePath("../../.."));
-        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/b")), RelativePath("c/d"));
-        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/b/c")), RelativePath("d"));
-        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/c/d")), RelativePath("../../b/c/d"));
-        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/b/c/d")), RelativePath("../../../a/b/c/d"));
-    }
-
-    func testComparison() {
-        XCTAssertTrue(AbsolutePath("/") <= AbsolutePath("/"));
-        XCTAssertTrue(AbsolutePath("/abc") < AbsolutePath("/def"));
-        XCTAssertTrue(AbsolutePath("/2") <= AbsolutePath("/2.1"));
-        XCTAssertTrue(AbsolutePath("/3.1") > AbsolutePath("/2"));
-        XCTAssertTrue(AbsolutePath("/2") >= AbsolutePath("/2"));
-        XCTAssertTrue(AbsolutePath("/2.1") >= AbsolutePath("/2"));
-    }
-
-    func testAncestry() {
-        XCTAssertTrue(AbsolutePath("/a/b/c/d/e/f").isDescendantOfOrEqual(to: AbsolutePath("/a/b/c/d")))
-        XCTAssertTrue(AbsolutePath("/a/b/c/d/e/f.swift").isDescendantOfOrEqual(to: AbsolutePath("/a/b/c")))
-        XCTAssertTrue(AbsolutePath("/").isDescendantOfOrEqual(to: AbsolutePath("/")))
-        XCTAssertTrue(AbsolutePath("/foo/bar").isDescendantOfOrEqual(to: AbsolutePath("/")))
-        XCTAssertFalse(AbsolutePath("/foo/bar").isDescendantOfOrEqual(to: AbsolutePath("/foo/bar/baz")))
-        XCTAssertFalse(AbsolutePath("/foo/bar").isDescendantOfOrEqual(to: AbsolutePath("/bar")))
-
-        XCTAssertFalse(AbsolutePath("/foo/bar").isDescendant(of: AbsolutePath("/foo/bar")))
-        XCTAssertTrue(AbsolutePath("/foo/bar").isDescendant(of: AbsolutePath("/foo")))
-
-        XCTAssertTrue(AbsolutePath("/a/b/c/d").isAncestorOfOrEqual(to: AbsolutePath("/a/b/c/d/e/f")))
-        XCTAssertTrue(AbsolutePath("/a/b/c").isAncestorOfOrEqual(to: AbsolutePath("/a/b/c/d/e/f.swift")))
-        XCTAssertTrue(AbsolutePath("/").isAncestorOfOrEqual(to: AbsolutePath("/")))
-        XCTAssertTrue(AbsolutePath("/").isAncestorOfOrEqual(to: AbsolutePath("/foo/bar")))
-        XCTAssertFalse(AbsolutePath("/foo/bar/baz").isAncestorOfOrEqual(to: AbsolutePath("/foo/bar")))
-        XCTAssertFalse(AbsolutePath("/bar").isAncestorOfOrEqual(to: AbsolutePath("/foo/bar")))
-
-        XCTAssertFalse(AbsolutePath("/foo/bar").isAncestor(of: AbsolutePath("/foo/bar")))
-        XCTAssertTrue(AbsolutePath("/foo").isAncestor(of: AbsolutePath("/foo/bar")))
-    }
-
-    func testAbsolutePathValidation() throws {
-        try XCTSkipOnWindows()
-
-        XCTAssertNoThrow(try AbsolutePath(validating: "/a/b/c/d"))
-
-        XCTAssertThrowsError(try AbsolutePath(validating: "~/a/b/d")) { error in
-            XCTAssertEqual("\(error)", "invalid absolute path '~/a/b/d'; absolute path must begin with '/'")
-        }
-
-        XCTAssertThrowsError(try AbsolutePath(validating: "a/b/d")) { error in
-            XCTAssertEqual("\(error)", "invalid absolute path 'a/b/d'")
-        }
-    }
-
-    func testRelativePathValidation() throws {
-        try XCTSkipOnWindows()
-
-        XCTAssertNoThrow(try RelativePath(validating: "a/b/c/d"))
-
-        XCTAssertThrowsError(try RelativePath(validating: "/a/b/d")) { error in
-            XCTAssertEqual("\(error)", "invalid relative path '/a/b/d'; relative path should not begin with '/'")
-            //XCTAssertEqual("\(error)", "invalid relative path '/a/b/d'; relative path should not begin with '/' or '~'")
-        }
-
-        /*XCTAssertThrowsError(try RelativePath(validating: "~/a/b/d")) { error in
-            XCTAssertEqual("\(error)", "invalid relative path '~/a/b/d'; relative path should not begin with '/' or '~'")
-        }*/
-    }
-
-    func testCodable() throws {
-        try XCTSkipOnWindows()
-
+    @Test(
+        .skipHostOS(.windows)
+    )
+    func codable() throws {
         struct Foo: Codable, Equatable {
             var path: AbsolutePath
         }
@@ -392,48 +558,56 @@ class PathTests: XCTestCase {
             let foo = Foo(path: "/path/to/foo")
             let data = try JSONEncoder().encode(foo)
             let decodedFoo = try JSONDecoder().decode(Foo.self, from: data)
-            XCTAssertEqual(foo, decodedFoo)
+            #expect(foo == decodedFoo)
         }
 
         do {
             let foo = Foo(path: "/path/to/../to/foo")
             let data = try JSONEncoder().encode(foo)
             let decodedFoo = try JSONDecoder().decode(Foo.self, from: data)
-            XCTAssertEqual(foo, decodedFoo)
-            XCTAssertEqual(foo.path.pathString, windows ? #"\path\to\foo"# : "/path/to/foo")
-            XCTAssertEqual(decodedFoo.path.pathString, windows ? #"\path\to\foo"# : "/path/to/foo")
+            #expect(foo == decodedFoo)
+            #expect(foo.path.pathString == (windows ? #"\path\to\foo"# : "/path/to/foo"))
+            #expect(decodedFoo.path.pathString == (windows ? #"\path\to\foo"# : "/path/to/foo"))
         }
 
         do {
             let bar = Bar(path: "path/to/bar")
             let data = try JSONEncoder().encode(bar)
             let decodedBar = try JSONDecoder().decode(Bar.self, from: data)
-            XCTAssertEqual(bar, decodedBar)
+            #expect(bar == decodedBar)
         }
 
         do {
             let bar = Bar(path: "path/to/../to/bar")
             let data = try JSONEncoder().encode(bar)
             let decodedBar = try JSONDecoder().decode(Bar.self, from: data)
-            XCTAssertEqual(bar, decodedBar)
-            XCTAssertEqual(bar.path.pathString, "path/to/bar")
-            XCTAssertEqual(decodedBar.path.pathString, "path/to/bar")
+            #expect(bar == decodedBar)
+            #expect(bar.path.pathString == "path/to/bar")
+            #expect(decodedBar.path.pathString == "path/to/bar")
         }
 
         do {
             let data = try JSONEncoder().encode(Baz(path: ""))
-            XCTAssertThrowsError(try JSONDecoder().decode(Foo.self, from: data))
-            XCTAssertNoThrow(try JSONDecoder().decode(Bar.self, from: data)) // empty string is a valid relative path
+            #expect(throws: (any Error).self) { 
+                try JSONDecoder().decode(Foo.self, from: data)
+            }
+            #expect(throws: Never.self) { 
+                try JSONDecoder().decode(Bar.self, from: data)
+            } // empty string is a valid relative path
         }
 
         do {
             let data = try JSONEncoder().encode(Baz(path: "foo"))
-            XCTAssertThrowsError(try JSONDecoder().decode(Foo.self, from: data))
+            #expect(throws: (any Error).self) { 
+                try JSONDecoder().decode(Foo.self, from: data)
+            }
         }
 
         do {
             let data = try JSONEncoder().encode(Baz(path: "/foo"))
-            XCTAssertThrowsError(try JSONDecoder().decode(Bar.self, from: data))
+            #expect(throws: (any Error).self) { 
+                try JSONDecoder().decode(Bar.self, from: data)
+            }
         }
     }
 

--- a/Tests/BasicsTests/FileSystem/TemporaryFileTests.swift
+++ b/Tests/BasicsTests/FileSystem/TemporaryFileTests.swift
@@ -9,83 +9,84 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
-import XCTest
+import Testing
 
 import Basics
 
-class TemporaryAsyncFileTests: XCTestCase {
-    func testBasicTemporaryDirectory() async throws {
-        // Test can create and remove temp directory.
+struct TemporaryAsyncFileTests {
+    @Test
+    func basicTemporaryDirectory() async throws {
         let path1: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
             // Do some async task
             try await Task.sleep(nanoseconds: 1_000)
-            
-            XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
+
+            #expect(localFileSystem.isDirectory(tempDirPath))
             return tempDirPath
         }.value
-        XCTAssertFalse(localFileSystem.isDirectory(path1))
-        
+        #expect(!localFileSystem.isDirectory(path1))
+
         // Test temp directory is not removed when its not empty.
         let path2: AbsolutePath = try await withTemporaryDirectory { tempDirPath in
-            XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
+            #expect(localFileSystem.isDirectory(tempDirPath))
             // Create a file inside the temp directory.
             let filePath = tempDirPath.appending("somefile")
             // Do some async task
             try await Task.sleep(nanoseconds: 1_000)
-            
+
             try localFileSystem.writeFileContents(filePath, bytes: [])
             return tempDirPath
         }.value
-        XCTAssertTrue(localFileSystem.isDirectory(path2))
+        #expect(localFileSystem.isDirectory(path2))
         // Cleanup.
         try localFileSystem.removeFileTree(path2)
-        XCTAssertFalse(localFileSystem.isDirectory(path2))
-        
+        #expect(!localFileSystem.isDirectory(path2))
+
         // Test temp directory is removed when its not empty and removeTreeOnDeinit is enabled.
         let path3: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
-            XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
+            #expect(localFileSystem.isDirectory(tempDirPath))
             let filePath = tempDirPath.appending("somefile")
             // Do some async task
             try await Task.sleep(nanoseconds: 1_000)
-            
+
             try localFileSystem.writeFileContents(filePath, bytes: [])
             return tempDirPath
         }.value
-        XCTAssertFalse(localFileSystem.isDirectory(path3))
+        #expect(!localFileSystem.isDirectory(path3))
     }
-    
-    func testCanCreateUniqueTempDirectories() async throws {
+
+    @Test
+    func canCreateUniqueTempDirectories() async throws {
         let (pathOne, pathTwo): (AbsolutePath, AbsolutePath) = try await withTemporaryDirectory(removeTreeOnDeinit: true) { pathOne in
             let pathTwo: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { pathTwo in
                 // Do some async task
                 try await Task.sleep(nanoseconds: 1_000)
-                
-                XCTAssertTrue(localFileSystem.isDirectory(pathOne))
-                XCTAssertTrue(localFileSystem.isDirectory(pathTwo))
+
+                #expect(localFileSystem.isDirectory(pathOne))
+                #expect(localFileSystem.isDirectory(pathTwo))
                 // Their paths should be different.
-                XCTAssertTrue(pathOne != pathTwo)
+                #expect(pathOne != pathTwo)
                 return pathTwo
             }.value
             return (pathOne, pathTwo)
         }.value
-        XCTAssertFalse(localFileSystem.isDirectory(pathOne))
-        XCTAssertFalse(localFileSystem.isDirectory(pathTwo))
+        #expect(!localFileSystem.isDirectory(pathOne))
+        #expect(!localFileSystem.isDirectory(pathTwo))
     }
-    
-    func testCancelOfTask() async throws {
+
+    @Test
+    func cancelOfTask() async throws {
         let task: Task<AbsolutePath, Error> = try withTemporaryDirectory { path in
-            
+
             try await Task.sleep(nanoseconds: 1_000_000_000)
-            XCTAssertTrue(Task.isCancelled)
-            XCTAssertFalse(localFileSystem.isDirectory(path))
+            #expect(Task.isCancelled)
+            #expect(!localFileSystem.isDirectory(path))
             return path
         }
         task.cancel()
-        do {
-            // The correct path is to throw an error here
-            let _ = try await task.value
-            XCTFail("The correct path here is to throw an error")
-        } catch {}
+        await #expect(throws: (any Error).self, "Error did not error when accessing `task.value`") {
+            try await task.value
+        }
     }
 }

--- a/Tests/BasicsTests/FileSystem/VFSTests.swift
+++ b/Tests/BasicsTests/FileSystem/VFSTests.swift
@@ -39,108 +39,110 @@ func testWithTemporaryDirectory(
 
 
 struct VFSTests {
-    @Test(
-        .skipHostOS(.windows)
-    )
+    @Test
     func localBasics() throws {
-        // tiny PE binary from: https://archive.is/w01DO
-        let contents: [UInt8] = [
-            0x4d, 0x5a, 0x00, 0x00, 0x50, 0x45, 0x00, 0x00, 0x4c, 0x01, 0x01, 0x00,
-            0x6a, 0x2a, 0x58, 0xc3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x04, 0x00, 0x03, 0x01, 0x0b, 0x01, 0x08, 0x00, 0x04, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00,
-            0x04, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
-            0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x68, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x02
-        ]
+        try withKnownIssue("Permission issues on Windows") {
+            // tiny PE binary from: https://archive.is/w01DO
+            let contents: [UInt8] = [
+                0x4d, 0x5a, 0x00, 0x00, 0x50, 0x45, 0x00, 0x00, 0x4c, 0x01, 0x01, 0x00,
+                0x6a, 0x2a, 0x58, 0xc3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x04, 0x00, 0x03, 0x01, 0x0b, 0x01, 0x08, 0x00, 0x04, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00,
+                0x04, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
+                0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x68, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x02
+            ]
 
-        let fs = localFileSystem
-        try withTemporaryFile { [contents] vfsPath in
-            try withTemporaryDirectory(removeTreeOnDeinit: true) { [contents] tempDirPath in
-                let file = tempDirPath.appending("best")
-                try fs.writeFileContents(file, string: "best")
+            let fs = localFileSystem
+            try withTemporaryFile { [contents] vfsPath in
+                try withTemporaryDirectory(removeTreeOnDeinit: true) { [contents] tempDirPath in
+                    let file = tempDirPath.appending("best")
+                    try fs.writeFileContents(file, string: "best")
 
-                let sym = tempDirPath.appending("hello")
-                try fs.createSymbolicLink(sym, pointingAt: file, relative: false)
+                    let sym = tempDirPath.appending("hello")
+                    try fs.createSymbolicLink(sym, pointingAt: file, relative: false)
 
-                let executable = tempDirPath.appending("exec-foo")
-                try fs.writeFileContents(executable, bytes: ByteString(contents))
-#if !os(Windows)
-                try fs.chmod(.executable, path: executable, options: [])
-#endif
+                    let executable = tempDirPath.appending("exec-foo")
+                    try fs.writeFileContents(executable, bytes: ByteString(contents))
+    #if !os(Windows)
+                    try fs.chmod(.executable, path: executable, options: [])
+    #endif
 
-                let executableSym = tempDirPath.appending("exec-sym")
-                try fs.createSymbolicLink(executableSym, pointingAt: executable, relative: false)
+                    let executableSym = tempDirPath.appending("exec-sym")
+                    try fs.createSymbolicLink(executableSym, pointingAt: executable, relative: false)
 
-                try fs.createDirectory(tempDirPath.appending("dir"))
-                try fs.writeFileContents(tempDirPath.appending(components: ["dir", "file"]), bytes: [])
+                    try fs.createDirectory(tempDirPath.appending("dir"))
+                    try fs.writeFileContents(tempDirPath.appending(components: ["dir", "file"]), bytes: [])
 
-                try VirtualFileSystem.serializeDirectoryTree(tempDirPath, into: AbsolutePath(vfsPath.path), fs: fs, includeContents: [executable])
+                    try VirtualFileSystem.serializeDirectoryTree(tempDirPath, into: AbsolutePath(vfsPath.path), fs: fs, includeContents: [executable])
+                }
+
+                let vfs = try VirtualFileSystem(path: vfsPath.path, fs: fs)
+
+                // exists()
+                #expect(vfs.exists(AbsolutePath("/")))
+                #expect(!vfs.exists(AbsolutePath("/does-not-exist")))
+
+                // isFile()
+                let filePath = AbsolutePath("/best")
+                #expect(vfs.exists(filePath))
+                #expect(vfs.isFile(filePath))
+                #expect(try vfs.getFileInfo(filePath).fileType == .typeRegular)
+                #expect(!vfs.isDirectory(filePath))
+                #expect(!vfs.isFile(AbsolutePath("/does-not-exist")))
+                #expect(!vfs.isSymlink(AbsolutePath("/does-not-exist")))
+                #expect(throws: (any Error).self) { 
+                    try vfs.getFileInfo(AbsolutePath("/does-not-exist"))
+                }
+
+                // isSymlink()
+                let symPath = AbsolutePath("/hello")
+                #expect(vfs.isSymlink(symPath))
+                #expect(vfs.isFile(symPath))
+                #expect(try vfs.getFileInfo(symPath).fileType == .typeSymbolicLink)
+                #expect(!vfs.isDirectory(symPath))
+
+                // isExecutableFile
+                let executablePath = AbsolutePath("/exec-foo")
+                let executableSymPath = AbsolutePath("/exec-sym")
+                #expect(vfs.isExecutableFile(executablePath))
+                #expect(vfs.isExecutableFile(executableSymPath))
+                #expect(vfs.isSymlink(executableSymPath))
+                #expect(!vfs.isExecutableFile(symPath))
+                #expect(!vfs.isExecutableFile(filePath))
+                #expect(!vfs.isExecutableFile(AbsolutePath("/does-not-exist")))
+                #expect(!vfs.isExecutableFile(AbsolutePath("/")))
+
+                // readFileContents
+                let execFileContents = try vfs.readFileContents(executablePath)
+                #expect(execFileContents == ByteString(contents))
+
+                // isDirectory()
+                #expect(vfs.isDirectory(AbsolutePath("/")))
+                #expect(!vfs.isDirectory(AbsolutePath("/does-not-exist")))
+
+                // getDirectoryContents()
+                let dirContents = try vfs.getDirectoryContents(AbsolutePath("/"))
+                #expect(dirContents.sorted() == ["best", "dir", "exec-foo", "exec-sym", "hello"])
+                #expect {try vfs.getDirectoryContents(AbsolutePath("/does-not-exist"))} throws: { error in
+                    (error.localizedDescription == "no such file or directory: \(AbsolutePath("/does-not-exist"))")
+                }
+
+                let thisDirectoryContents = try vfs.getDirectoryContents(AbsolutePath("/"))
+                #expect(!thisDirectoryContents.contains(where: { $0 == "." }))
+                #expect(!thisDirectoryContents.contains(where: { $0 == ".." }))
+                #expect(thisDirectoryContents.sorted() == ["best", "dir", "exec-foo", "exec-sym", "hello"])
+
+                let contents = try vfs.getDirectoryContents(AbsolutePath("/dir"))
+                #expect(contents == ["file"])
+
+                let fileContents = try vfs.readFileContents(AbsolutePath("/dir/file"))
+                #expect(fileContents == "")
             }
-
-            let vfs = try VirtualFileSystem(path: vfsPath.path, fs: fs)
-
-            // exists()
-            #expect(vfs.exists(AbsolutePath("/")))
-            #expect(!vfs.exists(AbsolutePath("/does-not-exist")))
-
-            // isFile()
-            let filePath = AbsolutePath("/best")
-            #expect(vfs.exists(filePath))
-            #expect(vfs.isFile(filePath))
-            #expect(try vfs.getFileInfo(filePath).fileType == .typeRegular)
-            #expect(!vfs.isDirectory(filePath))
-            #expect(!vfs.isFile(AbsolutePath("/does-not-exist")))
-            #expect(!vfs.isSymlink(AbsolutePath("/does-not-exist")))
-            #expect(throws: (any Error).self) { 
-                try vfs.getFileInfo(AbsolutePath("/does-not-exist"))
-            }
-
-            // isSymlink()
-            let symPath = AbsolutePath("/hello")
-            #expect(vfs.isSymlink(symPath))
-            #expect(vfs.isFile(symPath))
-            #expect(try vfs.getFileInfo(symPath).fileType == .typeSymbolicLink)
-            #expect(!vfs.isDirectory(symPath))
-
-            // isExecutableFile
-            let executablePath = AbsolutePath("/exec-foo")
-            let executableSymPath = AbsolutePath("/exec-sym")
-            #expect(vfs.isExecutableFile(executablePath))
-            #expect(vfs.isExecutableFile(executableSymPath))
-            #expect(vfs.isSymlink(executableSymPath))
-            #expect(!vfs.isExecutableFile(symPath))
-            #expect(!vfs.isExecutableFile(filePath))
-            #expect(!vfs.isExecutableFile(AbsolutePath("/does-not-exist")))
-            #expect(!vfs.isExecutableFile(AbsolutePath("/")))
-
-            // readFileContents
-            let execFileContents = try vfs.readFileContents(executablePath)
-            #expect(execFileContents == ByteString(contents))
-
-            // isDirectory()
-            #expect(vfs.isDirectory(AbsolutePath("/")))
-            #expect(!vfs.isDirectory(AbsolutePath("/does-not-exist")))
-
-            // getDirectoryContents()
-            let dirContents = try vfs.getDirectoryContents(AbsolutePath("/"))
-            #expect(dirContents.sorted() == ["best", "dir", "exec-foo", "exec-sym", "hello"])
-            #expect {try vfs.getDirectoryContents(AbsolutePath("/does-not-exist"))} throws: { error in
-                (error.localizedDescription == "no such file or directory: \(AbsolutePath("/does-not-exist"))")
-            }
-
-            let thisDirectoryContents = try vfs.getDirectoryContents(AbsolutePath("/"))
-            #expect(!thisDirectoryContents.contains(where: { $0 == "." }))
-            #expect(!thisDirectoryContents.contains(where: { $0 == ".." }))
-            #expect(thisDirectoryContents.sorted() == ["best", "dir", "exec-foo", "exec-sym", "hello"])
-
-            let contents = try vfs.getDirectoryContents(AbsolutePath("/dir"))
-            #expect(contents == ["file"])
-
-            let fileContents = try vfs.readFileContents(AbsolutePath("/dir/file"))
-            #expect(fileContents == "")
+        } when: {
+            ProcessInfo.hostOperatingSystem == .windows
         }
     }
 }

--- a/Tests/BasicsTests/FileSystem/VFSTests.swift
+++ b/Tests/BasicsTests/FileSystem/VFSTests.swift
@@ -9,10 +9,11 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import Basics
 import func TSCBasic.withTemporaryFile
-import XCTest
+import Testing
 
 import struct TSCBasic.ByteString
 
@@ -36,21 +37,23 @@ func testWithTemporaryDirectory(
     }.value
 }
 
-class VFSTests: XCTestCase {
-    func testLocalBasics() throws {
-        try XCTSkipOnWindows()
 
+struct VFSTests {
+    @Test(
+        .skipHostOS(.windows)
+    )
+    func localBasics() throws {
         // tiny PE binary from: https://archive.is/w01DO
         let contents: [UInt8] = [
-          0x4d, 0x5a, 0x00, 0x00, 0x50, 0x45, 0x00, 0x00, 0x4c, 0x01, 0x01, 0x00,
-          0x6a, 0x2a, 0x58, 0xc3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-          0x04, 0x00, 0x03, 0x01, 0x0b, 0x01, 0x08, 0x00, 0x04, 0x00, 0x00, 0x00,
-          0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00,
-          0x04, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
-          0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
-          0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-          0x68, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-          0x02
+            0x4d, 0x5a, 0x00, 0x00, 0x50, 0x45, 0x00, 0x00, 0x4c, 0x01, 0x01, 0x00,
+            0x6a, 0x2a, 0x58, 0xc3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x04, 0x00, 0x03, 0x01, 0x0b, 0x01, 0x08, 0x00, 0x04, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00,
+            0x04, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
+            0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x68, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x02
         ]
 
         let fs = localFileSystem
@@ -80,63 +83,64 @@ class VFSTests: XCTestCase {
             let vfs = try VirtualFileSystem(path: vfsPath.path, fs: fs)
 
             // exists()
-            XCTAssertTrue(vfs.exists(AbsolutePath("/")))
-            XCTAssertFalse(vfs.exists(AbsolutePath("/does-not-exist")))
+            #expect(vfs.exists(AbsolutePath("/")))
+            #expect(!vfs.exists(AbsolutePath("/does-not-exist")))
 
             // isFile()
             let filePath = AbsolutePath("/best")
-            XCTAssertTrue(vfs.exists(filePath))
-            XCTAssertTrue(vfs.isFile(filePath))
-            XCTAssertEqual(try vfs.getFileInfo(filePath).fileType, .typeRegular)
-            XCTAssertFalse(vfs.isDirectory(filePath))
-            XCTAssertFalse(vfs.isFile(AbsolutePath("/does-not-exist")))
-            XCTAssertFalse(vfs.isSymlink(AbsolutePath("/does-not-exist")))
-            XCTAssertThrowsError(try vfs.getFileInfo(AbsolutePath("/does-not-exist")))
+            #expect(vfs.exists(filePath))
+            #expect(vfs.isFile(filePath))
+            #expect(try vfs.getFileInfo(filePath).fileType == .typeRegular)
+            #expect(!vfs.isDirectory(filePath))
+            #expect(!vfs.isFile(AbsolutePath("/does-not-exist")))
+            #expect(!vfs.isSymlink(AbsolutePath("/does-not-exist")))
+            #expect(throws: (any Error).self) { 
+                try vfs.getFileInfo(AbsolutePath("/does-not-exist"))
+            }
 
             // isSymlink()
             let symPath = AbsolutePath("/hello")
-            XCTAssertTrue(vfs.isSymlink(symPath))
-            XCTAssertTrue(vfs.isFile(symPath))
-            XCTAssertEqual(try vfs.getFileInfo(symPath).fileType, .typeSymbolicLink)
-            XCTAssertFalse(vfs.isDirectory(symPath))
+            #expect(vfs.isSymlink(symPath))
+            #expect(vfs.isFile(symPath))
+            #expect(try vfs.getFileInfo(symPath).fileType == .typeSymbolicLink)
+            #expect(!vfs.isDirectory(symPath))
 
             // isExecutableFile
             let executablePath = AbsolutePath("/exec-foo")
             let executableSymPath = AbsolutePath("/exec-sym")
-            XCTAssertTrue(vfs.isExecutableFile(executablePath))
-            XCTAssertTrue(vfs.isExecutableFile(executableSymPath))
-            XCTAssertTrue(vfs.isSymlink(executableSymPath))
-            XCTAssertFalse(vfs.isExecutableFile(symPath))
-            XCTAssertFalse(vfs.isExecutableFile(filePath))
-            XCTAssertFalse(vfs.isExecutableFile(AbsolutePath("/does-not-exist")))
-            XCTAssertFalse(vfs.isExecutableFile(AbsolutePath("/")))
+            #expect(vfs.isExecutableFile(executablePath))
+            #expect(vfs.isExecutableFile(executableSymPath))
+            #expect(vfs.isSymlink(executableSymPath))
+            #expect(!vfs.isExecutableFile(symPath))
+            #expect(!vfs.isExecutableFile(filePath))
+            #expect(!vfs.isExecutableFile(AbsolutePath("/does-not-exist")))
+            #expect(!vfs.isExecutableFile(AbsolutePath("/")))
 
             // readFileContents
             let execFileContents = try vfs.readFileContents(executablePath)
-            XCTAssertEqual(execFileContents, ByteString(contents))
+            #expect(execFileContents == ByteString(contents))
 
             // isDirectory()
-            XCTAssertTrue(vfs.isDirectory(AbsolutePath("/")))
-            XCTAssertFalse(vfs.isDirectory(AbsolutePath("/does-not-exist")))
+            #expect(vfs.isDirectory(AbsolutePath("/")))
+            #expect(!vfs.isDirectory(AbsolutePath("/does-not-exist")))
 
             // getDirectoryContents()
-            do {
-                _ = try vfs.getDirectoryContents(AbsolutePath("/does-not-exist"))
-                XCTFail("Unexpected success")
-            } catch {
-                XCTAssertEqual(error.localizedDescription, "no such file or directory: \(AbsolutePath("/does-not-exist"))")
+            let dirContents = try vfs.getDirectoryContents(AbsolutePath("/"))
+            #expect(dirContents.sorted() == ["best", "dir", "exec-foo", "exec-sym", "hello"])
+            #expect {try vfs.getDirectoryContents(AbsolutePath("/does-not-exist"))} throws: { error in
+                (error.localizedDescription == "no such file or directory: \(AbsolutePath("/does-not-exist"))")
             }
 
             let thisDirectoryContents = try vfs.getDirectoryContents(AbsolutePath("/"))
-            XCTAssertFalse(thisDirectoryContents.contains(where: { $0 == "." }))
-            XCTAssertFalse(thisDirectoryContents.contains(where: { $0 == ".." }))
-            XCTAssertEqual(thisDirectoryContents.sorted(), ["best", "dir", "exec-foo", "exec-sym", "hello"])
+            #expect(!thisDirectoryContents.contains(where: { $0 == "." }))
+            #expect(!thisDirectoryContents.contains(where: { $0 == ".." }))
+            #expect(thisDirectoryContents.sorted() == ["best", "dir", "exec-foo", "exec-sym", "hello"])
 
             let contents = try vfs.getDirectoryContents(AbsolutePath("/dir"))
-            XCTAssertEqual(contents, ["file"])
+            #expect(contents == ["file"])
 
             let fileContents = try vfs.readFileContents(AbsolutePath("/dir/file"))
-            XCTAssertEqual(fileContents, "")
+            #expect(fileContents == "")
         }
     }
 }


### PR DESCRIPTION
Convert posted test from XCTest to Swift Testing, while updating to ensuring we mark the tests that currently fail on windows.

Tests/BasicsTests/FileSystem/FileSystemTests.swift
Tests/BasicsTests/FileSystem/PathShimTests.swift
Tests/BasicsTests/FileSystem/PathTests.swift
Tests/BasicsTests/FileSystem/TemporaryFileTests.swift
Tests/BasicsTests/FileSystem/VFSTests.swift

Depends on https://github.com/swiftlang/swift/pull/81217
Partially Addresses: #8433
Issue: rdar://148248105