### PR TITLE
Tests: Fix 22 warning in BuildCommandTests

### DIFF
--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -806,51 +806,51 @@ class BuildCommandXcodeTests: BuildCommandTestCases {
     }
 
     override func testAutomaticParseableInterfacesWithLibraryEvolution() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testNonReachableProductsAndTargetsFunctional() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testCodeCoverage() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testBuildStartMessage() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testBinSymlink() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testSymlink() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testSwiftGetVersion() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testParseableInterfaces() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testProductAndTarget() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testImportOfMissedDepWarning() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testGetTaskAllowEntitlement() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 
     override func testBuildCompleteMessage() async throws {
-        try XCTSkip("Test not implemented for xcode build system.")
+        throw XCTSkip("Test not implemented for xcode build system.")
     }
 }
 #endif


### PR DESCRIPTION
### Motivation:

Reduce noise from solvable warnings.

### Modifications:

We should `throw XCTSkip("...")` but `try XCTSkipIf(true, "...")`. The `BuildCommandTests` was mixing both (i.e., `try XCTSkip("...")`), making the test a nop actually.

### Result:

Less 22 warnings I guess -:)
