### PR TITLE
Tests: Enable some BuildTests/**/*.swift tests on Windows

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Binaries/MyVendedSourceGenBuildTool.artifactbundle/info.json
+++ b/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Binaries/MyVendedSourceGenBuildTool.artifactbundle/info.json
@@ -12,6 +12,10 @@
                 {
                     "path": "mytool-linux/mytool",
                     "supportedTriples": ["x86_64-unknown-linux-gnu"]
+                },
+                {
+                    "path": "mytool-windows/mytool.bat",
+                    "supportedTriples": ["x86_64-unknown-windows-msvc", "aarch64-unknown-windows-msvc"]
                 }
             ]
         }

--- a/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Binaries/MyVendedSourceGenBuildTool.artifactbundle/mytool-windows/mytool.bat
+++ b/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Binaries/MyVendedSourceGenBuildTool.artifactbundle/mytool-windows/mytool.bat
@@ -1,0 +1,21 @@
+@echo off
+
+set verbose=false
+IF NOT "%1"=="" (
+    IF "%1"=="--verbose" (
+        SET verbose=true
+        SHIFT
+    )
+)
+
+set input=%1
+set output=%2
+shift
+shift
+
+
+if "%verbose%" == "true" (
+    echo "[mytool-windows] '%input%' '%output%'"
+)
+@echo on
+echo f | xcopy.exe /f "%input%" "%output%"

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2040,8 +2040,6 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
     }
 
     func test_symbolGraphExtract_arguments() async throws {
-        try XCTSkipOnWindows()
-
         // ModuleGraph:
         // .
         // ├── A (Swift)
@@ -2110,33 +2108,38 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
 
         // A
         do {
+            let expectedModuleMap = AbsolutePath("/path/to/build/\(triple)/debug/C.build/module.modulemap").pathString
             try XCTAssertMatchesSubSequences(
                 result.moduleBuildDescription(for: "A").symbolGraphExtractArguments(),
                 // Swift Module dependencies
-                ["-I", "/path/to/build/\(triple)/debug/Modules"],
+                ["-I", .equal(AbsolutePath("/path/to/build/\(triple)/debug/Modules").pathString)],
                 // C Module dependencies
-                ["-Xcc", "-I", "-Xcc", "/Pkg/Sources/C/include"],
-                ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/C.build/module.modulemap"]
+                ["-Xcc", "-I", "-Xcc", .equal(AbsolutePath("/Pkg/Sources/C/include").pathString)],
+                ["-Xcc", "-fmodule-map-file=\(expectedModuleMap)"]
             )
         }
 
         // D
         do {
+            let expectedBModuleMap = AbsolutePath("/path/to/build/\(triple)/debug/B.build/module.modulemap").pathString
+            let expectedCModuleMap = AbsolutePath("/path/to/build/\(triple)/debug/C.build/module.modulemap").pathString
+            let expectedDModuleMap = AbsolutePath("/path/to/build/\(triple)/debug/D.build/module.modulemap").pathString
+            let expectedModuleCache = AbsolutePath("/path/to/build/\(triple)/debug/ModuleCache").pathString
             try XCTAssertMatchesSubSequences(
                 result.moduleBuildDescription(for: "D").symbolGraphExtractArguments(),
                 // Self Module
-                ["-I", "/Pkg/Sources/D/include"],
-                ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/D.build/module.modulemap"],
+                ["-I", .equal(AbsolutePath("/Pkg/Sources/D/include").pathString)],
+                ["-Xcc", "-fmodule-map-file=\(expectedDModuleMap)"],
 
                 // C Module dependencies
-                ["-Xcc", "-I", "-Xcc", "/Pkg/Sources/C/include"],
-                ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/C.build/module.modulemap"],
+                ["-Xcc", "-I", "-Xcc", .equal(AbsolutePath("/Pkg/Sources/C/include").pathString)],
+                ["-Xcc", "-fmodule-map-file=\(expectedCModuleMap)"],
 
                 // General Args
                 [
                     "-Xcc", "-fmodules",
                     "-Xcc", "-fmodule-name=D",
-                    "-Xcc", "-fmodules-cache-path=/path/to/build/\(triple)/debug/ModuleCache",
+                    "-Xcc", "-fmodules-cache-path=\(expectedModuleCache)",
                 ]
             )
 
@@ -2144,7 +2147,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             try XCTAssertMatchesSubSequences(
                 result.moduleBuildDescription(for: "D").symbolGraphExtractArguments(),
                 // Swift Module dependencies
-                ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/B.build/module.modulemap"]
+                ["-Xcc", "-fmodule-map-file=\(expectedBModuleMap)"]
             )
 #endif
         }
@@ -4701,8 +4704,6 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
     }
 
     func testUserToolchainCompileFlags() async throws {
-        try XCTSkipOnWindows()
-
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -4955,8 +4956,6 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
     }
 
     func testUserToolchainWithToolsetCompileFlags() async throws {
-        try XCTSkipOnWindows(because: "Path delimiters donw's work well on Windows")
-
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -5083,7 +5082,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         let exeCompileArguments = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         let exeCompileArgumentsPattern: [StringPattern] = [
             jsonFlag(tool: .swiftCompiler),
-            "-ld-path=/fake/toolchain/usr/bin/linker",
+            "-ld-path=\(AbsolutePath("/fake/toolchain/usr/bin/linker").pathString)",
             "-g", cliFlag(tool: .swiftCompiler),
             .anySequence,
             "-Xcc", jsonFlag(tool: .cCompiler), "-Xcc", "-g", "-Xcc", cliFlag(tool: .cCompiler),
@@ -5108,7 +5107,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         let exeLinkArguments = try result.buildProduct(for: "exe").linkArguments()
         let exeLinkArgumentsPattern: [StringPattern] = [
             jsonFlag(tool: .swiftCompiler),
-            "-ld-path=/fake/toolchain/usr/bin/linker",
+            "-ld-path=\(AbsolutePath("/fake/toolchain/usr/bin/linker").pathString)",
             "-g", cliFlag(tool: .swiftCompiler),
             .anySequence,
             "-Xlinker", jsonFlag(tool: .linker), "-Xlinker", cliFlag(tool: .linker),
@@ -5125,8 +5124,6 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
     }
 
     func testUserToolchainWithSDKSearchPaths() async throws {
-        try XCTSkipOnWindows()
-
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -7066,6 +7063,7 @@ class BuildPlanNativeTests: BuildPlanTestCase {
     override func testDuplicateProductNamesWithNonDefaultLibsThrowError() async throws {
         try await super.testDuplicateProductNamesWithNonDefaultLibsThrowError()
     }
+
 }
 
 class BuildPlanSwiftBuildTests: BuildPlanTestCase {

--- a/Tests/BuildTests/PluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/PluginsBuildPlanTests.swift
@@ -18,7 +18,7 @@ import PackageModel
 
 final class PluginsBuildPlanTests: XCTestCase {
     func testBuildToolsDatabasePath() async throws {
-        try XCTSkipOnWindows()
+        try XCTSkipOnWindows(because: "Fails to build the project to due to incorrect Path handling.  Possibly related to https://github.com/swiftlang/swift-package-manager/issues/8511")
 
         try await fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath)

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -22,11 +22,12 @@ import class Basics.ObservabilitySystem
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 import func PackageGraph.loadModulesGraph
 import class PackageModel.Manifest
+import struct PackageGraph.ModulesGraph
 import struct PackageModel.TargetDescription
 
 class PrepareForIndexTests: XCTestCase {
     func testPrepare() async throws {
-        try XCTSkipOnWindows()
+        try XCTSkipOnWindows(because: "coreCommands.count = 0 instead of 1. Possibly related to https://github.com/swiftlang/swift-package-manager/issues/8511")
 
         let (graph, fs, scope) = try macrosPackageGraph()
 
@@ -94,10 +95,7 @@ class PrepareForIndexTests: XCTestCase {
         XCTAssertTrue(manifest.targets.keys.contains(name))
     }
 
-    // enable-testing requires the non-exportable-decls, make sure they aren't skipped.
-    func testEnableTesting() async throws {
-        try XCTSkipOnWindows()
-
+    func testEnableTestingSetup() throws-> (fs: InMemoryFileSystem, observability: TestingObservability, graph: ModulesGraph) {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/lib/lib.swift",
@@ -105,7 +103,6 @@ class PrepareForIndexTests: XCTestCase {
         )
 
         let observability = ObservabilitySystem.makeForTesting()
-        let scope = observability.topScope
 
         let graph = try loadModulesGraph(
             fileSystem: fs,
@@ -119,8 +116,16 @@ class PrepareForIndexTests: XCTestCase {
                     ]
                 ),
             ],
-            observabilityScope: scope
+            observabilityScope: observability.topScope
         )
+        return (fs, observability, graph)
+    }
+
+    func testEnableTestingDebugConfiguration() async throws {
+        // enable-testing requires the non-exportable-decls, make sure they aren't skipped.
+        let (fs, observability, graph) = try self.testEnableTestingSetup()
+        let scope = observability.topScope
+
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         // Under debug, enable-testing is turned on by default. Make sure the flag is not added.
@@ -143,6 +148,17 @@ class PrepareForIndexTests: XCTestCase {
             return swiftCommand.otherArguments.contains("-experimental-skip-non-exportable-decls")
                 && !swiftCommand.otherArguments.contains("-enable-testing")
         }))
+    }
+
+    func testEnableTestingReleaseConfiguration() async throws {
+        try XCTSkipOnWindows(because: """
+            Assertion failure.  ("0") is not equal to ("1"). Possibly related to https://github.com/swiftlang/swift-package-manager/issues/8511
+        """)
+
+        let (fs, observability, graph) = try self.testEnableTestingSetup()
+        let scope = observability.topScope
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         // Under release, enable-testing is turned off by default so we should see our flag
         let releasePlan = try await BuildPlan(
@@ -167,7 +183,7 @@ class PrepareForIndexTests: XCTestCase {
     }
 
     func testPrepareNoLazy() async throws {
-        try XCTSkipOnWindows()
+        try XCTSkipOnWindows(because: "coreCommands.count = 0 instead of 1. Possibly related to https://github.com/swiftlang/swift-package-manager/issues/8511")
 
         let (graph, fs, scope) = try macrosPackageGraph()
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -16145,7 +16145,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testInvalidTrait_WhenParentPackageEnablesTraits() async throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: #"\tmp\ws doesn't exist in file system"#)
+        try XCTSkipOnWindows(because: #"\tmp\ws doesn't exist in file system"#)
 
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
@@ -16208,7 +16208,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testInvalidTraitConfiguration_ForRootPackage() async throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: #"\tmp\ws doesn't exist in file system"#)
+        try XCTSkipOnWindows(because: #"\tmp\ws doesn't exist in file system"#)
 
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()


### PR DESCRIPTION
- Enable the BuildPlanTests on Windows
- Split a PrepareForIndexTests tests into two withthe passing, and failing on Windows
- update/add a message on some skipped windows tests, with a reference to GitHub Issue

Related to: #8433
Depends on: #8569
rdar://148248105
