### PR TITLE
Tests: Merge Windows helper function and update GH issues

### DIFF
--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -40,6 +40,7 @@ import enum TSCUtility.Git
 @_exported import enum TSCTestSupport.StringPattern
 
 public let isInCiEnvironment = ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] != nil
+public let isSelfHostedCiEnvironment = ProcessInfo.processInfo.environment["SWIFTCI_IS_SELF_HOSTED"] != nil
 
 /// Test helper utility for executing a block with a temporary directory.
 public func testWithTemporaryDirectory(
@@ -286,18 +287,6 @@ public func executeSwiftBuild(
         buildSystem: buildSystem
     )
     return try await SwiftPM.Build.execute(args, packagePath: packagePath, env: env)
-}
-
-public func skipOnWindowsAsTestCurrentlyFails(because reason: String? = nil) throws {
-    #if os(Windows)
-    let failureCause: String
-    if let reason {
-        failureCause = " because \(reason.description)"
-    } else {
-        failureCause = ""
-    }
-    throw XCTSkip("Skipping tests on windows\(failureCause)")
-    #endif
 }
 
 @discardableResult

--- a/Tests/BasicsTests/AsyncProcessTests.swift
+++ b/Tests/BasicsTests/AsyncProcessTests.swift
@@ -144,7 +144,7 @@ final class AsyncProcessTests: XCTestCase {
     }
 
     func testFindExecutable() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "https://github.com/swiftlang/swift-package-manager/issues/8547: Assertion failure when trying to find ls executable")
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8547: Assertion failure when trying to find ls executable")
 
         try testWithTemporaryDirectory { tmpdir in
             // This process should always work.
@@ -426,8 +426,8 @@ final class AsyncProcessTests: XCTestCase {
 
     func testAsyncStream() async throws {
         // rdar://133548796
-        try XCTSkipIfCI()
-        try skipOnWindowsAsTestCurrentlyFails(because: "https://github.com/swiftlang/swift-package-manager/issues/8547: 'swift test' was hanging.")
+        try XCTSkipIfPlatformCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8547: 'swift test' was hanging.")
 
         let (stdoutStream, stdoutContinuation) = AsyncProcess.ReadableStream.makeStream()
         let (stderrStream, stderrContinuation) = AsyncProcess.ReadableStream.makeStream()
@@ -484,8 +484,8 @@ final class AsyncProcessTests: XCTestCase {
 
     func testAsyncStreamHighLevelAPI() async throws {
         // rdar://133548796
-        try XCTSkipIfCI()
-        try skipOnWindowsAsTestCurrentlyFails(because: "https://github.com/swiftlang/swift-package-manager/issues/8547: 'swift test' was hanging.")
+        try XCTSkipIfPlatformCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8547: 'swift test' was hanging.")
 
         let result = try await AsyncProcess.popen(
             scriptName: "echo\(ProcessInfo.batSuffix)", // maps to 'processInputs/echo' script

--- a/Tests/BasicsTests/FileSystem/PathTests.swift
+++ b/Tests/BasicsTests/FileSystem/PathTests.swift
@@ -12,7 +12,7 @@ import Basics
 import Foundation
 import XCTest
 
-import _InternalTestSupport // for skipOnWindowsAsTestCurrentlyFails()
+import _InternalTestSupport // for XCTSkipOnWindows()
 
 #if os(Windows)
 private var windows: Bool { true }
@@ -57,7 +57,7 @@ class PathTests: XCTestCase {
     }
 
     func testRepeatedPathSeparators() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "all assertions fail")
+        try XCTSkipOnWindows(because: "all assertions fail")
 
         XCTAssertEqual(AbsolutePath("/ab//cd//ef").pathString, windows ? #"\ab\cd\ef"# : "/ab/cd/ef")
         XCTAssertEqual(AbsolutePath("/ab///cd//ef").pathString, windows ? #"\ab\cd\ef"# : "/ab/cd/ef")
@@ -66,7 +66,7 @@ class PathTests: XCTestCase {
     }
 
     func testTrailingPathSeparators() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "trailing path seperator is not removed from pathString")
+        try XCTSkipOnWindows(because: "trailing path seperator is not removed from pathString")
 
         XCTAssertEqual(AbsolutePath("/ab/cd/ef/").pathString, windows ? #"\ab\cd\ef"# : "/ab/cd/ef")
         XCTAssertEqual(AbsolutePath("/ab/cd/ef//").pathString, windows ? #"\ab\cd\ef"# : "/ab/cd/ef")
@@ -75,7 +75,7 @@ class PathTests: XCTestCase {
     }
 
     func testDotPathComponents() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         XCTAssertEqual(AbsolutePath("/ab/././cd//ef").pathString, "/ab/cd/ef")
         XCTAssertEqual(AbsolutePath("/ab/./cd//ef/.").pathString, "/ab/cd/ef")
@@ -84,7 +84,7 @@ class PathTests: XCTestCase {
     }
 
     func testDotDotPathComponents() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         XCTAssertEqual(AbsolutePath("/..").pathString, windows ? #"\"# : "/")
         XCTAssertEqual(AbsolutePath("/../../../../..").pathString, windows ? #"\"# : "/")
@@ -102,7 +102,7 @@ class PathTests: XCTestCase {
     }
 
     func testCombinationsAndEdgeCases() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         XCTAssertEqual(AbsolutePath("///").pathString, windows ? #"\"# : "/")
         XCTAssertEqual(AbsolutePath("/./").pathString, windows ? #"\"# : "/")
@@ -133,7 +133,7 @@ class PathTests: XCTestCase {
     }
 
     func testDirectoryNameExtraction() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         XCTAssertEqual(AbsolutePath("/").dirname, windows ? #"\"# : "/")
         XCTAssertEqual(AbsolutePath("/a").dirname, windows ? #"\"# : "/")
@@ -152,7 +152,7 @@ class PathTests: XCTestCase {
     }
 
     func testBaseNameExtraction() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         XCTAssertEqual(AbsolutePath("/").basename, windows ? #"\"# : "/")
         XCTAssertEqual(AbsolutePath("/a").basename, "a")
@@ -170,7 +170,7 @@ class PathTests: XCTestCase {
     }
 
     func testBaseNameWithoutExt() throws{
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         XCTAssertEqual(AbsolutePath("/").basenameWithoutExt, windows ? #"\"# : "/")
         XCTAssertEqual(AbsolutePath("/a").basenameWithoutExt, "a")
@@ -195,7 +195,7 @@ class PathTests: XCTestCase {
     }
 
     func testSuffixExtraction() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "expected nil is not the actual")
+        try XCTSkipOnWindows(because: "expected nil is not the actual")
 
         XCTAssertEqual(RelativePath("a").suffix, nil)
         XCTAssertEqual(RelativePath("a").extension, nil)
@@ -222,7 +222,7 @@ class PathTests: XCTestCase {
     }
 
     func testParentDirectory() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         XCTAssertEqual(AbsolutePath("/").parentDirectory, AbsolutePath("/"))
         XCTAssertEqual(AbsolutePath("/").parentDirectory.parentDirectory, AbsolutePath("/"))
@@ -233,7 +233,7 @@ class PathTests: XCTestCase {
 
     @available(*, deprecated)
     func testConcatenation() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("")).pathString, windows ? #"\"# : "/")
         XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath(".")).pathString, windows ? #"\"# : "/")
@@ -272,7 +272,7 @@ class PathTests: XCTestCase {
     }
 
     func testPathComponents() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         XCTAssertEqual(AbsolutePath("/").components, ["/"])
         XCTAssertEqual(AbsolutePath("/.").components, ["/"])
@@ -302,7 +302,7 @@ class PathTests: XCTestCase {
     }
 
     func testRelativePathFromAbsolutePaths() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         XCTAssertEqual(AbsolutePath("/").relative(to: AbsolutePath("/")), RelativePath("."));
         XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/")), RelativePath("a/b/c/d"));
@@ -345,7 +345,7 @@ class PathTests: XCTestCase {
     }
 
     func testAbsolutePathValidation() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         XCTAssertNoThrow(try AbsolutePath(validating: "/a/b/c/d"))
 
@@ -359,7 +359,7 @@ class PathTests: XCTestCase {
     }
 
     func testRelativePathValidation() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         XCTAssertNoThrow(try RelativePath(validating: "a/b/c/d"))
 
@@ -374,7 +374,7 @@ class PathTests: XCTestCase {
     }
 
     func testCodable() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         struct Foo: Codable, Equatable {
             var path: AbsolutePath

--- a/Tests/BasicsTests/FileSystem/VFSTests.swift
+++ b/Tests/BasicsTests/FileSystem/VFSTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 import struct TSCBasic.ByteString
 
-import _InternalTestSupport // for skipOnWindowsAsTestCurrentlyFails
+import _InternalTestSupport // for XCTSkipOnWindows
 
 func testWithTemporaryDirectory(
     function: StaticString = #function,
@@ -38,7 +38,7 @@ func testWithTemporaryDirectory(
 
 class VFSTests: XCTestCase {
     func testLocalBasics() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         // tiny PE binary from: https://archive.is/w01DO
         let contents: [UInt8] = [

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -226,7 +226,7 @@ final class HTTPClientTests: XCTestCase {
     }
 
     func testExponentialBackoff() async throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "https://github.com/swiftlang/swift-package-manager/issues/8501")
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8501")
 
         let counter = SendableBox(0)
         let lastCall = SendableBox<Date>()

--- a/Tests/BasicsTests/LegacyHTTPClientTests.swift
+++ b/Tests/BasicsTests/LegacyHTTPClientTests.swift
@@ -350,7 +350,7 @@ final class LegacyHTTPClientTests: XCTestCase {
     }
 
     func testExponentialBackoff() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "https://github.com/swiftlang/swift-package-manager/issues/8501")
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8501")
 
         let count = ThreadSafeBox<Int>(0)
         let lastCall = ThreadSafeBox<Date>()

--- a/Tests/BasicsTests/Serialization/SerializedJSONTests.swift
+++ b/Tests/BasicsTests/Serialization/SerializedJSONTests.swift
@@ -12,7 +12,7 @@
 
 @testable import Basics
 import XCTest
-import _InternalTestSupport // for skipOnWindowsAsTestCurrentlyFails
+import _InternalTestSupport // for XCTSkipOnWindows
 
 final class SerializedJSONTests: XCTestCase {
     func testPathInterpolation() throws {
@@ -34,7 +34,7 @@ final class SerializedJSONTests: XCTestCase {
     }
 
     func testPathInterpolationFailsOnWindows() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "Expectations are not met. Possibly related to https://github.com/swiftlang/swift-package-manager/issues/8511")
+        try XCTSkipOnWindows(because: "Expectations are not met. Possibly related to https://github.com/swiftlang/swift-package-manager/issues/8511")
 
 #if os(Windows)
         var path = try AbsolutePath(validating: #"\\?\C:\Users"#)

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -356,7 +356,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
         // https://github.com/apple/swift-corelibs-foundation/pull/2593 tries to address the latter part
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        try XCTSkipIfCI()
+        try XCTSkipIfPlatformCI()
         let netrcContent = "default login default password default"
         let netrc = try NetrcAuthorizationWrapper(underlying: NetrcParser.parse(netrcContent))
         let authData = Data("default:default".utf8)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -620,7 +620,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
     }
 
     func testPackageNameFlag() async throws {
-        try XCTSkipIfCI() // test is disabled because it isn't stable, see rdar://118239206
+        try XCTSkipIfPlatformCI() // test is disabled because it isn't stable, see rdar://118239206
         let isFlagSupportedInDriver = try DriverSupport.checkToolchainDriverFlags(
             flags: ["package-name"],
             toolchain: UserToolchain.default,
@@ -2040,7 +2040,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
     }
 
     func test_symbolGraphExtract_arguments() async throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         // ModuleGraph:
         // .
@@ -4701,7 +4701,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
     }
 
     func testUserToolchainCompileFlags() async throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         let fs = InMemoryFileSystem(
             emptyFiles:
@@ -4955,7 +4955,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
     }
 
     func testUserToolchainWithToolsetCompileFlags() async throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "Path delimiters donw's work well on Windows")
+        try XCTSkipOnWindows(because: "Path delimiters donw's work well on Windows")
 
         let fileSystem = InMemoryFileSystem(
             emptyFiles:
@@ -5125,7 +5125,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
     }
 
     func testUserToolchainWithSDKSearchPaths() async throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         let fileSystem = InMemoryFileSystem(
             emptyFiles:

--- a/Tests/BuildTests/BuildSystemDelegateTests.swift
+++ b/Tests/BuildTests/BuildSystemDelegateTests.swift
@@ -30,7 +30,7 @@ final class BuildSystemDelegateTests: XCTestCase {
     }
 
     func testFilterNonFatalCodesignMessages() async throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "https://github.com/swiftlang/swift-package-manager/issues/8540: Package fails to build when the test is being executed")
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8540: Package fails to build when the test is being executed")
 
         try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
         // Note: we can re-use the `TestableExe` fixture here since we just need an executable.

--- a/Tests/BuildTests/PluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/PluginsBuildPlanTests.swift
@@ -18,7 +18,7 @@ import PackageModel
 
 final class PluginsBuildPlanTests: XCTestCase {
     func testBuildToolsDatabasePath() async throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         try await fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath)

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -26,7 +26,7 @@ import struct PackageModel.TargetDescription
 
 class PrepareForIndexTests: XCTestCase {
     func testPrepare() async throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         let (graph, fs, scope) = try macrosPackageGraph()
 
@@ -96,7 +96,7 @@ class PrepareForIndexTests: XCTestCase {
 
     // enable-testing requires the non-exportable-decls, make sure they aren't skipped.
     func testEnableTesting() async throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         let fs = InMemoryFileSystem(
             emptyFiles:
@@ -167,7 +167,7 @@ class PrepareForIndexTests: XCTestCase {
     }
 
     func testPrepareNoLazy() async throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         let (graph, fs, scope) = try macrosPackageGraph()
 

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -860,6 +860,7 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
 
     override func testParseableInterfaces() async throws {
         try XCTSkipIfWorkingDirectoryUnsupported()
+
         try await fixture(name: "Miscellaneous/ParseableInterfaces") { fixturePath in
             do {
                 let result = try await build(["--enable-parseable-module-interfaces"], packagePath: fixturePath)

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -139,7 +139,7 @@ class RunCommandTestCase: CommandsBuildProviderTestCase {
     }
 
     func testSwiftRunSIGINT() throws {
-        try XCTSkipIfCI()
+        try XCTSkipIfPlatformCI()
         try fixture(name: "Miscellaneous/SwiftRun") { fixturePath in
             let mainFilePath = fixturePath.appending("main.swift")
             try localFileSystem.removeFileTree(mainFilePath)

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -577,7 +577,7 @@ class TestCommandTestCase: CommandsBuildProviderTestCase {
     }
 
     func testFatalErrorDisplayedCorrectNumberOfTimesWhenSingleXCTestHasFatalErrorInBuildCompilation() async throws {
-        try XCTSkipIfCI()
+        try XCTSkipIfPlatformCI()
         // Test for GitHub Issue #6605
         // GIVEN we have a Swift Package that has a fatalError building the tests
         let expected = 1

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -165,7 +165,7 @@ final class PackageGraphPerfTests: XCTestCasePerf {
     }
 
     func testRecursiveDependencies() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         var resolvedTarget = ResolvedModule.mock(packageIdentity: "pkg", name: "t0")
         for i in 1..<1000 {

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -25,7 +25,7 @@ import struct TSCBasic.ByteString
 
 final class ModulesGraphTests: XCTestCase {
     func testBasic() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "Possibly related to: https://github.com/swiftlang/swift-package-manager/issues/8511")
+        try XCTSkipOnWindows(because: "Possibly related to: https://github.com/swiftlang/swift-package-manager/issues/8511")
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Foo/Sources/Foo/source.swift",

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -680,7 +680,7 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         // platforms just getting lucky?  I'm feeling lucky.
         throw XCTSkip("Foundation Process.terminationStatus race condition (apple/swift-corelibs-foundation#4589")
 #else
-        try XCTSkipIfCI()
+        try XCTSkipIfPlatformCI()
 
         try await testWithTemporaryDirectory { path in
             let total = 100

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -564,7 +564,7 @@ final class PackageBuilderTests: XCTestCase {
     }
 
     func testTestManifestSearch() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "possibly related to https://github.com/swiftlang/swift-package-manager/issues/8511")
+        try XCTSkipOnWindows(because: "possibly related to https://github.com/swiftlang/swift-package-manager/issues/8511")
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/pkg/foo.swift",

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -19,7 +19,7 @@ import struct TSCBasic.ByteString
 
 final class PkgConfigParserTests: XCTestCase {
     func testCircularPCFile() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         let observability = ObservabilitySystem.makeForTesting()
 
@@ -36,7 +36,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     func testGTK3PCFile() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         try! loadPCFile("gtk+-3.0.pc") { parser in
             XCTAssertEqual(parser.variables, [
@@ -58,7 +58,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     func testEmptyCFlags() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         try! loadPCFile("empty_cflags.pc") { parser in
             XCTAssertEqual(parser.variables, [
@@ -74,7 +74,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     func testCFlagsCaseInsensitveKeys() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         try! loadPCFile("case_insensitive.pc") { parser in
             XCTAssertEqual(parser.cFlags, ["-I/usr/local/include"])
@@ -82,7 +82,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     func testVariableinDependency() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         try! loadPCFile("deps_variable.pc") { parser in
             XCTAssertEqual(parser.variables, [
@@ -108,7 +108,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     func testEscapedSpaces() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         try! loadPCFile("escaped_spaces.pc") { parser in
             XCTAssertEqual(parser.variables, [
@@ -125,7 +125,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     func testDummyDependency() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         try loadPCFile("dummy_dependency.pc") { parser in
             XCTAssertEqual(parser.variables, [
@@ -213,7 +213,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     func testAbsolutePathDependency() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         let libffiPath = "/usr/local/opt/libffi/lib/pkgconfig/libffi.pc"
 
@@ -248,7 +248,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     func testUnevenQuotes() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         do {
             try loadPCFile("quotes_failure.pc")
@@ -259,7 +259,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     func testSysrootDir() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         // sysroot should be prepended to all path variables, and should therefore appear in cflags and libs.
         try loadPCFile("gtk+-3.0.pc", sysrootDir: "/opt/sysroot/somewhere") { parser in

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -87,7 +87,7 @@ class PkgConfigTests: XCTestCase {
     }
 
     func testEnvVar() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         // Pc file.
         try Environment.makeCustom(["PKG_CONFIG_PATH": inputsDir.pathString]) {
@@ -152,7 +152,7 @@ class PkgConfigTests: XCTestCase {
     }
 
     func testExplicitPkgConfigDirectories() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         // Pc file.
         for result in try pkgConfigArgs(
@@ -212,7 +212,7 @@ class PkgConfigTests: XCTestCase {
     }
 
     func testDependencies() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         // Use additionalSearchPaths instead of pkgConfigArgs to test handling
         // of search paths when loading dependencies.

--- a/Tests/QueryEngineTests/QueryEngineTests.swift
+++ b/Tests/QueryEngineTests/QueryEngineTests.swift
@@ -100,7 +100,7 @@ private struct Expression: CachingQuery {
 
 final class QueryEngineTests: XCTestCase {
   func testFilePathHashing() throws {
-    try skipOnWindowsAsTestCurrentlyFails(because: "https://github.com/swiftlang/swift-package-manager/issues/8541")
+    try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8541")
 
     let path = "/root"
 

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -19,7 +19,7 @@ class GitRepositoryProviderTests: XCTestCase {
     func testIsValidDirectory() throws {
         // Skipping all tests that call git on Windows.
         // We have a hang in CI when running in parallel.
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { sandbox in
             let provider = GitRepositoryProvider()
 
@@ -45,7 +45,7 @@ class GitRepositoryProviderTests: XCTestCase {
     }
 
     func testIsValidDirectoryThrowsPrintableError() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { temp in
             let provider = GitRepositoryProvider()
             let expectedErrorMessage = "not a git repository"
@@ -60,7 +60,7 @@ class GitRepositoryProviderTests: XCTestCase {
     }
 
     func testGitShellErrorIsPrintable() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         let stdOut = "An error from Git - stdout"
         let stdErr = "An error from Git - stderr"
         let arguments = ["git", "error"]
@@ -89,7 +89,7 @@ class GitRepositoryProviderTests: XCTestCase {
     }
 
     func testGitShellErrorEmptyStdOut() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         let stdErr = "An error from Git - stderr"
         let result = AsyncProcessResult(
             arguments: ["git", "error"],
@@ -107,7 +107,7 @@ class GitRepositoryProviderTests: XCTestCase {
     }
 
     func testGitShellErrorEmptyStdErr() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         let stdOut = "An error from Git - stdout"
         let result = AsyncProcessResult(
             arguments: ["git", "error"],

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -64,7 +64,7 @@ class GitRepositoryTests: XCTestCase {
     func testProvider() throws {
         // Skipping all tests that call git on Windows.
         // We have a hang in CI when running in parallel.
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             let testRepoPath = path.appending("test-repo")
             try! makeDirectories(testRepoPath)
@@ -129,8 +129,8 @@ class GitRepositoryTests: XCTestCase {
     /// `Inputs`, which has known commit hashes. See the `construct.sh` script
     /// contained within it for more information.
     func testRawRepository() throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "https://github.com/swiftlang/swift-package-manager/issues/8385: test repository has non-portable file names")
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8385: test repository has non-portable file names")
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
 
         try testWithTemporaryDirectory { path in
             // Unarchive the static test repository.
@@ -190,7 +190,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testSubmoduleRead() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
@@ -214,7 +214,7 @@ class GitRepositoryTests: XCTestCase {
 
     /// Test the Git file system view.
     func testGitFileView() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
@@ -303,7 +303,7 @@ class GitRepositoryTests: XCTestCase {
 
     /// Test the handling of local checkouts.
     func testCheckouts() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             // Create a test repository.
             let testRepoPath = path.appending("test-repo")
@@ -350,7 +350,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testFetch() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -390,7 +390,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testHasUnpushedCommits() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -427,7 +427,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testSetRemote() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -458,7 +458,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testUncommittedChanges() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -486,7 +486,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testBranchOperations() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -517,7 +517,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testRevisionOperations() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let repositoryPath = path.appending("test-repo")
@@ -543,7 +543,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testCheckoutRevision() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -587,7 +587,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testSubmodules() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             let provider = GitRepositoryProvider()
 
@@ -677,7 +677,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testAlternativeObjectStoreValidation() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test-repo")
@@ -711,7 +711,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testAreIgnored() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test_repo")
@@ -733,7 +733,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testAreIgnoredWithSpaceInRepoPath() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             // Create a repo.
             let testRepoPath = path.appending("test repo")
@@ -750,7 +750,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testMissingDefaultBranch() throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { path in
             // Create a repository.
             let testRepoPath = path.appending("test-repo")
@@ -788,7 +788,7 @@ class GitRepositoryTests: XCTestCase {
     }
     
     func testValidDirectoryLocalRelativeOrigin() async throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { tmpDir in
             // Create a repository.
             let packageDir = tmpDir.appending("SomePackage")
@@ -835,7 +835,7 @@ class GitRepositoryTests: XCTestCase {
     }
     
     func testValidDirectoryLocalAbsoluteOrigin() async throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { tmpDir in
             // Create a repository.
             let packageDir = tmpDir.appending("SomePackage")
@@ -886,7 +886,7 @@ class GitRepositoryTests: XCTestCase {
     }
     
     func testValidDirectoryRemoteOrigin() async throws {
-        try XCTSkipIfWindowsCI()
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try testWithTemporaryDirectory { tmpDir in
             // Create a repository.
             let packageDir = tmpDir.appending("SomePackage")

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -233,7 +233,7 @@ final class ManifestSourceGenerationTests: XCTestCase {
     }
 
     func testAdvancedFeatures() async throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         let manifestContents = """
             // swift-tools-version:5.3
@@ -795,7 +795,7 @@ final class ManifestSourceGenerationTests: XCTestCase {
     }
 
     func testStrictMemorySafety() async throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "compilation error:  type 'SwiftSetting' has no member 'strictMemorySafety'")
+        try XCTSkipOnWindows(because: "compilation error:  type 'SwiftSetting' has no member 'strictMemorySafety'")
 
         let manifestContents = """
             // swift-tools-version:6.2
@@ -864,7 +864,7 @@ final class ManifestSourceGenerationTests: XCTestCase {
     }
 
     func testDefaultIsolation() async throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: "there are compilation errors")
+        try XCTSkipOnWindows(because: "there are compilation errors")
 
         let manifest = Manifest.createRootManifest(
             displayName: "pkg",

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -26,7 +26,7 @@ import struct TSCUtility.Version
 final class RegistryPackageContainerTests: XCTestCase {
 
     override func setUpWithError() throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
     }
 
     func testToolsVersionCompatibleVersions() async throws {

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -125,7 +125,7 @@ private let v1Range: VersionSetSpecifier = .range("1.0.0" ..< "2.0.0")
 
 final class SourceControlPackageContainerTests: XCTestCase {
     func testVprefixVersions() async throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         let fs = InMemoryFileSystem()
         try fs.createMockToolchain()
@@ -172,7 +172,7 @@ final class SourceControlPackageContainerTests: XCTestCase {
     }
 
     func testVersions() async throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         let fs = InMemoryFileSystem()
         try fs.createMockToolchain()
@@ -270,7 +270,7 @@ final class SourceControlPackageContainerTests: XCTestCase {
     }
 
     func testPreReleaseVersions() async throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         let fs = InMemoryFileSystem()
         try fs.createMockToolchain()
@@ -319,7 +319,7 @@ final class SourceControlPackageContainerTests: XCTestCase {
     }
 
     func testSimultaneousVersions() async throws {
-        try skipOnWindowsAsTestCurrentlyFails()
+        try XCTSkipOnWindows()
 
         let fs = InMemoryFileSystem()
         try fs.createMockToolchain()

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -38,7 +38,7 @@ final class WorkspaceTests: XCTestCase {
     //     ]
     //     let matches = windowsPassingTests.filter { $0 == self.invocation?.selector}
     //     if matches.count == 0 {
-    //         try skipOnWindowsAsTestCurrentlyFails()
+    //         try XCTSkipOnWindows()
     //     }
     // }
 
@@ -774,7 +774,6 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
     }
-
 
     func testCanResolveWithIncompatiblePackages() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
@@ -2233,7 +2232,6 @@ final class WorkspaceTests: XCTestCase {
             }
         }
     }
-
 
     func testMinimumRequiredToolsVersionInDependencyResolution() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
@@ -3887,6 +3885,8 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolvedFileSchemeToolsVersion() async throws {
+        let fs = InMemoryFileSystem()
+
         for pair in [
             (ToolsVersion.v5_2, ToolsVersion.v5_2),
             (ToolsVersion.v5_6, ToolsVersion.v5_6),
@@ -7782,7 +7782,6 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-
     func testDownloadedArtifactNotAnArchiveError() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
@@ -8038,7 +8037,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testArtifactChecksum() async throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: #"""
+        try XCTSkipOnWindows(because: #"""
         threw error "\tmp\ws doesn't exist in file system" because there is an issue with InMemoryFileSystem readFileContents(...) on Windows
         """#)
 
@@ -15511,7 +15510,6 @@ final class WorkspaceTests: XCTestCase {
         metadata: [String: RegistryReleaseMetadata],
         mirrors: DependencyMirrors? = nil
     ) async throws -> MockWorkspace {
-
         // let sandbox = AbsolutePath.root.appending("swiftpm-tests-can-be-deleted/tmp/ws")
         let sandbox = AbsolutePath.root.appending(components: ["swiftpm-tests-can-be-deleted", "tmp", "ws"])
         let fs = InMemoryFileSystem()

--- a/Utilities/README.md
+++ b/Utilities/README.md
@@ -6,7 +6,7 @@ Here are some steps the worked running on Windows.
 2. Launch a `Powershell.exe` session
 3. Run the following in power shell to start a container running the nightly toolchain
     ```
-    docker run --pull always --rm --interactive --tty swiftlang/swift:nightly-main-windowsservercore-1809 powershell.exe
+    docker run --pull always --rm --interactive --tty swiftlang/swift:nightly-6.1-windowsservercore-1809 powershell.exe
     ```
 4. When the container start, clone the "merged" PR to `C:\source`
     ```


### PR DESCRIPTION
Update the GitHub issue reference on some skipped tests, and also merge the skipIfOnWindowsBecause..() and XCTSkipOnWindows() helper functions to make aid with discoverability.
    
Also, update the Git Tests to be skipped only in the self hosted pipelines, as that is the environment where the tests are hanging.