### PR TITLE
Avoid building targets that are conditional on platform when building all

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -239,7 +239,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
         let pifBuilder = try await getPIFBuilder()
         let pif = try pifBuilder.generatePIF(
-            printPIFManifestGraphviz: buildParameters.printPIFManifestGraphviz
+            printPIFManifestGraphviz: buildParameters.printPIFManifestGraphviz,
+            buildParameters: buildParameters
         )
 
         try self.fileSystem.writeIfChanged(path: buildParameters.pifManifest, string: pif)

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -667,6 +667,11 @@ final class MiscellaneousTestCase: XCTestCase {
     }
 
     func testRootPackageWithConditionalsSwiftBuild() async throws {
+#if os(Linux)
+        if FileManager.default.contents(atPath: "/etc/system-release").map { String(decoding: $0, as: UTF8.self) == "Amazon Linux release 2 (Karoo)\n" } ?? false {
+            throw XCTSkip("Skipping Swift Build testing on Amazon Linux because of platform issues.")
+        }
+#endif
         try await fixture(name: "Miscellaneous/RootPackageWithConditionals") { path in
             _ = try await SwiftPM.Build.execute(["--build-system=swiftbuild"], packagePath: path, env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"])
         }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -665,4 +665,13 @@ final class MiscellaneousTestCase: XCTestCase {
             XCTAssertEqual(errors, [], "unexpected errors: \(errors)")
         }
     }
+
+    func testRootPackageWithConditionalsSwiftBuild() async throws {
+        try await fixture(name: "Miscellaneous/RootPackageWithConditionals") { path in
+            let (_, stderr) = try await SwiftPM.Build.execute(["--build-system=swiftbuild"], packagePath: path, env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"])
+            let errors = stderr.components(separatedBy: .newlines).filter { !$0.contains("[logging] misuse") && !$0.isEmpty }
+                                                                  .filter { !$0.contains("Unable to locate libSwiftScan") }
+            XCTAssertEqual(errors, [], "unexpected errors: \(errors)")
+        }
+    }
 }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -668,10 +668,7 @@ final class MiscellaneousTestCase: XCTestCase {
 
     func testRootPackageWithConditionalsSwiftBuild() async throws {
         try await fixture(name: "Miscellaneous/RootPackageWithConditionals") { path in
-            let (_, stderr) = try await SwiftPM.Build.execute(["--build-system=swiftbuild"], packagePath: path, env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"])
-            let errors = stderr.components(separatedBy: .newlines).filter { !$0.contains("[logging] misuse") && !$0.isEmpty }
-                                                                  .filter { !$0.contains("Unable to locate libSwiftScan") }
-            XCTAssertEqual(errors, [], "unexpected errors: \(errors)")
+            _ = try await SwiftPM.Build.execute(["--build-system=swiftbuild"], packagePath: path, env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"])
         }
     }
 }


### PR DESCRIPTION
When using the swiftbuild build system, and building all targets with a project
that contains a target that is depended on only when on a specific platform that
target should be skipped. Make the All(Excluding|Including)Tests generated
targets depend only on targets that are reachable from the roots through
dependencies that are either unconditional or are conditioned on the current
platform.