### PR TITLE
Make add-dependency idempotent

### DIFF
--- a/Sources/PackageModelSyntax/ManifestEditError.swift
+++ b/Sources/PackageModelSyntax/ManifestEditError.swift
@@ -23,6 +23,7 @@ package enum ManifestEditError: Error {
     case cannotFindArrayLiteralArgument(argumentName: String, node: Syntax)
     case oldManifest(ToolsVersion, expected: ToolsVersion)
     case cannotAddSettingsToPluginTarget
+    case existingDependency(dependencyName: String)
 }
 
 extension ToolsVersion {
@@ -46,6 +47,8 @@ extension ManifestEditError: CustomStringConvertible {
             "package manifest version \(version) is too old: please update to manifest version \(expectedVersion) or newer"
         case .cannotAddSettingsToPluginTarget:
             "plugin targets do not support settings"
+        case .existingDependency(let name):
+            "unable to add dependency '\(name)' because it already exists in the list of dependencies"
         }
     }
 }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -963,7 +963,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             try await executeAddURLDependencyAndAssert(
                 packagePath: path,
                 initialManifest: manifest,
-                url: "https://github.com/swiftlang/swift-syntax.git",
+                url: url,
                 requirementArgs: ["--exact", "601.0.1"],
                 expectedManifestString: expected
             )

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -40,9 +40,14 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
     private func execute(
         _ args: [String] = [],
         packagePath: AbsolutePath? = nil,
+        manifest: String? = nil,
         env: Environment? = nil
     ) async throws -> (stdout: String, stderr: String) {
         var environment = env ?? [:]
+        if let manifest, let packagePath {
+            try localFileSystem.writeFileContents(packagePath.appending("Package.swift"), string: manifest)
+        }
+
         // don't ignore local packages when caching
         environment["SWIFTPM_TESTS_PACKAGECACHE"] = "1"
         return try await executeSwiftPackage(
@@ -875,109 +880,178 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
         }
     }
 
