### PR TITLE
Unskip all BuildPlanSwiftBuildTests for Swift Build

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -964,6 +964,7 @@ extension ProjectModel.BuildSettings.Platform {
         case .windows: .windows
         case .wasi: .wasi
         case .openbsd: .openbsd
+        case .freebsd: .openbsd // FIXME: Add `freebsd` to Swift Build.
         default: preconditionFailure("Unexpected platform: \(platform.name)")
         }
     }

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -964,7 +964,7 @@ extension ProjectModel.BuildSettings.Platform {
         case .windows: .windows
         case .wasi: .wasi
         case .openbsd: .openbsd
-        case .freebsd: .openbsd // FIXME: Add `freebsd` to Swift Build.
+        case .freebsd: .freebsd
         default: preconditionFailure("Unexpected platform: \(platform.name)")
         }
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -6999,18 +6999,18 @@ class BuildPlanSwiftBuildTests: BuildPlanTestCase {
     }
 
     override func testPackageNameFlag() async throws {
-#if os(Windows)
+        #if os(Windows)
         throw XCTSkip("Skip until there is a resolution to the partial linking with Windows that results in a 'subsystem must be defined' error.")
-#endif
+        #endif
 
-#if os(Linux)
+        #if os(Linux)
         if FileManager.default.contents(atPath: "/etc/system-release").map { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ?? false {
             throw XCTSkip("Skipping Swift Build testing on Amazon Linux because of platform issues.")
         }
         // Linking error: "/usr/bin/ld.gold: fatal error: -pie and -static are incompatible".
         // Tracked by GitHub issue: https://github.com/swiftlang/swift-package-manager/issues/8499
         throw XCTSkip("Skipping Swift Build testing on Linux because of linking issues.")
-#endif
+        #endif
 
         try await super.testPackageNameFlag()
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -705,36 +705,36 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             if isFlagSupportedInDriver {
                 let moduleFlag1 = output.range(of: "-module-name DataModel")
                 XCTAssertNotNil(moduleFlag1)
-                let stdoutNext1 = output[moduleFlag1!.upperBound...]
-                let packageFlag1 = stdoutNext1.range(of: "-package-name libpkg")
+                let outNext1 = output[moduleFlag1!.upperBound...]
+                let packageFlag1 = outNext1.range(of: "-package-name libpkg")
                 XCTAssertNotNil(packageFlag1)
 
-                let moduleFlag2 = stdoutNext1.range(of: "-module-name DataManager")
+                let moduleFlag2 = outNext1.range(of: "-module-name DataManager")
                 XCTAssertNotNil(moduleFlag2)
                 XCTAssertTrue(packageFlag1!.upperBound < moduleFlag2!.lowerBound)
-                let stdoutNext2 = stdoutNext1[moduleFlag2!.upperBound...]
-                let packageFlag2 = stdoutNext2.range(of: "-package-name libpkg")
+                let outNext2 = outNext1[moduleFlag2!.upperBound...]
+                let packageFlag2 = outNext2.range(of: "-package-name libpkg")
                 XCTAssertNotNil(packageFlag2)
 
-                let moduleFlag3 = stdoutNext2.range(of: "-module-name Core")
+                let moduleFlag3 = outNext2.range(of: "-module-name Core")
                 XCTAssertNotNil(moduleFlag3)
                 XCTAssertTrue(packageFlag2!.upperBound < moduleFlag3!.lowerBound)
-                let stdoutNext3 = stdoutNext2[moduleFlag3!.upperBound...]
-                let packageFlag3 = stdoutNext3.range(of: "-package-name libpkg")
+                let outNext3 = outNext2[moduleFlag3!.upperBound...]
+                let packageFlag3 = outNext3.range(of: "-package-name libpkg")
                 XCTAssertNotNil(packageFlag3)
 
-                let moduleFlag4 = stdoutNext3.range(of: "-module-name MainLib")
+                let moduleFlag4 = outNext3.range(of: "-module-name MainLib")
                 XCTAssertNotNil(moduleFlag4)
                 XCTAssertTrue(packageFlag3!.upperBound < moduleFlag4!.lowerBound)
-                let stdoutNext4 = stdoutNext3[moduleFlag4!.upperBound...]
-                let packageFlag4 = stdoutNext4.range(of: "-package-name libpkg")
+                let outNext4 = outNext3[moduleFlag4!.upperBound...]
+                let packageFlag4 = outNext4.range(of: "-package-name libpkg")
                 XCTAssertNotNil(packageFlag4)
 
-                let moduleFlag5 = stdoutNext4.range(of: "-module-name ExampleApp")
+                let moduleFlag5 = outNext4.range(of: "-module-name ExampleApp")
                 XCTAssertNotNil(moduleFlag5)
                 XCTAssertTrue(packageFlag4!.upperBound < moduleFlag5!.lowerBound)
-                let stdoutNext5 = stdoutNext4[moduleFlag5!.upperBound...]
-                let packageFlag5 = stdoutNext5.range(of: "-package-name")
+                let outNext5 = ou   tNext4[moduleFlag5!.upperBound...]
+                let packageFlag5 = outNext5.range(of: "-package-name")
                 XCTAssertNil(packageFlag5)
             } else {
                 XCTAssertNoMatch(output, .contains("-package-name"))

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -695,15 +695,17 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             fileSystem: localFileSystem
         )
         try await fixture(name: "Miscellaneous/TargetPackageAccess") { fixturePath in
-            let (stdout, _) = try await executeSwiftBuild(
+            let (stdout, stderr) = try await executeSwiftBuild(
                 fixturePath.appending("libPkg"),
                 extraArgs: ["-v"],
                 buildSystem: buildSystemProvider
             )
+            let output = stdout + "\n" + stderr
+            
             if isFlagSupportedInDriver {
-                let moduleFlag1 = stdout.range(of: "-module-name DataModel")
+                let moduleFlag1 = output.range(of: "-module-name DataModel")
                 XCTAssertNotNil(moduleFlag1)
-                let stdoutNext1 = stdout[moduleFlag1!.upperBound...]
+                let stdoutNext1 = output[moduleFlag1!.upperBound...]
                 let packageFlag1 = stdoutNext1.range(of: "-package-name libpkg")
                 XCTAssertNotNil(packageFlag1)
 
@@ -735,9 +737,9 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 let packageFlag5 = stdoutNext5.range(of: "-package-name")
                 XCTAssertNil(packageFlag5)
             } else {
-                XCTAssertNoMatch(stdout, .contains("-package-name"))
+                XCTAssertNoMatch(output, .contains("-package-name"))
             }
-            XCTAssertMatch(stdout, .contains("Build complete!"))
+            XCTAssertMatch(output, .contains("Build complete!"))
         }
     }
 
@@ -6994,14 +6996,6 @@ class BuildPlanSwiftBuildTests: BuildPlanTestCase {
 
     override func testDuplicateProductNamesWithNonDefaultLibsThrowError() async throws {
         try await super.testDuplicateProductNamesWithNonDefaultLibsThrowError()
-    }
-
-    override func testTargetsWithPackageAccess() async throws {
-        throw XCTSkip("Skip until swift build system can support this case.")
-    }
-
-    override func testTestModule() async throws {
-        throw XCTSkip("Skip until swift build system can support this case.")
     }
 
     override func testPackageNameFlag() async throws {


### PR DESCRIPTION
### Motivation:

Increase test coverage for the new PIF builder (for **Swift Build**). 

### Modifications:

Enable/unskip all tests in `BuildPlanSwiftBuildTests` when using Swift Build.

#### testTargetsWithPackageAccess

The build error logging, when using `--build-system swiftbuild`, redirects all build tasks command lines to `ObservabilityScope`, including those checked by this test. These are then redirected to _stderr_ together with all other logging. I feel this makes sense, providing a nice flexibility when filtering the `swift build` output, etc.

As such, this updates the `testTargetsWithPackageAccess` to reflect that.

### Result:

All `BuildPlanSwiftBuildTests` are now green on **macOS**; and just 1 test is skipped on **Linux** and **Windows**.
