### PR TITLE
Skip failing test in `TestCommandTests.swift`

### DIFF
--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -577,6 +577,7 @@ class TestCommandTestCase: CommandsBuildProviderTestCase {
     }
 
     func testFatalErrorDisplayedCorrectNumberOfTimesWhenSingleXCTestHasFatalErrorInBuildCompilation() async throws {
+        try XCTSkipIfCI()
         // Test for GitHub Issue #6605
         // GIVEN we have a Swift Package that has a fatalError building the tests
         let expected = 1


### PR DESCRIPTION
rdar://149936169

This test is currently failing on CI (https://ci.swift.org/job/oss-swift-package-amazon-linux-2-aarch64/4188) and blocks toolchain builds for swift.org.
