### PR TITLE
Use async methods when loading manifests

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -59,4 +59,20 @@ extension DispatchQueue {
             }
         }
     }
+
+    package func asyncResult<T: Sendable>(_ callback: @escaping @Sendable (Result<T, Error>) -> Void, _ closure: @escaping @Sendable () async throws -> T) {
+        let completion: @Sendable (Result<T, Error>) -> Void = {
+            result in self.async {
+                callback(result)
+            }
+        }
+
+        Task {
+            do {
+                completion(.success(try await closure()))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
 }

--- a/Sources/Commands/PackageCommands/ResetCommands.swift
+++ b/Sources/Commands/PackageCommands/ResetCommands.swift
@@ -27,15 +27,15 @@ extension SwiftPackageCommand {
         }
     }
 
-    struct PurgeCache: SwiftCommand {
+    struct PurgeCache: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Purge the global repository cache.")
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        func run(_ swiftCommandState: SwiftCommandState) throws {
-            try swiftCommandState.getActiveWorkspace().purgeCache(observabilityScope: swiftCommandState.observabilityScope)
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
+            try await swiftCommandState.getActiveWorkspace().purgeCache(observabilityScope: swiftCommandState.observabilityScope)
         }
     }
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -201,10 +201,18 @@ extension ManifestLoaderProtocol {
         delegateQueue: DispatchQueue
     ) async throws -> Manifest {
         // find the manifest path and parse it's tools-version
-        let manifestPath = try ManifestLoader.findManifest(packagePath: packagePath, fileSystem: fileSystem, currentToolsVersion: currentToolsVersion)
+        let manifestPath = try ManifestLoader.findManifest(
+            packagePath: packagePath, 
+            fileSystem: fileSystem, 
+            currentToolsVersion: currentToolsVersion
+        )
         let manifestToolsVersion = try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: fileSystem)
         // validate the manifest tools-version against the toolchain tools-version
-        try manifestToolsVersion.validateToolsVersion(currentToolsVersion, packageIdentity: packageIdentity, packageVersion: packageVersion?.version?.description ?? packageVersion?.revision)
+        try manifestToolsVersion.validateToolsVersion(
+            currentToolsVersion, 
+            packageIdentity: packageIdentity, 
+            packageVersion: packageVersion?.version?.description ?? packageVersion?.revision
+        )
 
         return try await self.load(
             manifestPath: manifestPath,
@@ -652,7 +660,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 )
             ]).write(to: vfsOverlayTempFilePath, fileSystem: localFileSystem)
 
