### PR TITLE
Docs: Refer to swiftly in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ $> swift --version
 Apple Swift version 5.3
 ```
 
-Note: Alternatively use tools like [swiftenv](https://github.com/kylef/swiftenv) that help manage toolchains versions.
+Note: Alternatively use tools like [swiftly](https://www.swift.org/swiftly/documentation/swiftlydocs/) that help manage toolchains versions.
 
 ## Local Development
 


### PR DESCRIPTION
The Swift toolchain installation on swift.org indicate to use swiftly to install the toolchain on macOS and Linux. Update the CONTRIBUTING.md file to refer to swiftly for toolchain management.