### PR TITLE
Tests: Minor tweaks in Swift Build related tests

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -6911,23 +6911,15 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
     }
 }
 
-class BuildPlanNativeTests: BuildPlanTestCase {
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .native
-    }
-
-    override func testDuplicateProductNamesWithNonDefaultLibsThrowError() async throws {
-        try await super.testDuplicateProductNamesWithNonDefaultLibsThrowError()
+final class BuildPlanNativeTests: BuildPlanTestCase {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .native
     }
 }
 
-class BuildPlanSwiftBuildTests: BuildPlanTestCase {
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .swiftbuild
-    }
-
-    override func testDuplicateProductNamesWithNonDefaultLibsThrowError() async throws {
-        try await super.testDuplicateProductNamesWithNonDefaultLibsThrowError()
+final class BuildPlanSwiftBuildTests: BuildPlanTestCase {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .swiftbuild
     }
 
     override func testTargetsWithPackageAccess() async throws {
@@ -6948,8 +6940,6 @@ class BuildPlanSwiftBuildTests: BuildPlanTestCase {
             throw XCTSkip("Skipping SwiftBuild testing on Amazon Linux because of platform issues.")
         }
 #endif
-
         try await super.testPackageNameFlag()
     }
-
 }

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -455,25 +455,14 @@ class APIDiffTestCase: CommandsBuildProviderTestCase {
     }
 }
 
-class APIDiffNativeTests: APIDiffTestCase {
-
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .native
+final class APIDiffNativeTests: APIDiffTestCase {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .native
     }
-
-    override func skipIfApiDigesterUnsupportedOrUnset() throws {
-        try super.skipIfApiDigesterUnsupportedOrUnset()
-    }
-
 }
 
-class APIDiffSwiftBuildTests: APIDiffTestCase {
-
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .swiftbuild
-    }
-
-    override func skipIfApiDigesterUnsupportedOrUnset() throws {
-        try super.skipIfApiDigesterUnsupportedOrUnset()
+final class APIDiffSwiftBuildTests: APIDiffTestCase {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .swiftbuild
     }
 }

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -782,27 +782,17 @@ class BuildCommandTestCases: CommandsBuildProviderTestCase {
 
 }
 
-
-class BuildCommandNativeTests: BuildCommandTestCases {
-
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .native
-    }
-
-    override func testUsage() async throws {
-        try await super.testUsage()
+final class BuildCommandNativeTests: BuildCommandTestCases {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .native
     }
 }
 
 #if os(macOS)
-// Xcode build system tests can only function on macOS
-class BuildCommandXcodeTests: BuildCommandTestCases {
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .xcode
-    }
-
-    override func testUsage() async throws {
-        try await super.testUsage()
+/// Xcode build system tests can only function on macOS.
+final class BuildCommandXcodeTests: BuildCommandTestCases {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .xcode
     }
 
     override func testAutomaticParseableInterfacesWithLibraryEvolution() async throws {
@@ -855,10 +845,9 @@ class BuildCommandXcodeTests: BuildCommandTestCases {
 }
 #endif
 
-class BuildCommandSwiftBuildTests: BuildCommandTestCases {
-
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .swiftbuild
+final class BuildCommandSwiftBuildTests: BuildCommandTestCases {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .swiftbuild
     }
 
     override func testNonReachableProductsAndTargetsFunctional() async throws {
@@ -892,7 +881,7 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
     override func testImportOfMissedDepWarning() async throws {
         throw XCTSkip("SWBINTTODO: Test fails because the warning message regarding missing imports is expected to be more verbose and actionable at the SwiftPM level with mention of the involved targets. This needs to be investigated. See case targetDiagnostic(TargetDiagnosticInfo) as a message type that may help.")
     }
-
+        
     override func testProductAndTarget() async throws {
         throw XCTSkip("SWBINTTODO: Test fails because there isn't a clear warning message about the lib1 being an automatic product and that the default product is being built instead. This needs to be investigated")
     }
@@ -946,5 +935,4 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
         try await super.testBuildCompleteMessage()
         #endif
     }
-
 }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -3836,26 +3836,15 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
     }
 }
 
-
-class PackageCommandNativeTests: PackageCommandTestCase {
-
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .native
-    }
-
-    override func testNoParameters() async throws {
-        try await super.testNoParameters()
+final class PackageCommandNativeTests: PackageCommandTestCase {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .native
     }
 }
 
-class PackageCommandSwiftBuildTests: PackageCommandTestCase {
-
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .swiftbuild
-    }
-
-    override func testNoParameters() async throws {
-        try await super.testNoParameters()
+final class PackageCommandSwiftBuildTests: PackageCommandTestCase {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .swiftbuild
     }
 
     override func testCommandPluginBuildingCallbacks() async throws {

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -234,24 +234,15 @@ class RunCommandTestCase: CommandsBuildProviderTestCase {
 
 }
 
-class RunCommandNativeTests: RunCommandTestCase {
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .native
-    }
-
-    override func testUsage() async throws {
-        try await super.testUsage()
+final class RunCommandNativeTests: RunCommandTestCase {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .native
     }
 }
 
-
-class RunCommandSwiftBuildTests: RunCommandTestCase {
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .swiftbuild
-    }
-
-    override func testUsage() async throws {
-        try await super.testUsage()
+final class RunCommandSwiftBuildTests: RunCommandTestCase {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .swiftbuild
     }
 
     override func testMultipleExecutableAndExplicitExecutable() async throws {

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -601,27 +601,17 @@ class TestCommandTestCase: CommandsBuildProviderTestCase {
             }
         }
     }
-
 }
 
-class TestCommandNativeTests: TestCommandTestCase {
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .native
-    }
-
-    override func testUsage() async throws {
-        try await super.testUsage()
+final class TestCommandNativeTests: TestCommandTestCase {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .native
     }
 }
 
-
-class TestCommandSwiftBuildTests: TestCommandTestCase {
-    override open var buildSystemProvider: BuildSystemProvider.Kind {
-        return .swiftbuild
-    }
-
-    override func testUsage() async throws {
-        try await super.testUsage()
+final class TestCommandSwiftBuildTests: TestCommandTestCase {
+    override public var buildSystemProvider: BuildSystemProvider.Kind {
+        .swiftbuild
     }
 
     override func testFatalErrorDisplayedCorrectNumberOfTimesWhenSingleXCTestHasFatalErrorInBuildCompilation() async throws {


### PR DESCRIPTION
_[One line description of your change]_

### Motivation:

This includes some (minor) tweaks I did in **Swift Build** related tests while working on the much bigger #8454.

### Modifications:

Minor improvments to all `BuildSystemProviderTestCase` subclasses. For instance, these tests:

![BuildSystemProviderTestCase Subclasses](https://github.com/user-attachments/assets/a2da6648-5ecf-48b7-85fd-b73c4e672f88)

Plus some changes to sibling classes too.

Related to #8454.