### PR TITLE
Use `GENERATE_PRELINK_OBJECT_FILE` in `PackagePIFProjectBuilder`

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -423,7 +423,7 @@ extension PackagePIFProjectBuilder {
                 .spm_mangledToBundleIdentifier()
             settings[.EXECUTABLE_NAME] = executableName
             settings[.CLANG_ENABLE_MODULES] = "YES"
-            settings[.GENERATE_MASTER_OBJECT_FILE] = "NO"
+            settings[.GENERATE_PRELINK_OBJECT_FILE] = "NO"
             settings[.STRIP_INSTALLED_PRODUCT] = "NO"
 
             // Macros build as executables, so they need slightly different


### PR DESCRIPTION
Fixing build failure in https://ci.swift.org/job/oss-swift-pr-test-macoss/4978/console introduced by https://github.com/swiftlang/swift-build/pull/452.
