### PR TITLE
Add FreeBSD support to SwiftBuild PIF builder

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -969,6 +969,7 @@ extension ProjectModel.BuildSettings.Platform {
         case .windows: .windows
         case .wasi: .wasi
         case .openbsd: .openbsd
+        case .freebsd: .freebsd
         default: preconditionFailure("Unexpected platform: \(platform.name)")
         }
     }


### PR DESCRIPTION
### Motivation:

Add **FreeBSD** support to SwiftBuild PIF builder (i.e., when using `--build-system swiftbuild`).

### Modifications:

Just a quick change in how we map a `PackageModel.Platform` value to a `SwiftBuild.ProjectModel.BuildSettings.Platform` one.