-            let _ = try await validateImports(
+            try await validateImports(
                 manifestPath: manifestTempFilePath,
                 toolsVersion: toolsVersion
             )

--- a/Sources/PackageMetadata/PackageMetadata.swift
+++ b/Sources/PackageMetadata/PackageMetadata.swift
@@ -329,15 +329,15 @@ public struct PackageSearchClient {
         timeout: DispatchTimeInterval? = .none,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @escaping (Result<Set<PackageIdentity>, Error>) -> Void
+        completion: @Sendable @escaping (Result<Set<PackageIdentity>, Error>) -> Void
     ) {
-        registryClient.lookupIdentities(
-            scmURL: scmURL,
-            timeout: timeout,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue,
-            completion: completion
-        )
+        callbackQueue.asyncResult(completion) {
+            try await registryClient.lookupIdentities(
+                scmURL: scmURL,
+                timeout: timeout,
+                observabilityScope: observabilityScope
+            )
+        }
     }
 
     public func lookupSCMURLs(
@@ -345,21 +345,16 @@ public struct PackageSearchClient {
         timeout: DispatchTimeInterval? = .none,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @escaping (Result<Set<SourceControlURL>, Error>) -> Void
+        completion: @Sendable @escaping (Result<Set<SourceControlURL>, Error>) -> Void
     ) {
-        registryClient.getPackageMetadata(
-            package: package,
-            timeout: timeout,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue
-        ) { result in
-            do {
-                let metadata = try result.get()
-                let alternateLocations = metadata.alternateLocations
-                return completion(.success(Set(alternateLocations)))
-            } catch {
-                return completion(.failure(error))
-            }
+        callbackQueue.asyncResult(completion) {
+            let metadata = try await registryClient.getPackageMetadata(
+                package: package,
+                timeout: timeout,
+                observabilityScope: observabilityScope
+            )
+            let alternateLocations = metadata.alternateLocations
+            return Set(alternateLocations)
         }
     }
 }

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -2352,7 +2352,7 @@ extension Result {
 }
 
 extension DispatchQueue {
-    func asyncResult<T>(_ callback: @escaping (Result<T, Error>) -> Void, _ closure: @escaping () async throws -> T) {
+    public func asyncResult<T>(_ callback: @escaping (Result<T, Error>) -> Void, _ closure: @escaping () async throws -> T) {
         let completion: (Result<T, Error>) -> Void = { result in self.async { callback(result) } }
         Task {
             do {

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -2350,17 +2350,3 @@ extension Result {
         }
     }
 }
-
-extension DispatchQueue {
-    public func asyncResult<T>(_ callback: @escaping (Result<T, Error>) -> Void, _ closure: @escaping () async throws -> T) {
-        let completion: (Result<T, Error>) -> Void = { result in self.async { callback(result) } }
-        Task {
-            do {
-                completion(.success(try await closure()))
-            } catch {
-                completion(.failure(error))
-            }
-        }
-    }
-}
-

--- a/Sources/Workspace/PackageContainer/FileSystemPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/FileSystemPackageContainer.swift
@@ -78,26 +78,19 @@ public struct FileSystemPackageContainer: PackageContainer {
             }
 
             // Load the manifest.
-            // FIXME: this should not block
-            return try await withCheckedThrowingContinuation { continuation in
-                manifestLoader.load(
-                    packagePath: packagePath,
-                    packageIdentity: self.package.identity,
-                    packageKind: self.package.kind,
-                    packageLocation: self.package.locationString,
-                    packageVersion: nil,
-                    currentToolsVersion: self.currentToolsVersion,
-                    identityResolver: self.identityResolver,
-                    dependencyMapper: self.dependencyMapper,
-                    fileSystem: self.fileSystem,
-                    observabilityScope: self.observabilityScope,
-                    delegateQueue: .sharedConcurrent,
-                    callbackQueue: .sharedConcurrent,
-                    completion: {
-                        continuation.resume(with: $0)
-                    }
-                )
-            }
+            return try await manifestLoader.load(
+                packagePath: packagePath,
+                packageIdentity: self.package.identity,
+                packageKind: self.package.kind,
+                packageLocation: self.package.locationString,
+                packageVersion: nil,
+                currentToolsVersion: self.currentToolsVersion,
+                identityResolver: self.identityResolver,
+                dependencyMapper: self.dependencyMapper,
+                fileSystem: self.fileSystem,
+                observabilityScope: self.observabilityScope,
+                delegateQueue: .sharedConcurrent
+            )
         }
     }
 

--- a/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
@@ -148,8 +148,7 @@ public class RegistryPackageContainer: PackageContainer {
                 dependencyMapper: self.dependencyMapper,
                 fileSystem: result.fileSystem,
                 observabilityScope: self.observabilityScope,
-                delegateQueue: .sharedConcurrent,
-                callbackQueue: .sharedConcurrent
+                delegateQueue: .sharedConcurrent
             )
         }
 

--- a/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
@@ -397,26 +397,19 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
 
     private func loadManifest(fileSystem: FileSystem, version: Version?, revision: String) async throws -> Manifest {
         // Load the manifest.
-        // FIXME: this should not block
-        return try await withCheckedThrowingContinuation { continuation in
-            self.manifestLoader.load(
-                packagePath: .root,
-                packageIdentity: self.package.identity,
-                packageKind: self.package.kind,
-                packageLocation: self.package.locationString,
-                packageVersion: (version: version, revision: revision),
-                currentToolsVersion: self.currentToolsVersion,
-                identityResolver: self.identityResolver,
-                dependencyMapper: self.dependencyMapper,
-                fileSystem: fileSystem,
-                observabilityScope: self.observabilityScope,
-                delegateQueue: .sharedConcurrent,
-                callbackQueue: .sharedConcurrent,
-                completion: {
-                    continuation.resume(with: $0)
-                }
-            )
-        }
+        return try await self.manifestLoader.load(
+            packagePath: .root,
+            packageIdentity: self.package.identity,
+            packageKind: self.package.kind,
+            packageLocation: self.package.locationString,
+            packageVersion: (version: version, revision: revision),
+            currentToolsVersion: self.currentToolsVersion,
+            identityResolver: self.identityResolver,
+            dependencyMapper: self.dependencyMapper,
+            fileSystem: fileSystem,
+            observabilityScope: self.observabilityScope,
+            delegateQueue: .sharedConcurrent
+        )
     }
 
     public func getEnabledTraits(traitConfiguration: TraitConfiguration, at revision: String?, version: Version?) async throws -> Set<String> {

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -507,7 +507,6 @@ extension Workspace {
         // Ensure the cache path exists and validate that edited dependencies.
         self.createCacheDirectories(observabilityScope: observabilityScope)
 
-        // FIXME: this should not block
         // Load the root manifests and currently checked out manifests.
         let rootManifests = try await self.loadRootManifests(
             packages: root.packages,

--- a/Sources/Workspace/Workspace+Editing.swift
+++ b/Sources/Workspace/Workspace+Editing.swift
@@ -66,19 +66,13 @@ extension Workspace {
         // If there is something present at the destination, we confirm it has
         // a valid manifest with name canonical location as the package we are trying to edit.
         if fileSystem.exists(destination) {
-            // FIXME: this should not block
-            let manifest = try await withCheckedThrowingContinuation { continuation in
-                self.loadManifest(
-                    packageIdentity: dependency.packageRef.identity,
-                    packageKind: .fileSystem(destination),
-                    packagePath: destination,
-                    packageLocation: dependency.packageRef.locationString,
-                    observabilityScope: observabilityScope,
-                    completion: {
-                      continuation.resume(with: $0)
-                    }
-                )
-            }
+            let manifest = try await self.loadManifest(
+                packageIdentity: dependency.packageRef.identity,
+                packageKind: .fileSystem(destination),
+                packagePath: destination,
+                packageLocation: dependency.packageRef.locationString,
+                observabilityScope: observabilityScope
+            )
 
             guard dependency.packageRef.canonicalLocation == manifest.canonicalPackageLocation else {
                 return observabilityScope

--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -842,19 +842,15 @@ extension Workspace {
         }
 
         // Load and return the manifest.
-        return await withCheckedContinuation { continuation in
-            self.loadManifest(
-                packageIdentity: managedDependency.packageRef.identity,
-                packageKind: packageKind,
-                packagePath: packagePath,
-                packageLocation: managedDependency.packageRef.locationString,
-                packageVersion: packageVersion,
-                fileSystem: fileSystem,
-                observabilityScope: observabilityScope
-            ) { result in
-                continuation.resume(returning: try? result.get())
-            }
-        }
+        return try? await self.loadManifest(
+            packageIdentity: managedDependency.packageRef.identity,
+            packageKind: packageKind,
+            packagePath: packagePath,
+            packageLocation: managedDependency.packageRef.locationString,
+            packageVersion: packageVersion,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope
+        )
     }
 
     /// Load the manifest at a given path.
@@ -867,9 +863,8 @@ extension Workspace {
         packageLocation: String,
         packageVersion: Version? = nil,
         fileSystem: FileSystem? = nil,
-        observabilityScope: ObservabilityScope,
-        completion: @escaping (Result<Manifest, Error>) -> Void
-    ) {
+        observabilityScope: ObservabilityScope
+    ) async throws -> Manifest {
         let fileSystem = fileSystem ?? self.fileSystem
 
         // Load the manifest, bracketed by the calls to the delegate callbacks.
@@ -886,63 +881,63 @@ extension Workspace {
         }
 
         var manifestLoadingDiagnostics = [Diagnostic]()
+        defer { manifestLoadingScope.emit(manifestLoadingDiagnostics) }
 
         let start = DispatchTime.now()
-        self.manifestLoader.load(
-            packagePath: packagePath,
-            packageIdentity: packageIdentity,
-            packageKind: packageKind,
-            packageLocation: packageLocation,
-            packageVersion: packageVersion.map { (version: $0, revision: nil) },
-            currentToolsVersion: self.currentToolsVersion,
-            identityResolver: self.identityResolver,
-            dependencyMapper: self.dependencyMapper,
-            fileSystem: fileSystem,
-            observabilityScope: manifestLoadingScope,
-            delegateQueue: .sharedConcurrent,
-            callbackQueue: .sharedConcurrent
-        ) { result in
+        let manifest: Manifest
+        do {
+            manifest = try await self.manifestLoader.load(
+                packagePath: packagePath,
+                packageIdentity: packageIdentity,
+                packageKind: packageKind,
+                packageLocation: packageLocation,
+                packageVersion: packageVersion.map { (version: $0, revision: nil) },
+                currentToolsVersion: self.currentToolsVersion,
+                identityResolver: self.identityResolver,
+                dependencyMapper: self.dependencyMapper,
+                fileSystem: fileSystem,
+                observabilityScope: manifestLoadingScope,
+                delegateQueue: .sharedConcurrent
+            )
+        } catch {
             let duration = start.distance(to: .now())
-            var result = result
-            switch result {
-            case .failure(let error):
-                manifestLoadingDiagnostics.append(.error(error))
-                self.delegate?.didLoadManifest(
-                    packageIdentity: packageIdentity,
-                    packagePath: packagePath,
-                    url: packageLocation,
-                    version: packageVersion,
-                    packageKind: packageKind,
-                    manifest: nil,
-                    diagnostics: manifestLoadingDiagnostics,
-                    duration: duration
-                )
-            case .success(let manifest):
-                let validator = ManifestValidator(
-                    manifest: manifest,
-                    sourceControlValidator: self.repositoryManager,
-                    fileSystem: self.fileSystem
-                )
-                let validationIssues = validator.validate()
-                if !validationIssues.isEmpty {
-                    // Diagnostics.fatalError indicates that a more specific diagnostic has already been added.
-                    result = .failure(Diagnostics.fatalError)
-                    manifestLoadingDiagnostics.append(contentsOf: validationIssues)
-                }
-                self.delegate?.didLoadManifest(
-                    packageIdentity: packageIdentity,
-                    packagePath: packagePath,
-                    url: packageLocation,
-                    version: packageVersion,
-                    packageKind: packageKind,
-                    manifest: manifest,
-                    diagnostics: manifestLoadingDiagnostics,
-                    duration: duration
-                )
-            }
-            manifestLoadingScope.emit(manifestLoadingDiagnostics)
-            completion(result)
+            manifestLoadingDiagnostics.append(.error(error))
+            self.delegate?.didLoadManifest(
+                packageIdentity: packageIdentity,
+                packagePath: packagePath,
+                url: packageLocation,
+                version: packageVersion,
+                packageKind: packageKind,
+                manifest: nil,
+                diagnostics: manifestLoadingDiagnostics,
+                duration: duration
+            )
+            throw error
         }
+
+        let duration = start.distance(to: .now())
+        let validator = ManifestValidator(
+            manifest: manifest,
+            sourceControlValidator: self.repositoryManager,
+            fileSystem: self.fileSystem
+        )
+        let validationIssues = validator.validate()
+        if !validationIssues.isEmpty {
+            // Diagnostics.fatalError indicates that a more specific diagnostic has already been added.
+            manifestLoadingDiagnostics.append(contentsOf: validationIssues)
+            throw Diagnostics.fatalError
+        }
+        self.delegate?.didLoadManifest(
+            packageIdentity: packageIdentity,
+            packagePath: packagePath,
+            url: packageLocation,
+            version: packageVersion,
+            packageKind: packageKind,
+            manifest: manifest,
+            diagnostics: manifestLoadingDiagnostics,
+            duration: duration
+        )
+        return manifest
     }
 
     /// Validates that all the edited dependencies are still present in the file system.

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -84,11 +84,9 @@ extension Workspace {
             dependencyMapper: any DependencyMapper,
             fileSystem: any FileSystem,
             observabilityScope: ObservabilityScope,
-            delegateQueue: DispatchQueue,
-            callbackQueue: DispatchQueue,
-            completion: @escaping (Result<Manifest, Error>) -> Void
-        ) {
-            self.underlying.load(
+            delegateQueue: DispatchQueue
+        ) async throws -> Manifest {
+            let manifest = try await self.underlying.load(
                 manifestPath: manifestPath,
                 manifestToolsVersion: manifestToolsVersion,
                 packageIdentity: packageIdentity,
@@ -99,81 +97,69 @@ extension Workspace {
                 dependencyMapper: dependencyMapper,
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope,
-                delegateQueue: delegateQueue,
-                callbackQueue: callbackQueue
-            ) { result in
-                switch result {
-                case .failure(let error):
-                    completion(.failure(error))
-                case .success(let manifest):
-                    self.transformSourceControlDependenciesToRegistry(
-                        manifest: manifest,
-                        transformationMode: transformationMode,
-                        observabilityScope: observabilityScope,
-                        callbackQueue: callbackQueue,
-                        completion: completion
-                    )
-                }
-            }
+                delegateQueue: delegateQueue
+            )
+            return try await self.transformSourceControlDependenciesToRegistry(
+                manifest: manifest,
+                transformationMode: transformationMode,
+                observabilityScope: observabilityScope
+            )
         }
 
-        func resetCache(observabilityScope: ObservabilityScope) {
-            self.underlying.resetCache(observabilityScope: observabilityScope)
+        func resetCache(observabilityScope: ObservabilityScope) async {
+            await self.underlying.resetCache(observabilityScope: observabilityScope)
         }
 
-        func purgeCache(observabilityScope: ObservabilityScope) {
-            self.underlying.purgeCache(observabilityScope: observabilityScope)
+        func purgeCache(observabilityScope: ObservabilityScope) async {
+            await self.underlying.purgeCache(observabilityScope: observabilityScope)
         }
 
         private func transformSourceControlDependenciesToRegistry(
             manifest: Manifest,
             transformationMode: TransformationMode,
-            observabilityScope: ObservabilityScope,
-            callbackQueue: DispatchQueue,
-            completion: @escaping (Result<Manifest, Error>) -> Void
-        ) {
-            let sync = DispatchGroup()
-            let transformations = ThreadSafeKeyValueStore<PackageDependency, PackageIdentity>()
-            for dependency in manifest.dependencies {
-                if case .sourceControl(let settings) = dependency, case .remote(let url) = settings.location {
-                    sync.enter()
-                    self.mapRegistryIdentity(
-                        url: url,
-                        observabilityScope: observabilityScope,
-                        callbackQueue: callbackQueue
-                    ) { result in
-                        defer { sync.leave() }
-                        switch result {
-                        case .failure(let error):
-                            // do not raise error, only report it as warning
-                            observabilityScope.emit(
-                                warning: "failed querying registry identity for '\(url)'",
-                                underlyingError: error
-                            )
-                        case .success(.some(let identity)):
-                            transformations[dependency] = identity
-                        case .success(.none):
-                            // no identity found
-                            break
+            observabilityScope: ObservabilityScope
+        ) async throws -> Manifest {
+            var transformations = [PackageDependency: PackageIdentity]()
+
+            try await withThrowingTaskGroup(of: (PackageDependency, PackageIdentity?).self) { group in
+                for dependency in manifest.dependencies {
+                    if case .sourceControl(let settings) = dependency, case .remote(let url) = settings.location {
+                        group.addTask {
+                            do {
+                                let identity = try await self.mapRegistryIdentity(
+                                    url: url,
+                                    observabilityScope: observabilityScope
+                                )
+                                return (dependency, identity)
+                            } catch {
+                                // do not raise error, only report it as warning
+                                observabilityScope.emit(
+                                    warning: "failed querying registry identity for '\(url)'",
+                                    underlyingError: error
+                                )
+                                return (dependency, nil)
+                            }
                         }
+                    }
+                }
+
+                // Collect the results from the group
+                for try await (dependency, identity) in group {
+                    if let identity {
+                        transformations[dependency] = identity
                     }
                 }
             }
 
             // update the manifest with the transformed dependencies
-            sync.notify(queue: callbackQueue) {
-                do {
-                    let updatedManifest = try self.transformManifest(
-                        manifest: manifest,
-                        transformations: transformations.get(),
-                        transformationMode: transformationMode,
-                        observabilityScope: observabilityScope
-                    )
-                    completion(.success(updatedManifest))
-                } catch {
-                    return completion(.failure(error))
-                }
-            }
+            let updatedManifest = try self.transformManifest(
+                manifest: manifest,
+                transformations: transformations,
+                transformationMode: transformationMode,
+                observabilityScope: observabilityScope
+            )
+
+            return updatedManifest
         }
 
         private func transformManifest(
@@ -344,35 +330,29 @@ extension Workspace {
 
         private func mapRegistryIdentity(
             url: SourceControlURL,
-            observabilityScope: ObservabilityScope,
-            callbackQueue: DispatchQueue,
-            completion: @escaping (Result<PackageIdentity?, Error>) -> Void
-        ) {
+            observabilityScope: ObservabilityScope
+        ) async throws -> PackageIdentity? {
             if let cached = self.identityLookupCache[url], cached.expirationTime > .now() {
                 switch cached.result {
                 case .success(let identity):
-                    return completion(.success(identity))
+                    return identity;
                 case .failure:
                     // server error, do not try again
-                    return completion(.success(.none))
+                    return nil
                 }
             }
 
-            self.registryClient.lookupIdentities(
-                scmURL: url,
-                observabilityScope: observabilityScope,
-                callbackQueue: callbackQueue
-            ) { result in
-                switch result {
-                case .failure(let error):
-                    self.identityLookupCache[url] = (result: .failure(error), expirationTime: .now() + self.cacheTTL)
-                    completion(.failure(error))
-                case .success(let identities):
-                    // FIXME: returns first result... need to consider how to address multiple ones
-                    let identity = identities.sorted().first
-                    self.identityLookupCache[url] = (result: .success(identity), expirationTime: .now() + self.cacheTTL)
-                    completion(.success(identity))
-                }
+            do {
+                let identities = try await self.registryClient.lookupIdentities(
+                    scmURL: url,
+                    observabilityScope: observabilityScope
+                )
+                let identity = identities.sorted().first
+                self.identityLookupCache[url] = (result: .success(identity), expirationTime: .now() + self.cacheTTL)
+                return identity
+            } catch {
+                self.identityLookupCache[url] = (result: .failure(error), expirationTime: .now() + self.cacheTTL)
+                throw error
             }
         }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -847,10 +847,10 @@ extension Workspace {
     ///
     /// - Parameters:
     ///     - observabilityScope: The observability scope that reports errors, warnings, etc
-    public func purgeCache(observabilityScope: ObservabilityScope) {
+    public func purgeCache(observabilityScope: ObservabilityScope) async {
         self.repositoryManager.purgeCache(observabilityScope: observabilityScope)
         self.registryDownloadsManager.purgeCache(observabilityScope: observabilityScope)
-        self.manifestLoader.purgeCache(observabilityScope: observabilityScope)
+        await self.manifestLoader.purgeCache(observabilityScope: observabilityScope)
     }
 
     /// Resets the entire workspace by removing the data directory.
@@ -875,7 +875,7 @@ extension Workspace {
 
         self.repositoryManager.reset(observabilityScope: observabilityScope)
         self.registryDownloadsManager.reset(observabilityScope: observabilityScope)
-        self.manifestLoader.resetCache(observabilityScope: observabilityScope)
+        await self.manifestLoader.resetCache(observabilityScope: observabilityScope)
         do {
             try self.fileSystem.removeFileTree(self.location.scratchDirectory)
         } catch {
@@ -1025,10 +1025,45 @@ extension Workspace {
         packages: [AbsolutePath],
         observabilityScope: ObservabilityScope
     ) async throws -> [AbsolutePath: Manifest] {
-        try await withCheckedThrowingContinuation { continuation in
-            self.loadRootManifests(packages: packages, observabilityScope: observabilityScope) { result in
-                continuation.resume(with: result)
+        try await withThrowingTaskGroup(of: Optional<(AbsolutePath, Manifest)>.self) { group in
+            var rootManifests = [AbsolutePath: Manifest]()
+            for package in Set(packages) {
+                group.addTask {
+                    // TODO: this does not use the identity resolver which is probably fine since its the root packages
+                    do {
+                        let manifest = try await self.loadManifest(
+                            packageIdentity: PackageIdentity(path: package),
+                            packageKind: .root(package),
+                            packagePath: package,
+                            packageLocation: package.pathString,
+                            observabilityScope: observabilityScope
+                        )
+                        return (package, manifest)
+                    } catch {
+                        return nil
+                    }
+                }
             }
+
+            // Collect the results.
+            for try await result in group {
+                if let (package, manifest) = result {
+                    // Store the manifest.
+                    rootManifests[package] = manifest
+                }
+            }
+
+            // Check for duplicate root packages after all manifests are loaded.
+            let duplicateRoots = rootManifests.values.spm_findDuplicateElements(by: \.displayName)
+            if let firstDuplicateSet = duplicateRoots.first, let firstDuplicate = firstDuplicateSet.first {
+                observabilityScope.emit(error: "found multiple top-level packages named '\(firstDuplicate.displayName)'")
+                // Decide how to handle duplicates, e.g., throw an error or return an empty dictionary.
+                // For now, matching the original behavior of returning an empty dictionary on error.
+                // Consider throwing an error instead for better error propagation.
+                return [:]
+            }
+
+            return rootManifests
         }
     }
 
@@ -1039,38 +1074,11 @@ extension Workspace {
         observabilityScope: ObservabilityScope,
         completion: @escaping (Result<[AbsolutePath: Manifest], Error>) -> Void
     ) {
-        let lock = NSLock()
-        let sync = DispatchGroup()
-        var rootManifests = [AbsolutePath: Manifest]()
-        for package in Set(packages) {
-            sync.enter()
-            // TODO: this does not use the identity resolver which is probably fine since its the root packages
-            self.loadManifest(
-                packageIdentity: PackageIdentity(path: package),
-                packageKind: .root(package),
-                packagePath: package,
-                packageLocation: package.pathString,
+        DispatchQueue.sharedConcurrent.asyncResult(completion) {
+            try await self.loadRootManifests(
+                packages: packages,
                 observabilityScope: observabilityScope
-            ) { result in
-                defer { sync.leave() }
-                if case .success(let manifest) = result {
-                    lock.withLock {
-                        rootManifests[package] = manifest
-                    }
-                }
-            }
-        }
-
-        sync.notify(queue: .sharedConcurrent) {
-            // Check for duplicate root packages.
-            let duplicateRoots = rootManifests.values.spm_findDuplicateElements(by: \.displayName)
-            if !duplicateRoots.isEmpty {
-                let name = duplicateRoots[0][0].displayName
-                observabilityScope.emit(error: "found multiple top-level packages named '\(name)'")
-                return completion(.success([:]))
-            }
-
-            completion(.success(rootManifests))
+            )
         }
     }
 
@@ -1216,16 +1224,34 @@ extension Workspace {
         packageGraph: ModulesGraph,
         observabilityScope: ObservabilityScope
     ) async throws -> Package {
-        try await withCheckedThrowingContinuation { continuation in
-            self.loadPackage(
-                with: identity,
-                packageGraph: packageGraph,
-                observabilityScope: observabilityScope,
-                completion: {
-                    continuation.resume(with: $0)
-                }
-            )
+        guard let previousPackage = packageGraph.package(for: identity) else {
+            throw StringError("could not find package with identity \(identity)")
         }
+
+        let manifest = try await self.loadManifest(
+            packageIdentity: identity,
+            packageKind: previousPackage.underlying.manifest.packageKind,
+            packagePath: previousPackage.path,
+            packageLocation: previousPackage.underlying.manifest.packageLocation,
+            observabilityScope: observabilityScope
+        )
+        let builder = PackageBuilder(
+            identity: identity,
+            manifest: manifest,
+            productFilter: .everything,
+            // TODO: this will not be correct when reloading a transitive dependencies if `ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION` is enabled
+            path: previousPackage.path,
+            additionalFileRules: self.configuration.additionalFileRules,
+            binaryArtifacts: packageGraph.binaryArtifacts[identity] ?? [:],
+            prebuilts: [:],
+            shouldCreateMultipleTestProducts: self.configuration.shouldCreateMultipleTestProducts,
+            createREPLProduct: self.configuration.createREPLProduct,
+            fileSystem: self.fileSystem,
+            observabilityScope: observabilityScope,
+            // For now we enable all traits
+            enabledTraits: Set(manifest.traits.map(\.name))
+        )
+        return try builder.construct()
     }
 
     /// Loads a single package in the context of a previously loaded graph. This can be useful for incremental loading
@@ -1237,37 +1263,12 @@ extension Workspace {
         observabilityScope: ObservabilityScope,
         completion: @escaping (Result<Package, Error>) -> Void
     ) {
-        guard let previousPackage = packageGraph.package(for: identity) else {
-            return completion(.failure(StringError("could not find package with identity \(identity)")))
-        }
-
-        self.loadManifest(
-            packageIdentity: identity,
-            packageKind: previousPackage.underlying.manifest.packageKind,
-            packagePath: previousPackage.path,
-            packageLocation: previousPackage.underlying.manifest.packageLocation,
-            observabilityScope: observabilityScope
-        ) { result in
-            let result = result.tryMap { manifest -> Package in
-                let builder = PackageBuilder(
-                    identity: identity,
-                    manifest: manifest,
-                    productFilter: .everything,
-                    // TODO: this will not be correct when reloading a transitive dependencies if `ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION` is enabled
-                    path: previousPackage.path,
-                    additionalFileRules: self.configuration.additionalFileRules,
-                    binaryArtifacts: packageGraph.binaryArtifacts[identity] ?? [:],
-                    prebuilts: [:],
-                    shouldCreateMultipleTestProducts: self.configuration.shouldCreateMultipleTestProducts,
-                    createREPLProduct: self.configuration.createREPLProduct,
-                    fileSystem: self.fileSystem,
-                    observabilityScope: observabilityScope,
-                    // For now we enable all traits
-                    enabledTraits: Set(manifest.traits.map(\.name))
-                )
-                return try builder.construct()
-            }
-            completion(result)
+        DispatchQueue.sharedConcurrent.asyncResult(completion) {
+            try await self.loadPackage(
+                with: identity,
+                packageGraph: packageGraph,
+                observabilityScope: observabilityScope
+            )
         }
     }
 

--- a/Sources/_InternalTestSupport/MockManifestLoader.swift
+++ b/Sources/_InternalTestSupport/MockManifestLoader.swift
@@ -61,22 +61,18 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
         dependencyMapper: DependencyMapper,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
-        delegateQueue: DispatchQueue,
-        callbackQueue: DispatchQueue,
-        completion: @escaping (Result<Manifest, Error>) -> Void
-    ) {
-        callbackQueue.async {
-            let key = Key(url: packageLocation, version: packageVersion?.version)
-            if let result = self.manifests[key] {
-                return completion(.success(result))
-            } else {
-                return completion(.failure(MockManifestLoaderError.unknownRequest("\(key)")))
-            }
+        delegateQueue: DispatchQueue
+    ) async throws -> Manifest {
+        let key = Key(url: packageLocation, version: packageVersion?.version)
+        if let result = self.manifests[key] {
+            return result
+        } else {
+            throw MockManifestLoaderError.unknownRequest("\(key)")
         }
     }
 
-    public func resetCache(observabilityScope: ObservabilityScope) {}
-    public func purgeCache(observabilityScope: ObservabilityScope) {}
+    public func resetCache(observabilityScope: ObservabilityScope) async {}
+    public func purgeCache(observabilityScope: ObservabilityScope) async {}
 }
 
 extension ManifestLoader {
@@ -120,8 +116,7 @@ extension ManifestLoader {
             dependencyMapper: dependencyMapper ?? DefaultDependencyMapper(identityResolver: identityResolver),
             fileSystem: fileSystem,
             observabilityScope: observabilityScope,
-            delegateQueue: .sharedConcurrent,
-            callbackQueue: .sharedConcurrent
+            delegateQueue: .sharedConcurrent
         )
     }
 }
@@ -167,8 +162,7 @@ extension ManifestLoader {
             dependencyMapper: dependencyMapper ?? DefaultDependencyMapper(identityResolver: identityResolver),
             fileSystem: fileSystem,
             observabilityScope: observabilityScope,
-            delegateQueue: .sharedConcurrent,
-            callbackQueue: .sharedConcurrent
+            delegateQueue: .sharedConcurrent
         )
     }
 }

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -458,8 +458,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
                 dependencyMapper: dependencyMapper,
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope,
-                delegateQueue: .sharedConcurrent,
-                callbackQueue: .sharedConcurrent
+                delegateQueue: .sharedConcurrent
             )
         }
     }

--- a/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
@@ -107,7 +107,7 @@ final class ManifestLoaderCacheTests: XCTestCase {
 
             // Resetting the cache should allow us to remove the cache
             // directory without triggering assertions in sqlite.
-            manifestLoader.purgeCache(observabilityScope: observability.topScope)
+            await manifestLoader.purgeCache(observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             try fileSystem.removeFileTree(path)
         }
@@ -198,7 +198,7 @@ final class ManifestLoaderCacheTests: XCTestCase {
             try await check(loader: noCacheLoader, expectCached: false)
         }
 
-        manifestLoader.purgeCache(observabilityScope: observability.topScope)
+        await manifestLoader.purgeCache(observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
     }
 

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -638,8 +638,7 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 dependencyMapper: dependencyMapper,
                 fileSystem: localFileSystem,
                 observabilityScope: observability.topScope,
-                delegateQueue: .sharedConcurrent,
-                callbackQueue: .sharedConcurrent
+                delegateQueue: .sharedConcurrent
             )
 
             XCTAssertNoDiagnostics(observability.diagnostics)
@@ -658,8 +657,7 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     dependencyMapper: dependencyMapper,
                     fileSystem: localFileSystem,
                     observabilityScope: observability.topScope,
-                    delegateQueue: .sharedConcurrent,
-                    callbackQueue: .sharedConcurrent
+                    delegateQueue: .sharedConcurrent
                 )
 
                 XCTAssertNoDiagnostics(observability.diagnostics)
@@ -722,8 +720,7 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     dependencyMapper: dependencyMapper,
                     fileSystem: localFileSystem,
                     observabilityScope: observability.topScope,
-                    delegateQueue: .sharedConcurrent,
-                    callbackQueue: .sharedConcurrent
+                    delegateQueue: .sharedConcurrent
                 )
 
                 XCTAssertEqual(manifest.displayName, "Trivial-\(random)")

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -63,8 +63,7 @@ final class ManifestSourceGenerationTests: XCTestCase {
                 dependencyMapper: dependencyMapper,
                 fileSystem: fs,
                 observabilityScope: observability.topScope,
-                delegateQueue: .sharedConcurrent,
-                callbackQueue: .sharedConcurrent
+                delegateQueue: .sharedConcurrent
             )
 
             XCTAssertNoDiagnostics(observability.diagnostics)
@@ -92,8 +91,7 @@ final class ManifestSourceGenerationTests: XCTestCase {
                 dependencyMapper: dependencyMapper,
                 fileSystem: fs,
                 observabilityScope: observability.topScope,
-                delegateQueue: .sharedConcurrent,
-                callbackQueue: .sharedConcurrent
+                delegateQueue: .sharedConcurrent
             )
 
             XCTAssertNoDiagnostics(observability.diagnostics)

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -262,30 +262,28 @@ final class RegistryPackageContainerTests: XCTestCase {
             )
 
             struct MockManifestLoader: ManifestLoaderProtocol {
-                func load(manifestPath: AbsolutePath,
-                          manifestToolsVersion: ToolsVersion,
-                          packageIdentity: PackageIdentity,
-                          packageKind: PackageReference.Kind,
-                          packageLocation: String,
-                          packageVersion: (version: Version?, revision: String?)?,
-                          identityResolver: IdentityResolver,
-                          dependencyMapper: DependencyMapper,
-                          fileSystem: FileSystem,
-                          observabilityScope: ObservabilityScope,
-                          delegateQueue: DispatchQueue,
-                          callbackQueue: DispatchQueue,
-                          completion: @escaping (Result<Manifest, Error>) -> Void) {
-                    completion(.success(
-                        Manifest.createManifest(
-                            displayName: packageIdentity.description,
-                            path: manifestPath,
-                            packageKind: packageKind,
-                            packageIdentity: packageIdentity,
-                            packageLocation: packageLocation,
-                            platforms: [],
-                            toolsVersion: manifestToolsVersion
-                        )
-                    ))
+                func load(
+                    manifestPath: AbsolutePath,
+                    manifestToolsVersion: ToolsVersion,
+                    packageIdentity: PackageIdentity,
+                    packageKind: PackageReference.Kind,
+                    packageLocation: String,
+                    packageVersion: (version: Version?, revision: String?)?,
+                    identityResolver: IdentityResolver,
+                    dependencyMapper: DependencyMapper,
+                    fileSystem: FileSystem,
+                    observabilityScope: ObservabilityScope,
+                    delegateQueue: DispatchQueue
+                ) async throws -> Manifest {
+                    Manifest.createManifest(
+                        displayName: packageIdentity.description,
+                        path: manifestPath,
+                        packageKind: packageKind,
+                        packageIdentity: packageIdentity,
+                        packageLocation: packageLocation,
+                        platforms: [],
+                        toolsVersion: manifestToolsVersion
+                    )
                 }
 
                 func resetCache(observabilityScope: ObservabilityScope) {}

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -12695,28 +12695,20 @@ final class WorkspaceTests: XCTestCase {
                 dependencyMapper: DependencyMapper,
                 fileSystem: FileSystem,
                 observabilityScope: ObservabilityScope,
-                delegateQueue: DispatchQueue,
-                callbackQueue: DispatchQueue,
-                completion: @escaping (Result<Manifest, Error>) -> Void
-            ) {
+                delegateQueue: DispatchQueue
+            ) async throws -> Manifest {
                 if let error {
-                    callbackQueue.async {
-                        completion(.failure(error))
-                    }
+                    throw error
                 } else {
-                    callbackQueue.async {
-                        completion(.success(
-                            Manifest.createManifest(
-                                displayName: packageIdentity.description,
-                                path: manifestPath,
-                                packageKind: packageKind,
-                                packageIdentity: packageIdentity,
-                                packageLocation: packageLocation,
-                                platforms: [],
-                                toolsVersion: manifestToolsVersion
-                            )
-                        ))
-                    }
+                    return Manifest.createManifest(
+                        displayName: packageIdentity.description,
+                        path: manifestPath,
+                        packageKind: packageKind,
+                        packageIdentity: packageIdentity,
+                        packageLocation: packageLocation,
+                        platforms: [],
+                        toolsVersion: manifestToolsVersion
+                    )
                 }
             }
 


### PR DESCRIPTION
### Motivation:

This follows on from my work to convert the registry code to `async` methods.

### Modifications:

Switch to using async methods when loading manifests, converting synchronous code to the simpler async equivalents and converting sync API calls to their synchronous versions.

### Result:

This resolves several warnings and FIXMEs, makes the code easier to read and generally implements concurrency in a more idiomatic way.
