### PR TITLE
Adopt MemberImportVisibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -153,6 +153,7 @@ let package = Package(
             name: "PackageDescription",
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .define("USE_IMPL_ONLY_IMPORTS"),
                 .unsafeFlags(["-package-description-version", "999.0"]),
                 .unsafeFlags(["-enable-library-evolution"]),

--- a/Package.swift
+++ b/Package.swift
@@ -296,6 +296,7 @@ let package = Package(
             dependencies: ["Basics"],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -876,7 +876,10 @@ let package = Package(
         ),
         .testTarget(
             name: "PackageGraphTests",
-            dependencies: ["PackageGraph", "_InternalTestSupport"]
+            dependencies: ["PackageGraph", "_InternalTestSupport"],
+            swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
+            ],
         ),
         .testTarget(
             name: "PackageGraphPerformanceTests",

--- a/Package.swift
+++ b/Package.swift
@@ -203,6 +203,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .enableExperimentalFeature("AccessLevelOnImport"),
                 .unsafeFlags(["-static"]),
             ]

--- a/Package.swift
+++ b/Package.swift
@@ -466,6 +466,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -220,6 +220,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .enableExperimentalFeature("StrictConcurrency"),
                 .enableExperimentalFeature("AccessLevelOnImport"),
                 .enableExperimentalFeature("InternalImportsByDefault"),

--- a/Package.swift
+++ b/Package.swift
@@ -171,6 +171,7 @@ let package = Package(
             // messing with the manifest loader.
             dependencies: ["PackageDescription"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-package-description-version", "999.0"]),
                 .unsafeFlags(["-enable-library-evolution"], .when(platforms: [.macOS])),
                 .unsafeFlags(["-Xfrontend", "-module-link-name", "-Xfrontend", "AppleProductTypes"])

--- a/Package.swift
+++ b/Package.swift
@@ -357,6 +357,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt", "README.md"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -539,6 +539,7 @@ let package = Package(
                 "PackageSigning",
             ],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -503,7 +503,10 @@ let package = Package(
                 "SPMBuildCore",
                 "PackageGraph",
             ],
-            exclude: ["CMakeLists.txt", "README.md"]
+            exclude: ["CMakeLists.txt", "README.md"],
+            swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
+            ]
         ),
         .target(
             /** High level functionality */

--- a/Package.swift
+++ b/Package.swift
@@ -271,6 +271,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -479,6 +479,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -562,6 +562,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -402,6 +402,7 @@ let package = Package(
                 "PackageCollectionsModel",
             ],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,19 @@ if let resourceDirPath = ProcessInfo.processInfo.environment["SWIFTCI_INSTALL_RP
     packageLibraryLinkSettings = []
 }
 
+// Common experimental flags to be added to all targets.
+let commonExperimentalFeatures: [SwiftSetting] = [
+    .enableExperimentalFeature("MemberImportVisibility"),
+]
+
+// Certain targets fail to compile with MemberImportVisibility enabled on 6.0.3
+// but work with >=6.1. These targets opt in to using `swift6CompatibleExperimentalFeatures`.
+#if swift(>=6.1)
+let swift6CompatibleExperimentalFeatures = commonExperimentalFeatures
+#else
+let swift6CompatibleExperimentalFeatures: [SwiftSetting] = []
+#endif
+
 /** SwiftPMDataModel is the subset of SwiftPM product that includes just its data model.
  This allows some clients (such as IDEs) that use SwiftPM's data model but not its build system
  to not have to depend on SwiftDriver, SwiftLLBuild, etc. We should probably have better names here,
@@ -152,8 +165,7 @@ let package = Package(
         .target(
             name: "PackageDescription",
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .define("USE_IMPL_ONLY_IMPORTS"),
                 .unsafeFlags(["-package-description-version", "999.0"]),
                 .unsafeFlags(["-enable-library-evolution"]),
@@ -170,8 +182,7 @@ let package = Package(
             // AppleProductTypes library when they import it without further
             // messing with the manifest loader.
             dependencies: ["PackageDescription"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-package-description-version", "999.0"]),
                 .unsafeFlags(["-enable-library-evolution"], .when(platforms: [.macOS])),
                 .unsafeFlags(["-Xfrontend", "-module-link-name", "-Xfrontend", "AppleProductTypes"])
@@ -183,8 +194,7 @@ let package = Package(
         .target(
             name: "PackagePlugin",
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-package-description-version", "999.0"]),
                 .unsafeFlags(["-enable-library-evolution"]),
             ],
@@ -202,8 +212,7 @@ let package = Package(
                 "SPMBuildCore",
             ],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .enableExperimentalFeature("AccessLevelOnImport"),
                 .unsafeFlags(["-static"]),
             ]
@@ -219,8 +228,7 @@ let package = Package(
                 .product(name: "SystemPackage", package: "swift-system"),
             ],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .enableExperimentalFeature("StrictConcurrency"),
                 .enableExperimentalFeature("AccessLevelOnImport"),
                 .enableExperimentalFeature("InternalImportsByDefault"),
@@ -240,8 +248,7 @@ let package = Package(
                 .product(name: "SystemPackage", package: "swift-system"),
             ],
             exclude: ["CMakeLists.txt", "Vendor/README.md"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: swift6CompatibleExperimentalFeatures + [
                 .enableExperimentalFeature("StrictConcurrency"),
                 .enableExperimentalFeature("AccessLevelOnImport"),
                 .unsafeFlags(["-static"]),
@@ -253,8 +260,7 @@ let package = Package(
             name: "LLBuildManifest",
             dependencies: ["Basics"],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -270,8 +276,7 @@ let package = Package(
                 "PackageSigning",
             ],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -284,8 +289,7 @@ let package = Package(
                 "PackageModel",
             ],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -295,8 +299,7 @@ let package = Package(
             name: "SPMLLBuild",
             dependencies: ["Basics"],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -308,8 +311,7 @@ let package = Package(
             name: "PackageModel",
             dependencies: ["Basics"],
             exclude: ["CMakeLists.txt", "README.md"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: swift6CompatibleExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -323,8 +325,7 @@ let package = Package(
                 "PackageModel",
             ] + swiftSyntaxDependencies(["SwiftBasicFormat", "SwiftDiagnostics", "SwiftIDEUtils", "SwiftParser", "SwiftSyntax", "SwiftSyntaxBuilder"]),
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -338,8 +339,7 @@ let package = Package(
                 "SourceControl",
             ],
             exclude: ["CMakeLists.txt", "README.md"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -356,8 +356,7 @@ let package = Package(
                 .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             exclude: ["CMakeLists.txt", "README.md"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -371,8 +370,7 @@ let package = Package(
             exclude: [
                 "Formats/v1.md",
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -387,8 +385,7 @@ let package = Package(
                 "PackageModel",
                 "SourceControl",
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: swift6CompatibleExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -401,8 +398,7 @@ let package = Package(
                 "Basics",
                 "PackageCollectionsModel",
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -414,8 +410,7 @@ let package = Package(
                 "PackageModel",
             ],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -429,8 +424,7 @@ let package = Package(
                 "PackageModel",
             ],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -446,8 +440,7 @@ let package = Package(
                 .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -465,8 +458,7 @@ let package = Package(
                 "DriverSupport",
             ],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -478,8 +470,7 @@ let package = Package(
                 .product(name: "SwiftDriver", package: "swift-driver"),
             ],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -492,8 +483,7 @@ let package = Package(
                 .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -504,9 +494,7 @@ let package = Package(
                 "PackageGraph",
             ],
             exclude: ["CMakeLists.txt", "README.md"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
-            ]
+            swiftSettings: commonExperimentalFeatures
         ),
         .target(
             /** High level functionality */
@@ -523,8 +511,7 @@ let package = Package(
                 .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -538,8 +525,7 @@ let package = Package(
                 "PackageRegistry",
                 "PackageSigning",
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -561,8 +547,7 @@ let package = Package(
                 "SwiftBuildSupport",
             ],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -584,8 +569,7 @@ let package = Package(
                 "SwiftBuildSupport",
             ] + swiftSyntaxDependencies(["SwiftIDEUtils"]),
             exclude: ["CMakeLists.txt", "README.md"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: swift6CompatibleExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -601,8 +585,7 @@ let package = Package(
                 "PackageModel",
             ],
             exclude: ["CMakeLists.txt", "README.md"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -618,8 +601,7 @@ let package = Package(
                 "PackageCollections",
                 "PackageModel",
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -641,8 +623,7 @@ let package = Package(
                 "SPMBuildCore",
                 "Workspace",
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-static"]),
             ]
         ),
@@ -750,8 +731,7 @@ let package = Package(
             name: "CompilerPluginSupport",
             dependencies: ["PackageDescription"],
             exclude: ["CMakeLists.txt"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
+            swiftSettings: commonExperimentalFeatures + [
                 .unsafeFlags(["-package-description-version", "999.0"]),
                 .unsafeFlags(["-enable-library-evolution"]),
             ]
@@ -877,9 +857,7 @@ let package = Package(
         .testTarget(
             name: "PackageGraphTests",
             dependencies: ["PackageGraph", "_InternalTestSupport"],
-            swiftSettings: [
-                .enableExperimentalFeature("MemberImportVisibility"),
-            ]
+            swiftSettings: commonExperimentalFeatures
         ),
         .testTarget(
             name: "PackageGraphPerformanceTests",

--- a/Package.swift
+++ b/Package.swift
@@ -241,6 +241,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt", "Vendor/README.md"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .enableExperimentalFeature("StrictConcurrency"),
                 .enableExperimentalFeature("AccessLevelOnImport"),
                 .unsafeFlags(["-static"]),

--- a/Package.swift
+++ b/Package.swift
@@ -879,7 +879,7 @@ let package = Package(
             dependencies: ["PackageGraph", "_InternalTestSupport"],
             swiftSettings: [
                 .enableExperimentalFeature("MemberImportVisibility"),
-            ],
+            ]
         ),
         .testTarget(
             name: "PackageGraphPerformanceTests",

--- a/Package.swift
+++ b/Package.swift
@@ -415,6 +415,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -339,6 +339,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt", "README.md"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -751,6 +751,7 @@ let package = Package(
             dependencies: ["PackageDescription"],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-package-description-version", "999.0"]),
                 .unsafeFlags(["-enable-library-evolution"]),
             ]

--- a/Package.swift
+++ b/Package.swift
@@ -388,6 +388,7 @@ let package = Package(
                 "SourceControl",
             ],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -585,6 +585,7 @@ let package = Package(
             ] + swiftSyntaxDependencies(["SwiftIDEUtils"]),
             exclude: ["CMakeLists.txt", "README.md"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -642,6 +642,7 @@ let package = Package(
                 "Workspace",
             ],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -430,6 +430,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -372,6 +372,7 @@ let package = Package(
                 "Formats/v1.md",
             ],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -493,6 +493,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -184,6 +184,7 @@ let package = Package(
             name: "PackagePlugin",
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-package-description-version", "999.0"]),
                 .unsafeFlags(["-enable-library-evolution"]),
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -619,6 +619,7 @@ let package = Package(
                 "PackageModel",
             ],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -602,6 +602,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt", "README.md"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -285,6 +285,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -254,6 +254,7 @@ let package = Package(
             dependencies: ["Basics"],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -447,6 +447,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -309,6 +309,7 @@ let package = Package(
             dependencies: ["Basics"],
             exclude: ["CMakeLists.txt", "README.md"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -524,6 +524,7 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -324,6 +324,7 @@ let package = Package(
             ] + swiftSyntaxDependencies(["SwiftBasicFormat", "SwiftDiagnostics", "SwiftIDEUtils", "SwiftParser", "SwiftSyntax", "SwiftSyntaxBuilder"]),
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
+                .enableExperimentalFeature("MemberImportVisibility"),
                 .unsafeFlags(["-static"]),
             ]
         ),

--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import TSCBasic
 import struct Foundation.Data
 import struct Foundation.Date
 import struct Foundation.URL

--- a/Sources/Basics/Collections/Dictionary+Extensions.swift
+++ b/Sources/Basics/Collections/Dictionary+Extensions.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import TSCBasic
+
 extension Dictionary {
     @inlinable
     @discardableResult

--- a/Sources/Basics/ProgressAnimation/ThrottledProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/ThrottledProgressAnimation.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import _Concurrency
+import TSCUtility
 
 /// A progress animation wrapper that throttles updates to a given interval.
 final class ThrottledProgressAnimation: ProgressAnimationProtocol {

--- a/Sources/Basics/SQLite.swift
+++ b/Sources/Basics/SQLite.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import TSCBasic
 import Foundation
 
 #if SWIFT_PACKAGE && (os(Windows) || os(Android))

--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import TSCUtility
 import enum TSCBasic.JSON
 
 extension Triple {

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -18,6 +18,7 @@ import PackageModel
 
 import OrderedCollections
 import SPMBuildCore
+import TSCUtility
 
 import struct TSCBasic.SortedArray
 
@@ -434,7 +435,7 @@ extension SortedArray where Element == AbsolutePath {
     }
 }
 
-extension Triple {
+extension Basics.Triple {
     var supportsFrameworks: Bool {
         return self.isDarwin()
     }

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -15,6 +15,7 @@ import Basics
 import Foundation
 import PackageGraph
 import PackageLoading
+import TSCUtility
 
 @_spi(SwiftPMInternal)
 import PackageModel

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Clang.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Clang.swift
@@ -16,6 +16,7 @@ import struct Basics.InternalError
 import class Basics.ObservabilityScope
 import struct PackageGraph.ResolvedModule
 import PackageModel
+import SPMBuildCore
 
 extension LLBuildManifestBuilder {
     /// Create a llbuild target for a Clang target description.

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import PackageModel
+
 import struct Basics.AbsolutePath
 import struct Basics.InternalError
 import struct LLBuildManifest.Node

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Resources.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Resources.swift
@@ -13,6 +13,8 @@
 import struct LLBuildManifest.Node
 import struct Basics.RelativePath
 
+import PackageModel
+
 extension LLBuildManifestBuilder {
     /// Adds command for creating the resources bundle of the given target.
     ///

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -24,10 +24,14 @@ import struct Basics.Environment
 
 #if USE_IMPL_ONLY_IMPORTS
 @_implementationOnly import class DriverSupport.SPMSwiftDriverExecutor
+@_implementationOnly import Foundation
 @_implementationOnly import SwiftDriver
+@_implementationOnly import TSCUtility
 #else
 import class DriverSupport.SPMSwiftDriverExecutor
+import Foundation
 import SwiftDriver
+import TSCUtility
 #endif
 
 import PackageModel
@@ -81,7 +85,8 @@ extension LLBuildManifestBuilder {
             args: commandLine,
             diagnosticsOutput: .handler(self.observabilityScope.makeDiagnosticsHandler()),
             fileSystem: self.fileSystem,
-            executor: executor
+            executor: executor,
+            compilerIntegratedTooling: false
         )
         try driver.checkLDPathOption(commandLine: commandLine)
 
@@ -297,6 +302,7 @@ extension LLBuildManifestBuilder {
             args: commandLine,
             fileSystem: self.fileSystem,
             executor: executor,
+            compilerIntegratedTooling: false,
             externalTargetModuleDetailsMap: dependencyModuleDetailsMap,
             interModuleDependencyOracle: dependencyOracle
         )

--- a/Sources/Build/BuildPlan/BuildPlan+Clang.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Clang.swift
@@ -10,6 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
+import PackageGraph
+import PackageLoading
+import SPMBuildCore
+
 import class PackageModel.BinaryModule
 import class PackageModel.ClangModule
 import class PackageModel.SwiftModule

--- a/Sources/Build/BuildPlan/BuildPlan+Swift.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Swift.swift
@@ -16,6 +16,10 @@ import class PackageModel.BinaryModule
 import class PackageModel.ClangModule
 import class PackageModel.SystemLibraryModule
 
+import PackageGraph
+import PackageLoading
+import SPMBuildCore
+
 extension BuildPlan {
     func plan(swiftTarget: SwiftModuleBuildDescription) throws {
         // We need to iterate recursive dependencies because Swift compiler needs to see all the targets a target

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -19,6 +19,7 @@ import PackageGraph
 import PackageLoading
 import PackageModel
 import SPMBuildCore
+import TSCBasic
 
 #if USE_IMPL_ONLY_IMPORTS
 @_implementationOnly import SwiftDriver
@@ -90,7 +91,7 @@ extension [String] {
 
 extension BuildParameters {
     /// Returns the directory to be used for module cache.
-    public var moduleCache: AbsolutePath {
+    public var moduleCache: Basics.AbsolutePath {
         get throws {
             // FIXME: We use this hack to let swiftpm's functional test use shared
             // cache so it doesn't become painfully slow.
@@ -168,9 +169,9 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     /// Return value of `inputs()`
     package enum Input {
         /// Any file in this directory affects the build plan
-        case directoryStructure(AbsolutePath)
+        case directoryStructure(Basics.AbsolutePath)
         /// The file at the given path affects the build plan
-        case file(AbsolutePath)
+        case file(Basics.AbsolutePath)
     }
 
     public enum Error: Swift.Error, CustomStringConvertible, Equatable {
@@ -276,7 +277,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         pluginConfiguration: PluginConfiguration? = nil,
         pluginTools: [ResolvedModule.ID: [String: PluginTool]] = [:],
         additionalFileRules: [FileRuleDescription] = [],
-        pkgConfigDirectories: [AbsolutePath] = [],
+        pkgConfigDirectories: [Basics.AbsolutePath] = [],
         disableSandbox: Bool = false,
         fileSystem: any FileSystem,
         observabilityScope: ObservabilityScope
@@ -698,7 +699,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 .map { .directoryStructure($0) }
 
             // Add the output paths of any prebuilds that were run, so that we redo the plan if they change.
-            var derivedSourceDirPaths: [AbsolutePath] = []
+            var derivedSourceDirPaths: [Basics.AbsolutePath] = []
             for result in self.prebuildCommandResults.values.flatMap({ $0 }) {
                 derivedSourceDirPaths.append(contentsOf: result.outputDirectories)
             }
@@ -768,7 +769,7 @@ extension BuildPlan {
         modulesGraph: ModulesGraph,
         tools: [ResolvedModule.ID: [String: PluginTool]],
         additionalFileRules: [FileRuleDescription],
-        pkgConfigDirectories: [AbsolutePath],
+        pkgConfigDirectories: [Basics.AbsolutePath],
         fileSystem: any FileSystem,
         observabilityScope: ObservabilityScope,
         surfaceDiagnostics: Bool = false
@@ -895,8 +896,8 @@ extension BuildPlan {
         try pluginResults.map { pluginResult in
             // As we go we will collect a list of prebuild output directories whose contents should be input to the
             // build, and a list of the files in those directories after running the commands.
-            var derivedFiles: [AbsolutePath] = []
-            var prebuildOutputDirs: [AbsolutePath] = []
+            var derivedFiles: [Basics.AbsolutePath] = []
+            var prebuildOutputDirs: [Basics.AbsolutePath] = []
             for command in pluginResult.prebuildCommands {
                 observabilityScope
                     .emit(
@@ -1248,7 +1249,7 @@ extension Basics.Diagnostic {
 
 extension BuildParameters {
     /// Returns a named bundle's path inside the build directory.
-    func bundlePath(named name: String) -> AbsolutePath {
+    func bundlePath(named name: String) -> Basics.AbsolutePath {
         self.buildPath.appending(component: name + self.triple.nsbundleExtension)
     }
 }
@@ -1257,7 +1258,7 @@ extension BuildParameters {
 func generateResourceInfoPlist(
     fileSystem: FileSystem,
     target: ResolvedModule,
-    path: AbsolutePath
+    path: Basics.AbsolutePath
 ) throws -> Bool {
     guard let defaultLocalization = target.defaultLocalization else {
         return false

--- a/Sources/Build/LLBuildDescription.swift
+++ b/Sources/Build/LLBuildDescription.swift
@@ -15,6 +15,7 @@ import Foundation
 import LLBuildManifest
 import SPMBuildCore
 import PackageGraph
+import PackageModel
 
 import struct TSCBasic.ByteString
 

--- a/Sources/Build/SwiftCompilerOutputParser.swift
+++ b/Sources/Build/SwiftCompilerOutputParser.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 import Foundation
 
 import class TSCUtility.JSONMessageStreamingParser

--- a/Sources/Commands/PackageCommands/APIDiff.swift
+++ b/Sources/Commands/PackageCommands/APIDiff.swift
@@ -17,6 +17,8 @@ import Dispatch
 import PackageGraph
 import PackageModel
 import SourceControl
+import SPMBuildCore
+import TSCUtility
 import _Concurrency
 
 struct DeprecatedAPIDiff: ParsableCommand {

--- a/Sources/Commands/PackageCommands/AddDependency.swift
+++ b/Sources/Commands/PackageCommands/AddDependency.swift
@@ -13,6 +13,8 @@
 import ArgumentParser
 import Basics
 import CoreCommands
+import Foundation
+import PackageGraph
 import PackageModel
 import PackageModelSyntax
 import SwiftParser

--- a/Sources/Commands/PackageCommands/AddProduct.swift
+++ b/Sources/Commands/PackageCommands/AddProduct.swift
@@ -13,6 +13,8 @@
 import ArgumentParser
 import Basics
 import CoreCommands
+import Foundation
+import PackageGraph
 import PackageModel
 import PackageModelSyntax
 import SwiftParser

--- a/Sources/Commands/PackageCommands/AddTarget.swift
+++ b/Sources/Commands/PackageCommands/AddTarget.swift
@@ -13,6 +13,8 @@
 import ArgumentParser
 import Basics
 import CoreCommands
+import Foundation
+import PackageGraph
 import PackageModel
 import PackageModelSyntax
 import SwiftParser

--- a/Sources/Commands/PackageCommands/AddTargetDependency.swift
+++ b/Sources/Commands/PackageCommands/AddTargetDependency.swift
@@ -13,6 +13,8 @@
 import ArgumentParser
 import Basics
 import CoreCommands
+import Foundation
+import PackageGraph
 import PackageModel
 import PackageModelSyntax
 import SwiftParser

--- a/Sources/Commands/PackageCommands/ArchiveSource.swift
+++ b/Sources/Commands/PackageCommands/ArchiveSource.swift
@@ -13,6 +13,8 @@
 import ArgumentParser
 import Basics
 import CoreCommands
+import PackageGraph
+import PackageModel
 import SourceControl
 
 extension SwiftPackageCommand {

--- a/Sources/Commands/PackageCommands/CompletionCommand.swift
+++ b/Sources/Commands/PackageCommands/CompletionCommand.swift
@@ -11,7 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
+import Basics
 import CoreCommands
+import PackageModel
+import PackageGraph
 
 import var TSCBasic.stdoutStream
 

--- a/Sources/Commands/PackageCommands/Config.swift
+++ b/Sources/Commands/PackageCommands/Config.swift
@@ -13,6 +13,7 @@
 import ArgumentParser
 import Basics
 import CoreCommands
+import PackageGraph
 import Workspace
 
 import var TSCBasic.stderrStream

--- a/Sources/Commands/PackageCommands/Describe.swift
+++ b/Sources/Commands/PackageCommands/Describe.swift
@@ -15,6 +15,8 @@ import Basics
 import CoreCommands
 import Foundation
 import PackageModel
+import PackageGraph
+import Workspace
 
 import struct TSCBasic.StringError
 

--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -15,6 +15,10 @@ import Basics
 import CoreCommands
 import Foundation
 import PackageModel
+import PackageGraph
+import SPMBuildCore
+import TSCBasic
+import Workspace
 import XCBuildSupport
 
 struct DumpSymbolGraph: AsyncSwiftCommand {

--- a/Sources/Commands/PackageCommands/EditCommands.swift
+++ b/Sources/Commands/PackageCommands/EditCommands.swift
@@ -14,6 +14,7 @@ import ArgumentParser
 import Basics
 import CoreCommands
 import SourceControl
+import Workspace
 
 extension SwiftPackageCommand {
     struct Edit: AsyncSwiftCommand {

--- a/Sources/Commands/PackageCommands/Format.swift
+++ b/Sources/Commands/PackageCommands/Format.swift
@@ -14,6 +14,9 @@ import ArgumentParser
 import Basics
 import CoreCommands
 import PackageModel
+import PackageGraph
+import TSCBasic
+import Workspace
 
 import class Basics.AsyncProcess
 
@@ -34,7 +37,7 @@ extension SwiftPackageCommand {
         func run(_ swiftCommandState: SwiftCommandState) async throws {
             // Look for swift-format binary.
             // FIXME: This should be moved to user toolchain.
-            let swiftFormatInEnv = lookupExecutablePath(filename: Environment.current["SWIFT_FORMAT"])
+            let swiftFormatInEnv = Basics.lookupExecutablePath(filename: Environment.current["SWIFT_FORMAT"])
             guard let swiftFormat = swiftFormatInEnv ?? AsyncProcess.findExecutable("swift-format") else {
                 swiftCommandState.observabilityScope.emit(error: "Could not find swift-format in PATH or SWIFT_FORMAT")
                 throw TSCUtility.Diagnostics.fatalError

--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -16,6 +16,7 @@ import Basics
 @_spi(SwiftPMInternal)
 import CoreCommands
 
+import PackageModel
 import Workspace
 import SPMBuildCore
 

--- a/Sources/Commands/PackageCommands/Install.swift
+++ b/Sources/Commands/PackageCommands/Install.swift
@@ -14,8 +14,11 @@ import ArgumentParser
 import struct Basics.Environment
 import CoreCommands
 import Foundation
+import PackageGraph
 import PackageModel
+import SPMBuildCore
 import TSCBasic
+import Workspace
 
 extension SwiftPackageCommand {
     struct Install: AsyncSwiftCommand {

--- a/Sources/Commands/PackageCommands/Learn.swift
+++ b/Sources/Commands/PackageCommands/Learn.swift
@@ -13,6 +13,7 @@
 import ArgumentParser
 import Basics
 import CoreCommands
+import Foundation
 import PackageGraph
 import PackageModel
 

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -15,10 +15,12 @@ import Basics
 import _Concurrency
 import CoreCommands
 import Dispatch
-
+import SPMBuildCore
 import PackageGraph
-
 import PackageModel
+import TSCBasic
+import TSCUtility
+import Workspace
 
 struct PluginCommand: AsyncSwiftCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/Commands/PackageCommands/ResetCommands.swift
+++ b/Sources/Commands/PackageCommands/ResetCommands.swift
@@ -12,6 +12,7 @@
 
 import ArgumentParser
 import CoreCommands
+import Workspace
 
 extension SwiftPackageCommand {
     struct Clean: SwiftCommand {

--- a/Sources/Commands/PackageCommands/Resolve.swift
+++ b/Sources/Commands/PackageCommands/Resolve.swift
@@ -11,8 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
+import Basics
 import CoreCommands
 import TSCUtility
+import Workspace
 
 import struct PackageGraph.TraitConfiguration
 

--- a/Sources/Commands/PackageCommands/ShowExecutables.swift
+++ b/Sources/Commands/PackageCommands/ShowExecutables.swift
@@ -14,6 +14,8 @@ import ArgumentParser
 import Basics
 import CoreCommands
 import Foundation
+import PackageModel
+import PackageGraph
 import Workspace
 
 struct ShowExecutables: AsyncSwiftCommand {

--- a/Sources/Commands/PackageCommands/Update.swift
+++ b/Sources/Commands/PackageCommands/Update.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
+import Basics
 import CoreCommands
 import Dispatch
 import PackageModel

--- a/Sources/Commands/Snippets/Cards/SnippetCard.swift
+++ b/Sources/Commands/Snippets/Cards/SnippetCard.swift
@@ -12,7 +12,10 @@
 
 import Basics
 import CoreCommands
+import Foundation
 import PackageModel
+import PackageGraph
+import SPMBuildCore
 
 import func TSCBasic.exec
 import enum TSCBasic.ProcessEnv

--- a/Sources/Commands/Snippets/Cards/SnippetGroupCard.swift
+++ b/Sources/Commands/Snippets/Cards/SnippetGroupCard.swift
@@ -12,6 +12,7 @@
 
 import CoreCommands
 import PackageModel
+import TSCUtility
 
 /// A card showing the snippets in a ``SnippetGroup``.
 struct SnippetGroupCard: Card {

--- a/Sources/Commands/Snippets/Cards/TopCard.swift
+++ b/Sources/Commands/Snippets/Cards/TopCard.swift
@@ -14,6 +14,7 @@ import CoreCommands
 import Foundation
 import PackageGraph
 import PackageModel
+import TSCUtility
 
 /// The top menu card for a package's help contents, including snippets.
 struct TopCard: Card {

--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -16,6 +16,7 @@ import CoreCommands
 import Foundation
 import PackageGraph
 import PackageModel
+import SPMBuildCore
 
 import enum TSCBasic.ProcessEnv
 import func TSCBasic.exec

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -28,6 +28,7 @@ import PackageGraph
 import PackageModel
 
 import SPMBuildCore
+import TSCUtility
 
 import func TSCLibc.exit
 import Workspace

--- a/Sources/Commands/Utilities/DependenciesSerializer.swift
+++ b/Sources/Commands/Utilities/DependenciesSerializer.swift
@@ -10,8 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 import PackageModel
 import PackageGraph
+import TSCUtility
 
 import enum TSCBasic.JSON
 import protocol TSCBasic.OutputByteStream

--- a/Sources/Commands/Utilities/MultiRootSupport.swift
+++ b/Sources/Commands/Utilities/MultiRootSupport.swift
@@ -13,6 +13,8 @@
 import Basics
 import CoreCommands
 import Foundation
+import TSCBasic
+
 #if canImport(FoundationXML)
 import FoundationXML
 #endif
@@ -44,7 +46,7 @@ public struct XcodeWorkspaceLoader: WorkspaceLoader {
     }
 
     /// Load the given workspace and return the file ref paths from it.
-    public func load(workspace: AbsolutePath) throws -> [AbsolutePath] {
+    public func load(workspace: Basics.AbsolutePath) throws -> [Basics.AbsolutePath] {
         let path = workspace.appending("contents.xcworkspacedata")
         let contents: Data = try self.fileSystem.readFileContents(path)
 
@@ -56,9 +58,9 @@ public struct XcodeWorkspaceLoader: WorkspaceLoader {
         }
 
         /// Convert the parsed result into absolute paths.
-        var result: [AbsolutePath] = []
+        var result: [Basics.AbsolutePath] = []
         for location in delegate.locations {
-            let path: AbsolutePath
+            let path: Basics.AbsolutePath
 
             switch location.kind {
             case .absolute:

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -12,6 +12,7 @@
 
 import ArgumentParser
 import Basics
+import Foundation
 import PackageGraph
 import PackageModel
 import SPMBuildCore

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -14,6 +14,7 @@ import Basics
 import CoreCommands
 import PackageModel
 import SPMBuildCore
+import TSCUtility
 import Workspace
 
 import struct TSCBasic.FileSystemError

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -16,6 +16,7 @@ import SPMBuildCore
 import XCBuildSupport
 import SwiftBuildSupport
 import PackageGraph
+import Workspace
 
 import class Basics.ObservabilityScope
 import struct PackageGraph.ModulesGraph

--- a/Sources/CoreCommands/SwiftCommandObservabilityHandler.swift
+++ b/Sources/CoreCommands/SwiftCommandObservabilityHandler.swift
@@ -13,6 +13,7 @@
 @_spi(SwiftPMInternal)
 import Basics
 import Dispatch
+import PackageModel
 
 import protocol TSCBasic.OutputByteStream
 import class TSCBasic.TerminalController

--- a/Sources/DriverSupport/DriverSupportUtils.swift
+++ b/Sources/DriverSupport/DriverSupportUtils.swift
@@ -12,7 +12,7 @@
 
 @_spi(SwiftPMInternal)
 import Basics
-
+import Foundation
 import PackageModel
 import SwiftDriver
 import class TSCBasic.Process
@@ -42,6 +42,7 @@ public enum DriverSupport {
             let driver = try Driver(
                 args: ["swiftc"],
                 executor: executor,
+                compilerIntegratedTooling: false,
                 compilerExecutableDir: TSCAbsolutePath(toolchain.swiftCompilerPath.parentDirectory)
             )
             let supportedFlagSet = Set(driver.supportedFrontendFlags.map { $0.trimmingCharacters(in: ["-"]) })

--- a/Sources/PackageCollections/PackageCollections+Validation.swift
+++ b/Sources/PackageCollections/PackageCollections+Validation.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import Foundation
 import PackageCollectionsModel
 import PackageModel
 

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -13,6 +13,7 @@
 import _Concurrency
 import Basics
 import PackageModel
+import Foundation
 
 import protocol TSCBasic.Closable
 

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -24,6 +24,7 @@ import PackageCollectionsModel
 import PackageCollectionsSigning
 import PackageModel
 import SourceControl
+import TSCBasic
 
 import struct TSCUtility.Version
 
@@ -64,7 +65,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         self.httpClient = customHTTPClient ?? Self.makeDefaultHTTPClient()
         self.signatureValidator = customSignatureValidator ?? PackageCollectionSigning(
             trustedRootCertsDir: configuration.trustedRootCertsDir ??
-                (try? fileSystem.swiftPMConfigurationDirectory.appending("trust-root-certs").asURL) ?? AbsolutePath.root.asURL,
+                (try? fileSystem.swiftPMConfigurationDirectory.appending("trust-root-certs").asURL) ?? Basics.AbsolutePath.root.asURL,
             additionalTrustedRootCerts: sourceCertPolicy.allRootCerts.map { Array($0) },
             observabilityScope: observabilityScope
         )

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -13,6 +13,7 @@
 import _Concurrency
 import Basics
 import Dispatch
+import TSCBasic
 import struct Foundation.Data
 import class Foundation.JSONDecoder
 import class Foundation.JSONEncoder
@@ -20,12 +21,12 @@ import struct Foundation.URL
 
 struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     let fileSystem: FileSystem
-    let path: AbsolutePath
+    let path: Basics.AbsolutePath
 
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
-    init(fileSystem: FileSystem, path: AbsolutePath? = nil) {
+    init(fileSystem: FileSystem, path: Basics.AbsolutePath? = nil) {
         self.fileSystem = fileSystem
 
         self.path = path ?? (try? fileSystem.swiftPMConfigurationDirectory.appending("collections.json")) ?? .root

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -20,6 +20,7 @@ import class Foundation.JSONEncoder
 import class Foundation.NSLock
 import struct Foundation.URL
 import PackageModel
+import TSCUtility
 
 import protocol TSCBasic.Closable
 

--- a/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
+++ b/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
@@ -15,6 +15,7 @@ import Basics
 import Dispatch
 import Foundation
 import PackageCollectionsModel
+import SwiftASN1
 
 #if USE_IMPL_ONLY_IMPORTS
 @_implementationOnly import _CryptoExtras

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -10,6 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if USE_IMPL_ONLY_IMPORTS
+@_implementationOnly import Foundation
+#else
+import Foundation
+#endif
 
 extension Package {
     /// A package dependency of a Swift package.

--- a/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
@@ -14,17 +14,18 @@ import Basics
 import Dispatch
 import Foundation
 import PackageModel
+import TSCBasic
 
 import struct TSCUtility.Version
 
 public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
     let fileSystem: FileSystem
-    let directoryPath: AbsolutePath
+    let directoryPath: Basics.AbsolutePath
 
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
-    public init(fileSystem: FileSystem, directoryPath: AbsolutePath) {
+    public init(fileSystem: FileSystem, directoryPath: Basics.AbsolutePath) {
         self.fileSystem = fileSystem
         self.directoryPath = directoryPath
 

--- a/Sources/PackageFingerprint/PackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/PackageFingerprintStorage.swift
@@ -13,6 +13,7 @@
 import Basics
 import Dispatch
 import PackageModel
+import TSCBasic
 
 import struct TSCUtility.Version
 

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -14,6 +14,7 @@ import Basics
 import OrderedCollections
 import PackageLoading
 import PackageModel
+import Foundation
 
 import func TSCBasic.bestMatch
 import func TSCBasic.findCycle

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -384,8 +384,6 @@ enum GraphError: Error {
     case unexpectedCycle
 }
 
-// TODO: Rename this back and only import what is required from TSCBasic to omit importing its implementation of topologicalSort
-
 /// Perform a topological sort of an graph.
 ///
 /// This function is optimized for use cases where cycles are unexpected, and

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -384,6 +384,8 @@ enum GraphError: Error {
     case unexpectedCycle
 }
 
+// TODO: Rename this back and only import what is required from TSCBasic to omit importing its implementation of topologicalSort
+
 /// Perform a topological sort of an graph.
 ///
 /// This function is optimized for use cases where cycles are unexpected, and

--- a/Sources/PackageGraph/Resolution/PubGrub/ContainerProvider.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/ContainerProvider.swift
@@ -13,6 +13,7 @@
 import Basics
 import Dispatch
 import PackageModel
+import TSCBasic
 
 /// An utility class around PackageContainerProvider that allows "prefetching" the containers
 /// in parallel. The basic idea is to kick off container fetching before starting the resolution

--- a/Sources/PackageGraph/Resolution/PubGrub/DiagnosticReportBuilder.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/DiagnosticReportBuilder.swift
@@ -10,6 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
+import PackageModel
+import TSCUtility
+
 struct DiagnosticReportBuilder {
     let rootNode: DependencyResolutionNode
     let incompatibilities: [DependencyResolutionNode: [Incompatibility]]

--- a/Sources/PackageGraph/Resolution/ResolvedModule.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedModule.swift
@@ -12,6 +12,7 @@
 
 import PackageModel
 
+import func TSCBasic.topologicalSort
 import struct Basics.IdentifiableSet
 
 @available(*, deprecated, renamed: "ResolvedModule")

--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -13,6 +13,8 @@
 import Basics
 import Foundation
 import PackageModel
+import TSCBasic
+import TSCUtility
 
 public struct ManifestValidator {
     static var supportedLocalBinaryDependencyExtensions: [String] {
@@ -160,7 +162,7 @@ public struct ManifestValidator {
                     continue
                 }
 
-                guard let relativePath = try? RelativePath(validating: path) else {
+                guard let relativePath = try? Basics.RelativePath(validating: path) else {
                     diagnostics.append(.invalidLocalBinaryPath(path: path, targetName: target.name))
                     continue
                 }
@@ -274,7 +276,7 @@ public struct ManifestValidator {
 }
 
 public protocol ManifestSourceControlValidator {
-    func isValidDirectory(_ path: AbsolutePath) throws -> Bool
+    func isValidDirectory(_ path: Basics.AbsolutePath) throws -> Bool
 }
 
 extension Basics.Diagnostic {
@@ -344,7 +346,7 @@ extension Basics.Diagnostic {
         }
     }
 
-    static func invalidSourceControlDirectory(_ path: AbsolutePath, underlyingError: Error? = nil) -> Self {
+    static func invalidSourceControlDirectory(_ path: Basics.AbsolutePath, underlyingError: Error? = nil) -> Self {
         .error("cannot clone from local directory \(path)\nPlease git init or use \"path:\" for \(path)\(errorSuffix(underlyingError))")
     }
 

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -14,6 +14,8 @@ import Basics
 import Dispatch
 import OrderedCollections
 import PackageModel
+import Foundation
+import TSCUtility
 
 import func TSCBasic.findCycle
 import struct TSCBasic.KeyedPair

--- a/Sources/PackageLoading/PkgConfig.swift
+++ b/Sources/PackageLoading/PkgConfig.swift
@@ -13,6 +13,8 @@
 import Basics
 import Foundation
 import OrderedCollections
+import TSCUtility
+import TSCBasic
 
 import class Basics.AsyncProcess
 
@@ -22,7 +24,7 @@ public struct PkgConfig {
     public let name: String
 
     /// The path to the definition file.
-    public let pcFile: AbsolutePath
+    public let pcFile: Basics.AbsolutePath
 
     /// The list of C compiler flags in the definition.
     public let cFlags: [String]
@@ -44,9 +46,9 @@ public struct PkgConfig {
     /// - throws: PkgConfigError
     public init(
         name: String,
-        additionalSearchPaths: [AbsolutePath]? = .none,
-        brewPrefix: AbsolutePath? = .none,
-        sysrootDir: AbsolutePath? = .none,
+        additionalSearchPaths: [Basics.AbsolutePath]? = .none,
+        brewPrefix: Basics.AbsolutePath? = .none,
+        sysrootDir: Basics.AbsolutePath? = .none,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
     ) throws {
@@ -63,16 +65,16 @@ public struct PkgConfig {
 
     private init(
         name: String,
-        additionalSearchPaths: [AbsolutePath],
-        brewPrefix: AbsolutePath?,
-        sysrootDir: AbsolutePath?,
+        additionalSearchPaths: [Basics.AbsolutePath],
+        brewPrefix: Basics.AbsolutePath?,
+        sysrootDir: Basics.AbsolutePath?,
         loadingContext: LoadingContext,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
     ) throws {
         loadingContext.pkgConfigStack.append(name)
 
-        if let path = try? AbsolutePath(validating: name) {
+        if let path = try? Basics.AbsolutePath(validating: name) {
             guard fileSystem.isFile(path) else { throw PkgConfigError.couldNotFindConfigFile(name: name) }
             self.name = path.basenameWithoutExt
             self.pcFile = path
@@ -127,7 +129,7 @@ public struct PkgConfig {
         loadingContext.pkgConfigStack.removeLast();
     }
 
-    private static var envSearchPaths: [AbsolutePath] {
+    private static var envSearchPaths: [Basics.AbsolutePath] {
         get throws {
             if let configPath = Environment.current["PKG_CONFIG_PATH"] {
                 #if os(Windows)
@@ -158,7 +160,7 @@ extension PkgConfig {
 /// See: https://www.freedesktop.org/wiki/Software/pkg-config/
 // This is only internal so it can be unit tested.
 internal struct PkgConfigParser {
-    public let pcFile: AbsolutePath
+    public let pcFile: Basics.AbsolutePath
     private let fileSystem: FileSystem
     public private(set) var variables = [String: String]()
     public private(set) var dependencies = [String]()
@@ -167,7 +169,7 @@ internal struct PkgConfigParser {
     public private(set) var libs = [String]()
     public private(set) var sysrootDir: String?
 
-    public init(pcFile: AbsolutePath, fileSystem: FileSystem, sysrootDir: String?) throws {
+    public init(pcFile: Basics.AbsolutePath, fileSystem: FileSystem, sysrootDir: String?) throws {
         guard fileSystem.isFile(pcFile) else {
             throw StringError("invalid pcfile \(pcFile)")
         }
@@ -268,7 +270,7 @@ internal struct PkgConfigParser {
         // Add pc_sysrootdir variable. This is the path of the sysroot directory for pc files.
         // pkgconf does not define pc_sysrootdir if the path of the .pc file is outside sysrootdir.
         // SwiftPM does not currently make that check.
-        variables["pc_sysrootdir"] = sysrootDir ?? AbsolutePath.root.pathString
+        variables["pc_sysrootdir"] = sysrootDir ?? Basics.AbsolutePath.root.pathString
 
         let fileContents: String = try fileSystem.readFileContents(pcFile)
         for line in fileContents.components(separatedBy: "\n") {
@@ -461,7 +463,7 @@ internal struct PCFileFinder {
     /// FIXME: This shouldn't use a static variable, since the first lookup
     /// will cache the result of whatever `brewPrefix` was passed in.  It is
     /// also not threadsafe.
-    public private(set) static var pkgConfigPaths: [AbsolutePath]? // FIXME: @testable(internal)
+    public private(set) static var pkgConfigPaths: [Basics.AbsolutePath]? // FIXME: @testable(internal)
     private static var shouldEmitPkgConfigPathsDiagnostic = false
 
     /// The built-in search path list.
@@ -469,7 +471,7 @@ internal struct PCFileFinder {
     /// By default, this is combined with the search paths inferred from
     /// `pkg-config` itself.
     static let searchPaths = [
-        try? AbsolutePath(validating: "/usr/local/lib/pkgconfig"),
+        try? Basics.AbsolutePath(validating: "/usr/local/lib/pkgconfig"),
         try? AbsolutePath(validating: "/usr/local/share/pkgconfig"),
         try? AbsolutePath(validating: "/usr/lib/pkgconfig"),
         try? AbsolutePath(validating: "/usr/share/pkgconfig"),
@@ -498,11 +500,11 @@ internal struct PCFileFinder {
         }
     }
 
-    public init(brewPrefix: AbsolutePath?) {
+    public init(brewPrefix: Basics.AbsolutePath?) {
         self.init(pkgConfigPath: brewPrefix?.appending(components: "bin", "pkg-config").pathString ?? "pkg-config")
     }
 
-    public init(pkgConfig: AbsolutePath? = .none) {
+    public init(pkgConfig: Basics.AbsolutePath? = .none) {
         self.init(pkgConfigPath: pkgConfig?.pathString ?? "pkg-config")
     }
 
@@ -516,10 +518,10 @@ internal struct PCFileFinder {
 
     public func locatePCFile(
         name: String,
-        customSearchPaths: [AbsolutePath],
+        customSearchPaths: [Basics.AbsolutePath],
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
-    ) throws -> AbsolutePath {
+    ) throws -> Basics.AbsolutePath {
         // FIXME: We should consider building a registry for all items in the
         // search paths, which is likely to be substantially more efficient if
         // we end up searching for a reasonably sized number of packages.

--- a/Sources/PackageLoading/Platform.swift
+++ b/Sources/PackageLoading/Platform.swift
@@ -12,12 +12,13 @@
 
 import Basics
 import Foundation
+import TSCBasic
 
 import class Basics.AsyncProcess
 
 private func isAndroid() -> Bool {
-    (try? localFileSystem.isFile(AbsolutePath(validating: "/system/bin/toolchain"))) ?? false ||
-        (try? localFileSystem.isFile(AbsolutePath(validating: "/system/bin/toybox"))) ?? false
+    (try? Basics.localFileSystem.isFile(AbsolutePath(validating: "/system/bin/toolchain"))) ?? false ||
+        (try? Basics.localFileSystem.isFile(AbsolutePath(validating: "/system/bin/toybox"))) ?? false
 }
 
 public enum Platform: Equatable, Sendable {
@@ -48,7 +49,7 @@ extension Platform {
         case "freebsd"?:
             return .freebsd
         case "linux"?:
-            return Platform.findCurrentPlatformLinux(localFileSystem)
+            return Platform.findCurrentPlatformLinux(Basics.localFileSystem)
         default:
             return nil
         }

--- a/Sources/PackageLoading/RegistryReleaseMetadataSerialization.swift
+++ b/Sources/PackageLoading/RegistryReleaseMetadataSerialization.swift
@@ -13,6 +13,7 @@
 import Basics
 import Foundation
 import PackageModel
+import TSCBasic
 
 public enum RegistryReleaseMetadataStorage {
     public static let fileName = ".registry-metadata"
@@ -20,13 +21,13 @@ public enum RegistryReleaseMetadataStorage {
     private static let encoder = JSONEncoder.makeWithDefaults()
     private static let decoder = JSONDecoder.makeWithDefaults()
 
-    public static func save(_ metadata: RegistryReleaseMetadata, to path: AbsolutePath, fileSystem: FileSystem) throws {
+    public static func save(_ metadata: RegistryReleaseMetadata, to path: Basics.AbsolutePath, fileSystem: FileSystem) throws {
         let codableMetadata = CodableRegistryReleaseMetadata(metadata)
         let data = try Self.encoder.encode(codableMetadata)
         try fileSystem.writeFileContents(path, data: data)
     }
 
-    public static func load(from path: AbsolutePath, fileSystem: FileSystem) throws -> RegistryReleaseMetadata {
+    public static func load(from path: Basics.AbsolutePath, fileSystem: FileSystem) throws -> RegistryReleaseMetadata {
         let codableMetadata = try Self.decoder.decode(
             path: path,
             fileSystem: fileSystem,

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -12,6 +12,7 @@
 
 import Basics
 import PackageModel
+import Foundation
 
 import class Basics.AsyncProcess
 import struct TSCBasic.RegEx

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -13,6 +13,7 @@
 import Basics
 import Foundation
 import PackageModel
+import TSCBasic
 
 /// A utility to compute the source/resource files of a target.
 public struct TargetSourcesBuilder {
@@ -23,19 +24,19 @@ public struct TargetSourcesBuilder {
     public let packageKind: PackageReference.Kind
 
     /// The package path.
-    public let packagePath: AbsolutePath
+    public let packagePath: Basics.AbsolutePath
 
     /// The target for which we're computing source/resource files.
     public let target: TargetDescription
 
     /// The path of the target.
-    public let targetPath: AbsolutePath
+    public let targetPath: Basics.AbsolutePath
 
     /// The list of declared sources in the package manifest.
-    public let declaredSources: [AbsolutePath]?
+    public let declaredSources: [Basics.AbsolutePath]?
 
     /// The list of declared resources in the package manifest.
-    public let declaredResources: [(path: AbsolutePath, rule: TargetDescription.Resource.Rule)]
+    public let declaredResources: [(path: Basics.AbsolutePath, rule: TargetDescription.Resource.Rule)]
 
     /// The default localization.
     public let defaultLocalization: String?
@@ -47,7 +48,7 @@ public struct TargetSourcesBuilder {
     public let toolsVersion: ToolsVersion
 
     /// The set of paths that should be excluded from any consideration.
-    public let excludedPaths: Set<AbsolutePath>
+    public let excludedPaths: Set<Basics.AbsolutePath>
 
     /// The set of opaque directories extensions (should not be treated as source)
     private let opaqueDirectoriesExtensions: Set<String>
@@ -62,9 +63,9 @@ public struct TargetSourcesBuilder {
     public init(
         packageIdentity: PackageIdentity,
         packageKind: PackageReference.Kind,
-        packagePath: AbsolutePath,
+        packagePath: Basics.AbsolutePath,
         target: TargetDescription,
-        path: AbsolutePath,
+        path: Basics.AbsolutePath,
         defaultLocalization: String?,
         additionalFileRules: [FileRuleDescription],
         toolsVersion: ToolsVersion,
@@ -136,7 +137,7 @@ public struct TargetSourcesBuilder {
     }
 
     @discardableResult
-    private func validTargetPath(at: AbsolutePath) -> Error? {
+    private func validTargetPath(at: Basics.AbsolutePath) -> Error? {
         // Check if paths that are enumerated in targets: [] exist
         guard self.fileSystem.exists(at) else {
             return StringError("File not found")
@@ -165,11 +166,11 @@ public struct TargetSourcesBuilder {
     }
 
     /// Run the builder to produce the sources of the target.
-    public func run() throws -> (sources: Sources, resources: [Resource], headers: [AbsolutePath], ignored: [AbsolutePath], others: [AbsolutePath]) {
+    public func run() throws -> (sources: Sources, resources: [Resource], headers: [Basics.AbsolutePath], ignored: [Basics.AbsolutePath], others: [Basics.AbsolutePath]) {
         let contents = self.computeContents()
-        var pathToRule: [AbsolutePath: FileRuleDescription.Rule] = [:]
+        var pathToRule: [Basics.AbsolutePath: FileRuleDescription.Rule] = [:]
 
-        var handledResources = [AbsolutePath]()
+        var handledResources = [Basics.AbsolutePath]()
         for path in contents {
             pathToRule[path] = Self.computeRule(
                 for: path,
@@ -222,7 +223,7 @@ public struct TargetSourcesBuilder {
     }
 
     /// Compute the rule for the given path.
-    private static func computeRule(for path: AbsolutePath,
+    private static func computeRule(for path: Basics.AbsolutePath,
                                     toolsVersion: ToolsVersion,
                                     additionalFileRules: [FileRuleDescription],
                                     observabilityScope: ObservabilityScope) -> FileRuleDescription.Rule {
@@ -232,12 +233,12 @@ public struct TargetSourcesBuilder {
     }
 
     private static func computeRule(
-        for path: AbsolutePath, 
+        for path: Basics.AbsolutePath, 
         toolsVersion: ToolsVersion,
         rules: [FileRuleDescription],
-        declaredResources: [(path: AbsolutePath, rule: TargetDescription.Resource.Rule)],
-        declaredSources: [AbsolutePath]?,
-        matchingResourceRuleHandler: (AbsolutePath) -> () = { _ in },
+        declaredResources: [(path: Basics.AbsolutePath, rule: TargetDescription.Resource.Rule)],
+        declaredSources: [Basics.AbsolutePath]?,
+        matchingResourceRuleHandler: (Basics.AbsolutePath) -> () = { _ in },
         observabilityScope: ObservabilityScope
     ) -> FileRuleDescription.Rule {
         var matchedRule: FileRuleDescription.Rule = .none
@@ -303,7 +304,7 @@ public struct TargetSourcesBuilder {
     }
 
     /// Returns the `Resource` file associated with a file and a particular rule, if there is one.
-    private static func resource(for path: AbsolutePath, with rule: FileRuleDescription.Rule, defaultLocalization: String?, targetName: String, targetPath: AbsolutePath, observabilityScope: ObservabilityScope) -> Resource? {
+    private static func resource(for path: Basics.AbsolutePath, with rule: FileRuleDescription.Rule, defaultLocalization: String?, targetName: String, targetPath: Basics.AbsolutePath, observabilityScope: ObservabilityScope) -> Resource? {
         switch rule {
         case .compile, .header, .none, .modulemap, .ignored:
             return nil
@@ -342,7 +343,7 @@ public struct TargetSourcesBuilder {
         }
     }
 
-    private func resource(for path: AbsolutePath, with rule: FileRuleDescription.Rule) -> Resource? {
+    private func resource(for path: Basics.AbsolutePath, with rule: FileRuleDescription.Rule) -> Resource? {
         return Self.resource(for: path, with: rule, defaultLocalization: defaultLocalization, targetName: target.name, targetPath: targetPath, observabilityScope: observabilityScope)
     }
 
@@ -406,7 +407,7 @@ public struct TargetSourcesBuilder {
     }
 
     /// Returns true if the given path is a declared source.
-    func isDeclaredSource(_ path: AbsolutePath) -> Bool {
+    func isDeclaredSource(_ path: Basics.AbsolutePath) -> Bool {
         return path == targetPath || declaredSources?.contains(path) == true
     }
 
@@ -414,9 +415,9 @@ public struct TargetSourcesBuilder {
     ///
     /// This avoids recursing into certain directories like exclude or the
     /// ones that should be copied as-is.
-    public func computeContents() -> [AbsolutePath] {
-        var contents: [AbsolutePath] = []
-        var queue: [AbsolutePath] = [targetPath]
+    public func computeContents() -> [Basics.AbsolutePath] {
+        var contents: [Basics.AbsolutePath] = []
+        var queue: [Basics.AbsolutePath] = [targetPath]
 
         // Ignore xcodeproj and playground directories.
         var ignoredDirectoryExtensions = ["xcodeproj", "playground", "xcworkspace"]
@@ -518,8 +519,8 @@ public struct TargetSourcesBuilder {
         return contents
     }
 
-    public static func computeContents(for generatedFiles: [AbsolutePath], toolsVersion: ToolsVersion, additionalFileRules: [FileRuleDescription], defaultLocalization: String?, targetName: String, targetPath: AbsolutePath, observabilityScope: ObservabilityScope) -> (sources: [AbsolutePath], resources: [Resource]) {
-        var sources = [AbsolutePath]()
+    public static func computeContents(for generatedFiles: [Basics.AbsolutePath], toolsVersion: ToolsVersion, additionalFileRules: [FileRuleDescription], defaultLocalization: String?, targetName: String, targetPath: Basics.AbsolutePath, observabilityScope: ObservabilityScope) -> (sources: [Basics.AbsolutePath], resources: [Resource]) {
+        var sources = [Basics.AbsolutePath]()
         var resources = [Resource]()
 
         generatedFiles.forEach { absPath in
@@ -613,7 +614,7 @@ public struct FileRuleDescription: Sendable {
     }
 
     /// Match the given path to the rule.
-    public func match(path: AbsolutePath, toolsVersion: ToolsVersion) -> Bool {
+    public func match(path: Basics.AbsolutePath, toolsVersion: ToolsVersion) -> Bool {
         if toolsVersion < self.toolsVersion {
             return false
         }
@@ -800,12 +801,12 @@ extension Resource {
 }
 
 extension Basics.Diagnostic {
-    static func symlinkInSources(symlink: RelativePath, targetName: String) -> Self {
+    static func symlinkInSources(symlink: Basics.RelativePath, targetName: String) -> Self {
         .warning("ignoring symlink at '\(symlink)' in target '\(targetName)'")
     }
 
     static func localizationDirectoryContainsSubDirectories(
-        localizationDirectory: RelativePath,
+        localizationDirectory: Basics.RelativePath,
         targetName: String
     ) -> Self {
         .error("localization directory '\(localizationDirectory)' in target '\(targetName)' contains sub-directories, which is forbidden")
@@ -839,7 +840,7 @@ extension PackageReference.Kind {
 }
 
 extension PackageModel.Resource {
-    fileprivate var destinationForGrouping: RelativePath? {
+    fileprivate var destinationForGrouping: Basics.RelativePath? {
         do {
             return try self.destination
         } catch {

--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -12,6 +12,7 @@
 
 import Basics
 import Foundation
+import TSCBasic
 
 import struct TSCUtility.Version
 
@@ -51,10 +52,10 @@ public struct ArtifactsArchiveMetadata: Equatable {
     }
 
     public struct Variant: Equatable {
-        public let path: RelativePath
+        public let path: Basics.RelativePath
         public let supportedTriples: [Triple]?
 
-        public init(path: RelativePath, supportedTriples: [Triple]?) {
+        public init(path: Basics.RelativePath, supportedTriples: [Triple]?) {
             self.path = path
             self.supportedTriples = supportedTriples
         }
@@ -62,7 +63,7 @@ public struct ArtifactsArchiveMetadata: Equatable {
 }
 
 extension ArtifactsArchiveMetadata {
-    public static func parse(fileSystem: FileSystem, rootPath: AbsolutePath) throws -> ArtifactsArchiveMetadata {
+    public static func parse(fileSystem: FileSystem, rootPath: Basics.AbsolutePath) throws -> ArtifactsArchiveMetadata {
         let path = rootPath.appending("info.json")
         guard fileSystem.exists(path) else {
             throw StringError("ArtifactsArchive info.json not found at '\(rootPath)'")

--- a/Sources/PackageModel/MinimumDeploymentTarget.swift
+++ b/Sources/PackageModel/MinimumDeploymentTarget.swift
@@ -11,12 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import Foundation
+import TSCUtility
 
 import class Basics.AsyncProcess
 
 public struct MinimumDeploymentTarget {
     private struct MinimumDeploymentTargetKey: Hashable {
-        let binaryPath: AbsolutePath
+        let binaryPath: Basics.AbsolutePath
         let platform: PackageModel.Platform
     }
 
@@ -28,7 +30,7 @@ public struct MinimumDeploymentTarget {
     private init() {
     }
 
-    public func computeMinimumDeploymentTarget(of binaryPath: AbsolutePath, platform: PackageModel.Platform) throws -> PlatformVersion {
+    public func computeMinimumDeploymentTarget(of binaryPath: Basics.AbsolutePath, platform: PackageModel.Platform) throws -> PlatformVersion {
         try self.minimumDeploymentTargets.memoize(MinimumDeploymentTargetKey(binaryPath: binaryPath, platform: platform)) {
             return try Self.computeMinimumDeploymentTarget(of: binaryPath, platform: platform) ?? platform.oldestSupportedVersion
         }
@@ -40,7 +42,7 @@ public struct MinimumDeploymentTarget {
         }
     }
 
-    static func computeMinimumDeploymentTarget(of binaryPath: AbsolutePath, platform: PackageModel.Platform) throws -> PlatformVersion? {
+    static func computeMinimumDeploymentTarget(of binaryPath: Basics.AbsolutePath, platform: PackageModel.Platform) throws -> PlatformVersion? {
         guard let (_, platformName) = platform.sdkNameAndPlatform else {
             return nil
         }
@@ -58,8 +60,8 @@ public struct MinimumDeploymentTarget {
 
     static func computeXCTestMinimumDeploymentTarget(with runResult: AsyncProcessResult, platform: PackageModel.Platform) throws -> PlatformVersion? {
         guard let output = try runResult.utf8Output().spm_chuzzle() else { return nil }
-        let sdkPath = try AbsolutePath(validating: output)
-        let xcTestPath = try AbsolutePath(validating: "Developer/Library/Frameworks/XCTest.framework/XCTest", relativeTo: sdkPath)
+        let sdkPath = try Basics.AbsolutePath(validating: output)
+        let xcTestPath = try Basics.AbsolutePath(validating: "Developer/Library/Frameworks/XCTest.framework/XCTest", relativeTo: sdkPath)
         return try computeMinimumDeploymentTarget(of: xcTestPath, platform: platform)
     }
 

--- a/Sources/PackageModel/Module/ClangModule.swift
+++ b/Sources/PackageModel/Module/ClangModule.swift
@@ -12,6 +12,7 @@
 
 import struct Basics.AbsolutePath
 import struct Basics.StringError
+import TSCBasic
 
 @available(*, deprecated, renamed: "ClangModule")
 public typealias ClangTarget = ClangModule
@@ -24,7 +25,7 @@ public final class ClangModule: Module {
     public static let defaultPublicHeadersComponent = "include"
 
     /// The path to include directory.
-    public let includeDir: AbsolutePath
+    public let includeDir: Basics.AbsolutePath
 
     /// The target's module map type, which determines whether this target vends a custom module map, a generated module map, or no module map at all.
     public let moduleMapType: ModuleMapType
@@ -32,7 +33,7 @@ public final class ClangModule: Module {
     /// The headers present in the target.
     ///
     /// Note that this contains both public and non-public headers.
-    public let headers: [AbsolutePath]
+    public let headers: [Basics.AbsolutePath]
 
     /// True if this is a C++ target.
     public let isCXX: Bool
@@ -48,15 +49,15 @@ public final class ClangModule: Module {
         potentialBundleName: String? = nil,
         cLanguageStandard: String?,
         cxxLanguageStandard: String?,
-        includeDir: AbsolutePath,
+        includeDir: Basics.AbsolutePath,
         moduleMapType: ModuleMapType,
-        headers: [AbsolutePath] = [],
+        headers: [Basics.AbsolutePath] = [],
         type: Kind,
-        path: AbsolutePath,
+        path: Basics.AbsolutePath,
         sources: Sources,
         resources: [Resource] = [],
-        ignored: [AbsolutePath] = [],
-        others: [AbsolutePath] = [],
+        ignored: [Basics.AbsolutePath] = [],
+        others: [Basics.AbsolutePath] = [],
         dependencies: [Module.Dependency] = [],
         buildSettings: BuildSettings.AssignmentTable = .init(),
         buildSettingsDescription: [TargetBuildSettingDescription.Setting] = [],

--- a/Sources/PackageModel/Module/Module.swift
+++ b/Sources/PackageModel/Module/Module.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import TSCUtility
 
 @available(*, deprecated, renamed: "Module")
 public typealias Target = Module

--- a/Sources/PackageModel/Module/PluginModule.swift
+++ b/Sources/PackageModel/Module/PluginModule.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
+
 @available(*, deprecated, renamed: "PluginModule")
 public typealias PluginTarget = PluginModule
 

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -12,6 +12,7 @@
 
 import Basics
 import Foundation
+import TSCBasic
 
 /// The canonical identifier for a package, based on its source location.
 public struct PackageIdentity: CustomStringConvertible, Sendable {
@@ -39,7 +40,7 @@ public struct PackageIdentity: CustomStringConvertible, Sendable {
 
     /// Creates a package identity from a file path.
     /// - Parameter path: An absolute path to the package.
-    public init(path: AbsolutePath) {
+    public init(path: Basics.AbsolutePath) {
         self.description = PackageIdentityParser(path.pathString).description
     }
 
@@ -310,7 +311,7 @@ struct PackageIdentityParser {
     }
 
     /// Compute the default name of a package given its path.
-    public static func computeDefaultName(fromPath path: AbsolutePath) -> String {
+    public static func computeDefaultName(fromPath path: Basics.AbsolutePath) -> String {
         Self.computeDefaultName(fromLocation: path.pathString)
     }
 

--- a/Sources/PackageModel/Snippets/Model/Snippet.swift
+++ b/Sources/PackageModel/Snippets/Model/Snippet.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import Foundation
 
 public struct Snippet {
     public var path: AbsolutePath

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -12,6 +12,7 @@
 
 import Basics
 import Foundation
+import TSCBasic
 
 import class Basics.AsyncProcess
 
@@ -20,7 +21,7 @@ import struct TSCUtility.Version
 /// Errors related to Swift SDKs.
 public enum SwiftSDKError: Swift.Error {
     /// A bundle archive should contain at least one directory with the `.artifactbundle` extension.
-    case invalidBundleArchive(AbsolutePath)
+    case invalidBundleArchive(Basics.AbsolutePath)
 
     /// A passed argument is neither a valid file system path nor a URL.
     case invalidPathOrURL(String)
@@ -41,10 +42,10 @@ public enum SwiftSDKError: Swift.Error {
     case invalidBundleName(String)
 
     /// No valid Swift SDKs were decoded from a metadata file.
-    case noSwiftSDKDecoded(AbsolutePath)
+    case noSwiftSDKDecoded(Basics.AbsolutePath)
 
     /// Path used for storing Swift SDK configuration data is not a directory.
-    case pathIsNotDirectory(AbsolutePath)
+    case pathIsNotDirectory(Basics.AbsolutePath)
 
     /// Swift SDK metadata couldn't be serialized with the latest serialization schema, potentially because it
     /// was deserialized from an earlier incompatible schema version or initialized manually with properties
@@ -63,7 +64,7 @@ public enum SwiftSDKError: Swift.Error {
 
     #if os(macOS)
     /// Quarantine attribute should be removed by the `xattr` command from an installed bundle.
-    case quarantineAttributePresent(bundlePath: AbsolutePath)
+    case quarantineAttributePresent(bundlePath: Basics.AbsolutePath)
     #endif
 }
 
@@ -191,7 +192,7 @@ public struct SwiftSDK: Equatable {
 
     /// Root directory path of the SDK used to compile for the target triple.
     @available(*, deprecated, message: "use `pathsConfiguration.sdkRootPath` instead")
-    public var sdk: AbsolutePath? {
+    public var sdk: Basics.AbsolutePath? {
         get {
             sdkRootDir
         }
@@ -202,7 +203,7 @@ public struct SwiftSDK: Equatable {
 
     /// Root directory path of the SDK used to compile for the target triple.
     @available(*, deprecated, message: "use `pathsConfiguration.sdkRootPath` instead")
-    public var sdkRootDir: AbsolutePath? {
+    public var sdkRootDir: Basics.AbsolutePath? {
         get {
             pathsConfiguration.sdkRootPath
         }
@@ -213,13 +214,13 @@ public struct SwiftSDK: Equatable {
 
     /// Path to a directory containing the toolchain (compilers/linker) to be used for the compilation.
     @available(*, deprecated, message: "use `toolset.rootPaths` instead")
-    public var binDir: AbsolutePath {
+    public var binDir: Basics.AbsolutePath {
         toolchainBinDir
     }
 
     /// Path to a directory containing the toolchain (compilers/linker) to be used for the compilation.
     @available(*, deprecated, message: "use `toolset.rootPaths` instead")
-    public var toolchainBinDir: AbsolutePath {
+    public var toolchainBinDir: Basics.AbsolutePath {
         toolset.rootPaths[0]
     }
 
@@ -260,12 +261,12 @@ public struct SwiftSDK: Equatable {
 
     public struct PathsConfiguration: Equatable {
         public init(
-            sdkRootPath: AbsolutePath?,
-            swiftResourcesPath: AbsolutePath? = nil,
-            swiftStaticResourcesPath: AbsolutePath? = nil,
-            includeSearchPaths: [AbsolutePath]? = nil,
-            librarySearchPaths: [AbsolutePath]? = nil,
-            toolsetPaths: [AbsolutePath]? = nil
+            sdkRootPath: Basics.AbsolutePath?,
+            swiftResourcesPath: Basics.AbsolutePath? = nil,
+            swiftStaticResourcesPath: Basics.AbsolutePath? = nil,
+            includeSearchPaths: [Basics.AbsolutePath]? = nil,
+            librarySearchPaths: [Basics.AbsolutePath]? = nil,
+            toolsetPaths: [Basics.AbsolutePath]? = nil
         ) {
             self.sdkRootPath = sdkRootPath
             self.swiftResourcesPath = swiftResourcesPath
@@ -276,22 +277,22 @@ public struct SwiftSDK: Equatable {
         }
 
         /// Root directory path of the SDK used to compile for the target triple.
-        public var sdkRootPath: AbsolutePath?
+        public var sdkRootPath: Basics.AbsolutePath?
 
         /// Path containing Swift resources for dynamic linking.
-        public var swiftResourcesPath: AbsolutePath?
+        public var swiftResourcesPath: Basics.AbsolutePath?
 
         /// Path containing Swift resources for static linking.
-        public var swiftStaticResourcesPath: AbsolutePath?
+        public var swiftStaticResourcesPath: Basics.AbsolutePath?
 
         /// Array of paths containing headers.
-        public var includeSearchPaths: [AbsolutePath]?
+        public var includeSearchPaths: [Basics.AbsolutePath]?
 
         /// Array of paths containing libraries.
-        public var librarySearchPaths: [AbsolutePath]?
+        public var librarySearchPaths: [Basics.AbsolutePath]?
 
         /// Array of paths containing toolset files.
-        public var toolsetPaths: [AbsolutePath]?
+        public var toolsetPaths: [Basics.AbsolutePath]?
 
         /// Initialize paths configuration from values deserialized using v3 schema.
         /// - Parameters:
@@ -299,7 +300,7 @@ public struct SwiftSDK: Equatable {
         ///   - swiftSDKDirectory: directory used for converting relative paths in `properties` to absolute paths.
         fileprivate init(
             _ properties: SerializedDestinationV3.TripleProperties,
-            swiftSDKDirectory: AbsolutePath? = nil
+            swiftSDKDirectory: Basics.AbsolutePath? = nil
         ) throws {
             if let swiftSDKDirectory {
                 self.init(
@@ -346,7 +347,7 @@ public struct SwiftSDK: Equatable {
         /// - Parameters:
         ///   - properties: properties of a Swift SDK for the given triple.
         ///   - swiftSDKDirectory: directory used for converting relative paths in `properties` to absolute paths.
-        fileprivate init(_ properties: SwiftSDKMetadataV4.TripleProperties, swiftSDKDirectory: AbsolutePath? = nil) throws {
+        fileprivate init(_ properties: SwiftSDKMetadataV4.TripleProperties, swiftSDKDirectory: Basics.AbsolutePath? = nil) throws {
             if let swiftSDKDirectory {
                 self.init(
                     sdkRootPath: try AbsolutePath(validating: properties.sdkRootPath, relativeTo: swiftSDKDirectory),
@@ -422,8 +423,8 @@ public struct SwiftSDK: Equatable {
     @available(*, deprecated, message: "use `init(targetTriple:sdkRootDir:toolset:)` instead")
     public init(
         target: Triple? = nil,
-        sdk: AbsolutePath?,
-        binDir: AbsolutePath,
+        sdk: Basics.AbsolutePath?,
+        binDir: Basics.AbsolutePath,
         extraCCFlags: [String] = [],
         extraSwiftCFlags: [String] = [],
         extraCPPFlags: [String] = []
@@ -445,8 +446,8 @@ public struct SwiftSDK: Equatable {
     public init(
         hostTriple: Triple? = nil,
         targetTriple: Triple? = nil,
-        sdkRootDir: AbsolutePath?,
-        toolchainBinDir: AbsolutePath,
+        sdkRootDir: Basics.AbsolutePath?,
+        toolchainBinDir: Basics.AbsolutePath,
         extraFlags: BuildFlags = BuildFlags()
     ) {
         self.init(
@@ -501,7 +502,7 @@ public struct SwiftSDK: Equatable {
     /// Returns the bin directory for the host.
     private static func hostBinDir(
         fileSystem: FileSystem
-    ) throws -> AbsolutePath {
+    ) throws -> Basics.AbsolutePath {
         guard let cwd = fileSystem.currentWorkingDirectory else {
             return try AbsolutePath(validating: CommandLine.arguments[0]).parentDirectory
         }
@@ -511,8 +512,8 @@ public struct SwiftSDK: Equatable {
     /// The Swift SDK describing the host platform.
     @available(*, deprecated, renamed: "hostSwiftSDK")
     public static func hostDestination(
-        _ binDir: AbsolutePath? = nil,
-        originalWorkingDirectory: AbsolutePath? = nil,
+        _ binDir: Basics.AbsolutePath? = nil,
+        originalWorkingDirectory: Basics.AbsolutePath? = nil,
         environment: Environment
     ) throws -> SwiftSDK {
         try self.hostSwiftSDK(binDir, environment: environment)
@@ -520,10 +521,10 @@ public struct SwiftSDK: Equatable {
 
     /// The Swift SDK for the host platform.
     public static func hostSwiftSDK(
-        _ binDir: AbsolutePath? = nil,
+        _ binDir: Basics.AbsolutePath? = nil,
         environment: Environment = .current,
         observabilityScope: ObservabilityScope? = nil,
-        fileSystem: any FileSystem = localFileSystem
+        fileSystem: any FileSystem = Basics.localFileSystem
     ) throws -> SwiftSDK {
         try self.systemSwiftSDK(
             binDir,
@@ -538,10 +539,10 @@ public struct SwiftSDK: Equatable {
     /// Equivalent to `hostSwiftSDK`, except on macOS, where passing a non-nil `darwinPlatformOverride`
     /// will result in the SDK for the corresponding Darwin platform.
     private static func systemSwiftSDK(
-        _ binDir: AbsolutePath? = nil,
+        _ binDir: Basics.AbsolutePath? = nil,
         environment: Environment = .current,
         observabilityScope: ObservabilityScope? = nil,
-        fileSystem: any FileSystem = localFileSystem,
+        fileSystem: any FileSystem = Basics.localFileSystem,
         darwinPlatformOverride: DarwinPlatform? = nil
     ) throws -> SwiftSDK {
         // Select the correct binDir.
@@ -549,10 +550,10 @@ public struct SwiftSDK: Equatable {
             print("SWIFTPM_CUSTOM_BINDIR was deprecated in favor of SWIFTPM_CUSTOM_BIN_DIR")
         }
         let customBinDir = (environment["SWIFTPM_CUSTOM_BIN_DIR"] ?? environment["SWIFTPM_CUSTOM_BINDIR"])
-            .flatMap { try? AbsolutePath(validating: $0) }
+            .flatMap { try? Basics.AbsolutePath(validating: $0) }
         let binDir = try customBinDir ?? binDir ?? SwiftSDK.hostBinDir(fileSystem: fileSystem)
 
-        let sdkPath: AbsolutePath?
+        let sdkPath: Basics.AbsolutePath?
         #if os(macOS)
         let darwinPlatform = darwinPlatformOverride ?? .macOS
         // Get the SDK.
@@ -618,17 +619,17 @@ public struct SwiftSDK: Equatable {
     /// - SeeAlso: ``sdkPlatformPaths(for:environment:)``
     public struct PlatformPaths {
         /// Paths of directories containing auxiliary platform frameworks.
-        public var frameworks: [AbsolutePath]
+        public var frameworks: [Basics.AbsolutePath]
 
         /// Paths of directories containing auxiliary platform libraries.
-        public var libraries: [AbsolutePath]
+        public var libraries: [Basics.AbsolutePath]
     }
 
     /// Returns `macosx` sdk platform framework path.
     @available(*, deprecated, message: "use sdkPlatformPaths(for:) instead")
     public static func sdkPlatformFrameworkPaths(
         environment: Environment = .current
-    ) throws -> (fwk: AbsolutePath, lib: AbsolutePath) {
+    ) throws -> (fwk: Basics.AbsolutePath, lib: Basics.AbsolutePath) {
         let paths = try sdkPlatformPaths(for: .macOS, environment: environment)
         guard let frameworkPath = paths.frameworks.first else {
             throw StringError("could not determine SDK platform framework path")
@@ -659,15 +660,15 @@ public struct SwiftSDK: Equatable {
         }
 
         // For testing frameworks.
-        let frameworksPath = try AbsolutePath(validating: platformPath).appending(
+        let frameworksPath = try Basics.AbsolutePath(validating: platformPath).appending(
             components: "Developer", "Library", "Frameworks"
         )
-        let privateFrameworksPath = try AbsolutePath(validating: platformPath).appending(
+        let privateFrameworksPath = try Basics.AbsolutePath(validating: platformPath).appending(
             components: "Developer", "Library", "PrivateFrameworks"
         )
 
         // For testing libraries.
-        let librariesPath = try AbsolutePath(validating: platformPath).appending(
+        let librariesPath = try Basics.AbsolutePath(validating: platformPath).appending(
             components: "Developer", "usr", "lib"
         )
 
@@ -711,11 +712,11 @@ public struct SwiftSDK: Equatable {
     public static func deriveTargetSwiftSDK(
       hostSwiftSDK: SwiftSDK,
       hostTriple: Triple,
-      customToolsets: [AbsolutePath] = [],
-      customCompileDestination: AbsolutePath? = nil,
+      customToolsets: [Basics.AbsolutePath] = [],
+      customCompileDestination: Basics.AbsolutePath? = nil,
       customCompileTriple: Triple? = nil,
-      customCompileToolchain: AbsolutePath? = nil,
-      customCompileSDK: AbsolutePath? = nil,
+      customCompileToolchain: Basics.AbsolutePath? = nil,
+      customCompileSDK: Basics.AbsolutePath? = nil,
       swiftSDKSelector: String? = nil,
       architectures: [String] = [],
       store: SwiftSDKBundleStore,
@@ -833,7 +834,7 @@ public struct SwiftSDK: Equatable {
     /// Note: Use this operation if you want new root path to take priority over existing paths.
     ///
     /// - Parameter toolsetRootPath: new path to add to Swift SDK's toolset.
-    public mutating func prepend(toolsetRootPath path: AbsolutePath) {
+    public mutating func prepend(toolsetRootPath path: Basics.AbsolutePath) {
         self.toolset.rootPaths.insert(path, at: 0)
     }
 
@@ -843,7 +844,7 @@ public struct SwiftSDK: Equatable {
     /// have a lower priority vs. existing paths.
     ///
     /// - Parameter toolsetRootPath: new path to add to Swift SDK's toolset.
-    public mutating func append(toolsetRootPath: AbsolutePath) {
+    public mutating func append(toolsetRootPath: Basics.AbsolutePath) {
         self.toolset.rootPaths.append(toolsetRootPath)
     }
 }
@@ -851,7 +852,7 @@ public struct SwiftSDK: Equatable {
 extension SwiftSDK {
     /// Load a ``SwiftSDK`` description from a JSON representation from disk.
     public static func decode(
-        fromFile path: AbsolutePath,
+        fromFile path: Basics.AbsolutePath,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
     ) throws -> [SwiftSDK] {
@@ -874,7 +875,7 @@ extension SwiftSDK {
     /// Load a ``SwiftSDK`` description from a semantically versioned JSON representation from disk.
     private static func decode(
         semanticVersion: SemanticVersionInfo,
-        fromFile path: AbsolutePath,
+        fromFile path: Basics.AbsolutePath,
         fileSystem: FileSystem,
         decoder: JSONDecoder,
         observabilityScope: ObservabilityScope
@@ -946,7 +947,7 @@ extension SwiftSDK {
         targetTriple: Triple,
         properties: SwiftSDKMetadataV4.TripleProperties,
         toolset: Toolset = .init(),
-        swiftSDKDirectory: AbsolutePath? = nil
+        swiftSDKDirectory: Basics.AbsolutePath? = nil
     ) throws {
         self.init(
             targetTriple: targetTriple,
@@ -965,7 +966,7 @@ extension SwiftSDK {
         targetTriple: Triple,
         properties: SerializedDestinationV3.TripleProperties,
         toolset: Toolset = .init(),
-        swiftSDKDirectory: AbsolutePath? = nil
+        swiftSDKDirectory: Basics.AbsolutePath? = nil
     ) throws {
         self.init(
             targetTriple: targetTriple,
@@ -977,7 +978,7 @@ extension SwiftSDK {
     /// Load a ``SwiftSDK`` description from a legacy JSON representation from disk.
     private init(
         legacy version: VersionInfo,
-        fromFile path: AbsolutePath,
+        fromFile path: Basics.AbsolutePath,
         fileSystem: FileSystem,
         decoder: JSONDecoder
     ) throws {
@@ -1089,8 +1090,8 @@ private struct SemanticVersionInfo: Decodable {
 /// Represents v1 schema of `destination.json` files used for cross-compilation.
 private struct SerializedDestinationV1: Codable {
     let target: String?
-    let sdk: AbsolutePath?
-    let binDir: AbsolutePath
+    let sdk: Basics.AbsolutePath?
+    let binDir: Basics.AbsolutePath
     let extraCCFlags: [String]
     let extraSwiftCFlags: [String]
     let extraCPPFlags: [String]
@@ -1169,13 +1170,13 @@ struct SwiftSDKMetadataV4: Decodable {
     let targetTriples: [String: TripleProperties]
 }
 
-extension Optional where Wrapped == AbsolutePath {
+extension Optional where Wrapped == Basics.AbsolutePath {
     fileprivate var configurationString: String {
         self?.pathString ?? "not set"
     }
 }
 
-extension Optional where Wrapped == [AbsolutePath] {
+extension Optional where Wrapped == [Basics.AbsolutePath] {
     fileprivate var configurationString: String {
         self?.map(\.pathString).description ?? "not set"
     }

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -12,6 +12,7 @@
 
 import Basics
 import Foundation
+import TSCUtility
 
 import class Basics.AsyncProcess
 
@@ -69,9 +70,9 @@ public final class UserToolchain: Toolchain {
 
     /// The target triple that should be used for compilation.
     @available(*, deprecated, renamed: "targetTriple")
-    public var triple: Triple { targetTriple }
+    public var triple: Basics.Triple { targetTriple }
 
-    public let targetTriple: Triple
+    public let targetTriple: Basics.Triple
 
     /// The list of CPU architectures to build for.
     public let architectures: [String]?
@@ -162,7 +163,7 @@ public final class UserToolchain: Toolchain {
     // MARK: - public API
 
     public static func determineLibrarian(
-        triple: Triple,
+        triple: Basics.Triple,
         binDirectories: [AbsolutePath],
         useXcrun: Bool,
         environment: Environment,
@@ -405,7 +406,7 @@ public final class UserToolchain: Toolchain {
 #endif
 
     internal static func deriveSwiftCFlags(
-        triple: Triple,
+        triple: Basics.Triple,
         swiftSDK: SwiftSDK,
         environment: Environment,
         fileSystem: any FileSystem
@@ -839,7 +840,7 @@ public final class UserToolchain: Toolchain {
         return .init(swiftCompilerPath: swiftCompilerPath)
     }
 
-    private static func derivePluginServerPath(triple: Triple) throws -> AbsolutePath? {
+    private static func derivePluginServerPath(triple: Basics.Triple) throws -> AbsolutePath? {
         if triple.isDarwin() {
             let pluginServerPathFindArgs = ["/usr/bin/xcrun", "--find", "swift-plugin-server"]
             if let path = try? AsyncProcess.checkNonZeroExit(arguments: pluginServerPathFindArgs, environment: [:])
@@ -889,7 +890,7 @@ public final class UserToolchain: Toolchain {
     // TODO: We should have some general utility to find tools.
     private static func deriveXCTestPath(
         swiftSDK: SwiftSDK,
-        triple: Triple,
+        triple: Basics.Triple,
         environment: Environment,
         fileSystem: any FileSystem
     ) throws -> AbsolutePath? {
@@ -970,9 +971,9 @@ public final class UserToolchain: Toolchain {
 
     /// Find the swift-testing path if it is within a path that will need extra search paths.
     private static func deriveSwiftTestingPath(
-        derivedSwiftCompiler: AbsolutePath,
+        derivedSwiftCompiler: Basics.AbsolutePath,
         swiftSDK: SwiftSDK,
-        triple: Triple,
+        triple: Basics.Triple,
         environment: Environment,
         fileSystem: any FileSystem
     ) throws -> AbsolutePath? {

--- a/Sources/PackageModelSyntax/AddTarget.swift
+++ b/Sources/PackageModelSyntax/AddTarget.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import Foundation
 import PackageModel
 import SwiftParser
 import SwiftSyntax

--- a/Sources/PackageModelSyntax/ManifestSyntaxRepresentable.swift
+++ b/Sources/PackageModelSyntax/ManifestSyntaxRepresentable.swift
@@ -12,6 +12,7 @@
 
 import Basics
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Describes an entity in the package model that can be represented as
 /// a syntax node.

--- a/Sources/PackageModelSyntax/PackageDependency+Syntax.swift
+++ b/Sources/PackageModelSyntax/PackageDependency+Syntax.swift
@@ -14,6 +14,7 @@ import Basics
 import PackageModel
 import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import struct TSCUtility.Version
 
 extension MappablePackageDependency.Kind: ManifestSyntaxRepresentable {

--- a/Sources/PackageModelSyntax/ProductDescription+Syntax.swift
+++ b/Sources/PackageModelSyntax/ProductDescription+Syntax.swift
@@ -13,6 +13,7 @@
 import Basics
 import PackageModel
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftParser
 
 extension ProductDescription: ManifestSyntaxRepresentable {

--- a/Sources/PackageModelSyntax/SyntaxEditUtils.swift
+++ b/Sources/PackageModelSyntax/SyntaxEditUtils.swift
@@ -15,6 +15,7 @@ import PackageModel
 import SwiftBasicFormat
 import SwiftSyntax
 import SwiftParser
+import SwiftSyntaxBuilder
 
 /// Default indent when we have to introduce indentation but have no context
 /// to get it right.

--- a/Sources/PackageModelSyntax/TargetDescription+Syntax.swift
+++ b/Sources/PackageModelSyntax/TargetDescription+Syntax.swift
@@ -13,8 +13,8 @@
 import Basics
 import PackageModel
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftParser
-
 
 extension TargetDescription: ManifestSyntaxRepresentable {
     /// The function name in the package manifest.

--- a/Sources/PackagePlugin/Utilities.swift
+++ b/Sources/PackagePlugin/Utilities.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
+
 extension Package {
     /// The list of targets matching the given names. Throws an error if any of
     /// the targets cannot be found.

--- a/Sources/PackageRegistry/ChecksumTOFU.swift
+++ b/Sources/PackageRegistry/ChecksumTOFU.swift
@@ -16,6 +16,7 @@ import Dispatch
 import Basics
 import PackageFingerprint
 import PackageModel
+import Foundation
 
 import struct TSCUtility.Version
 

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -16,6 +16,7 @@ import Dispatch
 import Foundation
 import PackageLoading
 import PackageModel
+import TSCBasic
 
 import struct TSCUtility.Version
 
@@ -23,8 +24,8 @@ public class RegistryDownloadsManager: AsyncCancellable {
     public typealias Delegate = RegistryDownloadsManagerDelegate
 
     private let fileSystem: FileSystem
-    private let path: AbsolutePath
-    private let cachePath: AbsolutePath?
+    private let path: Basics.AbsolutePath
+    private let cachePath: Basics.AbsolutePath?
     private let registryClient: RegistryClient
     private let delegate: Delegate?
 
@@ -33,13 +34,13 @@ public class RegistryDownloadsManager: AsyncCancellable {
         let version: Version
     }
 
-    private var pendingLookups = [PackageLookup: Task<AbsolutePath, Error>]()
+    private var pendingLookups = [PackageLookup: Task<Basics.AbsolutePath, Error>]()
     private var pendingLookupsLock = NSLock()
 
     public init(
         fileSystem: FileSystem,
-        path: AbsolutePath,
-        cachePath: AbsolutePath?,
+        path: Basics.AbsolutePath,
+        cachePath: Basics.AbsolutePath?,
         registryClient: RegistryClient,
         delegate: Delegate?
     ) {
@@ -55,9 +56,9 @@ public class RegistryDownloadsManager: AsyncCancellable {
         version: Version,
         observabilityScope: ObservabilityScope,
         delegateQueue: DispatchQueue
-    ) async throws -> AbsolutePath {
-        let packageRelativePath: RelativePath
-        let packagePath: AbsolutePath
+    ) async throws -> Basics.AbsolutePath {
+        let packageRelativePath: Basics.RelativePath
+        let packagePath: Basics.AbsolutePath
 
         packageRelativePath = try package.downloadPath(version: version)
         packagePath = self.path.appending(packageRelativePath)
@@ -127,7 +128,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
         observabilityScope: ObservabilityScope,
         delegateQueue: DispatchQueue,
         callbackQueue: DispatchQueue,
-        completion: @escaping (Result<AbsolutePath, Error>) -> Void
+        completion: @escaping (Result<Basics.AbsolutePath, Error>) -> Void
     ) {
         callbackQueue.asyncResult(completion) {
             try await self.lookup(
@@ -147,7 +148,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
     private func downloadAndPopulateCache(
         package: PackageIdentity,
         version: Version,
-        packagePath: AbsolutePath,
+        packagePath: Basics.AbsolutePath,
         observabilityScope: ObservabilityScope,
         delegateQueue: DispatchQueue
     ) async throws -> FetchDetails {
@@ -302,7 +303,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
         }
     }
 
-    private func initializeCacheIfNeeded(cachePath: AbsolutePath) throws {
+    private func initializeCacheIfNeeded(cachePath: Basics.AbsolutePath) throws {
         if !self.fileSystem.exists(cachePath) {
             try self.fileSystem.createDirectory(cachePath, recursive: true)
         }
@@ -345,7 +346,7 @@ extension RegistryDownloadsManager {
 }
 
 extension FileSystem {
-    func validPackageDirectory(_ path: AbsolutePath) throws -> Bool {
+    func validPackageDirectory(_ path: Basics.AbsolutePath) throws -> Bool {
         if !self.exists(path) {
             return false
         }
@@ -354,14 +355,14 @@ extension FileSystem {
 }
 
 extension PackageIdentity {
-    internal func downloadPath() throws -> RelativePath {
+    internal func downloadPath() throws -> Basics.RelativePath {
         guard let registryIdentity = self.registry else {
             throw StringError("invalid package identifier \(self), expected registry scope and name")
         }
         return try RelativePath(validating: registryIdentity.scope.description).appending(component: registryIdentity.name.description)
     }
 
-    internal func downloadPath(version: Version) throws -> RelativePath {
+    internal func downloadPath(version: Version) throws -> Basics.RelativePath {
         try self.downloadPath().appending(component: version.description)
     }
 }

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -18,6 +18,7 @@ import Basics
 import PackageLoading
 import PackageModel
 import PackageSigning
+import TSCBasic
 
 import struct TSCUtility.Version
 
@@ -590,7 +591,7 @@ extension VerifierConfiguration {
 
         // Load trusted roots from configured directory
         if let trustedRootsDirectoryPath = configuration.trustedRootCertificatesPath {
-            let trustedRootsDirectory: AbsolutePath
+            let trustedRootsDirectory: Basics.AbsolutePath
             do {
                 trustedRootsDirectory = try AbsolutePath(validating: trustedRootsDirectoryPath)
             } catch {

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
@@ -15,8 +15,11 @@ import Basics
 import Commands
 import CoreCommands
 import Foundation
+import PackageFingerprint
 import PackageModel
 import PackageRegistry
+import PackageSigning
+import Workspace
 
 import struct TSCBasic.SHA256
 

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
@@ -16,6 +16,7 @@ import Commands
 import CoreCommands
 import Foundation
 import PackageModel
+import PackageFingerprint
 import PackageRegistry
 import PackageSigning
 import Workspace

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand.swift
@@ -12,6 +12,7 @@
 
 import ArgumentParser
 import Basics
+import Commands
 import CoreCommands
 import Foundation
 import PackageModel

--- a/Sources/PackageSigning/CertificateStores.swift
+++ b/Sources/PackageSigning/CertificateStores.swift
@@ -12,8 +12,10 @@
 
 #if USE_IMPL_ONLY_IMPORTS
 @_implementationOnly import X509
+@_implementationOnly import SwiftASN1
 #else
 import X509
+import SwiftASN1
 #endif
 
 enum Certificates {

--- a/Sources/PackageSigning/SigningEntity/FilePackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/FilePackageSigningEntityStorage.swift
@@ -14,17 +14,18 @@ import Basics
 import Dispatch
 import Foundation
 import PackageModel
+import TSCBasic
 
 import struct TSCUtility.Version
 
 public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
     let fileSystem: FileSystem
-    let directoryPath: AbsolutePath
+    let directoryPath: Basics.AbsolutePath
 
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
-    public init(fileSystem: FileSystem, directoryPath: AbsolutePath) {
+    public init(fileSystem: FileSystem, directoryPath: Basics.AbsolutePath) {
         self.fileSystem = fileSystem
         self.directoryPath = directoryPath
 

--- a/Sources/PackageSigning/SigningIdentity.swift
+++ b/Sources/PackageSigning/SigningIdentity.swift
@@ -27,6 +27,7 @@ import X509
 #endif
 
 import Basics
+import TSCBasic
 
 public protocol SigningIdentity {}
 

--- a/Sources/PackageSigning/X509Extensions.swift
+++ b/Sources/PackageSigning/X509Extensions.swift
@@ -29,6 +29,7 @@ import X509
 #endif
 
 import Basics
+import TSCBasic
 
 #if canImport(Security)
 extension Certificate {

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -14,14 +14,15 @@ import Basics
 import Foundation
 import PackageGraph
 import PackageModel
+import TSCBasic
 
 /// Information about a library from a binary dependency.
 public struct LibraryInfo: Equatable {
     /// The path to the binary.
-    public let libraryPath: AbsolutePath
+    public let libraryPath: Basics.AbsolutePath
 
     /// The paths to the headers directories.
-    public let headersPaths: [AbsolutePath]
+    public let headersPaths: [Basics.AbsolutePath]
 }
 
 /// Information about an executable from a binary dependency.
@@ -30,7 +31,7 @@ public struct ExecutableInfo: Equatable {
     public let name: String
 
     /// The path to the executable.
-    public let executablePath: AbsolutePath
+    public let executablePath: Basics.AbsolutePath
 
     /// Supported triples, e.g. `x86_64-apple-macosx`
     public let supportedTriples: [Triple]

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -14,6 +14,7 @@ import Basics
 import class Foundation.ProcessInfo
 import PackageModel
 import PackageGraph
+import TSCBasic
 
 public struct BuildParameters: Encodable {
     public enum PrepareForIndexingMode: Encodable {
@@ -50,7 +51,7 @@ public struct BuildParameters: Encodable {
     public var destination: Destination
 
     /// The path to the data directory.
-    public var dataPath: AbsolutePath
+    public var dataPath: Basics.AbsolutePath
 
     /// The build configuration.
     public var configuration: BuildConfiguration
@@ -69,7 +70,7 @@ public struct BuildParameters: Encodable {
     public var flags: BuildFlags
 
     /// An array of paths to search for pkg-config `.pc` files.
-    public var pkgConfigDirectories: [AbsolutePath]
+    public var pkgConfigDirectories: [Basics.AbsolutePath]
 
     /// The architectures to build for.
     // FIXME: this may be inconsistent with `targetTriple`.
@@ -146,13 +147,13 @@ public struct BuildParameters: Encodable {
 
     public init(
         destination: Destination,
-        dataPath: AbsolutePath,
+        dataPath: Basics.AbsolutePath,
         configuration: BuildConfiguration,
         toolchain: Toolchain,
         triple: Triple? = nil,
         flags: BuildFlags,
         buildSystemKind: BuildSystemProvider.Kind = .native,
-        pkgConfigDirectories: [AbsolutePath] = [],
+        pkgConfigDirectories: [Basics.AbsolutePath] = [],
         architectures: [String]? = nil,
         workers: UInt32 = UInt32(ProcessInfo.processInfo.activeProcessorCount),
         shouldCreateDylibForDynamicProducts: Bool = true,
@@ -223,7 +224,7 @@ public struct BuildParameters: Encodable {
     }
 
     /// The path to the build directory (inside the data directory).
-    public var buildPath: AbsolutePath {
+    public var buildPath: Basics.AbsolutePath {
         // TODO: query the build system for this.
         switch buildSystemKind {
         case .xcode, .swiftbuild:
@@ -240,47 +241,47 @@ public struct BuildParameters: Encodable {
     }
 
     /// The path to the index store directory.
-    public var indexStore: AbsolutePath {
+    public var indexStore: Basics.AbsolutePath {
         assert(indexStoreMode != .off, "index store is disabled")
         return buildPath.appending(components: "index", "store")
     }
 
     /// The path to the code coverage directory.
-    public var codeCovPath: AbsolutePath {
+    public var codeCovPath: Basics.AbsolutePath {
         return buildPath.appending("codecov")
     }
 
     /// The path to the code coverage profdata file.
-    public var codeCovDataFile: AbsolutePath {
+    public var codeCovDataFile: Basics.AbsolutePath {
         return codeCovPath.appending("default.profdata")
     }
 
-    public var llbuildManifest: AbsolutePath {
+    public var llbuildManifest: Basics.AbsolutePath {
         // FIXME: this path isn't specific to `BuildParameters` due to its use of `..`
         // FIXME: it should be calculated in a different place
         return dataPath.appending(components: "..", configuration.dirname + ".yaml")
     }
 
-    public var pifManifest: AbsolutePath {
+    public var pifManifest: Basics.AbsolutePath {
         // FIXME: this path isn't specific to `BuildParameters` due to its use of `..`
         // FIXME: it should be calculated in a different place
         return dataPath.appending(components: "..", "manifest.pif")
     }
 
-    public var buildDescriptionPath: AbsolutePath {
+    public var buildDescriptionPath: Basics.AbsolutePath {
         // FIXME: this path isn't specific to `BuildParameters`, should be moved one directory level higher
         return buildPath.appending(components: "description.json")
     }
 
-    public var testOutputPath: AbsolutePath {
+    public var testOutputPath: Basics.AbsolutePath {
         return buildPath.appending(component: "testOutput.txt")
     }
     /// Returns the path to the binary of a product for the current build parameters.
-    public func binaryPath(for product: ResolvedProduct) throws -> AbsolutePath {
+    public func binaryPath(for product: ResolvedProduct) throws -> Basics.AbsolutePath {
         return try buildPath.appending(binaryRelativePath(for: product))
     }
 
-    public func macroBinaryPath(_ module: ResolvedModule) throws -> AbsolutePath {
+    public func macroBinaryPath(_ module: ResolvedModule) throws -> Basics.AbsolutePath {
         assert(module.type == .macro)
         #if BUILD_MACROS_AS_DYLIBS
         return buildPath.appending(try dynamicLibraryPath(for: module.name))
@@ -290,17 +291,17 @@ public struct BuildParameters: Encodable {
     }
 
     /// Returns the path to the dynamic library of a product for the current build parameters.
-    private func dynamicLibraryPath(for name: String) throws -> RelativePath {
+    private func dynamicLibraryPath(for name: String) throws -> Basics.RelativePath {
         try RelativePath(validating: "\(self.triple.dynamicLibraryPrefix)\(name)\(self.suffix)\(self.triple.dynamicLibraryExtension)")
     }
 
     /// Returns the path to the executable of a product for the current build parameters.
-    package func executablePath(for name: String) throws -> RelativePath {
+    package func executablePath(for name: String) throws -> Basics.RelativePath {
         try RelativePath(validating: "\(name)\(self.suffix)\(self.triple.executableExtension)")
     }
 
     /// Returns the path to the binary of a product for the current build parameters, relative to the build directory.
-    public func binaryRelativePath(for product: ResolvedProduct) throws -> RelativePath {
+    public func binaryRelativePath(for product: ResolvedProduct) throws -> Basics.RelativePath {
         switch product.type {
         case .executable, .snippet:
             return try executablePath(for: product.name)

--- a/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
@@ -15,6 +15,8 @@ import Foundation
 import PackageGraph
 import PackageLoading
 import PackageModel
+import TSCBasic
+import TSCUtility
 
 typealias WireInput = HostToPluginMessage.InputContext
 
@@ -24,10 +26,10 @@ internal struct PluginContextSerializer {
     let fileSystem: FileSystem
     let modulesGraph: ModulesGraph
     let buildEnvironment: BuildEnvironment
-    let pkgConfigDirectories: [AbsolutePath]
-    let sdkRootPath: AbsolutePath?
+    let pkgConfigDirectories: [Basics.AbsolutePath]
+    let sdkRootPath: Basics.AbsolutePath?
     var paths: [WireInput.URL] = []
-    var pathsToIds: [AbsolutePath: WireInput.URL.Id] = [:]
+    var pathsToIds: [Basics.AbsolutePath: WireInput.URL.Id] = [:]
     var targets: [WireInput.Target] = []
     var targetsToWireIDs: [ResolvedModule.ID: WireInput.Target.Id] = [:]
     var products: [WireInput.Product] = []
@@ -42,7 +44,7 @@ internal struct PluginContextSerializer {
     
     /// Adds a path to the serialized structure, if it isn't already there.
     /// Either way, this function returns the path's wire ID.
-    mutating func serialize(path: AbsolutePath) throws -> WireInput.URL.Id {
+    mutating func serialize(path: Basics.AbsolutePath) throws -> WireInput.URL.Id {
         // If we've already seen the path, just return the wire ID we already assigned to it.
         if let id = pathsToIds[path] { return id }
         

--- a/Sources/SPMBuildCore/Plugins/PluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginScriptRunner.swift
@@ -16,6 +16,8 @@ import Foundation
 import PackageModel
 import PackageLoading
 import PackageGraph
+import TSCBasic
+import TSCUtility
 
 /// Implements the mechanics of running and communicating with a plugin (implemented as a set of Swift source files). In most environments this is done by compiling the code to an executable, invoking it as a sandboxed subprocess, and communicating with it using pipes. Specific implementations are free to implement things differently, however.
 public protocol PluginScriptRunner {
@@ -23,7 +25,7 @@ public protocol PluginScriptRunner {
     /// Public protocol function that starts compiling the plugin script to an executable. The name is used as the basename for the executable and auxiliary files. The tools version controls the availability of APIs in PackagePlugin, and should be set to the tools version of the package that defines the plugin (not of the target to which it is being applied). This function returns immediately and then calls the completion handler on the callback queue when compilation ends.
     @available(*, noasync, message: "Use the async alternative")
     func compilePluginScript(
-        sourceFiles: [AbsolutePath],
+        sourceFiles: [Basics.AbsolutePath],
         pluginName: String,
         toolsVersion: ToolsVersion,
         observabilityScope: ObservabilityScope,
@@ -43,13 +45,13 @@ public protocol PluginScriptRunner {
     ///
     /// Every concrete implementation should cache any intermediates as necessary to avoid redundant work.
     func runPluginScript(
-        sourceFiles: [AbsolutePath],
+        sourceFiles: [Basics.AbsolutePath],
         pluginName: String,
         initialMessage: Data,
         toolsVersion: ToolsVersion,
-        workingDirectory: AbsolutePath,
-        writableDirectories: [AbsolutePath],
-        readOnlyDirectories: [AbsolutePath],
+        workingDirectory: Basics.AbsolutePath,
+        writableDirectories: [Basics.AbsolutePath],
+        readOnlyDirectories: [Basics.AbsolutePath],
         allowNetworkConnections: [SandboxNetworkPermission],
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
@@ -60,12 +62,12 @@ public protocol PluginScriptRunner {
 
     /// Returns the Triple that represents the host for which plugin script tools should be built, or for which binary
     /// tools should be selected.
-    var hostTriple: Triple { get throws }
+    var hostTriple: Basics.Triple { get throws }
 }
 
 public extension PluginScriptRunner {
     func compilePluginScript(
-        sourceFiles: [AbsolutePath],
+        sourceFiles: [Basics.AbsolutePath],
         pluginName: String,
         toolsVersion: ToolsVersion,
         observabilityScope: ObservabilityScope,
@@ -118,10 +120,10 @@ public struct PluginCompilationResult: Equatable {
     public var commandLine: [String]
     
     /// Path of the compiled executable.
-    public var executableFile: AbsolutePath
+    public var executableFile: Basics.AbsolutePath
 
     /// Path of the libClang diagnostics file emitted by the compiler.
-    public var diagnosticsFile: AbsolutePath
+    public var diagnosticsFile: Basics.AbsolutePath
     
     /// Any output emitted by the compiler (stdout and stderr combined).
     public var rawCompilerOutput: String
@@ -132,8 +134,8 @@ public struct PluginCompilationResult: Equatable {
     public init(
         succeeded: Bool,
         commandLine: [String],
-        executableFile: AbsolutePath,
-        diagnosticsFile: AbsolutePath,
+        executableFile: Basics.AbsolutePath,
+        diagnosticsFile: Basics.AbsolutePath,
         compilerOutput rawCompilerOutput: String,
         cached: Bool
     ) {

--- a/Sources/SPMBuildCore/ResolvedPackage+Extensions.swift
+++ b/Sources/SPMBuildCore/ResolvedPackage+Extensions.swift
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import PackageModel
+import TSCUtility
+
 import struct PackageGraph.ResolvedPackage
 import struct PackageGraph.ResolvedModule
 

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -15,16 +15,17 @@ import _Concurrency
 import Dispatch
 import Foundation
 import PackageModel
+import TSCBasic
 
 /// Manages a collection of bare repositories.
 public class RepositoryManager: Cancellable {
     public typealias Delegate = RepositoryManagerDelegate
 
     /// The path under which repositories are stored.
-    public let path: AbsolutePath
+    public let path: Basics.AbsolutePath
 
     /// The path to the directory where all cached git repositories are stored.
-    private let cachePath: AbsolutePath?
+    private let cachePath: Basics.AbsolutePath?
 
     // used in tests to disable skipping of local packages.
     private let cacheLocalPackages: Bool
@@ -67,9 +68,9 @@ public class RepositoryManager: Cancellable {
     ///   - delegate: The repository manager delegate.
     public init(
         fileSystem: FileSystem,
-        path: AbsolutePath,
+        path: Basics.AbsolutePath,
         provider: RepositoryProvider,
-        cachePath: AbsolutePath? =  .none,
+        cachePath: Basics.AbsolutePath? =  .none,
         cacheLocalPackages: Bool = false,
         maxConcurrentOperations: Int? = .none,
         initializationWarningHandler: (String) -> Void,
@@ -306,7 +307,7 @@ public class RepositoryManager: Cancellable {
     private func fetchAndPopulateCache(
         package: PackageIdentity,
         handle: RepositoryHandle,
-        repositoryPath: AbsolutePath,
+        repositoryPath: Basics.AbsolutePath,
         updateStrategy: RepositoryUpdateStrategy,
         observabilityScope: ObservabilityScope,
         delegateQueue: DispatchQueue
@@ -408,7 +409,7 @@ public class RepositoryManager: Cancellable {
     }
 
     /// Open a working copy checkout at a path
-    public func openWorkingCopy(at path: AbsolutePath) throws -> WorkingCheckout {
+    public func openWorkingCopy(at path: Basics.AbsolutePath) throws -> WorkingCheckout {
         try self.provider.openWorkingCopy(at: path)
     }
 
@@ -430,7 +431,7 @@ public class RepositoryManager: Cancellable {
     /// Create a working copy of the repository from a handle.
     private func createWorkingCopy(
         _ handle: RepositoryHandle,
-        at destinationPath: AbsolutePath,
+        at destinationPath: Basics.AbsolutePath,
         editable: Bool
     ) throws -> WorkingCheckout {
         try self.provider.createWorkingCopy(
@@ -448,12 +449,12 @@ public class RepositoryManager: Cancellable {
     }
 
     /// Returns true if the directory is valid git location.
-    public func isValidDirectory(_ directory: AbsolutePath) throws -> Bool {
+    public func isValidDirectory(_ directory: Basics.AbsolutePath) throws -> Bool {
         try self.provider.isValidDirectory(directory)
     }
 
     /// Returns true if the directory is valid git location for the specified repository
-    public func isValidDirectory(_ directory: AbsolutePath, for repository: RepositorySpecifier) throws -> Bool {
+    public func isValidDirectory(_ directory: Basics.AbsolutePath, for repository: RepositorySpecifier) throws -> Bool {
         try self.provider.isValidDirectory(directory, for: repository)
     }
 
@@ -472,7 +473,7 @@ public class RepositoryManager: Cancellable {
     }
 
     /// Sets up the cache directories if they don't already exist.
-    private func initializeCacheIfNeeded(cachePath: AbsolutePath) throws {
+    private func initializeCacheIfNeeded(cachePath: Basics.AbsolutePath) throws {
         // Create the supplied cache directory.
         if !self.fileSystem.exists(cachePath) {
             try self.fileSystem.createDirectory(cachePath, recursive: true)
@@ -526,10 +527,10 @@ extension RepositoryManager {
         ///
         /// This is intentionally hidden from the clients so that the manager is
         /// allowed to move repositories transparently.
-        fileprivate let subpath: RelativePath
+        fileprivate let subpath: Basics.RelativePath
 
         /// Create a handle.
-        fileprivate init(manager: RepositoryManager, repository: RepositorySpecifier, subpath: RelativePath) {
+        fileprivate init(manager: RepositoryManager, repository: RepositorySpecifier, subpath: Basics.RelativePath) {
             self.manager = manager
             self.repository = repository
             self.subpath = subpath
@@ -547,7 +548,7 @@ extension RepositoryManager {
         ///           expected to be non-existent when called.
         ///
         ///   - editable: The clone is expected to be edited by user.
-        public func createWorkingCopy(at path: AbsolutePath, editable: Bool) throws -> WorkingCheckout {
+        public func createWorkingCopy(at path: Basics.AbsolutePath, editable: Bool) throws -> WorkingCheckout {
             return try self.manager.createWorkingCopy(self, at: path, editable: editable)
         }
     }
@@ -596,7 +597,7 @@ extension RepositoryManager.RepositoryHandle: CustomStringConvertible {
 
 extension RepositorySpecifier {
     // relative path where the repository should be stored
-    internal func storagePath() throws -> RelativePath {
+    internal func storagePath() throws -> Basics.RelativePath {
         return try RelativePath(validating: self.fileSystemIdentifier)
     }
 

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -15,6 +15,7 @@ import Foundation
 import PackageGraph
 import PackageLoading
 import PackageModel
+import TSCUtility
 
 @_spi(SwiftPMInternal)
 import SPMBuildCore
@@ -24,7 +25,7 @@ import func TSCBasic.topologicalSort
 
 /// The parameters required by `PIFBuilder`.
 struct PIFBuilderParameters {
-    let triple: Triple
+    let triple: Basics.Triple
 
     /// Whether the toolchain supports `-package-name` option.
     let isPackageAccessModifierSupported: Bool

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import TSCUtility
 
 import struct Basics.AbsolutePath
 import class Basics.ObservabilitySystem

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import TSCUtility
 
 import struct Basics.AbsolutePath
 import class Basics.ObservabilitySystem
@@ -989,7 +990,7 @@ extension PackagePIFProjectBuilder {
 
 private struct PackageRegistrySignature: Encodable {
     enum Source: Encodable {
-        case registry(url: URL)
+        case registry(url: Foundation.URL)
     }
 
     let packageIdentity: String

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import TSCUtility
 
 import struct Basics.AbsolutePath
 import struct Basics.Diagnostic

--- a/Sources/SwiftSDKCommand/RemoveSwiftSDK.swift
+++ b/Sources/SwiftSDKCommand/RemoveSwiftSDK.swift
@@ -14,6 +14,7 @@ import ArgumentParser
 import Basics
 import CoreCommands
 import PackageModel
+import TSCBasic
 
 package struct RemoveSwiftSDK: SwiftSDKSubcommand {
     package static let configuration = CommandConfiguration(
@@ -33,12 +34,12 @@ package struct RemoveSwiftSDK: SwiftSDKSubcommand {
 
     func run(
         hostTriple: Triple,
-        _ swiftSDKsDirectory: AbsolutePath,
+        _ swiftSDKsDirectory: Basics.AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) async throws {
         let artifactBundleDirectory = swiftSDKsDirectory.appending(component: self.sdkIDOrBundleName)
 
-        let removedBundleDirectory: AbsolutePath
+        let removedBundleDirectory: Basics.AbsolutePath
         if fileSystem.exists(artifactBundleDirectory) {
             try fileSystem.removeFileTree(artifactBundleDirectory)
 

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -13,6 +13,7 @@
 import Basics
 import PackageModel
 import SPMBuildCore
+import TSCUtility
 
 import protocol TSCBasic.OutputByteStream
 

--- a/Sources/Workspace/ManagedArtifact.swift
+++ b/Sources/Workspace/ManagedArtifact.swift
@@ -14,6 +14,7 @@ import Basics
 import PackageGraph
 import PackageModel
 import SourceControl
+import TSCBasic
 
 extension Workspace {
     /// A downloaded artifact managed by the workspace.
@@ -28,7 +29,7 @@ extension Workspace {
         public let source: Source
 
         /// The path of the artifact on disk
-        public let path: AbsolutePath
+        public let path: Basics.AbsolutePath
 
         public let kind: BinaryModule.Kind
 
@@ -36,7 +37,7 @@ extension Workspace {
             packageRef: PackageReference,
             targetName: String,
             source: Source,
-            path: AbsolutePath,
+            path: Basics.AbsolutePath,
             kind: BinaryModule.Kind
         ) {
             self.packageRef = packageRef
@@ -52,7 +53,7 @@ extension Workspace {
             targetName: String,
             url: String,
             checksum: String,
-            path: AbsolutePath,
+            path: Basics.AbsolutePath,
             kind: BinaryModule.Kind
         ) -> ManagedArtifact {
             return ManagedArtifact(
@@ -68,7 +69,7 @@ extension Workspace {
         public static func local(
             packageRef: PackageReference,
             targetName: String,
-            path: AbsolutePath,
+            path: Basics.AbsolutePath,
             kind: BinaryModule.Kind,
             checksum: String? = nil
         ) -> ManagedArtifact {

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -14,6 +14,7 @@ import Basics
 import PackageGraph
 import PackageModel
 import SourceControl
+import TSCBasic
 
 import struct TSCUtility.Version
 
@@ -26,7 +27,7 @@ extension Workspace {
         /// Represents the state of the managed dependency.
         public indirect enum State: Equatable, CustomStringConvertible {
             /// The dependency is a local package on the file system.
-            case fileSystem(AbsolutePath)
+            case fileSystem(Basics.AbsolutePath)
 
             /// The dependency is a managed source control checkout.
             case sourceControlCheckout(CheckoutState)
@@ -39,9 +40,9 @@ extension Workspace {
             /// If the path is non-nil, the dependency is managed by a user and is
             /// located at the path. In other words, this dependency is being used
             /// for top of the tree style development.
-            case edited(basedOn: ManagedDependency?, unmanagedPath: AbsolutePath?)
+            case edited(basedOn: ManagedDependency?, unmanagedPath: Basics.AbsolutePath?)
 
-            case custom(version: Version, path: AbsolutePath)
+            case custom(version: Version, path: Basics.AbsolutePath)
 
             public var description: String {
                 switch self {
@@ -66,12 +67,12 @@ extension Workspace {
         public let state: State
 
         /// The checked out path of the dependency on disk, relative to the workspace checkouts path.
-        public let subpath: RelativePath
+        public let subpath: Basics.RelativePath
 
         internal init(
             packageRef: PackageReference,
             state: State,
-            subpath: RelativePath
+            subpath: Basics.RelativePath
         ) {
             self.packageRef = packageRef
             self.subpath = subpath
@@ -84,7 +85,7 @@ extension Workspace {
         /// - Parameters:
         ///     - subpath: The subpath inside the editable directory.
         ///     - unmanagedPath: A custom absolute path instead of the subpath.
-        public func edited(subpath: RelativePath, unmanagedPath: AbsolutePath?) throws -> ManagedDependency {
+        public func edited(subpath: Basics.RelativePath, unmanagedPath: Basics.AbsolutePath?) throws -> ManagedDependency {
             guard case .sourceControlCheckout =  self.state else {
                 throw InternalError("invalid dependency state: \(self.state)")
             }
@@ -116,7 +117,7 @@ extension Workspace {
         public static func sourceControlCheckout(
             packageRef: PackageReference,
             state: CheckoutState,
-            subpath: RelativePath
+            subpath: Basics.RelativePath
         ) throws -> ManagedDependency {
             switch packageRef.kind {
             case .localSourceControl, .remoteSourceControl:
@@ -134,7 +135,7 @@ extension Workspace {
         public static func registryDownload(
             packageRef: PackageReference,
             version: Version,
-            subpath: RelativePath
+            subpath: Basics.RelativePath
         ) throws -> ManagedDependency {
             guard case .registry = packageRef.kind else {
                 throw InternalError("invalid package type: \(packageRef.kind)")
@@ -149,9 +150,9 @@ extension Workspace {
         /// Create an edited dependency
         public static func edited(
             packageRef: PackageReference,
-            subpath: RelativePath,
+            subpath: Basics.RelativePath,
             basedOn: ManagedDependency?,
-            unmanagedPath: AbsolutePath?
+            unmanagedPath: Basics.AbsolutePath?
         ) -> ManagedDependency {
             return ManagedDependency(
                 packageRef: packageRef,

--- a/Sources/Workspace/ManagedPrebuilt.swift
+++ b/Sources/Workspace/ManagedPrebuilt.swift
@@ -12,6 +12,7 @@
 
 import Basics
 import PackageModel
+import TSCBasic
 
 extension Workspace {
     /// A downloaded prebuilt managed by the workspace.
@@ -23,7 +24,7 @@ extension Workspace {
         public let libraryName: String
 
         /// The path to the extracted prebuilt artifacts
-        public let path: AbsolutePath
+        public let path: Basics.AbsolutePath
 
         /// The products in the library
         public let products: [String]

--- a/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
@@ -17,6 +17,7 @@ import PackageGraph
 import PackageLoading
 import PackageModel
 import PackageRegistry
+import TSCBasic
 
 import struct TSCUtility.Version
 
@@ -178,7 +179,7 @@ public class RegistryPackageContainer: PackageContainer {
                 throw StringError("failed locating placeholder manifest for \(preferredToolsVersion)")
             }
             // replace the fake manifest with the real manifest content
-            let manifestPath = AbsolutePath.root.appending(component: placeholderManifestFileName)
+            let manifestPath = Basics.AbsolutePath.root.appending(component: placeholderManifestFileName)
             try fileSystem.removeFileTree(manifestPath)
             try fileSystem.writeFileContents(manifestPath, string: manifestContent)
             // finally, load the manifest
@@ -202,7 +203,7 @@ public class RegistryPackageContainer: PackageContainer {
         // ToolsVersionLoader is designed to scan files to decide which is the best tools-version
         // as such, this writes a fake manifest based on the information returned by the registry
         // with only the header line which is all that is needed by ToolsVersionLoader
-        let fileSystem = InMemoryFileSystem()
+        let fileSystem = Basics.InMemoryFileSystem()
         for manifest in manifests {
             let content = manifest.value.content ?? "// swift-tools-version:\(manifest.value.toolsVersion)"
             try fileSystem.writeFileContents(AbsolutePath.root.appending(component: manifest.key), string: content)

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -13,6 +13,7 @@
 import Basics
 import Foundation
 import PackageLoading
+import PackageGraph
 import PackageModel
 import SPMBuildCore
 

--- a/Sources/Workspace/Workspace+Editing.swift
+++ b/Sources/Workspace/Workspace+Editing.swift
@@ -11,6 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import _Concurrency
+import PackageModel
+import TSCBasic
+
 import struct Basics.AbsolutePath
 import class Basics.InMemoryFileSystem
 import class Basics.ObservabilityScope

--- a/Sources/Workspace/Workspace+PackageContainer.swift
+++ b/Sources/Workspace/Workspace+PackageContainer.swift
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SourceControl
+import TSCBasic
+
 import class Basics.ObservabilityScope
 import func Dispatch.dispatchPrecondition
 import class Dispatch.DispatchQueue

--- a/Sources/Workspace/Workspace+Prebuilts.swift
+++ b/Sources/Workspace/Workspace+Prebuilts.swift
@@ -12,6 +12,7 @@
 
 import Basics
 import Foundation
+import OrderedCollections
 import PackageModel
 
 import protocol TSCBasic.HashAlgorithm

--- a/Sources/Workspace/Workspace+ResolvedPackages.swift
+++ b/Sources/Workspace/Workspace+ResolvedPackages.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SourceControl
+
 import class Basics.ObservabilityScope
 import class PackageGraph.ResolvedPackagesStore
 import struct PackageModel.PackageReference

--- a/Sources/Workspace/Workspace+SourceControl.swift
+++ b/Sources/Workspace/Workspace+SourceControl.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import TSCBasic
+
 import struct Basics.AbsolutePath
 import struct Basics.InternalError
 import class Basics.ObservabilityScope

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -15,6 +15,7 @@ import Foundation
 import PackageGraph
 import PackageModel
 import SourceControl
+import TSCBasic
 
 import struct TSCUtility.Version
 
@@ -30,14 +31,14 @@ public actor WorkspaceState {
     public private(set) var prebuilts: Workspace.ManagedPrebuilts
 
     /// Path to the state file.
-    public let storagePath: AbsolutePath
+    public let storagePath: Basics.AbsolutePath
 
     /// storage
     private let storage: WorkspaceStateStorage
 
     init(
         fileSystem: FileSystem,
-        storageDirectory: AbsolutePath,
+        storageDirectory: Basics.AbsolutePath,
         initializationWarningHandler: (String) -> Void
     ) {
         self.storagePath = storageDirectory.appending("workspace-state.json")
@@ -101,12 +102,12 @@ public actor WorkspaceState {
 // MARK: - Serialization
 
 private struct WorkspaceStateStorage {
-    private let path: AbsolutePath
+    private let path: Basics.AbsolutePath
     private let fileSystem: FileSystem
     private let encoder = JSONEncoder.makeWithDefaults()
     private let decoder = JSONDecoder.makeWithDefaults()
 
-    init(path: AbsolutePath, fileSystem: FileSystem) {
+    init(path: Basics.AbsolutePath, fileSystem: FileSystem) {
         self.path = path
         self.fileSystem = fileSystem
     }
@@ -285,7 +286,7 @@ extension WorkspaceStateStorage {
                     let kind = try container.decode(String.self, forKey: .name)
                     switch kind {
                     case "local", "fileSystem":
-                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        let path = try container.decode(Basics.AbsolutePath.self, forKey: .path)
                         return self.init(underlying: .fileSystem(path))
                     case "checkout", "sourceControlCheckout":
                         let checkout = try container.decode(CheckoutInfo.self, forKey: .checkoutState)
@@ -295,14 +296,14 @@ extension WorkspaceStateStorage {
                         return try self
                             .init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version)))
                     case "edited":
-                        let path = try container.decode(AbsolutePath?.self, forKey: .path)
+                        let path = try container.decode(Basics.AbsolutePath?.self, forKey: .path)
                         return try self.init(underlying: .edited(
                             basedOn: basedOn.map { try .init($0) },
                             unmanagedPath: path
                         ))
                     case "custom":
                         let version = try container.decode(String.self, forKey: .version)
-                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        let path = try container.decode(Basics.AbsolutePath.self, forKey: .path)
                         return try self.init(underlying: .custom(
                             version: TSCUtility.Version(versionString: version),
                             path: path
@@ -456,7 +457,7 @@ extension WorkspaceStateStorage {
         struct Prebuilt: Codable {
             let packageRef: PackageReference
             let libraryName: String
-            let path: AbsolutePath
+            let path: Basics.AbsolutePath
             let products: [String]
             let cModules: [String]
 
@@ -669,7 +670,7 @@ extension WorkspaceStateStorage {
                     let kind = try container.decode(String.self, forKey: .name)
                     switch kind {
                     case "local", "fileSystem":
-                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        let path = try container.decode(Basics.AbsolutePath.self, forKey: .path)
                         return self.init(underlying: .fileSystem(path))
                     case "checkout", "sourceControlCheckout":
                         let checkout = try container.decode(CheckoutInfo.self, forKey: .checkoutState)
@@ -679,14 +680,14 @@ extension WorkspaceStateStorage {
                         return try self
                             .init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version)))
                     case "edited":
-                        let path = try container.decode(AbsolutePath?.self, forKey: .path)
+                        let path = try container.decode(Basics.AbsolutePath?.self, forKey: .path)
                         return try self.init(underlying: .edited(
                             basedOn: basedOn.map { try .init($0) },
                             unmanagedPath: path
                         ))
                     case "custom":
                         let version = try container.decode(String.self, forKey: .version)
-                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        let path = try container.decode(Basics.AbsolutePath.self, forKey: .path)
                         return try self.init(underlying: .custom(
                             version: TSCUtility.Version(versionString: version),
                             path: path
@@ -1025,7 +1026,7 @@ extension WorkspaceStateStorage {
                     let kind = try container.decode(String.self, forKey: .name)
                     switch kind {
                     case "local", "fileSystem":
-                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        let path = try container.decode(Basics.AbsolutePath.self, forKey: .path)
                         return self.init(underlying: .fileSystem(path))
                     case "checkout", "sourceControlCheckout":
                         let checkout = try container.decode(CheckoutInfo.self, forKey: .checkoutState)
@@ -1035,14 +1036,14 @@ extension WorkspaceStateStorage {
                         return try self
                             .init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version)))
                     case "edited":
-                        let path = try container.decode(AbsolutePath?.self, forKey: .path)
+                        let path = try container.decode(Basics.AbsolutePath?.self, forKey: .path)
                         return try self.init(underlying: .edited(
                             basedOn: basedOn.map { try .init($0) },
                             unmanagedPath: path
                         ))
                     case "custom":
                         let version = try container.decode(String.self, forKey: .version)
-                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        let path = try container.decode(Basics.AbsolutePath.self, forKey: .path)
                         return try self.init(underlying: .custom(
                             version: TSCUtility.Version(versionString: version),
                             path: path
@@ -1215,7 +1216,7 @@ extension Workspace.ManagedDependency {
 
 extension Workspace.ManagedArtifact {
     fileprivate init(_ artifact: WorkspaceStateStorage.V5.Artifact) throws {
-        let path = try AbsolutePath(validating: artifact.path)
+        let path = try Basics.AbsolutePath(validating: artifact.path)
         try self.init(
             packageRef: .init(artifact.packageRef),
             targetName: artifact.targetName,
@@ -1337,7 +1338,7 @@ extension WorkspaceStateStorage {
                         let checkout = try container.decode(CheckoutInfo.self, forKey: .checkoutState)
                         return try self.init(underlying: .sourceControlCheckout(.init(checkout)))
                     case "edited":
-                        let path = try container.decode(AbsolutePath?.self, forKey: .path)
+                        let path = try container.decode(Basics.AbsolutePath?.self, forKey: .path)
                         return try self.init(underlying: .edited(
                             basedOn: basedOn.map { try .init($0) },
                             unmanagedPath: path
@@ -1458,7 +1459,7 @@ extension Workspace.ManagedDependency {
 
 extension Workspace.ManagedArtifact {
     fileprivate init(_ artifact: WorkspaceStateStorage.V4.Artifact) throws {
-        let path = try AbsolutePath(validating: artifact.path)
+        let path = try Basics.AbsolutePath(validating: artifact.path)
         try self.init(
             packageRef: .init(artifact.packageRef),
             targetName: artifact.targetName,
@@ -1479,7 +1480,7 @@ extension PackageModel.PackageReference {
         case "local":
             kind = try .fileSystem(.init(validating: reference.location))
         case "remote":
-            if let path = try? AbsolutePath(validating: reference.location) {
+            if let path = try? Basics.AbsolutePath(validating: reference.location) {
                 kind = .localSourceControl(path)
             } else {
                 kind = .remoteSourceControl(SourceControlURL(reference.location))
@@ -1512,7 +1513,7 @@ extension CheckoutState {
 // backwards compatibility for older formats
 
 extension BinaryModule.Kind {
-    fileprivate static func forPath(_ path: AbsolutePath) -> Self {
+    fileprivate static func forPath(_ path: Basics.AbsolutePath) -> Self {
         if let kind = allCases.first(where: { $0.fileExtension == path.extension }) {
             return kind
         }

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -15,6 +15,7 @@ import Foundation
 import PackageGraph
 import PackageLoading
 import PackageModel
+import TSCUtility
 
 @_spi(SwiftPMInternal)
 import SPMBuildCore
@@ -24,7 +25,7 @@ import func TSCBasic.topologicalSort
 
 /// The parameters required by `PIFBuilder`.
 struct PIFBuilderParameters {
-    let triple: Triple
+    let triple: Basics.Triple
 
     /// Whether the toolchain supports `-package-name` option.
     let isPackageAccessModifierSupported: Bool

--- a/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
+++ b/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
@@ -17,6 +17,7 @@ import _InternalTestSupport
 @testable
 import PackageGraph
 
+import PackageModel
 import XCTest
 
 final class CrossCompilationPackageGraphTests: XCTestCase {

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import PackageLoading
+import TSCUtility
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 @testable import PackageGraph
@@ -2921,7 +2923,7 @@ final class ModulesGraphTests: XCTestCase {
         ]
 
         let expectedPlatformsForTests = customXCTestMinimumDeploymentTargets
-            .reduce(into: [Platform: PlatformVersion]()) { partialResult, entry in
+            .reduce(into: [PackageModel.Platform: PlatformVersion]()) { partialResult, entry in
                 if entry.value > entry.key.oldestSupportedVersion {
                     partialResult[entry.key] = entry.value
                 } else {

--- a/Tests/PackageGraphTests/TopologicalSortTests.swift
+++ b/Tests/PackageGraphTests/TopologicalSortTests.swift
@@ -37,7 +37,7 @@ extension Int {
 extension Int: @retroactive Identifiable {}
 
 private func topologicalSort(_ nodes: [Int], _ successors: [Int: [Int]]) throws -> [Int] {
-    return try topologicalSort(nodes, successors: { successors[$0] ?? [] })
+    return try topologicalSortIdentifiable(nodes, successors: { successors[$0] ?? [] })
 }
 private func topologicalSort(_ node: Int, _ successors: [Int: [Int]]) throws -> [Int] {
     return try topologicalSort([node], successors)

--- a/Tests/PackageGraphTests/VersionSetSpecifierTests.swift
+++ b/Tests/PackageGraphTests/VersionSetSpecifierTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import TSCUtility
 import XCTest
 
 import PackageGraph


### PR DESCRIPTION
Adopt the experimental feature MemberImportVisibility. 

### Motivation:

Due to a weakness in the existing Swift language implementation, a public extension declared in a library module can be accessible to source code that doesn’t directly import that module.

### Modifications:

Adopt MemberImportVisibility on all targets and adjust imports to be explicit. There were a few places where ambiguities were exposed. The most apparent one is the ambiguity between Basics.AbsolutePath and TSCBasics.AbsolutePath. In this case they're functionally equivalent since the Basics version just type aliases the TSCBasics version. There were a few others where identically named methods were defined in both a SwiftPM module and an imported dependency.

### Result:

SwiftPM compiles with no code included without a corresponding explicit import.