### PR TITLE
Output Swift Build PIF JSON for Graphviz visualization

### DIFF
--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -86,8 +86,13 @@ struct BuildCommandOptions: ParsableArguments {
 
     /// Whether to output a graphviz file visualization of the combined job graph for all targets
     @Flag(name: .customLong("print-manifest-job-graph"),
-          help: "Write the command graph for the build manifest as a graphviz file")
+          help: "Write the command graph for the build manifest as a Graphviz file")
     var printManifestGraphviz: Bool = false
+
+    /// Whether to output a graphviz file visualization of the PIF JSON sent to Swift Build.
+    @Flag(name: .customLong("print-pif-manifest-graph"),
+          help: "Write the PIF JSON sent to Swift Build as a Graphviz file")
+    var printPIFManifestGraphviz: Bool = false
 
     /// Specific target to build.
     @Option(help: "Build the specified target")
@@ -144,7 +149,7 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
             }
             let buildManifest = try await buildOperation.getBuildManifest()
             var serializer = DOTManifestSerializer(manifest: buildManifest)
-            // print to stdout
+            // Print to stdout.
             let outputStream = stdoutStream
             serializer.writeDOT(to: outputStream)
             outputStream.flush()
@@ -162,7 +167,12 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
             productsBuildParameters.testingParameters.enableCodeCoverage = true
             toolsBuildParameters.testingParameters.enableCodeCoverage = true
         }
-
+
+        if self.options.printPIFManifestGraphviz {
+            productsBuildParameters.printPIFManifestGraphviz = true
+            toolsBuildParameters.printPIFManifestGraphviz = true
+        }
+
         try await build(swiftCommandState, subset: subset, productsBuildParameters: productsBuildParameters, toolsBuildParameters: toolsBuildParameters)
     }
 

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -22,6 +22,7 @@ import PackageGraph
 
 import SPMBuildCore
 import XCBuildSupport
+import SwiftBuildSupport
 
 import class Basics.AsyncProcess
 import var TSCBasic.stdoutStream
@@ -173,7 +174,16 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
             toolsBuildParameters.printPIFManifestGraphviz = true
         }
 
