### PR TITLE
Prevent non-targets from depending on test targets

### DIFF
--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -309,9 +309,9 @@ extension Basics.Diagnostic {
         return .error("\(messagePrefix) in dependencies of target '\(targetName)'; valid packages are: \(validPackages.map{ "\($0.descriptionForValidation)" }.joined(separator: ", "))")
     }
 
-    static func invalidDependencyOnTestTarget(dependency: String, targetName: String) -> Self {
+    static func invalidDependencyOnTestTarget(dependency: Module.Dependency, targetName: String) -> Self {
         .error(
-            "Invalid dependency: '\(targetName)' cannot depend on test target dependency '\(dependency)'. Only test targets can depend on other test targets"
+            "Invalid dependency: '\(targetName)' cannot depend on test target dependency '\(dependency.name)'. Only test targets can depend on other test targets"
         )
     }
 

--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -309,6 +309,10 @@ extension Basics.Diagnostic {
         return .error("\(messagePrefix) in dependencies of target '\(targetName)'; valid packages are: \(validPackages.map{ "\($0.descriptionForValidation)" }.joined(separator: ", "))")
     }
 
+    static func invalidDependencyOnTestTarget(dependency: String, targetName: String) -> Self {
+        return .error("Invalid dependency: '\(targetName)' cannot depend on test target dependency '\(dependency)'. Only test targets can depend on other test targets")
+    }
+
     static func invalidBinaryLocation(targetName: String) -> Self {
         .error("invalid location for binary target '\(targetName)'")
     }

--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -310,7 +310,9 @@ extension Basics.Diagnostic {
     }
 
     static func invalidDependencyOnTestTarget(dependency: String, targetName: String) -> Self {
-        return .error("Invalid dependency: '\(targetName)' cannot depend on test target dependency '\(dependency)'. Only test targets can depend on other test targets")
+        .error(
+            "Invalid dependency: '\(targetName)' cannot depend on test target dependency '\(dependency)'. Only test targets can depend on other test targets"
+        )
     }
 
     static func invalidBinaryLocation(targetName: String) -> Self {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -948,17 +948,20 @@ public final class PackageBuilder {
                         ))
                 }
         }
-        
+
         // Ensure non-test targets do not depend on test targets.
         // Only test targets are allowed to have dependencies on other test targets.
         if !potentialModule.isTest {
             for dependency in dependencies {
                 if let depTarget = dependency.module, depTarget.type == .test {
-                    self.observabilityScope.emit(.invalidDependencyOnTestTarget(dependency: dependency.name, targetName: potentialModule.name))
+                    self.observabilityScope.emit(.invalidDependencyOnTestTarget(
+                        dependency: dependency.name,
+                        targetName: potentialModule.name
+                    ))
                 }
             }
         }
-        
+
         // Create the build setting assignment table for this target.
         let buildSettings = try self.buildSettings(
             for: manifestTarget,

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -948,7 +948,17 @@ public final class PackageBuilder {
                         ))
                 }
         }
