### PR TITLE
[Build] Enable diagnostic serialization by default for swift modules

### DIFF
--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -494,6 +494,8 @@ public final class SwiftModuleBuildDescription {
             args += ["-enable-batch-mode"]
         }
 
+        args += ["-serialize-diagnostics"]
+
         args += self.buildParameters.indexStoreArguments(for: self.target)
         args += self.optimizationArguments
         args += self.testingArguments
@@ -850,6 +852,7 @@ public final class SwiftModuleBuildDescription {
             let sourceFileName = source.basenameWithoutExt
             let partialModulePath = self.tempsPath.appending(component: sourceFileName + "~partial.swiftmodule")
             let swiftDepsPath = self.tempsPath.appending(component: sourceFileName + ".swiftdeps")
+            let diagnosticsPath = self.diagnosticFile(sourceFile: source)
 
             content +=
                 #"""
@@ -871,7 +874,8 @@ public final class SwiftModuleBuildDescription {
                 #"""
                     "\#(objectKey)": "\#(object._nativePathString(escaped: true))",
                     "swiftmodule": "\#(partialModulePath._nativePathString(escaped: true))",
-                    "swift-dependencies": "\#(swiftDepsPath._nativePathString(escaped: true))"
+                    "swift-dependencies": "\#(swiftDepsPath._nativePathString(escaped: true))",
+                    "diagnostics": "\#(diagnosticsPath._nativePathString(escaped: true))"
                   }\#((idx + 1) < sources.count ? "," : "")
 
                 """#
@@ -1052,5 +1056,15 @@ extension SwiftModuleBuildDescription {
         using plan: BuildPlan
     ) -> [ModuleBuildDescription.Dependency] {
         ModuleBuildDescription.swift(self).recursiveDependencies(using: plan)
+    }
+}
+
+extension SwiftModuleBuildDescription {
+    package var diagnosticFiles: [AbsolutePath] {
+        self.sources.compactMap { self.diagnosticFile(sourceFile: $0) }
+    }
+
+    private func diagnosticFile(sourceFile: AbsolutePath) -> AbsolutePath {
+        self.tempsPath.appending(component: "\(sourceFile.basenameWithoutExt).dia")
     }
 }

--- a/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
+++ b/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
@@ -178,7 +178,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         XCTAssertMatch(
             exe,
             [
-                "-enable-batch-mode", "-Onone", "-enable-testing",
+                "-enable-batch-mode", "-serialize-diagnostics", "-Onone", "-enable-testing",
                 "-j3", "-DSWIFT_PACKAGE", "-DDEBUG", "-Xcc",
                 "-fmodule-map-file=\(buildPath.appending(components: "lib.build", "module.modulemap"))",
                 "-Xcc", "-I", "-Xcc", "\(pkgPath.appending(components: "Sources", "lib", "include"))",


### PR DESCRIPTION
### Motivation:

Adds a flag and entry into outputs file map per file in a swift module to emit any diagnostics in serialized form.

This is preliminary work to for future `swift migrate` command that needs serialized diagnostics to get the fix-its and enables future improvements like diagnostic de-duplication.

### Modifications:

- Add a new flag to `compileArguments` : `-serialize-diagnostics`
- Add an entry per source file an swift module that presents a path to a `.dia` file where the diagnostic information should be stored.
- Add a computed property to fetch diagnostic file locations per swift module

### Result:

The build would now emit serialized diagnostic files for every swift module.
