### PR TITLE
Fix `SwiftBuildSupport/README.md`

### DIFF
--- a/Sources/SwiftBuildSupport/README.md
+++ b/Sources/SwiftBuildSupport/README.md
@@ -15,7 +15,7 @@ Work is continuing in these areas:
 * Conditional target dependencies (i.e. dependencies that are conditional on ".when()" specific platforms)
 * Plugin support
 * Friendly Error and Warning Descriptions and Fixups
-* Cross compiling Swift SDK's (e.g. Static Linux SDK, and WASM)
+* Cross compiling Swift SDK's (e.g. Static Linux SDK, and Wasm/WASI)
 * Improvements to test coverage
 * Task execution reporting
 

--- a/Sources/SwiftBuildSupport/README.md
+++ b/Sources/SwiftBuildSupport/README.md
@@ -15,7 +15,7 @@ Work is continuing in these areas:
 * Conditional target dependencies (i.e. dependencies that are conditional on ".when()" specific platforms)
 * Plugin support
 * Friendly Error and Warning Descriptions and Fixups
-* Cross compiling Swift SDK's (e.g. Static Linux SDK, and Wasm/WASI)
+* Cross compiling Swift SDK's (e.g. Static Linux SDK, and Wasm with WASI)
 * Improvements to test coverage
 * Task execution reporting
 


### PR DESCRIPTION
Fixed up incorrect wording:

1. Wasm is not an acronym, thus it's not uppercased [per the spec](https://webassembly.github.io/spec/core/intro/introduction.html#wasm).
2. Existing Swift SDKs support only WASI, while WASI-less Wasm modules can be created with Embedded Swift and Swift SDKs are not needed for that.