-
+        
+        // Ensure non-test targets do not depend on test targets.
+        // Only test targets are allowed to have dependencies on other test targets.
+        if !potentialModule.isTest {
+            for dependency in dependencies {
+                if let depTarget = dependency.module, depTarget.type == .test {
+                    self.observabilityScope.emit(.invalidDependencyOnTestTarget(dependency: dependency.name, targetName: potentialModule.name))
+                }
+            }
+        }
+        
         // Create the build setting assignment table for this target.
         let buildSettings = try self.buildSettings(
             for: manifestTarget,

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -955,7 +955,7 @@ public final class PackageBuilder {
             for dependency in dependencies {
                 if let depTarget = dependency.module, depTarget.type == .test {
                     self.observabilityScope.emit(.invalidDependencyOnTestTarget(
-                        dependency: dependency.name,
+                        dependency: dependency,
                         targetName: potentialModule.name
                     ))
                 }

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -409,7 +409,73 @@ final class ModulesGraphTests: XCTestCase {
             result.check(modules: "Bar", "Baz", "Foo")
         }
     }
-
+    
+    func testLibraryInvalidDependencyOnTestTarget() throws {
+        
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/Foo/Foo.swift",
+            "/Foo/Tests/FooTest/FooTest.swift"
+        )
+        
+        let observability = ObservabilitySystem.makeForTesting()
+        
+        let _ = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Foo",
+                    path: "/Foo",
+                    toolsVersion: .v6_0,
+                    products: [
+                        ProductDescription(name: "Foo", type: .library(.automatic), targets: ["FooTest"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Foo", dependencies: ["FooTest"]),
+                        TargetDescription(name: "FooTest", type: .test)
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope)
+        
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(
+                diagnostic: "Invalid dependency: 'Foo' cannot depend on test target dependency 'FooTest'. Only test targets can depend on other test targets",
+                severity: .error
+            )
+        }
+    }
+    
+    func testValidDependencyOnTestTarget() throws {
+        
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Tests/Foo/Foo.swift",
+            "/Foo/Tests/FooTest/FooTest.swift"
+        )
+        
+        let observability = ObservabilitySystem.makeForTesting()
+        
+        let _ = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Foo",
+                    path: "/Foo",
+                    toolsVersion: .v6_0,
+                    products: [
+                    ],
+                    targets: [
+                        TargetDescription(name: "Foo", dependencies: ["FooTest"], type: .test),
+                        TargetDescription(name: "FooTest", type: .test)
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope)
+        
+        XCTAssertNoDiagnostics(observability.diagnostics)
+    }
+    
     // Make sure there is no error when we reference Test targets in a package and then
     // use it as a dependency to another package. SR-2353
     func testTestTargetDeclInExternalPackage() throws {

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -409,17 +409,16 @@ final class ModulesGraphTests: XCTestCase {
             result.check(modules: "Bar", "Baz", "Foo")
         }
     }
-    
+
     func testLibraryInvalidDependencyOnTestTarget() throws {
-        
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Foo/Sources/Foo/Foo.swift",
             "/Foo/Tests/FooTest/FooTest.swift"
         )
-        
+
         let observability = ObservabilitySystem.makeForTesting()
-        
+
         let _ = try loadModulesGraph(
             fileSystem: fs,
             manifests: [
@@ -432,12 +431,13 @@ final class ModulesGraphTests: XCTestCase {
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["FooTest"]),
-                        TargetDescription(name: "FooTest", type: .test)
+                        TargetDescription(name: "FooTest", type: .test),
                     ]
                 ),
             ],
-            observabilityScope: observability.topScope)
-        
+            observabilityScope: observability.topScope
+        )
+
         testDiagnostics(observability.diagnostics) { result in
             result.check(
                 diagnostic: "Invalid dependency: 'Foo' cannot depend on test target dependency 'FooTest'. Only test targets can depend on other test targets",
@@ -445,17 +445,16 @@ final class ModulesGraphTests: XCTestCase {
             )
         }
     }
-    
+
     func testValidDependencyOnTestTarget() throws {
-        
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Foo/Tests/Foo/Foo.swift",
             "/Foo/Tests/FooTest/FooTest.swift"
         )
-        
+
         let observability = ObservabilitySystem.makeForTesting()
-        
+
         let _ = try loadModulesGraph(
             fileSystem: fs,
             manifests: [
@@ -467,15 +466,16 @@ final class ModulesGraphTests: XCTestCase {
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["FooTest"], type: .test),
-                        TargetDescription(name: "FooTest", type: .test)
+                        TargetDescription(name: "FooTest", type: .test),
                     ]
                 ),
             ],
-            observabilityScope: observability.topScope)
-        
+            observabilityScope: observability.topScope
+        )
+
         XCTAssertNoDiagnostics(observability.diagnostics)
     }
-    
+
     // Make sure there is no error when we reference Test targets in a package and then
     // use it as a dependency to another package. SR-2353
     func testTestTargetDeclInExternalPackage() throws {


### PR DESCRIPTION
Prevent non-targets from depending on test targets

### Motivation:

Fix for rdar://149007214 
Currently, only test targets are allowed to have dependencies on other test targets.

### Modifications:

Simply checked for each non-test target, if their dependency is of type test. If it is, throw an error.


### Result:

Swift package manager will give an error explaining that only testTargets can depend on other testTargets

Fixes #8478 