### PR TITLE
Adds DocC catalog to host SwiftPM documentation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -419,7 +419,7 @@ let package = Package(
         // MARK: Documentation
         
         .target(
-            name: "PackageManagerDocs",
+            name: "PackageManagerDocs"
         ),
         
         // MARK: Package Manager Functionality

--- a/Package.swift
+++ b/Package.swift
@@ -417,11 +417,11 @@ let package = Package(
         ),
 
         // MARK: Documentation
-        
+
         .target(
             name: "PackageManagerDocs"
         ),
-        
+
         // MARK: Package Manager Functionality
 
         .target(
@@ -1020,12 +1020,6 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     ]
 }
 
-if ProcessInfo.processInfo.environment["SWIFTPM_DOCC_ENABLED"] != nil {
-    package.dependencies += [
-        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
-    ]
-}
-
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/swiftlang/swift-tools-support-core.git", branch: relatedDependenciesBranch),
@@ -1040,6 +1034,8 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-collections.git", "1.0.1" ..< "1.2.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", "1.0.1" ..< "1.6.0"),
         .package(url: "https://github.com/swiftlang/swift-toolchain-sqlite.git", from: "1.0.0"),
+        // For use in previewing documentation
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
     ]
 } else {
     package.dependencies += [

--- a/Package.swift
+++ b/Package.swift
@@ -1014,6 +1014,12 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     ]
 }
 
+if ProcessInfo.processInfo.environment["SWIFTPM_DOCC_ENABLED"] != nil {
+    package.dependencies += [
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
+    ]
+}
+
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/swiftlang/swift-tools-support-core.git", branch: relatedDependenciesBranch),

--- a/Package.swift
+++ b/Package.swift
@@ -416,6 +416,12 @@ let package = Package(
             ]
         ),
 
+        // MARK: Documentation
+        
+        .target(
+            name: "PackageManagerDocs",
+        ),
+        
         // MARK: Package Manager Functionality
 
         .target(

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageManager.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageManager.md
@@ -1,0 +1,14 @@
+# ``PackageManagerDocs``
+
+@Metadata {
+    @DisplayName("Swift Package Manager")
+}
+
+Organize, manage, and edit Swift packages.
+
+## Overview
+
+The Swift Package Manager is a tool for managing distribution of source code, aimed at making it easy to share your code and reuse others’ code. The tool directly addresses the challenges of compiling and linking Swift packages, managing dependencies, versioning, and supporting flexible distribution and collaboration models.
+
+## Topics
+


### PR DESCRIPTION
Adds a `Documentation.docc` directory (a bare DocC catalog) as a stub for migrating existing content in `Documentation/` from general markdown into DocC, as well as providing a base for expanding that documentation. Follow up PRs will bring over and convert content from the `Documentation` directory more piecemeal