-        try await build(swiftCommandState, subset: subset, productsBuildParameters: productsBuildParameters, toolsBuildParameters: toolsBuildParameters)
+        do {
+            try await build(
+                swiftCommandState,
+                subset: subset,
+                productsBuildParameters: productsBuildParameters,
+                toolsBuildParameters: toolsBuildParameters
+            )
+        } catch SwiftBuildSupport.PIFGenerationError.printedPIFManifestGraphviz {
+            throw ExitCode.success
+        }
     }
 
     private func build(

--- a/Sources/Commands/Utilities/DOTManifestSerializer.swift
+++ b/Sources/Commands/Utilities/DOTManifestSerializer.swift
@@ -14,7 +14,7 @@ import LLBuildManifest
 
 import protocol TSCBasic.OutputByteStream
 
-/// Serializes an LLBuildManifest graph to a .dot file
+/// Serializes an LLBuildManifest graph to a .dot file.
 struct DOTManifestSerializer {
     var kindCounter = [String: Int]()
     var hasEmittedStyling = Set<String>()
@@ -25,7 +25,7 @@ struct DOTManifestSerializer {
         self.manifest = manifest
     }
 
-    /// Gets a unique label for a job name
+    /// Gets a unique label for a job name.
     mutating func label(for command: Command) -> String {
         let toolName = "\(type(of: command.tool).name)"
         var label = toolName
@@ -36,7 +36,7 @@ struct DOTManifestSerializer {
         return label
     }
 
-    /// Quote the name and escape the quotes and backslashes
+    /// Quote the name and escape the quotes and backslashes.
     func quoteName(_ name: String) -> String {
         "\"" + name.replacing("\"", with: "\\\"")
                    .replacing("\\", with: "\\\\") + "\""

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -127,6 +127,8 @@ public struct BuildParameters: Encodable {
 
     public var shouldSkipBuilding: Bool
 
+    public var printPIFManifestGraphviz: Bool = false
+
     /// Do minimal build to prepare for indexing
     public var prepareForIndexing: PrepareForIndexingMode
 

--- a/Sources/SwiftBuildSupport/DotPIFSerializer.swift
+++ b/Sources/SwiftBuildSupport/DotPIFSerializer.swift
@@ -1,0 +1,227 @@
+//
+//  DotPIFSerializer.swift
+//  SwiftPM
+//
+//  Created by Paulo Mattos on 2025-04-18.
+//
+
+import Basics
+import Foundation
+import protocol TSCBasic.OutputByteStream
+
+#if canImport(SwiftBuild)
+import SwiftBuild
+
+/// Serializes the specified PIF as a **Graphviz** directed graph.
+///
+/// * [DOT command line](https://graphviz.org/doc/info/command.html)
+/// * [DOT language specs](https://graphviz.org/doc/info/lang.html)
+func writePIF(_ workspace: PIF.Workspace, toDOT outputStream: OutputByteStream) {
+    var graph = DotPIFSerializer()
+
+    graph.node(
+        id: workspace.id,
+        label: "<workspace>\n\(workspace.id)",
+        shape: "box3d",
+        color: .black,
+        fontsize: 7
+    )
+
+    for project in workspace.projects.map(\.underlying) {
+        graph.edge(from: workspace.id, to: project.id, color: .lightskyblue)
+        graph.node(
+            id: project.id,
+            label: "<project>\n\(project.id)",
+            shape: "box3d",
+            color: .gray56,
+            fontsize: 7
+        )
+
+        for target in project.targets {
+            graph.edge(from: project.id, to: target.id, color: .lightskyblue)
+
+            switch target {
+            case .target(let target):
+                graph.node(
+                    id: target.id,
+                    label: "<target>\n\(target.id)\nproduct type: \(target.productType)\n\(target.buildPhases.summary)",
+                    shape: "box",
+                    color: .gray88,
+                    fontsize: 5
+                )
+
+            case .aggregate:
+                graph.node(
+                    id: target.id,
+                    label: "<aggregate target>\n\(target.id)",
+                    shape: "folder",
+                    color: .gray88,
+                    fontsize: 5,
+                    style: "bold"
+                )
+            }
+
+            for targetDependency in target.common.dependencies {
+                let linked = target.isLinkedAgainst(dependencyId: targetDependency.targetId)
+                graph.edge(from: target.id, to: targetDependency.targetId, color: .gray40, style: linked ? "filled" : "dotted")
+            }
+        }
+    }
+
+    graph.write(to: outputStream)
+}
+
+fileprivate struct DotPIFSerializer {
+    private var objects: [String] = []
+
+    mutating func write(to outputStream: OutputByteStream) {
+        func write(_ object: String) { outputStream.write("\(object)\n") }
+
+        write("digraph PIF {")
+        write("dpi=260;") // i.e., MacBook Pro 16" is 226 pixels per inch (3072 x 1920).
+        for object in objects {
+            write("  \(object);")
+        }
+        write("}")
+    }
+
+    mutating func node(
+        id: PIF.GUID,
+        label: String? = nil,
+        shape: String? = nil,
+        color: Color? = nil,
+        fontname: String? = "SF Mono Light",
+        fontsize: Int? = nil,
+        style: String? = nil,
+        margin: Int? = nil
+    ) {
+        var attributes: [String] = []
+
+        if let label { attributes.append("label=\(label.quote)") }
+        if let shape { attributes.append("shape=\(shape)") }
+        if let color { attributes.append("color=\(color)") }
+
+        if let fontname { attributes.append("fontname=\(fontname.quote)") }
+        if let fontsize { attributes.append("fontsize=\(fontsize)") }
+
+        if let style { attributes.append("style=\(style)") }
+        if let margin { attributes.append("margin=\(margin)") }
+
+        var node = "  \(id.quote)"
+        if !attributes.isEmpty {
+            let attributesList = attributes.joined(separator: ", ")
+            node += " [\(attributesList)]"
+        }
+        objects.append(node)
+    }
+
+    mutating func edge(
+        from left: PIF.GUID,
+        to right: PIF.GUID,
+        color: Color? = nil,
+        style: String? = nil
+    ) {
+        var attributes: [String] = []
+
+        if let color { attributes.append("color=\(color)") }
+        if let style { attributes.append("style=\(style)") }
+
+        var edge = "  \(left.quote) -> \(right.quote)"
+        if !attributes.isEmpty {
+            let attributesList = attributes.joined(separator: ", ")
+            edge += " [\(attributesList)]"
+        }
+        objects.append(edge)
+    }
+
+    /// Graphviz  default color scheme is **X11**:
+    /// * https://graphviz.org/doc/info/colors.html
+    enum Color: String {
+        case black
+        case gray
+        case gray40
+        case gray56
+        case gray88
+        case lightskyblue
+    }
+}
+
+// MARK: - Helpers
+
+fileprivate extension ProjectModel.BaseTarget {
+    func isLinkedAgainst(dependencyId: ProjectModel.GUID) -> Bool {
+        for buildPhase in self.common.buildPhases {
+            switch buildPhase {
+            case .frameworks(let frameworksPhase):
+                for buildFile in frameworksPhase.files {
+                    switch buildFile.ref {
+                    case .reference(let id):
+                        if dependencyId == id { return true }
+                    case .targetProduct(let id):
+                        if dependencyId == id { return true }
+                    }
+                }
+
+            case .sources, .shellScript, .headers, .copyFiles, .copyBundleResources:
+                break
+            }
+        }
+        return false
+    }
+}
+
+fileprivate extension [ProjectModel.BuildPhase] {
+    var summary: String {
+        var phases: [String] = []
+
+        for buildPhase in self {
+            switch buildPhase {
+            case .sources(let sourcesPhase):
+                var sources = "sources: "
+                if sourcesPhase.files.count == 1 {
+                    sources += "1 source file"
+                } else {
+                    sources += "\(sourcesPhase.files.count) source files"
+                }
+                phases.append(sources)
+
+            case .frameworks(let frameworksPhase):
+                var frameworks = "frameworks: "
+                if frameworksPhase.files.count == 1 {
+                    frameworks += "1 linked target"
+                } else {
+                    frameworks += "\(frameworksPhase.files.count) linked targets"
+                }
+                phases.append(frameworks)
+
+            case .shellScript:
+                phases.append("shellScript: 1 shell script")
+
+            case .headers, .copyFiles, .copyBundleResources:
+                break
+            }
+        }
+
+        guard !phases.isEmpty else { return "" }
+        return phases.joined(separator: "\n")
+    }
+}
+
+fileprivate extension PIF.GUID {
+    var quote: String {
+        self.value.quote
+    }
+}
+
+fileprivate extension String {
+    /// Quote the name and escape the quotes and backslashes.
+    var quote: String {
+        "\"" + self
+            .replacing("\"", with: "\\\"")
+            .replacing("\\", with: "\\\\")
+            .replacing("\n", with: "\\n") +
+        "\""
+    }
+}
+
+#endif

--- a/Sources/SwiftBuildSupport/DotPIFSerializer.swift
+++ b/Sources/SwiftBuildSupport/DotPIFSerializer.swift
@@ -78,7 +78,7 @@ fileprivate struct DotPIFSerializer {
         func write(_ object: String) { outputStream.write("\(object)\n") }
 
         write("digraph PIF {")
-        write("dpi=400;") // i.e., MacBook Pro 16" is 226 pixels per inch (3072 x 1920).
+        write("  dpi=400;") // i.e., MacBook Pro 16" is 226 pixels per inch (3072 x 1920).
         for object in objects {
             write("  \(object);")
         }
@@ -107,7 +107,7 @@ fileprivate struct DotPIFSerializer {
         if let style { attributes.append("style=\(style)") }
         if let margin { attributes.append("margin=\(margin)") }
 
-        var node = "  \(id.quote)"
+        var node = "\(id.quote)"
         if !attributes.isEmpty {
             let attributesList = attributes.joined(separator: ", ")
             node += " [\(attributesList)]"
@@ -126,7 +126,7 @@ fileprivate struct DotPIFSerializer {
         if let color { attributes.append("color=\(color)") }
         if let style { attributes.append("style=\(style)") }
 
-        var edge = "  \(left.quote) -> \(right.quote)"
+        var edge = "\(left.quote) -> \(right.quote)"
         if !attributes.isEmpty {
             let attributesList = attributes.joined(separator: ", ")
             edge += " [\(attributesList)]"

--- a/Sources/SwiftBuildSupport/DotPIFSerializer.swift
+++ b/Sources/SwiftBuildSupport/DotPIFSerializer.swift
@@ -78,7 +78,7 @@ fileprivate struct DotPIFSerializer {
         func write(_ object: String) { outputStream.write("\(object)\n") }
 
         write("digraph PIF {")
-        write("dpi=260;") // i.e., MacBook Pro 16" is 226 pixels per inch (3072 x 1920).
+        write("dpi=400;") // i.e., MacBook Pro 16" is 226 pixels per inch (3072 x 1920).
         for object in objects {
             write("  \(object);")
         }

--- a/Sources/SwiftBuildSupport/PIF.swift
+++ b/Sources/SwiftBuildSupport/PIF.swift
@@ -158,7 +158,7 @@ public enum PIF {
             }
         }
         
-        // FIXME: Delete this (rdar://149003797).
+        // FIXME: Delete this (https://github.com/swiftlang/swift-package-manager/issues/8552).
         public required init(from decoder: Decoder) throws {
             let superContainer = try decoder.container(keyedBy: HighLevelObject.CodingKeys.self)
             let contents = try superContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: .contents)
@@ -206,7 +206,7 @@ public enum PIF {
             }
         }
         
-        // FIXME: Delete this (rdar://149003797).
+        // FIXME: Delete this (https://github.com/swiftlang/swift-package-manager/issues/8552).
         public required init(from decoder: Decoder) throws {
             let superContainer = try decoder.container(keyedBy: HighLevelObject.CodingKeys.self)
             self.underlying = try superContainer.decode(ProjectModel.Project.self, forKey: .contents)
@@ -244,7 +244,8 @@ public enum PIF {
         }
         
         public required init(from decoder: Decoder) throws {
-            // FIXME: Remove all support for decoding PIF objects in SwiftBuildSupport? rdar://149003797
+            // FIXME: Remove all support for decoding PIF objects in SwiftBuildSupport?
+            // (https://github.com/swiftlang/swift-package-manager/issues/8552)
             fatalError("Decoding not implemented")
             /*
             let superContainer = try decoder.container(keyedBy: HighLevelObject.CodingKeys.self)

--- a/Sources/SwiftBuildSupport/PIF.swift
+++ b/Sources/SwiftBuildSupport/PIF.swift
@@ -117,18 +117,18 @@ public enum PIF {
     public final class Workspace: HighLevelObject {
         override class var type: String { "workspace" }
         
-        public let guid: GUID
+        public let id: GUID
         public var name: String
         public var path: AbsolutePath
         public var projects: [Project]
         var signature: String?
 
-        public init(guid: GUID, name: String, path: AbsolutePath, projects: [ProjectModel.Project]) {
-            precondition(!guid.value.isEmpty)
+        public init(id: GUID, name: String, path: AbsolutePath, projects: [ProjectModel.Project]) {
+            precondition(!id.value.isEmpty)
             precondition(!name.isEmpty)
             precondition(Set(projects.map(\.id)).count == projects.count)
             
-            self.guid = guid
+            self.id = id
             self.name = name
             self.path = path
             self.projects = projects.map { Project(wrapping: $0) }
@@ -145,7 +145,7 @@ public enum PIF {
             var superContainer = encoder.container(keyedBy: HighLevelObject.CodingKeys.self)
             var contents = superContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: .contents)
             
-            try contents.encode("\(guid)", forKey: .guid)
+            try contents.encode("\(id)", forKey: .guid)
             try contents.encode(name, forKey: .name)
             try contents.encode(path, forKey: .path)
             try contents.encode(projects.map(\.signature), forKey: .projects)
@@ -158,11 +158,12 @@ public enum PIF {
             }
         }
         
+        // FIXME: Delete this (rdar://149003797).
         public required init(from decoder: Decoder) throws {
             let superContainer = try decoder.container(keyedBy: HighLevelObject.CodingKeys.self)
             let contents = try superContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: .contents)
             
-            self.guid = try contents.decode(GUID.self, forKey: .guid)
+            self.id = try contents.decode(GUID.self, forKey: .guid)
             self.name = try contents.decode(String.self, forKey: .name)
             self.path = try contents.decode(AbsolutePath.self, forKey: .path)
             self.projects = try contents.decode([Project].self, forKey: .projects)
@@ -205,6 +206,7 @@ public enum PIF {
             }
         }
         
+        // FIXME: Delete this (rdar://149003797).
         public required init(from decoder: Decoder) throws {
             let superContainer = try decoder.container(keyedBy: HighLevelObject.CodingKeys.self)
             self.underlying = try superContainer.decode(ProjectModel.Project.self, forKey: .contents)

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -418,7 +418,7 @@ public enum PIFGenerationError: Error {
         supportedVersions: [SwiftLanguageVersion]
     )
 
-    /// Early exit from a method when using `--print-pif-manifest-graph`.
+    /// Early build termination when using `--print-pif-manifest-graph`.
     case printedPIFManifestGraphviz
 }
 

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -23,7 +23,6 @@ import SPMBuildCore
 import func TSCBasic.memoize
 import func TSCBasic.topologicalSort
 import var TSCBasic.stdoutStream
-import struct ArgumentParser.ExitCode
 
 #if canImport(SwiftBuild)
 import enum SwiftBuild.ProjectModel
@@ -125,7 +124,7 @@ public final class PIFBuilder {
 
             // Abort the build process, ensuring we don't add
             // further noise to stdout (and break `dot` graph parsing).
-            throw ExitCode.success
+            throw PIFGenerationError.printedPIFManifestGraphviz
         }
 
         return pifString
@@ -418,6 +417,9 @@ public enum PIFGenerationError: Error {
         versions: [SwiftLanguageVersion],
         supportedVersions: [SwiftLanguageVersion]
     )
+
+    /// Early exit from a method when using `--print-pif-manifest-graph`.
+    case printedPIFManifestGraphviz
 }
 
 extension PIFGenerationError: CustomStringConvertible {
@@ -436,6 +438,9 @@ extension PIFGenerationError: CustomStringConvertible {
         ):
             "None of the Swift language versions used in target '\(target)' settings are supported." +
             " (given: \(given), supported: \(supported))"
+
+        case .printedPIFManifestGraphviz:
+            "Printed PIF manifest as graphviz"
         }
     }
 }

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -969,7 +969,6 @@ extension ProjectModel.BuildSettings.Platform {
         case .windows: .windows
         case .wasi: .wasi
         case .openbsd: .openbsd
-        case .freebsd: .freebsd
         default: preconditionFailure("Unexpected platform: \(platform.name)")
         }
     }

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -238,7 +238,9 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         }
 
         let pifBuilder = try await getPIFBuilder()
-        let pif = try pifBuilder.generatePIF()
+        let pif = try pifBuilder.generatePIF(
+            printPIFManifestGraphviz: buildParameters.printPIFManifestGraphviz
+        )
 
         try self.fileSystem.writeIfChanged(path: buildParameters.pifManifest, string: pif)
 


### PR DESCRIPTION
### Motivation:

Improve visualization/debuggability of the **PIF JSON** sent over to Swift Build (when using the new `--build-system swiftbuild` option).

### Modifications:

This PR introduces the `--print-pif-manifest-graph` option to write out the PIF JSON sent to Swift Build as a [Graphviz file](https://graphviz.org) file. This follows a similar design we used for the existing `--print-manifest-job-graph` option.

All the serialization happens in the new `DotPIFSerializer.swift` file, with this function as the entry point:
```swift
func writePIF(_ workspace: PIF.Workspace, toDOT outputStream: OutputByteStream)
```

### Result:

With [Graphviz tool](https://graphviz.org) installed (i.e., provides the `dot` command below), we can then run commands like this:
```shell
swift build --build-system swiftbuild --print-pif-manifest-graph | dot -Tpng > PIF.png; open PIF.png
```
A few quick examples:

#### Sample Executable

```shell
(mkdir Foo; cd Foo; swift package init --name Foo --type executable)
swift build --build-system swiftbuild --package-path Foo --print-pif-manifest-graph | dot -Tpng > Foo.png
```
<img src="https://github.com/user-attachments/assets/2b72420b-fe9d-435c-8288-cb3953f10ee4" width=520/>

```
digraph PIF {
  dpi=400;
  "Workspace:/Users/pmattos/SwiftPM/graphviz-for-pif/Foo" [label="<workspace>\nWorkspace:/Users/pmattos/SwiftPM/graphviz-for-pif/Foo", shape=box3d, color=black, fontname="SF Mono Light", fontsize=7];
  "Workspace:/Users/pmattos/SwiftPM/graphviz-for-pif/Foo" -> "PACKAGE:foo" [color=lightskyblue];
  "PACKAGE:foo" [label="<project>\nPACKAGE:foo", shape=box3d, color=gray56, fontname="SF Mono Light", fontsize=7];
  "PACKAGE:foo" -> "PACKAGE-PRODUCT:Foo" [color=lightskyblue];
  "PACKAGE-PRODUCT:Foo" [label="<target>\nPACKAGE-PRODUCT:Foo\nproduct type: executable\nsources: 1 source file", shape=box, color=gray88, fontname="SF Mono Light", fontsize=5];
  "PACKAGE:foo" -> "PACKAGE-TARGET:Foo-1DD02E5F-testable" [color=lightskyblue];
  "PACKAGE-TARGET:Foo-1DD02E5F-testable" [label="<target>\nPACKAGE-TARGET:Foo-1DD02E5F-testable\nproduct type: objectFile\nsources: 1 source file", shape=box, color=gray88, fontname="SF Mono Light", fontsize=5];
  "Workspace:/Users/pmattos/SwiftPM/graphviz-for-pif/Foo" -> "AGGREGATE" [color=lightskyblue];
  "AGGREGATE" [label="<project>\nAGGREGATE", shape=box3d, color=gray56, fontname="SF Mono Light", fontsize=7];
  "AGGREGATE" -> "ALL-INCLUDING-TESTS" [color=lightskyblue];
  "ALL-INCLUDING-TESTS" [label="<aggregate target>\nALL-INCLUDING-TESTS", shape=folder, color=gray88, fontname="SF Mono Light", fontsize=5, style=bold];
  "ALL-INCLUDING-TESTS" -> "PACKAGE-PRODUCT:Foo" [color=gray40, style=dotted];
  "ALL-INCLUDING-TESTS" -> "PACKAGE-TARGET:Foo-1DD02E5F-testable" [color=gray40, style=dotted];
  "AGGREGATE" -> "ALL-EXCLUDING-TESTS" [color=lightskyblue];
  "ALL-EXCLUDING-TESTS" [label="<aggregate target>\nALL-EXCLUDING-TESTS", shape=folder, color=gray88, fontname="SF Mono Light", fontsize=5, style=bold];
  "ALL-EXCLUDING-TESTS" -> "PACKAGE-PRODUCT:Foo" [color=gray40, style=dotted];
  "ALL-EXCLUDING-TESTS" -> "PACKAGE-TARGET:Foo-1DD02E5F-testable" [color=gray40, style=dotted];
}
```

#### Sample Library

```shell
(mkdir Bar; cd Bar; swift package init --name Bar --type library)
swift build --build-system swiftbuild --package-path Bar --print-pif-manifest-graph | dot -Tpng > Bar.png
```
<img src="https://github.com/user-attachments/assets/8f81d147-a5c9-4a93-82a7-324fc0e9563a" width=820/>

```
digraph PIF {
  dpi=400;
  "Workspace:/Users/pmattos/SwiftPM/graphviz-for-pif/Bar" [label="<workspace>\nWorkspace:/Users/pmattos/SwiftPM/graphviz-for-pif/Bar", shape=box3d, color=black, fontname="SF Mono Light", fontsize=7];
  "Workspace:/Users/pmattos/SwiftPM/graphviz-for-pif/Bar" -> "PACKAGE:bar" [color=lightskyblue];
  "PACKAGE:bar" [label="<project>\nPACKAGE:bar", shape=box3d, color=gray56, fontname="SF Mono Light", fontsize=7];
  "PACKAGE:bar" -> "PACKAGE-PRODUCT:BarTests" [color=lightskyblue];
  "PACKAGE-PRODUCT:BarTests" [label="<target>\nPACKAGE-PRODUCT:BarTests\nproduct type: unitTest\nsources: 1 source file\nframeworks: 1 linked target", shape=box, color=gray88, fontname="SF Mono Light", fontsize=5];
  "PACKAGE-PRODUCT:BarTests" -> "PACKAGE-TARGET:Bar" [color=gray40, style=filled];
  "PACKAGE:bar" -> "PACKAGE-PRODUCT:Bar" [color=lightskyblue];
  "PACKAGE-PRODUCT:Bar" [label="<target>\nPACKAGE-PRODUCT:Bar\nproduct type: packageProduct\nframeworks: 1 linked target", shape=box, color=gray88, fontname="SF Mono Light", fontsize=5];
  "PACKAGE-PRODUCT:Bar" -> "PACKAGE-TARGET:Bar" [color=gray40, style=filled];
  "PACKAGE:bar" -> "PACKAGE-PRODUCT:Bar-1DAB67D8-dynamic" [color=lightskyblue];
  "PACKAGE-PRODUCT:Bar-1DAB67D8-dynamic" [label="<target>\nPACKAGE-PRODUCT:Bar-1DAB67D8-dynamic\nproduct type: dynamicLibrary\nframeworks: 1 linked target\nsources: 0 source files", shape=box, color=gray88, fontname="SF Mono Light", fontsize=5];
  "PACKAGE-PRODUCT:Bar-1DAB67D8-dynamic" -> "PACKAGE-TARGET:Bar" [color=gray40, style=filled];
  "PACKAGE:bar" -> "PACKAGE-TARGET:Bar" [color=lightskyblue];
  "PACKAGE-TARGET:Bar" [label="<target>\nPACKAGE-TARGET:Bar\nproduct type: objectFile\nsources: 1 source file", shape=box, color=gray88, fontname="SF Mono Light", fontsize=5];
  "PACKAGE:bar" -> "PACKAGE-TARGET:Bar-1DAB67D8-dynamic" [color=lightskyblue];
  "PACKAGE-TARGET:Bar-1DAB67D8-dynamic" [label="<target>\nPACKAGE-TARGET:Bar-1DAB67D8-dynamic\nproduct type: dynamicLibrary\nsources: 1 source file", shape=box, color=gray88, fontname="SF Mono Light", fontsize=5];
  "Workspace:/Users/pmattos/SwiftPM/graphviz-for-pif/Bar" -> "AGGREGATE" [color=lightskyblue];
  "AGGREGATE" [label="<project>\nAGGREGATE", shape=box3d, color=gray56, fontname="SF Mono Light", fontsize=7];
  "AGGREGATE" -> "ALL-INCLUDING-TESTS" [color=lightskyblue];
  "ALL-INCLUDING-TESTS" [label="<aggregate target>\nALL-INCLUDING-TESTS", shape=folder, color=gray88, fontname="SF Mono Light", fontsize=5, style=bold];
  "ALL-INCLUDING-TESTS" -> "PACKAGE-PRODUCT:BarTests" [color=gray40, style=dotted];
  "ALL-INCLUDING-TESTS" -> "PACKAGE-PRODUCT:Bar" [color=gray40, style=dotted];
  "ALL-INCLUDING-TESTS" -> "PACKAGE-TARGET:Bar" [color=gray40, style=dotted];
  "AGGREGATE" -> "ALL-EXCLUDING-TESTS" [color=lightskyblue];
  "ALL-EXCLUDING-TESTS" [label="<aggregate target>\nALL-EXCLUDING-TESTS", shape=folder, color=gray88, fontname="SF Mono Light", fontsize=5, style=bold];
  "ALL-EXCLUDING-TESTS" -> "PACKAGE-PRODUCT:Bar" [color=gray40, style=dotted];
  "ALL-EXCLUDING-TESTS" -> "PACKAGE-TARGET:Bar" [color=gray40, style=dotted];
}
```