### PR TITLE
Factor the working directory skip into a common function

### DIFF
--- a/Sources/_InternalTestSupport/XCTAssertHelpers.swift
+++ b/Sources/_InternalTestSupport/XCTAssertHelpers.swift
@@ -259,3 +259,21 @@ public struct CommandExecutionError: Error {
     public let stdout: String
     public let stderr: String
 }
+
+/// Skips the test if running on a platform which lacks the ability for build tasks to set a working directory due to lack of requisite system API.
+///
+/// Presently, relevant platforms include Amazon Linux 2 and OpenBSD.
+///
+/// - seealso: https://github.com/swiftlang/swift-package-manager/issues/8560
+public func XCTSkipIfWorkingDirectoryUnsupported() throws {
+    func unavailable() throws {
+        throw XCTSkip("Thread-safe process working directory support is unavailable on this platform.")
+    }
+    #if os(Linux)
+    if FileManager.default.contents(atPath: "/etc/system-release").map({ String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" }) ?? false {
+        try unavailable()
+    }
+    #elseif os(OpenBSD)
+    try unavailable()
+    #endif
+}

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -7068,14 +7068,11 @@ class BuildPlanSwiftBuildTests: BuildPlanTestCase {
     }
 
     override func testPackageNameFlag() async throws {
+        try XCTSkipIfWorkingDirectoryUnsupported()
 #if os(Windows)
         throw XCTSkip("Skip until there is a resolution to the partial linking with Windows that results in a 'subsystem must be defined' error.")
 #endif
-
 #if os(Linux)
-        if FileManager.default.contents(atPath: "/etc/system-release").map { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ?? false {
-            throw XCTSkip("Skipping Swift Build testing on Amazon Linux because of platform issues.")
-        }
         // Linking error: "/usr/bin/ld.gold: fatal error: -pie and -static are incompatible".
         // Tracked by GitHub issue: https://github.com/swiftlang/swift-package-manager/issues/8499
         throw XCTSkip("Skipping Swift Build testing on Linux because of linking issues.")

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -859,12 +859,7 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
     }
 
     override func testParseableInterfaces() async throws {
-        #if os(Linux)
-        if FileManager.default.contents(atPath: "/etc/system-release")
-                .map { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ?? false {
-            throw XCTSkip("https://github.com/swiftlang/swift-package-manager/issues/8545: Test currently fails on Amazon Linux 2")
-        }
-        #endif
+        try XCTSkipIfWorkingDirectoryUnsupported()
         try await fixture(name: "Miscellaneous/ParseableInterfaces") { fixturePath in
             do {
                 let result = try await build(["--enable-parseable-module-interfaces"], packagePath: fixturePath)
@@ -944,11 +939,7 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
 #endif
 
     override func testBuildSystemDefaultSettings() async throws {
-        #if os(Linux)
-        if FileManager.default.contents(atPath: "/etc/system-release").map( { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ) ?? false {
-            throw XCTSkip("Skipping SwiftBuild testing on Amazon Linux because of platform issues.")
-        }
-        #endif
+        try XCTSkipIfWorkingDirectoryUnsupported()
 
         if ProcessInfo.processInfo.environment["SWIFTPM_NO_SWBUILD_DEPENDENCY"] != nil {
             throw XCTSkip("SWIFTPM_NO_SWBUILD_DEPENDENCY is set so skipping because SwiftPM doesn't have the swift-build capability built inside.")
@@ -958,11 +949,7 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
     }
 
     override func testBuildCompleteMessage() async throws {
-        #if os(Linux)
-        if FileManager.default.contents(atPath: "/etc/system-release").map { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ?? false {
-            throw XCTSkip("Skipping Swift Build testing on Amazon Linux because of platform issues.")
-        }
-        #endif
+        try XCTSkipIfWorkingDirectoryUnsupported()
 
         try await super.testBuildCompleteMessage()
     }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -3906,11 +3906,8 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
 
 #if !os(macOS)
     override func testCommandPluginTestingCallbacks() async throws {
-#if os(Linux)
-        if FileManager.default.contents(atPath: "/etc/system-release").map { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ?? false {
-            throw XCTSkip("Skipping Swift Build testing on Amazon Linux because of platform issues.")
-        }
-#endif
+        try XCTSkipIfWorkingDirectoryUnsupported()
+
         try await super.testCommandPluginTestingCallbacks()
     }
 #endif


### PR DESCRIPTION
Also skips on OpenBSD, which has the same issue.