### PR TITLE
Test: Mark an Integration tests as intermittent

### DIFF
--- a/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
@@ -119,11 +119,14 @@ private struct SwiftPMTests {
                 let packagePath = tmpDir.appending(component: "foo")
                 try localFileSystem.createDirectory(packagePath)
                 try sh(swiftPackage, "--package-path", packagePath, "init", "--type", "library")
-                try withKnownIssue("""
+                try withKnownIssue(
+                    """
                        Linux: /lib/x86_64-linux-gnu/Scrt1.o:function _start: error: undefined reference to 'main'
                        Windows: lld-link: error: subsystem must be defined
                        MacOS: Could not find or use auto-linked library 'Testing': library 'Testing' not found
-                    """) {
+                    """,
+                    isIntermittent: true
+                ) {
                     try sh(swiftBuild, "--package-path", packagePath, "--build-system", buildSystemProvider.rawValue, "--vv")
                     let (stdout, stderr) = try sh(
                         swiftTest, "--package-path", packagePath, "--build-system", buildSystemProvider.rawValue, "--vv"


### PR DESCRIPTION
Mark the packageInitLibrary IntegrationTest intermittent as testing in Ci is reporting no issue was recorded
