### PR TITLE
Re-enable tests in Windows CI

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1194,6 +1194,10 @@ final class ParallelTestRunner {
                     let start = DispatchTime.now()
                     self.runningLock.withLock {
                         self.runningTests.insert(test.specifier)
+                        print("Starting tests:",  self.runningTests.count)
+                        for test in self.runningTests.sorted() {
+                            print(">", test)
+                        }
                     }
                     let result = testRunner.test(outputHandler: { _output in outputLock.withLock{ output += _output }})
                     self.runningLock.withLock {

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1194,14 +1194,10 @@ final class ParallelTestRunner {
                     let start = DispatchTime.now()
                     self.runningLock.withLock {
                         self.runningTests.insert(test.specifier)
-                        print("Started tests:",  self.runningTests.count)
-                        for test in self.runningTests.sorted() {
-                            print(">", test)
-                        }
                     }
                     let result = testRunner.test(outputHandler: { _output in outputLock.withLock{ output += _output }})
                     self.runningLock.withLock {
-                        self.runningTests.insert(test.specifier)
+                        self.runningTests.remove(test.specifier)
                         print("Running tests:",  self.runningTests.count)
                         for test in self.runningTests.sorted() {
                             print(">", test)

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1068,9 +1068,6 @@ final class ParallelTestRunner {
     /// The queue containing list of tests to run (producer).
     private let pendingTests = SynchronizedQueue<UnitTest?>()
 
-    private var runningTests = Set<String>()
-    private let runningLock = NSLock()
-
     /// The queue containing tests which are finished running.
     private let finishedTests = SynchronizedQueue<TestResult?>()
 
@@ -1192,21 +1189,7 @@ final class ParallelTestRunner {
                     var output = ""
                     let outputLock = NSLock()
                     let start = DispatchTime.now()
-                    self.runningLock.withLock {
-                        self.runningTests.insert(test.specifier)
-                        print("Starting tests:",  self.runningTests.count)
-                        for test in self.runningTests.sorted() {
-                            print(">", test)
-                        }
-                    }
                     let result = testRunner.test(outputHandler: { _output in outputLock.withLock{ output += _output }})
-                    self.runningLock.withLock {
-                        self.runningTests.remove(test.specifier)
-                        print("Running tests:",  self.runningTests.count)
-                        for test in self.runningTests.sorted() {
-                            print(">", test)
-                        }
-                    }
                     let duration = start.distance(to: .now())
                     if result == .failure {
                         self.ranSuccessfully = false

--- a/Sources/_InternalTestSupport/XCTAssertHelpers.swift
+++ b/Sources/_InternalTestSupport/XCTAssertHelpers.swift
@@ -45,6 +45,7 @@ public func XCTAssertEqual<T:Equatable, U:Equatable> (_ lhs:(T,U), _ rhs:(T,U), 
 }
 
 public func XCTSkipIfCI(file: StaticString = #filePath, line: UInt = #line) throws {
+    // TODO: is this actually the right variable now?
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] != nil {
         throw XCTSkip("Skipping because the test is being run on CI", file: file, line: line)
     }
@@ -52,7 +53,9 @@ public func XCTSkipIfCI(file: StaticString = #filePath, line: UInt = #line) thro
 
 public func XCTSkipIfWindowsCI(file: StaticString = #filePath, line: UInt = #line) throws {
     #if os(Windows)
-    try XCTSkipIfCI(file: file, line: line)
+    if ProcessInfo.processInfo.environment["SWIFTCI_IS_SELF_HOSTED"] != nil {
+        throw XCTSkip("Skipping because the test is being run on CI", file: file, line: line)
+    }
     #endif
 }
 

--- a/Sources/_InternalTestSupport/XCTAssertHelpers.swift
+++ b/Sources/_InternalTestSupport/XCTAssertHelpers.swift
@@ -50,6 +50,12 @@ public func XCTSkipIfCI(file: StaticString = #filePath, line: UInt = #line) thro
     }
 }
 
+public func XCTSkipIfWindowsCI(file: StaticString = #filePath, line: UInt = #line) throws {
+    #if os(Windows)
+    XCTSkipIfCI(file: file, line: line)
+    #endif
+}
+
 /// An `async`-friendly replacement for `XCTAssertThrowsError`.
 public func XCTAssertAsyncThrowsError<T>(
     _ expression: @autoclosure () async throws -> T,

--- a/Sources/_InternalTestSupport/XCTAssertHelpers.swift
+++ b/Sources/_InternalTestSupport/XCTAssertHelpers.swift
@@ -52,7 +52,7 @@ public func XCTSkipIfCI(file: StaticString = #filePath, line: UInt = #line) thro
 
 public func XCTSkipIfWindowsCI(file: StaticString = #filePath, line: UInt = #line) throws {
     #if os(Windows)
-    XCTSkipIfCI(file: file, line: line)
+    try XCTSkipIfCI(file: file, line: line)
     #endif
 }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -7033,7 +7033,8 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 let fileMap = try String(bytes: fs.readFileContents(file.path).contents, encoding: .utf8)
 
                 for diagnosticFile in buildDescription.diagnosticFiles {
-                    XCTAssertMatch(fileMap, .contains(diagnosticFile.pathString))
+                    let fileName = diagnosticFile.pathString.replacingOccurrences(of: "\\", with: "\\\\")
+                    XCTAssertMatch(fileMap, .contains(fileName))
                 }
             }
         }

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -17,6 +17,9 @@ import XCTest
 
 class GitRepositoryProviderTests: XCTestCase {
     func testIsValidDirectory() throws {
+        // Skipping all tests that call git on Windows.
+        // We have a hang in CI when running in parallel.
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { sandbox in
             let provider = GitRepositoryProvider()
 
@@ -42,6 +45,7 @@ class GitRepositoryProviderTests: XCTestCase {
     }
 
     func testIsValidDirectoryThrowsPrintableError() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { temp in
             let provider = GitRepositoryProvider()
             let expectedErrorMessage = "not a git repository"
@@ -56,6 +60,7 @@ class GitRepositoryProviderTests: XCTestCase {
     }
 
     func testGitShellErrorIsPrintable() throws {
+        try XCTSkipIfWindowsCI()
         let stdOut = "An error from Git - stdout"
         let stdErr = "An error from Git - stderr"
         let arguments = ["git", "error"]
@@ -84,6 +89,7 @@ class GitRepositoryProviderTests: XCTestCase {
     }
 
     func testGitShellErrorEmptyStdOut() throws {
+        try XCTSkipIfWindowsCI()
         let stdErr = "An error from Git - stderr"
         let result = AsyncProcessResult(
             arguments: ["git", "error"],
@@ -101,6 +107,7 @@ class GitRepositoryProviderTests: XCTestCase {
     }
 
     func testGitShellErrorEmptyStdErr() throws {
+        try XCTSkipIfWindowsCI()
         let stdOut = "An error from Git - stdout"
         let result = AsyncProcessResult(
             arguments: ["git", "error"],

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -62,6 +62,9 @@ class GitRepositoryTests: XCTestCase {
 
     /// Test the basic provider functions.
     func testProvider() throws {
+        // Skipping all tests that call git on Windows.
+        // We have a hang in CI when running in parallel.
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             let testRepoPath = path.appending("test-repo")
             try! makeDirectories(testRepoPath)
@@ -127,6 +130,7 @@ class GitRepositoryTests: XCTestCase {
     /// contained within it for more information.
     func testRawRepository() throws {
         try skipOnWindowsAsTestCurrentlyFails(because: "https://github.com/swiftlang/swift-package-manager/issues/8385: test repository has non-portable file names")
+        try XCTSkipIfWindowsCI()
 
         try testWithTemporaryDirectory { path in
             // Unarchive the static test repository.
@@ -186,6 +190,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testSubmoduleRead() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
@@ -209,6 +214,7 @@ class GitRepositoryTests: XCTestCase {
 
     /// Test the Git file system view.
     func testGitFileView() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
@@ -297,6 +303,7 @@ class GitRepositoryTests: XCTestCase {
 
     /// Test the handling of local checkouts.
     func testCheckouts() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             // Create a test repository.
             let testRepoPath = path.appending("test-repo")
@@ -343,6 +350,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testFetch() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -382,6 +390,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testHasUnpushedCommits() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -418,6 +427,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testSetRemote() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -448,6 +458,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testUncommittedChanges() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -475,6 +486,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testBranchOperations() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -505,6 +517,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testRevisionOperations() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let repositoryPath = path.appending("test-repo")
@@ -530,6 +543,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testCheckoutRevision() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -573,6 +587,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testSubmodules() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             let provider = GitRepositoryProvider()
 
@@ -662,6 +677,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testAlternativeObjectStoreValidation() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -695,6 +711,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testAreIgnored() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test_repo")
@@ -716,6 +733,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testAreIgnoredWithSpaceInRepoPath() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test repo")
@@ -732,6 +750,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testMissingDefaultBranch() throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { path in
             // Create a repository.
             let testRepoPath = path.appending("test-repo")
@@ -769,6 +788,7 @@ class GitRepositoryTests: XCTestCase {
     }
     
     func testValidDirectoryLocalRelativeOrigin() async throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { tmpDir in
             // Create a repository.
             let packageDir = tmpDir.appending("SomePackage")
@@ -815,6 +835,7 @@ class GitRepositoryTests: XCTestCase {
     }
     
     func testValidDirectoryLocalAbsoluteOrigin() async throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { tmpDir in
             // Create a repository.
             let packageDir = tmpDir.appending("SomePackage")
@@ -865,6 +886,7 @@ class GitRepositoryTests: XCTestCase {
     }
     
     func testValidDirectoryRemoteOrigin() async throws {
+        try XCTSkipIfWindowsCI()
         try testWithTemporaryDirectory { tmpDir in
             // Create a repository.
             let packageDir = tmpDir.appending("SomePackage")

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -158,7 +158,7 @@ def main() -> None:
             shlex.split(f"swift run swift-test --configuration {args.config} --parallel {swift_testing_arg} {xctest_arg} --scratch-path .test {ignore}"),
         )
 
-        integration_test_dir = REPO_ROOT_PATH / "IntegrationTests"
+        integration_test_dir = (REPO_ROOT_PATH / "IntegrationTests").as_posix()
         call(
             shlex.split(f"swift package --package-path {integration_test_dir} update"),
         )

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -152,20 +152,19 @@ def main() -> None:
             shlex.split(f"swift build --configuration {args.config} {ignore}"),
         )
 
-        if os.name != "nt": # turn off for Windows until we get the hang resolved
-            swift_testing_arg= "--enable-swift-testing" if args.enable_swift_testing else ""
-            xctest_arg= "--enable-xctest" if args.enable_swift_testing else ""
-            call(
-                shlex.split(f"swift run swift-test --configuration {args.config} --parallel {swift_testing_arg} {xctest_arg} --scratch-path .test {ignore}"),
-            )
+        swift_testing_arg= "--enable-swift-testing" if args.enable_swift_testing else ""
+        xctest_arg= "--enable-xctest" if args.enable_swift_testing else ""
+        call(
+            shlex.split(f"swift run swift-test --configuration {args.config} --parallel {swift_testing_arg} {xctest_arg} --scratch-path .test {ignore}"),
+        )
 
-            integration_test_dir = REPO_ROOT_PATH / "IntegrationTests"
-            call(
-                shlex.split(f"swift package --package-path {integration_test_dir} update"),
-            )
-            call(
-                shlex.split(f"swift run swift-test --package-path {integration_test_dir} --parallel {ignore}"),
-            )
+        integration_test_dir = REPO_ROOT_PATH / "IntegrationTests"
+        call(
+            shlex.split(f"swift package --package-path {integration_test_dir} update"),
+        )
+        call(
+            shlex.split(f"swift run swift-test --package-path {integration_test_dir} --parallel {ignore}"),
+        )
 
     if is_on_darwin():
         run_bootstrap(swiftpm_bin_dir=swiftpm_bin_dir)


### PR DESCRIPTION
The investigation is pointing to running git commands in parallel that is causing the hang with the Windows CI. Turn them off until we can figure out how to serialize them across xctest processes.

Once they completed, fixed the BuildPlanTests which were matching with backslashes.

Also had backslash issues when launching the integration tests.