### PR TITLE
Add `swift-docc-plugin` when env variable `DOCBUILD` is set

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1014,6 +1014,12 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     ]
 }
 
+if ProcessInfo.processInfo.environment["SWIFTPM_DOCC_ENABLED"] != nil {
+    package.dependencies += [
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
+    ]
+}
+
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/swiftlang/swift-tools-support-core.git", branch: relatedDependenciesBranch),


### PR DESCRIPTION
Adds the `swift-docc-plugin` to make it slightly more convenient to build documentation from targets in the project. Since this is built in the toolchain and generally eschews dependencies, I wrapped the dependency addition in an environment variable block `DOCBUILD` - just picked it, happy to tweak/change to anything else or use a different tactic if that's desired.

This is in support of adding more documentation to Swift Package Manager, leveraging Swift's DocC tooling. This is pre-work to enable CLI generation of documentation, as Xcode doesn't seem to be a path for generating the documentation due to an issue I found (#8486).