### PR TITLE
Add `swift test --attachments-path`.

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -127,7 +127,7 @@ struct TestEventStreamOptions: ParsableArguments {
 
     /// Path for writing attachments (Swift Testing only.)
     @Option(name: .customLong("attachments-path"),
-            help: "Path where attachments should be written (Swift Testing only)")
+            help: "Path where attachments should be written (Swift Testing only). This path must be an existing directory the current user can write to. If not specified, any attachments created during testing are discarded.")
     var attachmentsPath: AbsolutePath?
 }
 

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -124,6 +124,11 @@ struct TestEventStreamOptions: ParsableArguments {
     @Option(name: .customLong("experimental-attachments-path"),
             help: .private)
     var experimentalAttachmentsPath: AbsolutePath?
+
+    /// Path for writing attachments (Swift Testing only.)
+    @Option(name: .customLong("attachments-path"),
+            help: "Path where attachments should be written (Swift Testing only)")
+    var attachmentsPath: AbsolutePath?
 }
 
 struct TestCommandOptions: ParsableArguments {


### PR DESCRIPTION
This PR adds support for the `--attachments-path` CLI argument on `swift test` as approved in [ST-0009](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0009-attachments.md). We will maintain support for the older `--experimental-attachments-path` version through Swift 6.2.

The implementation of this option is held entirely in Swift Testing at this time, so no actual code is needed to support it, we just need to make sure Swift Argument Parser doesn't complain about it.

Resolves rdar://147753584.

@plemarquand has integration tests but they're blocked on a newer toolchain; unit testing of this argument exists in the Swift Testing repo.