### PR TITLE
Issue #8520 -  Skip failing tests in specific CI environments

### DIFF
--- a/IntegrationTests/Sources/IntegrationTestSupport/SkippedTestSupport.swift
+++ b/IntegrationTests/Sources/IntegrationTestSupport/SkippedTestSupport.swift
@@ -67,4 +67,12 @@ extension Trait where Self == Testing.ConditionTrait {
                 .map { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ?? false
         }
     }
+
+    /// Skip test based on the presence of an environment variable set that matches a prefix and issue
+    /// suffix.  i.e. SWIFTCI_EXHIBITS_GH_8520=1
+    public static func skipCIExhibitsIssue(_ issueSuffix: String, _ comment: Comment? = nil) -> Self {
+        disabled(comment ?? "SWIFTCI_EXHIBITS_\(issueSuffix) environment variable is set") {
+            ProcessInfo.processInfo.environment["SWIFTCI_EXHIBITS_\(issueSuffix)"] != nil
+        }
+    }
 }

--- a/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
@@ -185,7 +185,9 @@ private struct BasicTests {
         }
     }
 
-    @Test
+    @Test(
+        .skipCIExhibitsIssue("GH_8520", "Fails in specific CI environments")
+    )
     func testSwiftPackageLibsTests() throws {
         try withTemporaryDirectory { tempDir in
             // Create a new package with an executable target.

--- a/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
@@ -112,6 +112,7 @@ private struct SwiftPMTests {
     }
 
     @Test(
+        .skipCIExhibitsIssue("GH_8520", "Fails in specific CI environments"),
         .requireThreadSafeWorkingDirectory,
         .bug(id: 0, "SWBINTTODO: Linux: /lib/x86_64-linux-gnu/Scrt1.o:function _start: error:"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8380", "lld-link: error: subsystem must be defined"),


### PR DESCRIPTION
The testSwiftPackageLibsTests and
packageInitLibrary tests are failing in some
testing environments. Skip these tests until the
root cause can be determined.
* Add a new skipping trait that looks for a prefix
  environment variable and suffix
* Skip tests based on presence of that environment
  variable.