### PR TITLE
Closes  #8520  - Fix up test execution for IntegrationTests

### DIFF
--- a/IntegrationTests/Sources/IntegrationTestSupport/Helpers.swift
+++ b/IntegrationTests/Sources/IntegrationTestSupport/Helpers.swift
@@ -14,6 +14,8 @@ import TSCBasic
 import TSCTestSupport
 import enum TSCUtility.Git
 
+public typealias ShReturnType = (stdout: String, stderr: String, returnCode: ProcessResult.ExitStatus)
+
 public let sdkRoot: AbsolutePath? = {
     if let environmentPath = ProcessInfo.processInfo.environment["SDK_ROOT"] {
         return try! AbsolutePath(validating: environmentPath)
@@ -131,7 +133,7 @@ public func sh(
     env: [String: String] = [:],
     file: StaticString = #file,
     line: UInt = #line
-) throws -> (stdout: String, stderr: String) {
+) throws -> ShReturnType {
     let result = try _sh(arguments, env: env, file: file, line: line)
     let stdout = try result.utf8Output()
     let stderr = try result.utf8stderrOutput()
@@ -145,7 +147,7 @@ public func sh(
             )
     }
 
-    return (stdout, stderr)
+    return (stdout, stderr, result.exitStatus)
 }
 
 @discardableResult
@@ -154,7 +156,7 @@ public func shFails(
     env: [String: String] = [:],
     file: StaticString = #file,
     line: UInt = #line
-) throws -> (stdout: String, stderr: String) {
+) throws -> ShReturnType {
     let result = try _sh(arguments, env: env, file: file, line: line)
     let stdout = try result.utf8Output()
     let stderr = try result.utf8stderrOutput()
@@ -168,7 +170,7 @@ public func shFails(
             )
     }
 
-    return (stdout, stderr)
+    return (stdout, stderr, result.exitStatus)
 }
 
 @discardableResult

--- a/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift
@@ -414,29 +414,29 @@ private struct XCBuildTests {
             let fooPath = path.appending(component: "Foo")
 
             do {
-                let (_, stderr) = try sh(swiftTest, "--package-path", fooPath, "--build-system", "xcode")
-                #expect(stderr.contains("Test Suite 'FooTests.xctest'"))
-                #expect(stderr.contains("Test Suite 'CFooTests.xctest'"))
+                let output = try sh(swiftTest, "--package-path", fooPath, "--build-system", "xcode")
+                #expect(output.stderr.contains("Test Suite 'FooTests.xctest'"))
+                #expect(output.stderr.contains("Test Suite 'CFooTests.xctest'"))
             }
 
             do {
-                let (_, stderr) = try sh(
+                let output = try sh(
                     swiftTest,
                     "--package-path",
                     fooPath,
                     "--build-system",
                     "xcode",
                     "--filter",
-                    "CFooTests"
+                    "CFooTests",
                 )
-                #expect(stderr.contains("Test Suite 'Selected tests' started"))
-                #expect(stderr.contains("Test Suite 'CFooTests.xctest'"))
+                #expect(output.stderr.contains("Test Suite 'Selected tests' started"))
+                #expect(output.stderr.contains("Test Suite 'CFooTests.xctest'"))
             }
 
             do {
-                let (stdout, _) = try sh(swiftTest, "--package-path", fooPath, "--build-system", "xcode", "--parallel")
-                #expect(stdout.contains("Testing FooTests"))
-                #expect(stdout.contains("Testing CFooTests"))
+                let output = try sh(swiftTest, "--package-path", fooPath, "--build-system", "xcode", "--parallel")
+                #expect(output.stdout.contains("Testing FooTests"))
+                #expect(output.stdout.contains("Testing CFooTests"))
             }
         }
     }

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -810,7 +810,7 @@ def call_swiftpm(args, cmd, cwd=None):
     full_cmd = get_swiftpm_env_cmd(args) + cmd + get_swiftpm_flags(args)
     if cwd is None:
         cwd = args.project_root
-    call_output(full_cmd, cwd=cwd, stderr=True, verbose=True)
+    call(full_cmd, cwd=cwd)
 
 # -----------------------------------------------------------
 # Build-related helper functions


### PR DESCRIPTION
SPM has functionality to skip a set of tests
using an undocumented environment variable,
'_SWIFTPM_SKIP_TESTS_LIST'.  The presence of this variable causes test output to change around starting/ending of test suites.

Test Suite 'All tests' started
vs.
Test Suite 'Selected tests' started

* Remove checking for the 'All tests' string.
* Check the return code of the test execution.
* Set up environment variables to match bootstrap in the IntegrationTests execution.
* Change bootstrap to use a call() instead of call_output() as call_output will block until the process has finished. A swift-test may take a long time.  Certain CI environments expects output to stream out, and will cancel the build if none is detected for 30 mins.
* Update tests with using the 'checker', to output stdout/stderr for easier debugging of failed expects.