+    // Helper function to arbitrarily assert on manifest content
+    func assertManifest(_ packagePath: AbsolutePath, _ callback: (String) throws -> Void) throws {
+        let manifestPath = packagePath.appending("Package.swift")
+        XCTAssertFileExists(manifestPath)
+        let contents: String = try localFileSystem.readFileContents(manifestPath)
+        try callback(contents)
+    }
+
+    // Helper function to assert content exists in the manifest
+    func assertManifestContains(_ packagePath: AbsolutePath, _ expected: String) throws {
+        try assertManifest(packagePath) { manifestContents in
+            XCTAssertMatch(manifestContents, .contains(expected))
+        }
+    }
+
+    // Helper function to test adding a URL dependency and asserting the result
+    func executeAddURLDependencyAndAssert(
+        packagePath: AbsolutePath,
+        initialManifest: String? = nil,
+        url: String,
+        requirementArgs: [String],
+        expectedManifestString: String,
+    ) async throws {
+        _ = try await execute(
+            ["add-dependency", url] + requirementArgs,
+            packagePath: packagePath,
+            manifest: initialManifest
+        )
+        try assertManifestContains(packagePath, expectedManifestString)
+    }
+
+    func testPackageAddDifferentDependencyWithSameURLTwiceFails() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
+            let fs = localFileSystem
+            let path = tmpPath.appending("PackageB")
+            try fs.createDirectory(path)
+
+            let url = "https://github.com/swiftlang/swift-syntax.git"
+            let manifest = """
+                // swift-tools-version: 5.9
+                import PackageDescription
+                let package = Package(
+                    name: "client",
+                    dependencies: [
+                        .package(url: "\(url)", exact: "601.0.1")
+                    ],
+                    targets: [ .target(name: "client", dependencies: [ "library" ]) ]
+                )
+            """
+
+            try localFileSystem.writeFileContents(path.appending("Package.swift"), string: manifest)
+
+            await XCTAssertThrowsCommandExecutionError(
+                try await execute(["add-dependency", url, "--revision", "58e9de4e7b79e67c72a46e164158e3542e570ab6"], packagePath: path)
+            ) { error in
+                XCTAssertMatch(error.stderr, .contains("error: unable to add dependency 'https://github.com/swiftlang/swift-syntax.git' because it already exists in the list of dependencies"))
+            }
+        }
+    }
+
+    func testPackageAddSameDependencyTwiceHasNoEffect() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
+            let fs = localFileSystem
+            let path = tmpPath.appending("PackageB")
+            try fs.createDirectory(path)
+
+            let url = "https://github.com/swiftlang/swift-syntax.git"
+            let manifest = """
+                // swift-tools-version: 5.9
+                import PackageDescription
+                let package = Package(
+                    name: "client",
+                    dependencies: [
+                        .package(url: "\(url)", exact: "601.0.1"),
+                    ],
+                    targets: [ .target(name: "client", dependencies: [ "library" ]) ]
+                )
+            """
+            let expected = #".package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "601.0.1"),"#
+
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "https://github.com/swiftlang/swift-syntax.git",
+                requirementArgs: ["--exact", "601.0.1"],
+                expectedManifestString: expected
+            )
+
+            try assertManifest(path) {
+                let components = $0.components(separatedBy: expected)
+                XCTAssertEqual(components.count, 2, "Expected the dependency to be added exactly once.")
+            }
+        }
+    }
+
     func testPackageAddURLDependency() async throws {
         try await testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("PackageB")
             try fs.createDirectory(path)
 
-            try fs.writeFileContents(path.appending("Package.swift"), string:
-                """
+            let manifest = """
                 // swift-tools-version: 5.9
                 import PackageDescription
                 let package = Package(
                     name: "client",
                     targets: [ .target(name: "client", dependencies: [ "library" ]) ]
                 )
-                """
+            """
+
+            // Test adding with --exact using the new helper
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "https://github.com/swiftlang/swift-syntax.git",
+                requirementArgs: ["--exact", "1.0.0"],
+                expectedManifestString: #".package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "1.0.0"),"#,
             )
 
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "https://github.com/swiftlang/swift-syntax.git",
-                    "--exact",
-                    "1.0.0",
-                ],
-                packagePath: path
+            // Test adding with --branch
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "https://github.com/swiftlang/swift-syntax.git",
+                requirementArgs: ["--branch", "main"],
+                expectedManifestString: #".package(url: "https://github.com/swiftlang/swift-syntax.git", branch: "main"),"#
             )
 
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "https://github.com/swiftlang/swift-syntax.git",
-                    "--branch",
-                    "main",
-                ],
-                packagePath: path
+            // Test adding with --revision
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "https://github.com/swiftlang/swift-syntax.git",
+                requirementArgs: ["--revision", "58e9de4e7b79e67c72a46e164158e3542e570ab6"],
+                expectedManifestString: #".package(url: "https://github.com/swiftlang/swift-syntax.git", revision: "58e9de4e7b79e67c72a46e164158e3542e570ab6"),"#
             )
 
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "https://github.com/swiftlang/swift-syntax.git",
-                    "--revision",
-                    "58e9de4e7b79e67c72a46e164158e3542e570ab6",
-                ],
-                packagePath: path
+            // Test adding with --from
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "https://github.com/swiftlang/swift-syntax.git",
+                requirementArgs: ["--from", "1.0.0"],
+                expectedManifestString: #".package(url: "https://github.com/swiftlang/swift-syntax.git", from: "1.0.0"),"#
             )
 
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "https://github.com/swiftlang/swift-syntax.git",
-                    "--from",
-                    "1.0.0",
-                ],
-                packagePath: path
+            // Test adding with --from and --to
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "https://github.com/swiftlang/swift-syntax.git",
+                requirementArgs: ["--from", "2.0.0", "--to", "2.2.0"],
+                expectedManifestString: #".package(url: "https://github.com/swiftlang/swift-syntax.git", "2.0.0" ..< "2.2.0"),"#
             )
 
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "https://github.com/swiftlang/swift-syntax.git",
-                    "--from",
-                    "2.0.0",
-                    "--to",
-                    "2.2.0",
-                ],
-                packagePath: path
+            // Test adding with --up-to-next-minor-from
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "https://github.com/swiftlang/swift-syntax.git",
+                requirementArgs: ["--up-to-next-minor-from", "1.0.0"],
+                expectedManifestString: #".package(url: "https://github.com/swiftlang/swift-syntax.git", "1.0.0" ..< "1.1.0"),"#
             )
 
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "https://github.com/swiftlang/swift-syntax.git",
-                    "--up-to-next-minor-from",
-                    "1.0.0",
-                ],
-                packagePath: path
+            // Test adding with --up-to-next-minor-from and --to
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "https://github.com/swiftlang/swift-syntax.git",
+                requirementArgs: ["--up-to-next-minor-from", "3.0.0", "--to", "3.3.0"],
+                expectedManifestString: #".package(url: "https://github.com/swiftlang/swift-syntax.git", "3.0.0" ..< "3.3.0"),"#
             )
