### PR TITLE
Fix bootstrapping on OpenBSD

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -227,7 +227,7 @@ let package = Package(
             name: "Basics",
             dependencies: [
                 "_AsyncFileSystem",
-                .target(name: "SPMSQLite3", condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .visionOS, .macCatalyst, .linux, .custom("freebsd")])),
+                .target(name: "SPMSQLite3", condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .visionOS, .macCatalyst, .linux, .openbsd, .custom("freebsd")])),
                 .product(name: "SwiftToolchainCSQLite", package: "swift-toolchain-sqlite", condition: .when(platforms: [.windows, .android])),
                 .product(name: "DequeModule", package: "swift-collections"),
                 .product(name: "OrderedCollections", package: "swift-collections"),

--- a/Sources/SPMSQLite3/CMakeLists.txt
+++ b/Sources/SPMSQLite3/CMakeLists.txt
@@ -11,3 +11,6 @@ target_include_directories(SPMSQLite3 INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(SPMSQLite3 INTERFACE
   SQLite::SQLite3)
+if(CMAKE_SYSTEM_NAME STREQUAL OpenBSD)
+  target_link_options(SPMSQLite3 INTERFACE "-L/usr/local/lib")
+endif()

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -926,6 +926,10 @@ def get_swiftpm_flags(args):
         ])
 
     if '-openbsd' in args.build_target:
+        # Because of swiftlang/swift#80059, swiftpm only works
+        # with BTCFI disabled.
+        if 'aarch64' in args.build_target:
+            build_flags.extend(["-Xlinker", "-z", "-Xlinker", "nobtcfi"])
         build_flags.extend(["-Xlinker", "-z", "-Xlinker", "origin"])
         build_flags.extend(["-Xcc", "-I/usr/local/include"])
         build_flags.extend(["-Xlinker", "-L/usr/local/lib"])


### PR DESCRIPTION
### Motivation:

Ensure swiftpm bootstraps successfully to fully build an OpenBSD toolchain.

### Modifications:

* Add the nobtcfi linker flag to the bootstrap script for OpenBSD. This is unconditional for now since swiftpm uses Concurrency liberally and this triggers #80059, so swiftpm only builds on the configuration where BTCFI is disabled. We can revisit some of that perhaps later.

* Ensure SPMSQLite3 builds with the correct link library search path flag in CMakeLists.txt.

* Update Package.swift conditionals for SPMSQLite3.

### Result:

swiftpm successfully builds and bootstraps on OpenBSD.
