### PR TITLE
normalize abstracts and help content for swift commands

### DIFF
--- a/Sources/Commands/PackageCommands/APIDiff.swift
+++ b/Sources/Commands/PackageCommands/APIDiff.swift
@@ -38,7 +38,7 @@ struct DeprecatedAPIDiff: ParsableCommand {
 struct APIDiff: AsyncSwiftCommand {
     static let configuration = CommandConfiguration(
         commandName: "diagnose-api-breaking-changes",
-        abstract: "Diagnose API-breaking changes to Swift modules in a package",
+        abstract: "Diagnose API-breaking changes to Swift modules in a package.",
         discussion: """
         The diagnose-api-breaking-changes command can be used to compare the Swift API of \
         a package to a baseline revision, diagnosing any breaking changes which have \
@@ -59,7 +59,7 @@ struct APIDiff: AsyncSwiftCommand {
     """)
     var breakageAllowlistPath: AbsolutePath?
 
-    @Argument(help: "The baseline treeish to compare to (e.g. a commit hash, branch name, tag, etc.)")
+    @Argument(help: "The baseline treeish to compare to (for example, a commit hash, branch name, tag, and so on).")
     var treeish: String
 
     @Option(parsing: .upToNextOption,

--- a/Sources/Commands/PackageCommands/AddDependency.swift
+++ b/Sources/Commands/PackageCommands/AddDependency.swift
@@ -26,34 +26,34 @@ import Workspace
 extension SwiftPackageCommand {
     struct AddDependency: SwiftCommand {
         package static let configuration = CommandConfiguration(
-            abstract: "Add a package dependency to the manifest"
+            abstract: "Add a package dependency to the manifest."
         )
 
-        @Argument(help: "The URL or directory of the package to add")
+        @Argument(help: "The URL or directory of the package to add.")
         var dependency: String
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Option(help: "The exact package version to depend on")
+        @Option(help: "The exact package version to depend on.")
         var exact: Version?
 
-        @Option(help: "The specific package revision to depend on")
+        @Option(help: "The specific package revision to depend on.")
         var revision: String?
 
-        @Option(help: "The branch of the package to depend on")
+        @Option(help: "The branch of the package to depend on.")
         var branch: String?
 
-        @Option(help: "The package version to depend on (up to the next major version)")
+        @Option(help: "The package version to depend on (up to the next major version).")
         var from: Version?
 
-        @Option(help: "The package version to depend on (up to the next minor version)")
+        @Option(help: "The package version to depend on (up to the next minor version).")
         var upToNextMinorFrom: Version?
 
-        @Option(help: "Specify upper bound on the package version range (exclusive)")
+        @Option(help: "Specify upper bound on the package version range (exclusive).")
         var to: Version?
 
-        @Option(help: "Specify dependency type")
+        @Option(help: "Specify dependency type.")
         var type: DependencyType = .url
 
         enum DependencyType: String, Codable, CaseIterable, ExpressibleByArgument {

--- a/Sources/Commands/PackageCommands/AddProduct.swift
+++ b/Sources/Commands/PackageCommands/AddProduct.swift
@@ -36,20 +36,20 @@ extension SwiftPackageCommand {
         }
 
         package static let configuration = CommandConfiguration(
-            abstract: "Add a new product to the manifest")
+            abstract: "Add a new product to the manifest.")
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Argument(help: "The name of the new product")
+        @Argument(help: "The name of the new product.")
         var name: String
 
-        @Option(help: "The type of target to add")
+        @Option(help: "The type of target to add.")
         var type: CommandProductType = .library
 
         @Option(
             parsing: .upToNextOption,
-            help: "A list of targets that are part of this product"
+            help: "A list of targets that are part of this product."
         )
         var targets: [String] = []
 

--- a/Sources/Commands/PackageCommands/AddSetting.swift
+++ b/Sources/Commands/PackageCommands/AddSetting.swift
@@ -33,19 +33,19 @@ extension SwiftPackageCommand {
         }
 
         package static let configuration = CommandConfiguration(
-            abstract: "Add a new setting to the manifest"
+            abstract: "Add a new setting to the manifest."
         )
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Option(help: "The target to add the setting to")
+        @Option(help: "The target to add the setting to.")
         var target: String
 
         @Option(
             name: .customLong("swift"),
             parsing: .unconditionalSingleValue,
-            help: "The Swift language setting(s) to add. Supported settings: \(SwiftSetting.allCases.map(\.rawValue).joined(separator: ", "))"
+            help: "The Swift language setting(s) to add. Supported settings: \(SwiftSetting.allCases.map(\.rawValue).joined(separator: ", "))."
         )
         var _swiftSettings: [String]
 

--- a/Sources/Commands/PackageCommands/AddTarget.swift
+++ b/Sources/Commands/PackageCommands/AddTarget.swift
@@ -36,33 +36,33 @@ extension SwiftPackageCommand {
         }
 
         package static let configuration = CommandConfiguration(
-            abstract: "Add a new target to the manifest")
+            abstract: "Add a new target to the manifest.")
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Argument(help: "The name of the new target")
+        @Argument(help: "The name of the new target.")
         var name: String
 
-        @Option(help: "The type of target to add")
+        @Option(help: "The type of target to add.")
         var type: TargetType = .library
 
         @Option(
             parsing: .upToNextOption,
-            help: "A list of target dependency names"
+            help: "A list of target dependency names."
         )
         var dependencies: [String] = []
 
-        @Option(help: "The URL for a remote binary target")
+        @Option(help: "The URL for a remote binary target.")
         var url: String?
 
-        @Option(help: "The path to a local binary target")
+        @Option(help: "The path to a local binary target.")
         var path: String?
 
-        @Option(help: "The checksum for a remote binary target")
+        @Option(help: "The checksum for a remote binary target.")
         var checksum: String?
 
-        @Option(help: "The testing library to use when generating test targets, which can be one of 'xctest', 'swift-testing', or 'none'")
+        @Option(help: "The testing library to use when generating test targets, which can be one of 'xctest', 'swift-testing', or 'none'.")
         var testingLibrary: PackageModelSyntax.AddTarget.TestHarness = .default
 
         func run(_ swiftCommandState: SwiftCommandState) throws {

--- a/Sources/Commands/PackageCommands/AddTargetDependency.swift
+++ b/Sources/Commands/PackageCommands/AddTargetDependency.swift
@@ -26,18 +26,18 @@ import Workspace
 extension SwiftPackageCommand {
     struct AddTargetDependency: SwiftCommand {
         package static let configuration = CommandConfiguration(
-            abstract: "Add a new target dependency to the manifest")
+            abstract: "Add a new target dependency to the manifest.")
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Argument(help: "The name of the new dependency")
+        @Argument(help: "The name of the new dependency.")
         var dependencyName: String
 
-        @Argument(help: "The name of the target to update")
+        @Argument(help: "The name of the target to update.")
         var targetName: String
 
-        @Option(help: "The package in which the dependency resides")
+        @Option(help: "The package in which the dependency resides.")
         var package: String?
 
         func run(_ swiftCommandState: SwiftCommandState) throws {

--- a/Sources/Commands/PackageCommands/ArchiveSource.swift
+++ b/Sources/Commands/PackageCommands/ArchiveSource.swift
@@ -21,7 +21,7 @@ extension SwiftPackageCommand {
     struct ArchiveSource: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
             commandName: "archive-source",
-            abstract: "Create a source archive for the package"
+            abstract: "Create a source archive for the package."
         )
 
         @OptionGroup(visibility: .hidden)
@@ -29,7 +29,7 @@ extension SwiftPackageCommand {
 
         @Option(
             name: [.short, .long],
-            help: "The absolute or relative path for the generated source archive"
+            help: "The absolute or relative path for the generated source archive."
         )
         var output: AbsolutePath?
 

--- a/Sources/Commands/PackageCommands/CompletionCommand.swift
+++ b/Sources/Commands/PackageCommands/CompletionCommand.swift
@@ -22,7 +22,7 @@ extension SwiftPackageCommand {
     struct CompletionCommand: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
             commandName: "completion-tool",
-            abstract: "Completion command (for shell completions)"
+            abstract: "Command to generate shell completions."
         )
 
         enum Mode: String, CaseIterable, ExpressibleByArgument {
@@ -52,7 +52,7 @@ extension SwiftPackageCommand {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Argument(help: "Type of completions to list")
+        @Argument(help: "Type of completions to list.")
         var mode: Mode
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {

--- a/Sources/Commands/PackageCommands/ComputeChecksum.swift
+++ b/Sources/Commands/PackageCommands/ComputeChecksum.swift
@@ -24,7 +24,7 @@ struct ComputeChecksum: SwiftCommand {
     @OptionGroup(visibility: .hidden)
     var globalOptions: GlobalOptions
 
-    @Argument(help: "The absolute or relative path to the binary artifact")
+    @Argument(help: "The absolute or relative path to the binary artifact.")
     var path: AbsolutePath
 
     func run(_ swiftCommandState: SwiftCommandState) throws {

--- a/Sources/Commands/PackageCommands/Config.swift
+++ b/Sources/Commands/PackageCommands/Config.swift
@@ -30,7 +30,7 @@ extension SwiftPackageCommand {
 extension SwiftPackageCommand.Config {
     struct SetMirror: SwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Set a mirror for a dependency"
+            abstract: "Set a mirror for a dependency."
         )
 
         @OptionGroup(visibility: .hidden)
@@ -45,10 +45,10 @@ extension SwiftPackageCommand.Config {
         @Option(name: .customLong("mirror-url"), help: .hidden)
         var _deprecate_mirrorURL: String?
 
-        @Option(help: "The original url or identity")
+        @Option(help: "The original url or identity.")
         var original: String?
 
-        @Option(help: "The mirror url or identity")
+        @Option(help: "The mirror url or identity.")
         var mirror: String?
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
@@ -88,7 +88,7 @@ extension SwiftPackageCommand.Config {
 
     struct UnsetMirror: SwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Remove an existing mirror"
+            abstract: "Remove an existing mirror."
         )
 
         @OptionGroup(visibility: .hidden)
@@ -103,10 +103,10 @@ extension SwiftPackageCommand.Config {
         @Option(name: .customLong("mirror-url"), help: .hidden)
         var _deprecate_mirrorURL: String?
 
-        @Option(help: "The original url or identity")
+        @Option(help: "The original url or identity.")
         var original: String?
 
-        @Option(help: "The mirror url or identity")
+        @Option(help: "The mirror url or identity.")
         var mirror: String?
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
@@ -143,7 +143,7 @@ extension SwiftPackageCommand.Config {
 
     struct GetMirror: SwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Print mirror configuration for the given package dependency"
+            abstract: "Print mirror configuration for the given package dependency."
         )
 
         @OptionGroup(visibility: .hidden)
@@ -154,7 +154,7 @@ extension SwiftPackageCommand.Config {
         @Option(name: .customLong("original-url"), help: .hidden)
         var _deprecate_originalURL: String?
 
-        @Option(help: "The original url or identity")
+        @Option(help: "The original url or identity.")
         var original: String?
 
         func run(_ swiftCommandState: SwiftCommandState) throws {

--- a/Sources/Commands/PackageCommands/Describe.swift
+++ b/Sources/Commands/PackageCommands/Describe.swift
@@ -23,12 +23,12 @@ import struct TSCBasic.StringError
 extension SwiftPackageCommand {
     struct Describe: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Describe the current package")
-        
+            abstract: "Describe the current package.")
+
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
         
-        @Option(help: "Set the output format")
+        @Option(help: "Set the output format.")
         var type: DescribeMode = .text
         
         func run(_ swiftCommandState: SwiftCommandState) async throws {

--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -23,7 +23,7 @@ import XCBuildSupport
 
 struct DumpSymbolGraph: AsyncSwiftCommand {
     static let configuration = CommandConfiguration(
-        abstract: "Dump Symbol Graph")
+        abstract: "Dump symbol graphs.")
     static let defaultMinimumAccessLevel = SymbolGraphExtract.AccessLevel.public
 
     @OptionGroup(visibility: .hidden)
@@ -35,7 +35,7 @@ struct DumpSymbolGraph: AsyncSwiftCommand {
     @Flag(help: "Skip members inherited through classes or default implementations.")
     var skipSynthesizedMembers = false
 
-    @Option(help: "Include symbols with this access level or more. Possible values: \(SymbolGraphExtract.AccessLevel.allValueStrings.joined(separator: " | "))")
+    @Option(help: "Include symbols with this access level or more. Possible values: \(SymbolGraphExtract.AccessLevel.allValueStrings.joined(separator: " | ")).")
     var minimumAccessLevel = defaultMinimumAccessLevel
 
     @Flag(help: "Skip emitting doc comments for members inherited through classes or default implementations.")

--- a/Sources/Commands/PackageCommands/EditCommands.swift
+++ b/Sources/Commands/PackageCommands/EditCommands.swift
@@ -19,21 +19,21 @@ import Workspace
 extension SwiftPackageCommand {
     struct Edit: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Put a package in editable mode")
+            abstract: "Put a package in editable mode.")
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Option(help: "The revision to edit", transform: { Revision(identifier: $0) })
+        @Option(help: "The revision to edit.", transform: { Revision(identifier: $0) })
         var revision: Revision?
 
-        @Option(name: .customLong("branch"), help: "The branch to create")
+        @Option(name: .customLong("branch"), help: "The branch to create.")
         var checkoutBranch: String?
 
-        @Option(help: "Create or use the checkout at this path")
+        @Option(help: "Create or use the checkout at this path.")
         var path: AbsolutePath?
 
-        @Argument(help: "The identity of the package to edit")
+        @Argument(help: "The identity of the package to edit.")
         var packageIdentity: String
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {
@@ -53,16 +53,16 @@ extension SwiftPackageCommand {
 
     struct Unedit: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Remove a package from editable mode")
+            abstract: "Remove a package from editable mode.")
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
         @Flag(name: .customLong("force"),
-              help: "Unedit the package even if it has uncommitted and unpushed changes")
+              help: "Unedit the package even if it has uncommitted and unpushed changes.")
         var shouldForceRemove: Bool = false
 
-        @Argument(help: "The identity of the package to unedit")
+        @Argument(help: "The identity of the package to unedit.")
         var packageIdentity: String
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {

--- a/Sources/Commands/PackageCommands/Format.swift
+++ b/Sources/Commands/PackageCommands/Format.swift
@@ -31,7 +31,7 @@ extension SwiftPackageCommand {
         var globalOptions: GlobalOptions
 
         @Argument(parsing: .captureForPassthrough,
-                  help: "Pass flag through to the swift-format tool")
+                  help: "Pass flag through to the swift-format tool.")
         var swiftFormatFlags: [String] = []
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {

--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -23,7 +23,7 @@ import SPMBuildCore
 extension SwiftPackageCommand {
     struct Init: SwiftCommand {
         public static let configuration = CommandConfiguration(
-            abstract: "Initialize a new package")
+            abstract: "Initialize a new package.")
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
@@ -47,7 +47,7 @@ extension SwiftPackageCommand {
         @OptionGroup()
         var testLibraryOptions: TestLibraryOptions
 
-        @Option(name: .customLong("name"), help: "Provide custom package name")
+        @Option(name: .customLong("name"), help: "Provide custom package name.")
         var packageName: String?
 
         // This command should support creating the supplied --package-path if it isn't created.

--- a/Sources/Commands/PackageCommands/Install.swift
+++ b/Sources/Commands/PackageCommands/Install.swift
@@ -30,7 +30,7 @@ extension SwiftPackageCommand {
         @OptionGroup()
         var globalOptions: GlobalOptions
 
-        @Option(help: "The name of the executable product to install")
+        @Option(help: "The name of the executable product to install.")
         var product: String?
 
         func run(_ commandState: SwiftCommandState) async throws {

--- a/Sources/Commands/PackageCommands/Learn.swift
+++ b/Sources/Commands/PackageCommands/Learn.swift
@@ -23,7 +23,7 @@ extension SwiftPackageCommand {
         @OptionGroup()
         var globalOptions: GlobalOptions
 
-        static let configuration = CommandConfiguration(abstract: "Learn about Swift and this package")
+        static let configuration = CommandConfiguration(abstract: "Learn about Swift and this package.")
 
         func files(fileSystem: FileSystem, in directory: AbsolutePath, fileExtension: String? = nil) throws -> [AbsolutePath] {
             guard fileSystem.isDirectory(directory) else {

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -25,7 +25,7 @@ import Workspace
 struct PluginCommand: AsyncSwiftCommand {
     static let configuration = CommandConfiguration(
         commandName: "plugin",
-        abstract: "Invoke a command plugin or perform other actions on command plugins"
+        abstract: "Invoke a command plugin or perform other actions on command plugins."
     )
 
     @OptionGroup(visibility: .hidden)
@@ -33,20 +33,20 @@ struct PluginCommand: AsyncSwiftCommand {
 
     @Flag(
         name: .customLong("list"),
-        help: "List the available command plugins"
+        help: "List the available command plugins."
     )
     var listCommands: Bool = false
 
     struct PluginOptions: ParsableArguments {
         @Flag(
             name: .customLong("allow-writing-to-package-directory"),
-            help: "Allow the plugin to write to the package directory"
+            help: "Allow the plugin to write to the package directory."
         )
         var allowWritingToPackageDirectory: Bool = false
 
         @Option(
             name: .customLong("allow-writing-to-directory"),
-            help: "Allow the plugin to write to an additional directory"
+            help: "Allow the plugin to write to an additional directory."
         )
         var additionalAllowedWritableDirectories: [String] = []
 
@@ -123,7 +123,7 @@ struct PluginCommand: AsyncSwiftCommand {
 
         @Option(
             name: .customLong("package"),
-            help: "Limit available plugins to a single package with the given identity"
+            help: "Limit available plugins to a single package with the given identity."
         )
         var packageIdentity: String? = nil
     }
@@ -131,12 +131,12 @@ struct PluginCommand: AsyncSwiftCommand {
     @OptionGroup()
     var pluginOptions: PluginOptions
 
-    @Argument(help: "Verb of the command plugin to invoke")
+    @Argument(help: "Verb of the command plugin to invoke.")
     var command: String = ""
 
     @Argument(
         parsing: .captureForPassthrough,
-        help: "Arguments to pass to the command plugin"
+        help: "Arguments to pass to the command plugin."
     )
     var arguments: [String] = []
 

--- a/Sources/Commands/PackageCommands/ResetCommands.swift
+++ b/Sources/Commands/PackageCommands/ResetCommands.swift
@@ -17,7 +17,7 @@ import Workspace
 extension SwiftPackageCommand {
     struct Clean: SwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Delete build artifacts")
+            abstract: "Delete build artifacts.")
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
@@ -41,7 +41,7 @@ extension SwiftPackageCommand {
 
     struct Reset: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Reset the complete cache/build directory")
+            abstract: "Reset the complete cache/build directory.")
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions

--- a/Sources/Commands/PackageCommands/Resolve.swift
+++ b/Sources/Commands/PackageCommands/Resolve.swift
@@ -20,16 +20,16 @@ import enum PackageModel.TraitConfiguration
 
 extension SwiftPackageCommand {
     struct ResolveOptions: ParsableArguments {
-        @Option(help: "The version to resolve at", transform: { Version($0) })
+        @Option(help: "The version to resolve at.", transform: { Version($0) })
         var version: Version?
 
-        @Option(help: "The branch to resolve at")
+        @Option(help: "The branch to resolve at.")
         var branch: String?
 
-        @Option(help: "The revision to resolve at")
+        @Option(help: "The revision to resolve at.")
         var revision: String?
 
-        @Argument(help: "The name of the package to resolve")
+        @Argument(help: "The name of the package to resolve.")
         var packageName: String?
 
         /// Specifies the traits to build.
@@ -39,7 +39,7 @@ extension SwiftPackageCommand {
 
     struct Resolve: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Resolve package dependencies")
+            abstract: "Resolve package dependencies.")
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions

--- a/Sources/Commands/PackageCommands/ShowDependencies.swift
+++ b/Sources/Commands/PackageCommands/ShowDependencies.swift
@@ -23,12 +23,12 @@ import var TSCBasic.stdoutStream
 extension SwiftPackageCommand {
     struct ShowDependencies: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Print the resolved dependency graph")
+            abstract: "Print the resolved dependency graph.")
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Option(help: "Set the output format")
+        @Option(help: "Set the output format.")
         var format: ShowDependenciesMode = .text
 
         @Option(name: [.long, .customShort("o") ],

--- a/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
+++ b/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
@@ -29,7 +29,7 @@ public struct SwiftPackageCommand: AsyncParsableCommand {
     public static var configuration = CommandConfiguration(
         commandName: "package",
         _superCommandName: "swift",
-        abstract: "Perform operations on Swift packages",
+        abstract: "Perform operations on Swift packages.",
         discussion: "SEE ALSO: swift build, swift run, swift test",
         version: SwiftVersion.current.completeDisplayString,
         subcommands: [

--- a/Sources/Commands/PackageCommands/ToolsVersionCommand.swift
+++ b/Sources/Commands/PackageCommands/ToolsVersionCommand.swift
@@ -21,15 +21,15 @@ import Workspace
 struct ToolsVersionCommand: SwiftCommand {
     static let configuration = CommandConfiguration(
         commandName: "tools-version",
-        abstract: "Manipulate tools version of the current package")
+        abstract: "Manipulate tools version of the current package.")
 
     @OptionGroup(visibility: .hidden)
     var globalOptions: GlobalOptions
 
-    @Flag(help: "Set tools version of package to the current tools version in use")
+    @Flag(help: "Set tools version of package to the current tools version in use.")
     var setCurrent: Bool = false
 
-    @Option(help: "Set tools version of package to the given value")
+    @Option(help: "Set tools version of package to the given value.")
     var set: String?
 
     enum ToolsVersionMode {

--- a/Sources/Commands/PackageCommands/Update.swift
+++ b/Sources/Commands/PackageCommands/Update.swift
@@ -21,16 +21,16 @@ import Workspace
 extension SwiftPackageCommand {
     struct Update: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Update package dependencies")
-        
+            abstract: "Update package dependencies.")
+
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
         
         @Flag(name: [.long, .customShort("n")],
-              help: "Display the list of dependencies that can be updated")
+              help: "Display the list of dependencies that can be updated.")
         var dryRun: Bool = false
         
-        @Argument(help: "The packages to update")
+        @Argument(help: "The packages to update.")
         var packages: [String] = []
         
         func run(_ swiftCommandState: SwiftCommandState) async throws {

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -72,35 +72,35 @@ struct BuildCommandOptions: ParsableArguments {
     }
 
     /// If the test should be built.
-    @Flag(help: "Build both source and test targets")
+    @Flag(help: "Build both source and test targets.")
     var buildTests: Bool = false
 
     /// Whether to enable code coverage.
     @Flag(name: .customLong("code-coverage"),
           inversion: .prefixedEnableDisable,
-          help: "Enable code coverage")
+          help: "Enable code coverage.")
     var enableCodeCoverage: Bool = false
 
     /// If the binary output path should be printed.
-    @Flag(name: .customLong("show-bin-path"), help: "Print the binary output path")
+    @Flag(name: .customLong("show-bin-path"), help: "Print the binary output path.")
     var shouldPrintBinPath: Bool = false
 
     /// Whether to output a graphviz file visualization of the combined job graph for all targets
     @Flag(name: .customLong("print-manifest-job-graph"),
-          help: "Write the command graph for the build manifest as a Graphviz file")
+          help: "Write the command graph for the build manifest as a Graphviz file.")
     var printManifestGraphviz: Bool = false
 
     /// Whether to output a graphviz file visualization of the PIF JSON sent to Swift Build.
     @Flag(name: .customLong("print-pif-manifest-graph"),
-          help: "Write the PIF JSON sent to Swift Build as a Graphviz file")
+          help: "Write the PIF JSON sent to Swift Build as a Graphviz file.")
     var printPIFManifestGraphviz: Bool = false
 
     /// Specific target to build.
-    @Option(help: "Build the specified target")
+    @Option(help: "Build the specified target.")
     var target: String?
 
     /// Specific product to build.
-    @Option(help: "Build the specified product")
+    @Option(help: "Build the specified product.")
     var product: String?
 
     /// Testing library options.
@@ -115,7 +115,7 @@ struct BuildCommandOptions: ParsableArguments {
     package var traits: TraitOptions
 
     /// If should link the Swift stdlib statically.
-    @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Link Swift stdlib statically")
+    @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Link Swift stdlib statically.")
     public var shouldLinkStaticSwiftStdlib: Bool = false
 }
 
@@ -124,7 +124,7 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
     public static var configuration = CommandConfiguration(
         commandName: "build",
         _superCommandName: "swift",
-        abstract: "Build sources into binary products",
+        abstract: "Build sources into binary products.",
         discussion: "SEE ALSO: swift run, swift package, swift test",
         version: SwiftVersion.current.completeDisplayString,
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])

--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -62,11 +62,11 @@ struct RunCommandOptions: ParsableArguments {
         static func help(for value: RunCommandOptions.RunMode) -> ArgumentHelp? {
             switch value {
             case .repl:
-                return "Launch Swift REPL for the package"
+                return "Launch Swift REPL for the package."
             case .debugger:
-                return "Launch the executable in a debugger session"
+                return "Launch the executable in a debugger session."
             case .run:
-                return "Launch the executable with the provided arguments"
+                return "Launch the executable with the provided arguments."
             }
         }
     }
@@ -75,17 +75,17 @@ struct RunCommandOptions: ParsableArguments {
     @Flag var mode: RunMode = .run
 
     /// If the executable product should be built before running.
-    @Flag(name: .customLong("skip-build"), help: "Skip building the executable product")
+    @Flag(name: .customLong("skip-build"), help: "Skip building the executable product.")
     var shouldSkipBuild: Bool = false
 
     var shouldBuild: Bool { !shouldSkipBuild }
 
     /// If the test should be built.
-    @Flag(name: .customLong("build-tests"), help: "Build both source and test targets")
+    @Flag(name: .customLong("build-tests"), help: "Build both source and test targets.")
     var shouldBuildTests: Bool = false
 
     /// The executable product to run.
-    @Argument(help: "The executable to run", completion: .shellCommand("swift package completion-tool list-executables"))
+    @Argument(help: "The executable to run.", completion: .shellCommand("swift package completion-tool list-executables"))
     var executable: String?
 
     /// Specifies the traits to build the product with.
@@ -94,7 +94,7 @@ struct RunCommandOptions: ParsableArguments {
 
     /// The arguments to pass to the executable.
     @Argument(parsing: .captureForPassthrough,
-              help: "The arguments to pass to the executable")
+              help: "The arguments to pass to the executable.")
     var arguments: [String] = []
 }
 
@@ -103,7 +103,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
     public static var configuration = CommandConfiguration(
         commandName: "run",
         _superCommandName: "swift",
-        abstract: "Build and run an executable product",
+        abstract: "Build and run an executable product.",
         discussion: "SEE ALSO: swift build, swift package, swift test",
         version: SwiftVersion.current.completeDisplayString,
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -81,7 +81,7 @@ extension TestError: CustomStringConvertible {
 
 struct SharedOptions: ParsableArguments {
     @Flag(name: .customLong("skip-build"),
-          help: "Skip building the test target")
+          help: "Skip building the test target.")
     var shouldSkipBuilding: Bool = false
 
     /// The test product to use. This is useful when there are multiple test products
@@ -160,12 +160,12 @@ struct TestCommandOptions: ParsableArguments {
 
     /// List the tests and exit.
     @Flag(name: [.customLong("list-tests"), .customShort("l")],
-          help: "Lists test methods in specifier format")
+          help: "Lists test methods in specifier format.")
     var _deprecated_shouldListTests: Bool = false
 
     /// If the path of the exported code coverage JSON should be printed.
     @Flag(name: [.customLong("show-codecov-path"), .customLong("show-code-coverage-path"), .customLong("show-coverage-path")],
-          help: "Print the path of the exported code coverage JSON file")
+          help: "Print the path of the exported code coverage JSON file.")
     var shouldPrintCodeCovPath: Bool = false
 
     var testCaseSpecifier: TestCaseSpecifier {
@@ -180,13 +180,13 @@ struct TestCommandOptions: ParsableArguments {
     var _testCaseSpecifier: String?
 
     @Option(help: """
-        Run test cases matching regular expression, Format: <test-target>.<test-case> \
-        or <test-target>.<test-case>/<test>
+        Run test cases that match a regular expression, Format: '<test-target>.<test-case>' \
+        or '<test-target>.<test-case>/<test>'.
         """)
     var filter: [String] = []
 
     @Option(name: .customLong("skip"),
-            help: "Skip test cases matching regular expression, Example: --skip PerformanceTests")
+            help: "Skip test cases that match regular expression, Example: '--skip PerformanceTests'.")
     var _testCaseSkip: [String] = []
 
     /// Path where the xUnit xml file should be generated.
@@ -210,7 +210,7 @@ struct TestCommandOptions: ParsableArguments {
     /// Whether to enable code coverage.
     @Flag(name: .customLong("code-coverage"),
           inversion: .prefixedEnableDisable,
-          help: "Enable code coverage")
+          help: "Enable code coverage.")
     var enableCodeCoverage: Bool = false
 
     /// Configure test output.
@@ -257,7 +257,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     public static var configuration = CommandConfiguration(
         commandName: "test",
         _superCommandName: "swift",
-        abstract: "Build and run tests",
+        abstract: "Build and run tests.",
         discussion: "SEE ALSO: swift build, swift run, swift package",
         version: SwiftVersion.current.completeDisplayString,
         subcommands: [

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -186,7 +186,7 @@ struct TestCommandOptions: ParsableArguments {
     var filter: [String] = []
 
     @Option(name: .customLong("skip"),
-            help: "Skip test cases that match regular expression, Example: '--skip PerformanceTests'.")
+            help: "Skip test cases that match a regular expression, Example: '--skip PerformanceTests'.")
     var _testCaseSkip: [String] = []
 
     /// Path where the xUnit xml file should be generated.

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -70,24 +70,24 @@ public struct LocationOptions: ParsableArguments {
 
     @Option(
         name: .customLong("package-path"),
-        help: "Specify the package path to operate on (default current directory). This changes the working directory before any other operation",
+        help: "Specify the package path to operate on (default current directory). This changes the working directory before any other operation.",
         completion: .directory
     )
     public var packageDirectory: AbsolutePath?
 
-    @Option(name: .customLong("cache-path"), help: "Specify the shared cache directory path", completion: .directory)
+    @Option(name: .customLong("cache-path"), help: "Specify the shared cache directory path.", completion: .directory)
     public var cacheDirectory: AbsolutePath?
 
     @Option(
         name: .customLong("config-path"),
-        help: "Specify the shared configuration directory path",
+        help: "Specify the shared configuration directory path.",
         completion: .directory
     )
     public var configurationDirectory: AbsolutePath?
 
     @Option(
         name: .customLong("security-path"),
-        help: "Specify the shared security directory path",
+        help: "Specify the shared security directory path.",
         completion: .directory
     )
     public var securityDirectory: AbsolutePath?
@@ -95,7 +95,7 @@ public struct LocationOptions: ParsableArguments {
     /// The custom .build directory, if provided.
     @Option(
         name: .customLong("scratch-path"),
-        help: "Specify a custom scratch directory path (default .build)",
+        help: "Specify a custom scratch directory path. (default .build)",
         completion: .directory
     )
     var _scratchDirectory: AbsolutePath?
@@ -121,7 +121,7 @@ public struct LocationOptions: ParsableArguments {
     /// Path to the directory containing installed Swift SDKs.
     @Option(
         name: .customLong("swift-sdks-path"),
-        help: "Path to the directory containing installed Swift SDKs",
+        help: "Path to the directory containing installed Swift SDKs.",
         completion: .directory
     )
     public var swiftSDKsDirectory: AbsolutePath?
@@ -165,7 +165,7 @@ public struct CachingOptions: ParsableArguments {
     @Flag(
         name: .customLong("dependency-cache"),
         inversion: .prefixedEnableDisable,
-        help: "Use a shared cache when fetching dependencies"
+        help: "Use a shared cache when fetching dependencies."
     )
     public var useDependenciesCache: Bool = true
 
@@ -180,7 +180,7 @@ public struct CachingOptions: ParsableArguments {
     /// Disables manifest caching.
     @Option(
         name: .customLong("manifest-cache"),
-        help: "Caching mode of Package.swift manifests (shared: shared cache, local: package's build directory, none: disabled)"
+        help: "Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)"
     )
     public var manifestCachingMode: ManifestCachingMode = .shared
 
@@ -197,7 +197,7 @@ public struct CachingOptions: ParsableArguments {
     /// Whether to use macro prebuilts or not
     @Flag(name: .customLong("experimental-prebuilts"),
           inversion: .prefixedEnableDisable,
-          help: "Whether to use prebuilt swift-syntax libraries for macros")
+          help: "Whether to use prebuilt swift-syntax libraries for macros.")
     public var usePrebuilts: Bool = false
 }
 
@@ -205,11 +205,11 @@ public struct LoggingOptions: ParsableArguments {
     public init() {}
 
     /// The verbosity of informational output.
-    @Flag(name: .shortAndLong, help: "Increase verbosity to include informational output")
+    @Flag(name: .shortAndLong, help: "Increase verbosity to include informational output.")
     public var verbose: Bool = false
 
     /// The verbosity of informational output.
-    @Flag(name: [.long, .customLong("vv")], help: "Increase verbosity to include debug output")
+    @Flag(name: [.long, .customLong("vv")], help: "Increase verbosity to include debug output.")
     public var veryVerbose: Bool = false
 
     /// Whether logging output should be limited to `.error`.
@@ -230,11 +230,11 @@ public struct SecurityOptions: ParsableArguments {
     public init() {}
 
     /// Disables sandboxing when executing subprocesses.
-    @Flag(name: .customLong("disable-sandbox"), help: "Disable using the sandbox when executing subprocesses")
+    @Flag(name: .customLong("disable-sandbox"), help: "Disable using the sandbox when executing subprocesses.")
     public var shouldDisableSandbox: Bool = false
 
     /// Force usage of the netrc file even in cases where it is not allowed.
-    @Flag(name: .customLong("netrc"), help: "Use netrc file even in cases where other credential stores are preferred")
+    @Flag(name: .customLong("netrc"), help: "Use netrc file even in cases where other credential stores are preferred.")
     public var forceNetrc: Bool = false
 
     /// Whether to load netrc files for authenticating with remote servers
@@ -243,14 +243,14 @@ public struct SecurityOptions: ParsableArguments {
     @Flag(
         inversion: .prefixedEnableDisable,
         exclusivity: .exclusive,
-        help: "Load credentials from a netrc file"
+        help: "Load credentials from a netrc file."
     )
     public var netrc: Bool = true
 
     /// The path to the netrc file used when `netrc` is `true`.
     @Option(
         name: .customLong("netrc-file"),
-        help: "Specify the netrc file path",
+        help: "Specify the netrc file path.",
         completion: .file()
     )
     public var netrcFilePath: AbsolutePath?
@@ -262,7 +262,7 @@ public struct SecurityOptions: ParsableArguments {
     @Flag(
         inversion: .prefixedEnableDisable,
         exclusivity: .exclusive,
-        help: "Search credentials in macOS keychain"
+        help: "Search credentials in macOS keychain."
     )
     public var keychain: Bool = true
     #else
@@ -283,7 +283,7 @@ public struct SecurityOptions: ParsableArguments {
     @Flag(
         inversion: .prefixedEnableDisable,
         exclusivity: .exclusive,
-        help: "Validate signature of a signed package release downloaded from registry"
+        help: "Validate signature of a signed package release downloaded from registry."
     )
     public var signatureValidation: Bool = true
 }
@@ -298,15 +298,15 @@ public struct ResolverOptions: ParsableArguments {
     /// Use Package.resolved file for resolving dependencies.
     @Flag(
         name: [.long, .customLong("disable-automatic-resolution"), .customLong("only-use-versions-from-resolved-file")],
-        help: "Only use versions from the Package.resolved file and fail resolution if it is out-of-date"
+        help: "Only use versions from the Package.resolved file and fail resolution if it is out-of-date."
     )
     public var forceResolvedVersions: Bool = false
 
     /// Skip updating dependencies from their remote during a resolution.
-    @Flag(name: .customLong("skip-update"), help: "Skip updating dependencies from their remote during a resolution")
+    @Flag(name: .customLong("skip-update"), help: "Skip updating dependencies from their remote during a resolution.")
     public var skipDependencyUpdate: Bool = false
 
-    @Flag(help: "Define automatic transformation of source control based dependencies to registry based ones")
+    @Flag(help: "Define automatic transformation of source control based dependencies to registry based ones.")
     public var sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation =
         .disabled
 
@@ -315,13 +315,13 @@ public struct ResolverOptions: ParsableArguments {
     @Flag(
         name: .customLong("experimental-prune-unused-dependencies"),
         help: ArgumentHelp(
-            "Enables the ability to prune unused dependencies of the package to avoid redundant loads during resolution",
+            "Enables the ability to prune unused dependencies of the package to avoid redundant loads during resolution.",
             visibility: .hidden
         )
     )
     public var pruneDependencies: Bool = false
 
-    @Option(help: "Default registry URL to use, instead of the registries.json configuration file")
+    @Option(help: "Default registry URL to use, instead of the registries.json configuration file.")
     public var defaultRegistryURL: URL?
 
     public enum SourceControlToRegistryDependencyTransformation: EnumerableFlag {
@@ -343,11 +343,11 @@ public struct ResolverOptions: ParsableArguments {
         public static func help(for value: SourceControlToRegistryDependencyTransformation) -> ArgumentHelp? {
             switch value {
             case .disabled:
-                return "disable source control to registry transformation"
+                return "Disable source control to registry transformation."
             case .identity:
-                return "look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins"
+                return "Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins."
             case .swizzle:
-                return "look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible"
+                return "Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible."
             }
         }
     }
@@ -363,28 +363,28 @@ public struct BuildOptions: ParsableArguments {
     @Option(
         name: .customLong("Xcc", withSingleDash: true),
         parsing: .unconditionalSingleValue,
-        help: "Pass flag through to all C compiler invocations"
+        help: "Pass flag through to all C compiler invocations."
     )
     var cCompilerFlags: [String] = []
 
     @Option(
         name: .customLong("Xswiftc", withSingleDash: true),
         parsing: .unconditionalSingleValue,
-        help: "Pass flag through to all Swift compiler invocations"
+        help: "Pass flag through to all Swift compiler invocations."
     )
     var swiftCompilerFlags: [String] = []
 
     @Option(
         name: .customLong("Xlinker", withSingleDash: true),
         parsing: .unconditionalSingleValue,
-        help: "Pass flag through to all linker invocations"
+        help: "Pass flag through to all linker invocations."
     )
     var linkerFlags: [String] = []
 
     @Option(
         name: .customLong("Xcxx", withSingleDash: true),
         parsing: .unconditionalSingleValue,
-        help: "Pass flag through to all C++ compiler invocations"
+        help: "Pass flag through to all C++ compiler invocations."
     )
     var cxxCompilerFlags: [String] = []
 
@@ -392,7 +392,7 @@ public struct BuildOptions: ParsableArguments {
         name: .customLong("Xxcbuild", withSingleDash: true),
         parsing: .unconditionalSingleValue,
         help: ArgumentHelp(
-            "Pass flag through to the Xcode build system invocations",
+            "Pass flag through to the Xcode build system invocations.",
             visibility: .hidden
         )
     )
@@ -402,7 +402,7 @@ public struct BuildOptions: ParsableArguments {
         name: .customLong("Xbuild-tools-swiftc", withSingleDash: true),
         parsing: .unconditionalSingleValue,
         help: ArgumentHelp(
-            "Pass flag to Swift compiler invocations for build-time executables (manifest and plugins)",
+            "Pass flag to Swift compiler invocations for build-time executables (manifest and plugins).",
             visibility: .hidden
         )
     )
@@ -412,7 +412,7 @@ public struct BuildOptions: ParsableArguments {
         name: .customLong("Xmanifest", withSingleDash: true),
         parsing: .unconditionalSingleValue,
         help: ArgumentHelp(
-            "Pass flag to the manifest build invocation. Deprecated: use '-Xbuild-tools-swiftc' instead",
+            "Pass flag to the manifest build invocation. Deprecated: use '-Xbuild-tools-swiftc' instead.",
             visibility: .hidden
         )
     )
@@ -466,14 +466,14 @@ public struct BuildOptions: ParsableArguments {
     /// Filter for selecting a specific Swift SDK to build with.
     @Option(
         name: .customLong("swift-sdk"),
-        help: "Filter for selecting a specific Swift SDK to build with"
+        help: "Filter for selecting a specific Swift SDK to build with."
     )
     public var swiftSDKSelector: String?
 
     /// Which compile-time sanitizers should be enabled.
     @Option(
         name: .customLong("sanitize"),
-        help: "Turn on runtime checks for erroneous behavior, possible values: \(Sanitizer.formattedValues)"
+        help: "Turn on runtime checks for erroneous behavior, possible values: \(Sanitizer.formattedValues)."
     )
     public var sanitizers: [Sanitizer] = []
 
@@ -481,7 +481,7 @@ public struct BuildOptions: ParsableArguments {
         EnabledSanitizers(Set(sanitizers))
     }
 
-    @Flag(help: "Enable or disable indexing-while-building feature")
+    @Flag(help: "Enable or disable indexing-while-building feature.")
     public var indexStoreMode: StoreMode = .autoIndexStore
 
     /// Instead of building the target, perform the minimal amount of work to prepare it for indexing.
@@ -504,7 +504,7 @@ public struct BuildOptions: ParsableArguments {
     public var shouldEnableParseableModuleInterfaces: Bool = false
 
     /// The number of jobs for llbuild to start (aka the number of schedulerLanes)
-    @Option(name: .shortAndLong, help: "The number of jobs to spawn in parallel during the build process")
+    @Option(name: .shortAndLong, help: "The number of jobs to spawn in parallel during the build process.")
     public var jobs: UInt32?
 
     /// Whether to use the integrated Swift driver rather than shelling out
@@ -514,7 +514,7 @@ public struct BuildOptions: ParsableArguments {
 
     /// A flag that indicates this build should check whether targets only import
     /// their explicitly-declared dependencies
-    @Option(help: "A flag that indicates this build should check whether targets only import their explicitly-declared dependencies")
+    @Option(help: "A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.")
     public var explicitTargetDependencyImportCheck: TargetDependencyImportCheckingMode = .none
 
     /// Whether to use the explicit module build flow (with the integrated driver)
@@ -526,7 +526,7 @@ public struct BuildOptions: ParsableArguments {
     var _buildSystem: BuildSystemProvider.Kind = .native
 
     /// The Debug Information Format to use.
-    @Option(name: .customLong("debug-info-format", withSingleDash: true), help: "The Debug Information Format to use")
+    @Option(name: .customLong("debug-info-format", withSingleDash: true), help: "The Debug Information Format to use.")
     public var debugInfoFormat: DebugInfoFormat = .dwarf
 
     public var buildSystem: BuildSystemProvider.Kind {
@@ -602,12 +602,12 @@ public struct LinkerOptions: ParsableArguments {
     @Flag(
         name: .customLong("dead-strip"),
         inversion: .prefixedEnableDisable,
-        help: "Disable/enable dead code stripping by the linker"
+        help: "Disable/enable dead code stripping by the linker."
     )
     public var linkerDeadStrip: Bool = true
 
     /// Disables adding $ORIGIN/@loader_path to the rpath, useful when deploying
-    @Flag(name: .customLong("disable-local-rpath"), help: "Disable adding $ORIGIN/@loader_path to the rpath by default")
+    @Flag(name: .customLong("disable-local-rpath"), help: "Disable adding $ORIGIN/@loader_path to the rpath by default.")
     public var shouldDisableLocalRpath: Bool = false
 }
 
@@ -622,7 +622,7 @@ public struct TestLibraryOptions: ParsableArguments {
     /// have the correct default value if the user didn't specify one.
     @Flag(name: .customLong("xctest"),
           inversion: .prefixedEnableDisable,
-          help: "Enable support for XCTest")
+          help: "Enable support for XCTest.")
     public var explicitlyEnableXCTestSupport: Bool?
 
     /// Whether to enable support for Swift Testing (as explicitly specified by the user.)
@@ -631,7 +631,7 @@ public struct TestLibraryOptions: ParsableArguments {
     /// have the correct default value if the user didn't specify one.
     @Flag(name: .customLong("swift-testing"),
           inversion: .prefixedEnableDisable,
-          help: "Enable support for Swift Testing")
+          help: "Enable support for Swift Testing.")
     public var explicitlyEnableSwiftTestingLibrarySupport: Bool?
 
     /// Legacy experimental equivalent of ``explicitlyEnableSwiftTestingLibrarySupport``.

--- a/Sources/PackageCollectionsCommand/PackageCollectionsCommand.swift
+++ b/Sources/PackageCollectionsCommand/PackageCollectionsCommand.swift
@@ -58,7 +58,7 @@ public struct PackageCollectionsCommand: AsyncParsableCommand {
     public static var configuration = CommandConfiguration(
         commandName: "package-collection",
         _superCommandName: "swift",
-        abstract: "Interact with package collections",
+        abstract: "Interact with package collections.",
         discussion: "SEE ALSO: swift build, swift package, swift run, swift test",
         version: SwiftVersion.current.completeDisplayString,
         subcommands: [
@@ -77,7 +77,7 @@ public struct PackageCollectionsCommand: AsyncParsableCommand {
     // MARK: Collections
 
     struct List: AsyncSwiftCommand {
-        static let configuration = CommandConfiguration(abstract: "List configured collections")
+        static let configuration = CommandConfiguration(abstract: "List configured collections.")
 
         @OptionGroup
         var jsonOptions: JSONOptions
@@ -101,7 +101,7 @@ public struct PackageCollectionsCommand: AsyncParsableCommand {
     }
 
     struct Refresh: AsyncSwiftCommand {
-        static let configuration = CommandConfiguration(abstract: "Refresh configured collections")
+        static let configuration = CommandConfiguration(abstract: "Refresh configured collections.")
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
@@ -115,18 +115,18 @@ public struct PackageCollectionsCommand: AsyncParsableCommand {
     }
 
     struct Add: AsyncSwiftCommand {
-        static let configuration = CommandConfiguration(abstract: "Add a new collection")
+        static let configuration = CommandConfiguration(abstract: "Add a new collection.")
 
-        @Argument(help: "URL of the collection to add")
+        @Argument(help: "URL of the collection to add.")
         var collectionURL: String
 
-        @Option(name: .long, help: "Sort order for the added collection")
+        @Option(name: .long, help: "Sort order for the added collection.")
         var order: Int?
 
-        @Flag(name: .long, help: "Trust the collection even if it is unsigned")
+        @Flag(name: .long, help: "Trust the collection even if it is unsigned.")
         var trustUnsigned: Bool = false
 
-        @Flag(name: .long, help: "Skip signature check if the collection is signed")
+        @Flag(name: .long, help: "Skip signature check if the collection is signed.")
         var skipSignatureCheck: Bool = false
 
         @OptionGroup(visibility: .hidden)
@@ -158,9 +158,9 @@ public struct PackageCollectionsCommand: AsyncParsableCommand {
     }
 
     struct Remove: AsyncSwiftCommand {
-        static let configuration = CommandConfiguration(abstract: "Remove a configured collection")
+        static let configuration = CommandConfiguration(abstract: "Remove a configured collection.")
 
-        @Argument(help: "URL of the collection to remove")
+        @Argument(help: "URL of the collection to remove.")
         var collectionURL: String
 
         @OptionGroup(visibility: .hidden)
@@ -186,15 +186,15 @@ public struct PackageCollectionsCommand: AsyncParsableCommand {
     }
 
     struct Search: AsyncSwiftCommand {
-        static var configuration = CommandConfiguration(abstract: "Search for packages by keywords or module names")
+        static var configuration = CommandConfiguration(abstract: "Search for packages by keywords or module names.")
 
         @OptionGroup
         var jsonOptions: JSONOptions
 
-        @Flag(help: "Pick the method for searching")
+        @Flag(help: "Pick the method for searching.")
         var searchMethod: SearchMethod
 
-        @Argument(help: "Search query")
+        @Argument(help: "The search query.")
         var searchQuery: String
 
         @OptionGroup(visibility: .hidden)
@@ -233,18 +233,18 @@ public struct PackageCollectionsCommand: AsyncParsableCommand {
     // MARK: Packages
 
     struct Describe: AsyncSwiftCommand {
-        static var configuration = CommandConfiguration(abstract: "Get metadata for a collection or a package included in an imported collection")
+        static var configuration = CommandConfiguration(abstract: "Get metadata for a collection or a package included in an imported collection.")
 
         @OptionGroup
         var jsonOptions: JSONOptions
 
-        @Argument(help: "URL of the package or collection to get information for")
+        @Argument(help: "URL of the package or collection to get information for.")
         var packageURL: String
 
-        @Option(name: .long, help: "Version of the package to get information for")
+        @Option(name: .long, help: "Version of the package to get information for.")
         var version: String?
 
-        @Flag(name: .long, help: "Skip signature check if the collection is signed")
+        @Flag(name: .long, help: "Skip signature check if the collection is signed.")
         var skipSignatureCheck: Bool = false
 
         @OptionGroup(visibility: .hidden)

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
@@ -113,7 +113,7 @@ extension PackageRegistryCommand {
         }
 
         static let configuration = CommandConfiguration(
-            abstract: "Log in to a registry"
+            abstract: "Log in to a registry."
         )
 
         static let maxPasswordLength = 512
@@ -125,29 +125,29 @@ extension PackageRegistryCommand {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Argument(help: "The registry URL")
+        @Argument(help: "The registry URL.")
         var url: URL?
 
         var registryURL: URL? {
             self.url
         }
 
-        @Option(help: "Username")
+        @Option(help: "The username for the registry.")
         var username: String?
 
-        @Option(help: "Password")
+        @Option(help: "The password for the registry.")
         var password: String?
 
-        @Option(help: "Access token")
+        @Option(help: "The access token for the registry.")
         var token: String?
 
         @Option(
             name: .customLong("token-file"),
-            help: "Path to the file containing access token"
+            help: "Path to the file containing access token."
         )
         var tokenFilePath: AbsolutePath?
 
-        @Flag(help: "Allow writing to netrc file without confirmation")
+        @Flag(help: "Allow writing to netrc file without confirmation.")
         var noConfirm: Bool = false
 
         private static let PLACEHOLDER_TOKEN_USER = "token"

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
@@ -38,7 +38,7 @@ extension PackageRegistryCommand {
         static let metadataFilename = "package-metadata.json"
 
         static let configuration = CommandConfiguration(
-            abstract: "Publish to a registry"
+            abstract: "Publish to a registry."
         )
 
         @OptionGroup(visibility: .hidden)
@@ -83,7 +83,7 @@ extension PackageRegistryCommand {
         )
         var certificateChainPaths: [AbsolutePath] = []
 
-        @Flag(name: .customLong("allow-insecure-http"), help: "Allow using a non-HTTPS registry URL")
+        @Flag(name: .customLong("allow-insecure-http"), help: "Allow using a non-HTTPS registry URL.")
         var allowInsecureHTTP: Bool = false
 
         @Flag(help: "Dry run only; prepare the archive and sign it but do not publish to the registry.")

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand.swift
@@ -23,7 +23,7 @@ public struct PackageRegistryCommand: AsyncParsableCommand {
     public static var configuration = CommandConfiguration(
         commandName: "package-registry",
         _superCommandName: "swift",
-        abstract: "Interact with package registry and manage related configuration",
+        abstract: "Interact with package registry and manage related configuration.",
         discussion: "SEE ALSO: swift package",
         version: SwiftVersion.current.completeDisplayString,
         subcommands: [
@@ -43,22 +43,22 @@ public struct PackageRegistryCommand: AsyncParsableCommand {
 
     struct Set: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Set a custom registry"
+            abstract: "Set a custom registry."
         )
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Flag(help: "Apply settings to all projects for this user")
+        @Flag(help: "Apply settings to all projects for this user.")
         var global: Bool = false
 
-        @Option(help: "Associate the registry with a given scope")
+        @Option(help: "Associate the registry with a given scope.")
         var scope: String?
 
-        @Flag(name: .customLong("allow-insecure-http"), help: "Allow using a non-HTTPS registry URL")
+        @Flag(name: .customLong("allow-insecure-http"), help: "Allow using a non-HTTPS registry URL.")
         var allowInsecureHTTP: Bool = false
 
-        @Argument(help: "The registry URL")
+        @Argument(help: "The registry URL.")
         var url: URL
 
         var registryURL: URL {
@@ -90,16 +90,16 @@ public struct PackageRegistryCommand: AsyncParsableCommand {
 
     struct Unset: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Remove a configured registry"
+            abstract: "Remove a configured registry."
         )
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Flag(help: "Apply settings to all projects for this user")
+        @Flag(help: "Apply settings to all projects for this user.")
         var global: Bool = false
 
-        @Option(help: "Associate the registry with a given scope")
+        @Option(help: "Associate the registry with a given scope.")
         var scope: String?
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -43,17 +43,17 @@ await { () async in
 struct SwiftBootstrapBuildTool: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "swift-bootstrap",
-        abstract: "Bootstrapping build tool, only use in the context of bootstrapping SwiftPM itself",
+        abstract: "Bootstrapping build tool, only use in the context of bootstrapping SwiftPM itself.",
         shouldDisplay: false
     )
 
     @Option(name: .customLong("package-path"),
-            help: "Specify the package path to operate on (default current directory). This changes the working directory before any other operation",
+            help: "Specify the package path to operate on (default current directory). This changes the working directory before any other operation.",
             completion: .directory)
     public var packageDirectory: AbsolutePath?
 
     /// The custom .build directory, if provided.
-    @Option(name: .customLong("scratch-path"), help: "Specify a custom scratch directory path (default .build)", completion: .directory)
+    @Option(name: .customLong("scratch-path"), help: "Specify a custom scratch directory path (default .build).", completion: .directory)
     var _scratchDirectory: AbsolutePath?
 
     @Option(name: .customLong("build-path"), help: .hidden)
@@ -63,53 +63,53 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
         self._scratchDirectory ?? self._deprecated_buildPath
     }
 
-    @Option(name: .shortAndLong, help: "Build with configuration")
+    @Option(name: .shortAndLong, help: "Build with configuration.")
     public var configuration: BuildConfiguration = .debug
 
     @Option(name: .customLong("Xcc", withSingleDash: true),
             parsing: .unconditionalSingleValue,
-            help: "Pass flag through to all C compiler invocations")
+            help: "Pass flag through to all C compiler invocations.")
     var cCompilerFlags: [String] = []
 
     @Option(name: .customLong("Xswiftc", withSingleDash: true),
             parsing: .unconditionalSingleValue,
-            help: "Pass flag through to all Swift compiler invocations")
+            help: "Pass flag through to all Swift compiler invocations.")
     var swiftCompilerFlags: [String] = []
 
     @Option(name: .customLong("Xlinker", withSingleDash: true),
             parsing: .unconditionalSingleValue,
-            help: "Pass flag through to all linker invocations")
+            help: "Pass flag through to all linker invocations.")
     var linkerFlags: [String] = []
 
     @Option(name: .customLong("Xcxx", withSingleDash: true),
             parsing: .unconditionalSingleValue,
-            help: "Pass flag through to all C++ compiler invocations")
+            help: "Pass flag through to all C++ compiler invocations.")
     var cxxCompilerFlags: [String] = []
 
     @Option(name: .customLong("Xxcbuild", withSingleDash: true),
             parsing: .unconditionalSingleValue,
             help: ArgumentHelp(
-                "Pass flag through to the Xcode build system invocations",
+                "Pass flag through to the Xcode build system invocations.",
                 visibility: .hidden))
     public var xcbuildFlags: [String] = []
 
     @Option(name: .customLong("Xbuild-tools-swiftc", withSingleDash: true),
             parsing: .unconditionalSingleValue,
-            help: ArgumentHelp("Pass flag to the manifest build invocation",
+            help: ArgumentHelp("Pass flag to the manifest build invocation.",
                                visibility: .hidden))
     public var manifestFlags: [String] = []
 
     @Option(
       name: .customLong("arch"),
-      help: ArgumentHelp("Build the package for the these architectures", visibility: .hidden))
+      help: ArgumentHelp("Build the package for the these architectures.", visibility: .hidden))
     public var architectures: [String] = []
 
     /// The verbosity of informational output.
-    @Flag(name: .shortAndLong, help: "Increase verbosity to include informational output")
+    @Flag(name: .shortAndLong, help: "Increase verbosity to include informational output.")
     public var verbose: Bool = false
 
     /// The verbosity of informational output.
-    @Flag(name: [.long, .customLong("vv")], help: "Increase verbosity to include debug output")
+    @Flag(name: [.long, .customLong("vv")], help: "Increase verbosity to include debug output.")
     public var veryVerbose: Bool = false
 
     /// Whether to use the integrated Swift driver rather than shelling out
@@ -119,7 +119,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
 
     /// An option that indicates this build should check whether targets only import
     /// their explicitly-declared dependencies
-    @Option(help: "Check that targets only import their explicitly-declared dependencies")
+    @Option(help: "Check that targets only import their explicitly-declared dependencies.")
     public var explicitTargetDependencyImportCheck: TargetDependencyImportCheckingMode = .none
 
     enum TargetDependencyImportCheckingMode: String, Codable, ExpressibleByArgument, CaseIterable {
@@ -128,7 +128,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
     }
 
     /// Disables adding $ORIGIN/@loader_path to the rpath, useful when deploying
-    @Flag(name: .customLong("disable-local-rpath"), help: "Disable adding $ORIGIN/@loader_path to the rpath by default")
+    @Flag(name: .customLong("disable-local-rpath"), help: "Disable adding $ORIGIN/@loader_path to the rpath by default.")
     public var shouldDisableLocalRpath: Bool = false
 
     /// The build system to use.

--- a/Sources/swift-build-prebuilts/BuildPrebuilts.swift
+++ b/Sources/swift-build-prebuilts/BuildPrebuilts.swift
@@ -72,16 +72,16 @@ let dockerImageRoot = "swiftlang/swift:nightly-"
 
 @main
 struct BuildPrebuilts: AsyncParsableCommand {
-    @Option(help: "The directory to generate the artifacts to")
+    @Option(help: "The directory to generate the artifacts to.")
     var stageDir = try! AbsolutePath(validating: FileManager.default.currentDirectoryPath).appending("stage")
 
-    @Flag(help: "Whether to build artifacts using docker")
+    @Flag(help: "Whether to build artifacts using docker.")
     var docker = false
 
-    @Flag(help: "Whether to build artifacts using docker only")
+    @Flag(help: "Whether to build artifacts using docker only.")
     var dockerOnly = false
 
-    @Option(help: "The command to use for docker")
+    @Option(help: "The command to use for docker.")
     var dockerCommand: String = "docker"
 
     mutating func run() async throws {

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -95,7 +95,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
 	
     func testCompletionTool() async throws {
         let stdout = try await execute(["completion-tool", "--help"]).stdout
-        XCTAssertMatch(stdout, .contains("OVERVIEW: Completion command (for shell completions)"))
+        XCTAssertMatch(stdout, .contains("OVERVIEW: Command to generate shell completions."))
     }
 
 	func testInitOverview() async throws {


### PR DESCRIPTION
Normalizes the structure of abstracts and the help content for commands

### Motivation:

The results from `--help` commands were inconsistent over the past years of organic growth.

### Modifications:

All command `help` and `abstracts` strings now use sentence casing and punctuation.