-
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "https://github.com/swiftlang/swift-syntax.git",
-                    "--up-to-next-minor-from",
-                    "3.0.0",
-                    "--to",
-                    "3.3.0",
-                ],
-                packagePath: path
-            )
-
-
-            let manifest = path.appending("Package.swift")
-            XCTAssertFileExists(manifest)
-            let contents: String = try fs.readFileContents(manifest)
-
-            XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "1.0.0"),"#))
-            XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", branch: "main"),"#))
-            XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", revision: "58e9de4e7b79e67c72a46e164158e3542e570ab6"),"#))
-            XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", from: "1.0.0"),"#))
-            XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", "2.0.0" ..< "2.2.0"),"#))
-            XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", "1.0.0" ..< "1.1.0"),"#))
-            XCTAssertMatch(contents, .contains(#".package(url: "https://github.com/swiftlang/swift-syntax.git", "3.0.0" ..< "3.3.0"),"#))
         }
     }
 
@@ -986,9 +1060,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             let fs = localFileSystem
             let path = tmpPath.appending("PackageB")
             try fs.createDirectory(path)
-
-            try fs.writeFileContents(path.appending("Package.swift"), string:
-                """
+            let manifest = """
                 // swift-tools-version: 5.9
                 import PackageDescription
                 let package = Package(
@@ -996,34 +1068,24 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                     targets: [ .target(name: "client", dependencies: [ "library" ]) ]
                 )
                 """
+
+            // Add absolute path dependency
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "/absolute",
+                requirementArgs: ["--type", "path"],
+                expectedManifestString: #".package(path: "/absolute"),"#
             )
 
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "/absolute",
-                    "--type",
-                    "path"
-                ],
-                packagePath: path
+            // Add relative path dependency (operates on the modified manifest)
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "../relative",
+                requirementArgs: ["--type", "path"],
+                expectedManifestString: #".package(path: "../relative"),"#
             )
-
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "../relative",
-                    "--type",
-                    "path"
-                ],
-                packagePath: path
-            )
-
-            let manifest = path.appending("Package.swift")
-            XCTAssertFileExists(manifest)
-            let contents: String = try fs.readFileContents(manifest)
-
-            XCTAssertMatch(contents, .contains(#".package(path: "/absolute"),"#))
-            XCTAssertMatch(contents, .contains(#".package(path: "../relative"),"#))
         }
     }
 
@@ -1033,8 +1095,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             let path = tmpPath.appending("PackageB")
             try fs.createDirectory(path)
 
-            try fs.writeFileContents(path.appending("Package.swift"), string:
-                """
+            let manifest = """
                 // swift-tools-version: 5.9
                 import PackageDescription
                 let package = Package(
@@ -1042,81 +1103,51 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                     targets: [ .target(name: "client", dependencies: [ "library" ]) ]
                 )
                 """
+
+            // Test adding with --exact
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "scope.name",
+                requirementArgs: ["--type", "registry", "--exact", "1.0.0"],
+                expectedManifestString: #".package(id: "scope.name", exact: "1.0.0"),"#
             )
 
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "scope.name",
-                    "--type",
-                    "registry",
-                    "--exact",
-                    "1.0.0",
-                ],
-                packagePath: path
+            // Test adding with --from
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "scope.name",
+                requirementArgs: ["--type", "registry", "--from", "1.0.0"],
+                expectedManifestString: #".package(id: "scope.name", from: "1.0.0"),"#
             )
 
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "scope.name",
-                    "--type",
-                    "registry",
-                    "--from",
-                    "1.0.0",
-                ],
-                packagePath: path
+            // Test adding with --from and --to
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "scope.name",
+                requirementArgs: ["--type", "registry", "--from", "2.0.0", "--to", "2.2.0"],
+                expectedManifestString: #".package(id: "scope.name", "2.0.0" ..< "2.2.0"),"#
             )
 
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "scope.name",
-                    "--type",
-                    "registry",
-                    "--from",
-                    "2.0.0",
-                    "--to",
-                    "2.2.0",
-                ],
-                packagePath: path
+            // Test adding with --up-to-next-minor-from
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "scope.name",
+                requirementArgs: ["--type", "registry", "--up-to-next-minor-from", "1.0.0"],
+                expectedManifestString: #".package(id: "scope.name", "1.0.0" ..< "1.1.0"),"#
             )
 
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "scope.name",
-                    "--type",
-                    "registry",
-                    "--up-to-next-minor-from",
-                    "1.0.0",
-                ],
-                packagePath: path
+            // Test adding with --up-to-next-minor-from and --to
+            try await executeAddURLDependencyAndAssert(
+                packagePath: path,
+                initialManifest: manifest,
+                url: "scope.name",
+                requirementArgs: ["--type", "registry", "--up-to-next-minor-from", "3.0.0", "--to", "3.3.0"],
+                expectedManifestString: #".package(id: "scope.name", "3.0.0" ..< "3.3.0"),"#
             )
