### PR TITLE
Improve Swift Build error formatting

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -353,15 +353,23 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                             }
                             progressAnimation.update(step: step, total: 100, text: message)
                         case .diagnostic(let info):
-                            if info.kind == .error {
-                                self.observabilityScope.emit(error: "\(info.location) \(info.message) \(info.fixIts)")
-                            } else if info.kind == .warning {
-                                self.observabilityScope.emit(warning: "\(info.location) \(info.message) \(info.fixIts)")
-                            } else if info.kind == .note {
-                                self.observabilityScope.emit(info: "\(info.location) \(info.message) \(info.fixIts)")
-                            } else if info.kind == .remark {
-                                self.observabilityScope.emit(debug: "\(info.location) \(info.message) \(info.fixIts)")
+                            let fixItsDescription = if info.fixIts.hasContent {
+                                ": " + info.fixIts.map { String(describing: $0) }.joined(separator: ", ")
+                            } else {
+                                ""
                             }
+                            let message = if let locationDescription = info.location.userDescription {
+                                "\(locationDescription) \(info.message)\(fixItsDescription)"
+                            } else {
+                                "\(info.message)\(fixItsDescription)"
+                            }
+                            let severity: Diagnostic.Severity = switch info.kind {
+                            case .error: .error
+                            case .warning: .warning
+                            case .note: .info
+                            case .remark: .debug
+                            }
+                            self.observabilityScope.emit(severity: severity, message: message)
                         case .taskOutput(let info):
                             self.observabilityScope.emit(info: "\(info.data)")
                         case .taskStarted(let info):
@@ -509,6 +517,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
     }
 }
 
+// MARK: - Helpers
+
 extension String {
     /// Escape the usual shell related things, such as quoting, but also handle Windows
     /// back-slashes.
@@ -539,5 +549,32 @@ extension PIFBuilderParameters {
 extension Basics.Diagnostic.Severity {
     var isVerbose: Bool {
         self <= .info
+    }
+}
+
+fileprivate extension SwiftBuild.SwiftBuildMessage.DiagnosticInfo.Location {
+    var userDescription: String? {
+        switch self {
+        case .path(let path, let fileLocation):
+            switch fileLocation {
+            case .textual(let line, let column):
+                var description = "\(path):\(line)"
+                if let column { description += ":\(column)" }
+                return description
+            case .object(let identifier):
+                return "\(path):\(identifier)"
+            case .none:
+                return path
+            }
+        
+        case .buildSettings(let names):
+            return names.joined(separator: ", ")
+        
+        case .buildFiles(let buildFiles, let targetGUID):
+            return "\(targetGUID): " + buildFiles.map { String(describing: $0) }.joined(separator: ", ")
+            
+        case .unknown:
+            return nil
+        }
     }
 }

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -552,6 +552,8 @@ extension Basics.Diagnostic.Severity {
     }
 }
 
+#if canImport(SwiftBuild)
+
 fileprivate extension SwiftBuild.SwiftBuildMessage.DiagnosticInfo.Location {
     var userDescription: String? {
         switch self {
@@ -578,3 +580,5 @@ fileprivate extension SwiftBuild.SwiftBuildMessage.DiagnosticInfo.Location {
         }
     }
 }
+
+#endif

--- a/Sources/_InternalTestSupport/Observability.swift
+++ b/Sources/_InternalTestSupport/Observability.swift
@@ -56,15 +56,14 @@ public struct TestingObservability {
         self.collector.hasWarnings
     }
 
-    final class Collector: ObservabilityHandlerProvider, DiagnosticsHandler, CustomStringConvertible {
+    fileprivate final class Collector: ObservabilityHandlerProvider, DiagnosticsHandler, CustomStringConvertible {
         var diagnosticsHandler: DiagnosticsHandler { self }
 
-        let diagnostics: ThreadSafeArrayStore<Basics.Diagnostic>
         private let verbose: Bool
+        let diagnostics = ThreadSafeArrayStore<Basics.Diagnostic>()
 
         init(verbose: Bool) {
             self.verbose = verbose
-            self.diagnostics = .init()
         }
 
         // TODO: do something useful with scope
@@ -98,6 +97,7 @@ public func XCTAssertNoDiagnostics(
 ) {
     let diagnostics = problemsOnly ? diagnostics.filter { $0.severity >= .warning } : diagnostics
     if diagnostics.isEmpty { return }
+    
     let description = diagnostics.map { "- " + $0.description }.joined(separator: "\n")
     XCTFail("Found unexpected diagnostics: \n\(description)", file: file, line: line)
 }

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -2952,7 +2952,7 @@ final class PIFBuilderTests: XCTestCase {
             "/Foo/Sources/qux/main.swift"
         )
 
-        let observability = ObservabilitySystem.makeForTesting()
+        let observability = ObservabilitySystem.makeForTesting(verbose: false) // Don't print expected [error]s.
         let graph = try loadModulesGraph(
             fileSystem: fs,
             manifests: [


### PR DESCRIPTION
### Motivation:

This improves a bit the error/warning output when building with the new `--build-system swiftbuild`. 

This was the current output:
```shell
warning: unknown Enabling the Swift language feature 'MemberImportVisibility' is recommended; set 'SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES' []
error: path("/Users/pmattos/Development/SampleProjects/SamplePackages/PackageAccessCLI/Sources/ExampleApp/main.swift", fileLocation: Optional(SwiftBuild.SwiftBuildMessage.DiagnosticInfo.Location.FileLocation.textual(line: 6, column: Optional(5)))) cannot find 'bar' in scope []
```

...and this is the improved one: 
```shell
warning: Enabling the Swift language feature 'MemberImportVisibility' is recommended; set 'SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES' 
error: /Users/pmattos/Development/SampleProjects/SamplePackages/PackageAccessCLI/Sources/ExampleApp/main.swift:5:5 cannot find 'foo2' in scope 
```

Eventually, we should consider adopting the error output style from the `--build-system native` instead, i.e.:
```shell
/Users/pmattos/Development/SampleProjects/SamplePackages/PackageAccessCLI/Sources/ExampleApp/main.swift:5:5: error: cannot find 'foo2' in scope
3 | print("Hello, world!")
4 | 
5 | _ = foo2()
  |     `- error: cannot find 'foo2' in scope
6 | _ = bar()
7 | 
```

### Modifications:

These formatting changes are strictly local to the new `SwiftBuildSupport` target.

### Result:

Slightly better error formatting :-)

