### PR TITLE
Revert "Enable more plugin related tests for non-macOS platforms"

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -651,9 +651,9 @@ extension PackagePIFBuilder.LinkedPackageBinary {
 
     init?(dependency: ResolvedModule.Dependency, package: ResolvedPackage) {
         switch dependency {
-        case .product(let productDependency, _):
-            guard productDependency.hasSourceTargets else { return nil }
-            self.init(name: productDependency.name, packageName: package.name, type: .product)
+        case .product(let producutDependency, _):
+            guard producutDependency.hasSourceTargets else { return nil }
+            self.init(name: producutDependency.name, packageName: package.name, type: .product)
 
         case .module(let moduleDependency, _):
             self.init(module: moduleDependency, package: package)

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -504,14 +504,20 @@ extension PackagePIFProjectBuilder {
         }
 
         // Additional settings for the linker.
+        let baselineOTHER_LDFLAGS: [String]
         let enableDuplicateLinkageCulling = UserDefaults.standard.bool(
             forKey: "IDESwiftPackagesEnableDuplicateLinkageCulling",
             defaultValue: true
         )
         if enableDuplicateLinkageCulling {
-            impartedSettings[.LD_WARN_DUPLICATE_LIBRARIES] = "NO"
+            baselineOTHER_LDFLAGS = [
+                "-Wl,-no_warn_duplicate_libraries",
+                "$(inherited)"
+            ]
+        } else {
+            baselineOTHER_LDFLAGS = ["$(inherited)"]
         }
-        impartedSettings[.OTHER_LDFLAGS] = (sourceModule.isCxx ? ["-lc++"] : []) + ["$(inherited)"]
+        impartedSettings[.OTHER_LDFLAGS] = (sourceModule.isCxx ? ["-lc++"] : []) + baselineOTHER_LDFLAGS
         impartedSettings[.OTHER_LDRFLAGS] = []
         log(
             .debug,

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -956,4 +956,13 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
 
         try await super.testBuildSystemDefaultSettings()
     }
+
+    override func testBuildCompleteMessage() async throws {
+        #if os(Linux)
+        throw XCTSkip("SWBINTTODO: Need to properly set LD_LIBRARY_PATH on linux")
+        #else
+        try await super.testBuildCompleteMessage()
+        #endif
+    }
+
 }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -3898,9 +3898,15 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
     }
 
     override func testCommandPluginBuildingCallbacks() async throws {
-        throw XCTSkip("SWBINTTODO: Test fails because plugin is not producing expected output to stdout.")
+        throw XCTSkip("SWBINTTODO: Test fails as plugins are not currenty supported")
     }
     override func testCommandPluginBuildTestability() async throws {
         throw XCTSkip("SWBINTTODO: Test fails as plugins are not currenty supported")
     }
+
+#if !os(macOS)
+    override func testCommandPluginTestingCallbacks() async throws {
+        throw XCTSkip("SWBINTTODO: Test fails on inability to find libclang on Linux. Also, plugins are not currently supported")
+    }
+#endif
 }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -701,35 +701,35 @@ class TestCommandSwiftBuildTests: TestCommandTestCase {
 
 #if !os(macOS)
     override func testSwiftTestXMLOutputVerifySingleTestFailureMessageWithFlagDisabledXCTest() async throws {
-        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
+        throw XCTSkip("Result XML could not be found. The build fails due to an LD_LIBRARY_PATH issue finding swift core libraries. https://github.com/swiftlang/swift-package-manager/issues/8416")
     }
 
     override func testSwiftTestXMLOutputVerifyMultipleTestFailureMessageWithFlagEnabledXCTest() async throws {
-        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
+        throw XCTSkip("Result XML could not be found. The build fails due to an LD_LIBRARY_PATH issue finding swift core libraries. https://github.com/swiftlang/swift-package-manager/issues/8416")
     }
 
     override func testSwiftTestXMLOutputVerifySingleTestFailureMessageWithFlagEnabledXCTest() async throws {
-        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
+        throw XCTSkip("Result XML could not be found. The build fails due to an LD_LIBRARY_PATH issue finding swift core libraries. https://github.com/swiftlang/swift-package-manager/issues/8416")
     }
 
     override func testSwiftTestXMLOutputVerifyMultipleTestFailureMessageWithFlagDisabledXCTest() async throws {
-        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
+        throw XCTSkip("Result XML could not be found. The build fails due to an LD_LIBRARY_PATH issue finding swift core libraries. https://github.com/swiftlang/swift-package-manager/issues/8416")
     }
 
     override func testSwiftTestSkip() async throws {
-        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
+        throw XCTSkip("This fails due to a linker error on Linux. https://github.com/swiftlang/swift-package-manager/issues/8439")
     }
 
     override func testSwiftTestXMLOutputWhenEmpty() async throws {
-        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
+        throw XCTSkip("This fails due to a linker error on Linux. https://github.com/swiftlang/swift-package-manager/issues/8439")
     }
 
     override func testSwiftTestFilter() async throws {
-        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
+        throw XCTSkip("This fails due to an unknown linker error on Linux. https://github.com/swiftlang/swift-package-manager/issues/8439")
     }
 
     override func testSwiftTestParallel() async throws {
-        throw XCTSkip("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms: https://github.com/swiftlang/swift-package-manager/issues/8479")
+        throw XCTSkip("This fails due to an unknown linker error on Linux. https://github.com/swiftlang/swift-package-manager/issues/8439")
     }
 #endif
 }


### PR DESCRIPTION
Reverts swiftlang/swift-package-manager#8477 due to Amazon Linux 2 failures https://ci.swift.org/job/oss-swift-package-amazon-linux-2/4177/console