### PR TITLE
Tests: Ensure we get clean test fixtures

### DIFF
--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -173,13 +173,22 @@ fileprivate func verifyFixtureExists(at fixtureSubpath: RelativePath, file: Stat
     return fixtureDir
 }
 
-fileprivate func setup(fixtureDir: AbsolutePath, in tmpDirPath: AbsolutePath, copyName: String, createGitRepo: Bool = true) throws -> AbsolutePath {
+fileprivate func setup(
+    fixtureDir: AbsolutePath,
+    in tmpDirPath: AbsolutePath,
+    copyName: String,
+    createGitRepo: Bool = true
+) throws -> AbsolutePath {
     func copy(from srcDir: AbsolutePath, to dstDir: AbsolutePath) throws {
-#if os(Windows)
+        #if os(Windows)
         try localFileSystem.copy(from: srcDir, to: dstDir)
-#else
+        #else
         try systemQuietly("cp", "-R", "-H", srcDir.pathString, dstDir.pathString)
-#endif
+        #endif
+        
+        // Ensure we get a clean test fixture.
+        try localFileSystem.removeFileTree(dstDir.appending(component: ".build"))
+        try localFileSystem.removeFileTree(dstDir.appending(component: ".swiftpm"))
     }
 
     // The fixture contains either a checkout or just a Git directory.

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -235,8 +235,8 @@ class BuildCommandTestCases: CommandsBuildProviderTestCase {
     func testSymlink() async throws {
         try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
             let fullPath = try resolveSymlinks(fixturePath)
-            let targetPath = try fullPath.appending(
-                components: ".build",
+            let targetPath = try fullPath.appending(components:
+                ".build",
                 UserToolchain.default.targetTriple.platformBuildPathComponent
             )
             // Test symlink.


### PR DESCRIPTION
### Motivation:

When running tests ensure the *test fixtures* we copy over to temporary directories don't carry over any previous build information.

### Modifications:

When copying packages from `/Fixtures/**` we now ensure we delete any `.build` or `.swiftpm` directories, if any.

### Result:

Safer tests hopefully :-)

PS. This was driving me nuts as I was playing around with a given `/Fixtures/Foo` but also running tests against it! The tests behaviour would vary depending on what `swift` commands I had previously ran in `/Fixtures/Foo`... fun times! 🙃