### PR TITLE
Tests: Enabled SourceControlTests on Windows

### DIFF
--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -110,10 +110,6 @@ class GitRepositoryTests: XCTestCase {
 
     /// Check hash validation.
     func testGitRepositoryHash() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: """
-        Test failed with: 0 [main] sh (9736) C:\\Program Files\\Git\\usr\\bin\\sh.exe: *** fatal error - add_item ("\\??\\C:\\Program Files\\Git", "/", ...) failed, errno 1
-        """)
-
         let validHash = "0123456789012345678901234567890123456789"
         XCTAssertNotEqual(GitRepository.Hash(validHash), nil)
 
@@ -190,10 +186,6 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testSubmoduleRead() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: """
-        Test failed with: 0 [main] sh (9736) C:\\Program Files\\Git\\usr\\bin\\sh.exe: *** fatal error - add_item ("\\??\\C:\\Program Files\\Git", "/", ...) failed, errno 1
-        """)
-
         try testWithTemporaryDirectory { path in
             let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
@@ -305,10 +297,6 @@ class GitRepositoryTests: XCTestCase {
 
     /// Test the handling of local checkouts.
     func testCheckouts() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: """
-        Test failed with: 0 [main] sh (9736) C:\\Program Files\\Git\\usr\\bin\\sh.exe: *** fatal error - add_item ("\\??\\C:\\Program Files\\Git", "/", ...) failed, errno 1
-        """)
-
         try testWithTemporaryDirectory { path in
             // Create a test repository.
             let testRepoPath = path.appending("test-repo")
@@ -355,10 +343,6 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testFetch() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: """
-        Test failed with: 0 [main] sh (9736) C:\\Program Files\\Git\\usr\\bin\\sh.exe: *** fatal error - add_item ("\\??\\C:\\Program Files\\Git", "/", ...) failed, errno 1
-        """)
-
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -398,10 +382,6 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testHasUnpushedCommits() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: """
-        Test failed with: 0 [main] sh (9736) C:\\Program Files\\Git\\usr\\bin\\sh.exe: *** fatal error - add_item ("\\??\\C:\\Program Files\\Git", "/", ...) failed, errno 1
-        """)
-
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -438,10 +418,6 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testSetRemote() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: """
-        Test failed with: 0 [main] sh (9736) C:\\Program Files\\Git\\usr\\bin\\sh.exe: *** fatal error - add_item ("\\??\\C:\\Program Files\\Git", "/", ...) failed, errno 1
-        """)
-
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -554,10 +530,6 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testCheckoutRevision() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: """
-        Test failed with: 0 [main] sh (9736) C:\\Program Files\\Git\\usr\\bin\\sh.exe: *** fatal error - add_item ("\\??\\C:\\Program Files\\Git", "/", ...) failed, errno 1
-        """)
-
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -690,8 +662,6 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testAlternativeObjectStoreValidation() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "test might hang in CI")
-
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -762,10 +732,6 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testMissingDefaultBranch() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: """
-        Test failed with: 0 [main] sh (9736) C:\\Program Files\\Git\\usr\\bin\\sh.exe: *** fatal error - add_item ("\\??\\C:\\Program Files\\Git", "/", ...) failed, errno 1
-        """)
-
         try testWithTemporaryDirectory { path in
             // Create a repository.
             let testRepoPath = path.appending("test-repo")

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -19,10 +19,6 @@ import XCTest
 
 final class RepositoryManagerTests: XCTestCase {
     func testBasics() async throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: """
-        Test failed with: 0 [main] sh (9736) C:\\Program Files\\Git\\usr\\bin\\sh.exe: *** fatal error - add_item ("\\??\\C:\\Program Files\\Git", "/", ...) failed, errno 1
-        """)
-
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()
 


### PR DESCRIPTION
Some tests in Tests/SourceControlTests are passing on Windows since upgrading the Git Version in the associated docker image, which was completd in https://github.com/swiftlang/swift-docker/pulls/452

Enable the tests that are skipped.

Relates to: #8433 
rdar://148248105
