### PR TITLE
Add an .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+xcode_trim_whitespace_on_empty_lines = true
+
+[*.{yml,yaml}]
+indent_size = 2


### PR DESCRIPTION
This encodes our indentation size and line ending preferences and such. This is an exact copy of the .editorconfig in swift-build, which uses the same conventions.