### PR TITLE
Tests: Improve a couple IntegrationTests tests

### DIFF
--- a/IntegrationTests/Sources/IntegrationTestSupport/Helpers.swift
+++ b/IntegrationTests/Sources/IntegrationTestSupport/Helpers.swift
@@ -14,6 +14,8 @@ import TSCBasic
 import TSCTestSupport
 import enum TSCUtility.Git
 
+public typealias ShReturnType = (stdout: String, stderr: String, returnCode: ProcessResult.ExitStatus)
+
 public let sdkRoot: AbsolutePath? = {
     if let environmentPath = ProcessInfo.processInfo.environment["SDK_ROOT"] {
         return try! AbsolutePath(validating: environmentPath)
@@ -131,7 +133,7 @@ public func sh(
     env: [String: String] = [:],
     file: StaticString = #file,
     line: UInt = #line
-) throws -> (stdout: String, stderr: String) {
+) throws -> ShReturnType {
     let result = try _sh(arguments, env: env, file: file, line: line)
     let stdout = try result.utf8Output()
     let stderr = try result.utf8stderrOutput()
@@ -145,7 +147,7 @@ public func sh(
             )
     }
 
-    return (stdout, stderr)
+    return (stdout, stderr, result.exitStatus)
 }
 
 @discardableResult
@@ -154,7 +156,7 @@ public func shFails(
     env: [String: String] = [:],
     file: StaticString = #file,
     line: UInt = #line
-) throws -> (stdout: String, stderr: String) {
+) throws -> ShReturnType {
     let result = try _sh(arguments, env: env, file: file, line: line)
     let stdout = try result.utf8Output()
     let stderr = try result.utf8stderrOutput()
@@ -168,7 +170,7 @@ public func shFails(
             )
     }
 
-    return (stdout, stderr)
+    return (stdout, stderr, result.exitStatus)
 }
 
 @discardableResult

--- a/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
@@ -192,7 +192,7 @@ private struct BasicTests {
             let packagePath = tempDir.appending(component: "Project")
             try localFileSystem.createDirectory(packagePath)
             try sh(swiftPackage, "--package-path", packagePath, "init", "--type", "library")
-            let testOutput = try sh(swiftTest, "--package-path", packagePath).stdout
+            let (testOutput, stderr, exitCode) = try sh(swiftTest, "--package-path", packagePath)
 
             // Check the test log.
             let checker = StringChecker(string: testOutput)
@@ -200,9 +200,14 @@ private struct BasicTests {
             #expect(checker.check(.contains("Test example() passed after")))
             #expect(checker.checkNext(.contains("Test run with 1 test passed after")))
 
+            // Check the return code
+            #expect(exitCode == .terminated(code: 0))
+
             // Check there were no compile errors or warnings.
-            #expect(testOutput.contains("error") == false)
-            #expect(testOutput.contains("warning") == false)
+            #expect(!testOutput.contains("error"))
+            #expect(!testOutput.contains("warning"))
+            #expect(!stderr.contains("error"))
+            #expect(!stderr.contains("warning"))
         }
     }
 
@@ -281,7 +286,7 @@ private struct BasicTests {
                     """
                 )
             )
-            let (runOutput, runError) = try sh(
+            let (runOutput, runError, exitCode) = try sh(
                 swiftRun, "--package-path", packagePath, "secho", "1", #""two""#
             )
 
@@ -292,6 +297,7 @@ private struct BasicTests {
             #expect(checker.check(.contains("Build of product 'secho' complete")))
 
             #expect(runOutput == "1 \"two\"\(ProcessInfo.EOL)")
+            #expect(exitCode == .terminated(code: 0))
         }
     }
 

--- a/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift
@@ -414,13 +414,13 @@ private struct XCBuildTests {
             let fooPath = path.appending(component: "Foo")
 
             do {
-                let (_, stderr) = try sh(swiftTest, "--package-path", fooPath, "--build-system", "xcode")
+                let (_, stderr, _) = try sh(swiftTest, "--package-path", fooPath, "--build-system", "xcode")
                 #expect(stderr.contains("Test Suite 'FooTests.xctest'"))
                 #expect(stderr.contains("Test Suite 'CFooTests.xctest'"))
             }
 
             do {
-                let (_, stderr) = try sh(
+                let (_, stderr, _) = try sh(
                     swiftTest,
                     "--package-path",
                     fooPath,
@@ -434,7 +434,7 @@ private struct XCBuildTests {
             }
 
             do {
-                let (stdout, _) = try sh(swiftTest, "--package-path", fooPath, "--build-system", "xcode", "--parallel")
+                let (stdout, _, _) = try sh(swiftTest, "--package-path", fooPath, "--build-system", "xcode", "--parallel")
                 #expect(stdout.contains("Testing FooTests"))
                 #expect(stdout.contains("Testing CFooTests"))
             }


### PR DESCRIPTION
Update a couple IntegrationTests to rely on the exit code of `swift-test` instead of the testing library console output.  This way, the test is more robust the the testing library console output changes.

Fixes: #8520