### PR TITLE
Add default values to testing framework options

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -615,7 +615,7 @@ public struct LinkerOptions: ParsableArguments {
 @_spi(SwiftPMInternal)
 public struct TestLibraryOptions: ParsableArguments {
     public init() {}
-
+    
     /// Whether to enable support for XCTest (as explicitly specified by the user.)
     ///
     /// Callers will generally want to use ``enableXCTestSupport`` since it will
@@ -623,8 +623,14 @@ public struct TestLibraryOptions: ParsableArguments {
     @Flag(name: .customLong("xctest"),
           inversion: .prefixedEnableDisable,
           help: "Enable support for XCTest")
-    public var explicitlyEnableXCTestSupport: Bool?
+    public var enableXCTestSupport: Bool = false
 
+    private var didSetEnableXCTestSupport = false
+
+    public var explicitlyEnableXCTestSupport: Bool? {
+        didSetEnableXCTestSupport ? enableXCTestSupport : nil
+    }
+    
     /// Whether to enable support for Swift Testing (as explicitly specified by the user.)
     ///
     /// Callers will generally want to use ``enableSwiftTestingLibrarySupport`` since it will
@@ -632,8 +638,13 @@ public struct TestLibraryOptions: ParsableArguments {
     @Flag(name: .customLong("swift-testing"),
           inversion: .prefixedEnableDisable,
           help: "Enable support for Swift Testing")
-    public var explicitlyEnableSwiftTestingLibrarySupport: Bool?
+    public var enableSwiftTestingLibrarySupport: Bool = true
 
+    private var didSetEnableSwiftTestingLibrarySupport = false
+    
+    public var explicitlyEnableSwiftTestingLibrarySupport: Bool? {
+        didSetEnableSwiftTestingLibrarySupport ? enableSwiftTestingLibrarySupport : nil
+    }
     /// Legacy experimental equivalent of ``explicitlyEnableSwiftTestingLibrarySupport``.
     ///
     /// This option will be removed in a future update.
@@ -642,6 +653,20 @@ public struct TestLibraryOptions: ParsableArguments {
           help: .private)
     public var explicitlyEnableExperimentalSwiftTestingLibrarySupport: Bool?
 
+    /// Validate if user explicitly enables/disables testing framework.
+    mutating public func validate() throws {
+        let args = CommandLine.arguments
+        
+        didSetEnableXCTestSupport = args.contains {
+            $0 == "--enable-xctest" || $0 == "--disable-xctest"
+        }
+
+        didSetEnableSwiftTestingLibrarySupport = args.contains {
+            $0 == "--enable-swift-testing" || $0 == "--disable-swift-testing"
+        }
+
+    }
+    
     /// The common implementation for `isEnabled()` and `isExplicitlyEnabled()`.
     ///
     /// It is intentional that `isEnabled()` is not simply this function with a


### PR DESCRIPTION
Adding default values when initializing packages

Motivation:

Currently, we try to encourage users to use swift testing as much as possible, as the current logic is as follows:

if users do not explicitly mention disabling swift testing, the initialized package will initialize as if the user wrote --enable-swift-test.
Likewise, currently, unless the package initialized is a macro, or if the user explicitly mentions --enable-xctest, then the xctest framework would not be used.
This change will allow users to see that the current defaults, improving the --help screen.

Modifications:

The only modifications I have done was change the flags' types from optional to boolean, then added a validation function that checks if the user explicitly mentioned either enabling or disabling swift testing.

Result:

Users, when writing --help, will see the default values for --enable-swift-test and --enable-xctest.