### PR TITLE
Enable more plugin related tests for non-macOS platforms

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -651,9 +651,9 @@ extension PackagePIFBuilder.LinkedPackageBinary {
 
     init?(dependency: ResolvedModule.Dependency, package: ResolvedPackage) {
         switch dependency {
-        case .product(let producutDependency, _):
-            guard producutDependency.hasSourceTargets else { return nil }
-            self.init(name: producutDependency.name, packageName: package.name, type: .product)
+        case .product(let productDependency, _):
+            guard productDependency.hasSourceTargets else { return nil }
+            self.init(name: productDependency.name, packageName: package.name, type: .product)
 
         case .module(let moduleDependency, _):
             self.init(module: moduleDependency, package: package)

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -509,7 +509,7 @@ extension PackagePIFProjectBuilder {
             defaultValue: true
         )
         if enableDuplicateLinkageCulling {
-            baselineOTHER_LDFLAGS = []
+            baselineOTHER_LDFLAGS = ["$(inherited)"]
             // The following linker option is specific to the macOS linker
             /*[
                 "-Wl,-no_warn_duplicate_libraries",

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -509,10 +509,12 @@ extension PackagePIFProjectBuilder {
             defaultValue: true
         )
         if enableDuplicateLinkageCulling {
-            baselineOTHER_LDFLAGS = [
+            baselineOTHER_LDFLAGS = []
+            // The following linker option is specific to the macOS linker
+            /*[
                 "-Wl,-no_warn_duplicate_libraries",
                 "$(inherited)"
-            ]
+            ]*/
         } else {
             baselineOTHER_LDFLAGS = ["$(inherited)"]
         }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -503,22 +503,14 @@ extension PackagePIFProjectBuilder {
         }
 
         // Additional settings for the linker.
-        let baselineOTHER_LDFLAGS: [String]
         let enableDuplicateLinkageCulling = UserDefaults.standard.bool(
             forKey: "IDESwiftPackagesEnableDuplicateLinkageCulling",
             defaultValue: true
         )
         if enableDuplicateLinkageCulling {
-            baselineOTHER_LDFLAGS = ["$(inherited)"]
-            // The following linker option is specific to the macOS linker
-            /*[
-                "-Wl,-no_warn_duplicate_libraries",
-                "$(inherited)"
-            ]*/
-        } else {
-            baselineOTHER_LDFLAGS = ["$(inherited)"]
+            impartedSettings[.LD_WARN_DUPLICATE_LIBRARIES] = "NO"
         }
-        impartedSettings[.OTHER_LDFLAGS] = (sourceModule.isCxx ? ["-lc++"] : []) + baselineOTHER_LDFLAGS
+        impartedSettings[.OTHER_LDFLAGS] = (sourceModule.isCxx ? ["-lc++"] : []) + ["$(inherited)"]
         impartedSettings[.OTHER_LDRFLAGS] = []
         log(
             .debug,

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -745,6 +745,10 @@ extension PackagePIFProjectBuilder {
             }
         }
 
+        if !sourceModule.isCxx {
+            impartedSettings[.LINKER_DRIVER] = "swiftc"
+        }
+
         // Impart the linker flags.
         for (platform, settingsByDeclaration) in sourceModule.allBuildSettings.impartedSettings {
             // Note: A `nil` platform means that the declaration applies to *all* platforms.

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -747,10 +747,6 @@ extension PackagePIFProjectBuilder {
             }
         }
 
-        if !sourceModule.isCxx {
-            impartedSettings[.LINKER_DRIVER] = "swiftc"
-        }
-
         // Impart the linker flags.
         for (platform, settingsByDeclaration) in sourceModule.allBuildSettings.impartedSettings {
             // Note: A `nil` platform means that the declaration applies to *all* platforms.

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -435,6 +435,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         var settings: [String: String] = [:]
         // An error with determining the override should not be fatal here.
         settings["CC"] = try? buildParameters.toolchain.getClangCompiler().pathString
+        // TODO see if this fixes some of the LD_LIBRARY_PATH problems on Linux
+        settings["LINKER_DRIVER"] = "swiftc"
         // Always specify the path of the effective Swift compiler, which was determined in the same way as for the
         // native build system.
         settings["SWIFT_EXEC"] = buildParameters.toolchain.swiftCompilerPath.pathString

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -443,8 +443,6 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         var settings: [String: String] = [:]
         // An error with determining the override should not be fatal here.
         settings["CC"] = try? buildParameters.toolchain.getClangCompiler().pathString
-        // TODO see if this fixes some of the LD_LIBRARY_PATH problems on Linux
-        settings["LINKER_DRIVER"] = "swiftc"
         // Always specify the path of the effective Swift compiler, which was determined in the same way as for the
         // native build system.
         settings["SWIFT_EXEC"] = buildParameters.toolchain.swiftCompilerPath.pathString

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -950,13 +950,4 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
 
         try await super.testBuildSystemDefaultSettings()
     }
-
-    override func testBuildCompleteMessage() async throws {
-        #if os(Linux)
-        throw XCTSkip("SWBINTTODO: Need to properly set LD_LIBRARY_PATH on linux")
-        #else
-        try await super.testBuildCompleteMessage()
-        #endif
-    }
-
 }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -3859,15 +3859,9 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
     }
 
     override func testCommandPluginBuildingCallbacks() async throws {
-        throw XCTSkip("SWBINTTODO: Test fails as plugins are not currenty supported")
+        throw XCTSkip("SWBINTTODO: Test fails because plugin is not producing expected output to stdout.")
     }
     override func testCommandPluginBuildTestability() async throws {
         throw XCTSkip("SWBINTTODO: Test fails as plugins are not currenty supported")
     }
-
-#if !os(macOS)
-    override func testCommandPluginTestingCallbacks() async throws {
-        throw XCTSkip("SWBINTTODO: Test fails on inability to find libclang on Linux. Also, plugins are not currently supported")
-    }
-#endif
 }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -699,10 +699,6 @@ class TestCommandSwiftBuildTests: TestCommandTestCase {
 #endif
 
 #if !os(macOS)
-    override func testSwiftTestXMLOutputVerifySingleTestFailureMessageWithFlagDisabledXCTest() async throws {
-        throw XCTSkip("Result XML could not be found. The build fails due to an LD_LIBRARY_PATH issue finding swift core libraries. https://github.com/swiftlang/swift-package-manager/issues/8416")
-    }
-
     override func testSwiftTestXMLOutputVerifyMultipleTestFailureMessageWithFlagEnabledXCTest() async throws {
         throw XCTSkip("Result XML could not be found. The build fails due to an LD_LIBRARY_PATH issue finding swift core libraries. https://github.com/swiftlang/swift-package-manager/issues/8416")
     }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -716,19 +716,19 @@ class TestCommandSwiftBuildTests: TestCommandTestCase {
     }
 
     override func testSwiftTestSkip() async throws {
-        throw XCTSkip("This fails due to a linker error on Linux. https://github.com/swiftlang/swift-package-manager/issues/8439")
+        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
     }
 
     override func testSwiftTestXMLOutputWhenEmpty() async throws {
-        throw XCTSkip("This fails due to a linker error on Linux. https://github.com/swiftlang/swift-package-manager/issues/8439")
+        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
     }
 
     override func testSwiftTestFilter() async throws {
-        throw XCTSkip("This fails due to an unknown linker error on Linux. https://github.com/swiftlang/swift-package-manager/issues/8439")
+        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
     }
 
     override func testSwiftTestParallel() async throws {
-        throw XCTSkip("This fails due to an unknown linker error on Linux. https://github.com/swiftlang/swift-package-manager/issues/8439")
+        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
     }
 #endif
 }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -699,16 +699,20 @@ class TestCommandSwiftBuildTests: TestCommandTestCase {
 #endif
 
 #if !os(macOS)
+    override func testSwiftTestXMLOutputVerifySingleTestFailureMessageWithFlagDisabledXCTest() async throws {
+        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
+    }
+
     override func testSwiftTestXMLOutputVerifyMultipleTestFailureMessageWithFlagEnabledXCTest() async throws {
-        throw XCTSkip("Result XML could not be found. The build fails due to an LD_LIBRARY_PATH issue finding swift core libraries. https://github.com/swiftlang/swift-package-manager/issues/8416")
+        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
     }
 
     override func testSwiftTestXMLOutputVerifySingleTestFailureMessageWithFlagEnabledXCTest() async throws {
-        throw XCTSkip("Result XML could not be found. The build fails due to an LD_LIBRARY_PATH issue finding swift core libraries. https://github.com/swiftlang/swift-package-manager/issues/8416")
+        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
     }
 
     override func testSwiftTestXMLOutputVerifyMultipleTestFailureMessageWithFlagDisabledXCTest() async throws {
-        throw XCTSkip("Result XML could not be found. The build fails due to an LD_LIBRARY_PATH issue finding swift core libraries. https://github.com/swiftlang/swift-package-manager/issues/8416")
+        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
     }
 
     override func testSwiftTestSkip() async throws {


### PR DESCRIPTION
There are tests that were formerly failing due to missing support for plugins in the old PIF builder.
Enable these test for better coverage with the new builder.

* Fix spelling in one of the APIs

* Remove macOS-specific linker flag in the PIF builder and use a setting that is target platform neutral

* Update skip comments for tests based on new analysis of the failures