-
-            _ = try await execute(
-                [
-                    "add-dependency",
-                    "scope.name",
-                    "--type",
-                    "registry",
-                    "--up-to-next-minor-from",
-                    "3.0.0",
-                    "--to",
-                    "3.3.0",
-                ],
-                packagePath: path
-            )
-
-            let manifest = path.appending("Package.swift")
-            XCTAssertFileExists(manifest)
-            let contents: String = try fs.readFileContents(manifest)
-
-            XCTAssertMatch(contents, .contains(#".package(id: "scope.name", exact: "1.0.0"),"#))
-            XCTAssertMatch(contents, .contains(#".package(id: "scope.name", from: "1.0.0"),"#))
-            XCTAssertMatch(contents, .contains(#".package(id: "scope.name", "2.0.0" ..< "2.2.0"),"#))
-            XCTAssertMatch(contents, .contains(#".package(id: "scope.name", "1.0.0" ..< "1.1.0"),"#))
-            XCTAssertMatch(contents, .contains(#".package(id: "scope.name", "3.0.0" ..< "3.3.0"),"#))
         }
     }
 


### PR DESCRIPTION
### Motivation:

If the same dependency is added twice with different version specifiers the manifest is no longer valid. If the same dependency is added twice with the same version specifier it remains valid, but less maintainable.

### Modifications:

If a manifest already contains the exact dependency and version that is being added via a `add-dependency` call, don't add it twice. Instead, do nothing.

If a manifest contains a dependency with the supplied URL but a different version qualifier then throw an error explaining that the supplied dependency has already been added.

### Result:

A manifest that continues to parse correctly.

Issue: #8519

