### PR TITLE
Ensure prebuilt Modules include path added to generated modules

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -27,6 +27,7 @@ import struct PackageGraph.ResolvedProduct
 import struct PackageGraph.ResolvedModule
 
 import struct PackageModel.Sources
+import enum PackageModel.BuildSettings
 import class PackageModel.SwiftModule
 import class PackageModel.Module
 import struct SPMBuildCore.BuildParameters
@@ -80,18 +81,30 @@ extension BuildPlan {
                 let discoveryMainFile = discoveryDerivedDir.appending(component: TestDiscoveryTool.mainFileName)
 
                 var discoveryPaths: [AbsolutePath] = []
+                var discoveryBuildSettings: BuildSettings.AssignmentTable = .init()
                 discoveryPaths.append(discoveryMainFile)
                 for testTarget in testProduct.modules {
                     let path = discoveryDerivedDir.appending(components: testTarget.name + ".swift")
                     discoveryPaths.append(path)
+                    // Add in the include path from the test targets to ensure this module builds
+                    if let flags = testTarget.underlying.buildSettings.assignments[.OTHER_SWIFT_FLAGS] {
+                        for assignment in flags {
+                            let values = assignment.values.filter({ $0.hasPrefix("-I") })
+                            if !values.isEmpty {
+                                discoveryBuildSettings.add(.init(values: values, conditions: []), for: .OTHER_SWIFT_FLAGS)
+                            }
+                        }
+                    }
                 }
 
                 let discoveryTarget = SwiftModule(
                     name: discoveryTargetName,
                     dependencies: testProduct.underlying.modules.map { .module($0, conditions: []) },
                     packageAccess: true, // test target is allowed access to package decls by default
-                    testDiscoverySrc: Sources(paths: discoveryPaths, root: discoveryDerivedDir)
+                    testDiscoverySrc: Sources(paths: discoveryPaths, root: discoveryDerivedDir),
+                    buildSettings: discoveryBuildSettings
                 )
+
                 let discoveryResolvedModule = ResolvedModule(
                     packageIdentity: testProduct.packageIdentity,
                     underlying: discoveryTarget,
@@ -127,12 +140,26 @@ extension BuildPlan {
                 let entryPointMainFile = entryPointDerivedDir.appending(component: entryPointMainFileName)
                 let entryPointSources = Sources(paths: [entryPointMainFile], root: entryPointDerivedDir)
 
+                var entryPointBuildSettings: BuildSettings.AssignmentTable = .init()
+                for testTarget in testProduct.modules {
+                    // Add in the include path from the test targets to ensure this module builds
+                    if let flags = testTarget.underlying.buildSettings.assignments[.OTHER_SWIFT_FLAGS] {
+                        for assignment in flags {
+                            let values = assignment.values.filter({ $0.hasPrefix("-I") })
+                            if !values.isEmpty {
+                                entryPointBuildSettings.add(.init(values: values, conditions: []), for: .OTHER_SWIFT_FLAGS)
+                            }
+                        }
+                    }
+                }
+
                 let entryPointTarget = SwiftModule(
                     name: testProduct.name,
                     type: .library,
                     dependencies: testProduct.underlying.modules.map { .module($0, conditions: []) } + swiftTargetDependencies,
                     packageAccess: true, // test target is allowed access to package decls
-                    testEntryPointSources: entryPointSources
+                    testEntryPointSources: entryPointSources,
+                    buildSettings: entryPointBuildSettings
                 )
                 let entryPointResolvedTarget = ResolvedModule(
                     packageIdentity: testProduct.packageIdentity,
@@ -249,7 +276,8 @@ private extension PackageModel.SwiftModule {
         type: PackageModel.Module.Kind? = nil,
         dependencies: [PackageModel.Module.Dependency],
         packageAccess: Bool,
-        testEntryPointSources sources: Sources
+        testEntryPointSources sources: Sources,
+        buildSettings: BuildSettings.AssignmentTable = .init()
     ) {
         self.init(
             name: name,
@@ -258,6 +286,7 @@ private extension PackageModel.SwiftModule {
             sources: sources,
             dependencies: dependencies,
             packageAccess: packageAccess,
+            buildSettings: buildSettings,
             usesUnsafeFlags: false
         )
     }

--- a/Sources/PackageModel/Module/SwiftModule.swift
+++ b/Sources/PackageModel/Module/SwiftModule.swift
@@ -28,7 +28,12 @@ public final class SwiftModule: Module {
         [defaultTestEntryPointName, "LinuxMain.swift"]
     }
 
-    public init(name: String, dependencies: [Module.Dependency], packageAccess: Bool, testDiscoverySrc: Sources) {
+    public init(
+        name: String,
+        dependencies: [Module.Dependency],
+        packageAccess: Bool,
+        testDiscoverySrc: Sources,
+        buildSettings: BuildSettings.AssignmentTable = .init()) {
         self.declaredSwiftVersions = []
 
         super.init(
@@ -38,7 +43,7 @@ public final class SwiftModule: Module {
             sources: testDiscoverySrc,
             dependencies: dependencies,
             packageAccess: packageAccess,
-            buildSettings: .init(),
+            buildSettings: buildSettings,
             buildSettingsDescription: [],
             pluginUsages: [],
             usesUnsafeFlags: false


### PR DESCRIPTION
For Windows and Linux, SwiftPM generates modules for test discovery and the test entry point. When testing macro targets, we add the swift-syntax prebuilt Modules directory to the include path for the test target. We also need to do this for the generated modules.

As a side effect, this also adds all include directories to the include path for these generated modules to ensure they build for other use cases that may need this.
