### PR TITLE
SwiftSDK: Remove hardcoded WASI sysroot path derivation

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -691,17 +691,6 @@ public struct SwiftSDK: Equatable {
         hostSDK: SwiftSDK,
         environment: Environment = .current
     ) -> SwiftSDK? {
-        if targetTriple.isWASI() {
-            let wasiSysroot = hostSDK.toolset.rootPaths.first?
-                .parentDirectory // usr
-                .appending(components: "share", "wasi-sysroot")
-            return SwiftSDK(
-                targetTriple: targetTriple,
-                toolset: hostSDK.toolset,
-                pathsConfiguration: .init(sdkRootPath: wasiSysroot)
-            )
-        }
-
         #if os(macOS)
         if let darwinPlatform = targetTriple.darwinPlatform {
             // the Darwin SDKs are trivially available on macOS

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -451,19 +451,6 @@ final class SwiftSDKBundleTests: XCTestCase {
         }
 
         do {
-            let targetSwiftSDK = try SwiftSDK.deriveTargetSwiftSDK(
-                hostSwiftSDK: hostSwiftSDK,
-                hostTriple: hostTriple,
-                swiftSDKSelector: "wasm32-unknown-wasi",
-                store: store,
-                observabilityScope: system.topScope,
-                fileSystem: fileSystem
-            )
-            // Ensure that triples that have a `defaultSwiftSDK` are handled
-            XCTAssertEqual(targetSwiftSDK.targetTriple?.triple, "wasm32-unknown-wasi")
-        }
-
-        do {
             // Check explicit overriding options.
             let customCompileSDK = AbsolutePath("/path/to/sdk")
             let archs = ["x86_64-apple-macosx10.15"]


### PR DESCRIPTION
Remove hardcoded WASI sysroot path derivation just for wasi-sysroot embedded in toolchains

### Motivation:

The previous implementation assumed there is $TOOLCHAIN_ROOT/share/wasi-sysroot when `--triple wasm32-unknown-wasi` is passed, but this is no longer the case with the [deprecation of the Wasm toolchain installation](https://github.com/swiftwasm/swift/issues/5604) in favor of Swift SDKs.

Due to this unnecessary branch, when `--triple wasm32-unknown-wasi` is passed together with `--swift-sdk`, `--swift-sdk` is just ignored: https://github.com/swiftlang/swift-package-manager/issues/8465

### Modifications:

This change removes the hardcoded path derivation for the WASI sysroot from the `SwiftSDK.deriveTargetSwiftSDK` method.

### Result:

When `--triple wasm32-unknown-wasi` is passed without `--swift-sdk`, no user visible change and they will keep getting the following:
```
error: emit-module command failed with exit code 1 (use -v to see invocation)
<unknown>:0: warning: libc not found for 'wasm32-unknown-wasi'; C stdlib may be unavailable
<unknown>:0: error: unable to load standard library for target 'wasm32-unknown-wasi'
```

When `--triple wasm32-unknown-wasi` is passed together with `--swift-sdk`, `--triple` is ignored and `--swift-sdk` is respected. 