### PR TITLE
stubs for initial DocC structure

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/Assets/command-icon.svg
+++ b/Sources/PackageManagerDocs/Documentation.docc/Assets/command-icon.svg
@@ -1,0 +1,4 @@
+<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 14 14">
+    <rect x="1" y="1" width="12" height="12" stroke="#555555" fill="none"/>
+    <path d="M4 4 l3 3 l-3 3 m3 0 l3.3 0" stroke="#555555" fill="none"/>
+</svg>

--- a/Sources/PackageManagerDocs/Documentation.docc/Assets/command-icon~dark.svg
+++ b/Sources/PackageManagerDocs/Documentation.docc/Assets/command-icon~dark.svg
@@ -1,0 +1,4 @@
+<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 14 14">
+    <rect x="1" y="1" width="12" height="12" stroke="#fff" fill="none"/>
+    <path d="M4 4 l3 3 l-3 3 m3 0 l3.3 0" stroke="#fff" fill="none"/>
+</svg>

--- a/Sources/PackageManagerDocs/Documentation.docc/GettingStarted.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/GettingStarted.md
@@ -1,0 +1,11 @@
+# Getting Started
+
+Learn to create and use a Swift package.
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/IntroducingPackages.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/IntroducingPackages.md
@@ -1,0 +1,11 @@
+# Introducing Packages
+
+Learn to create and use a Swift package.
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddDependency.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddDependency.md
@@ -1,0 +1,15 @@
+# swift package add-dependency
+
+Add a package dependency to the manifest.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddProduct.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddProduct.md
@@ -1,0 +1,15 @@
+# swift package add-product
+
+Add a new product to the manifest.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddTarget.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddTarget.md
@@ -1,0 +1,15 @@
+# swift package add-target
+
+Add a new target to the manifest.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddTargetDependency.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddTargetDependency.md
@@ -1,0 +1,15 @@
+# swift package add-target-dependency
+
+Add a new target dependency to the manifest.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageArchiveSource.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageArchiveSource.md
@@ -1,0 +1,15 @@
+# swift package archive-source
+
+Create a source archive for the package.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageClean.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageClean.md
@@ -1,0 +1,15 @@
+# swift package clean
+
+Delete build artifacts.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageCompletionTool.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageCompletionTool.md
@@ -1,0 +1,15 @@
+# swift package completion-tool
+
+Completion command (for shell completions).
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageComputeChecksum.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageComputeChecksum.md
@@ -1,0 +1,15 @@
+# swift package compute-checksum
+
+Compute the checksum for a binary artifact.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageConfigGetMirror.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageConfigGetMirror.md
@@ -1,0 +1,15 @@
+# swift package config get-mirror
+
+Print mirror configuration for the given package dependency.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageConfigSetMirror.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageConfigSetMirror.md
@@ -1,0 +1,15 @@
+# swift package config set-mirror
+
+Set a mirror for a dependency.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageConfigUnsetMirror.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageConfigUnsetMirror.md
@@ -1,0 +1,15 @@
+# swift package config unset-mirror
+
+Remove an existing mirror.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDescribe.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDescribe.md
@@ -1,0 +1,15 @@
+# swift package describe
+
+Describe the current package.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDiagnoseAPIBreakingChange.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDiagnoseAPIBreakingChange.md
@@ -1,0 +1,15 @@
+# swift package diagnose-api-breaking-changes
+
+Diagnose API-breaking changes to Swift modules in a package.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDumpPackage.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDumpPackage.md
@@ -1,0 +1,15 @@
+# swift package dump-package
+
+Print parsed Package.swift as JSON.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDumpSymbolGraph.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDumpSymbolGraph.md
@@ -1,0 +1,15 @@
+# swift package dump-symbol-graph
+
+Dump Symbol Graph.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageEdit.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageEdit.md
@@ -1,0 +1,15 @@
+# swift package edit
+
+Put a package in editable mode.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageInit.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageInit.md
@@ -1,0 +1,15 @@
+# swift package init
+
+Initialize a new package.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackagePlugin.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackagePlugin.md
@@ -1,0 +1,15 @@
+# swift package plugin
+
+Invoke a command plugin or perform other actions on command plugins.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackagePurgeCache.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackagePurgeCache.md
@@ -1,0 +1,15 @@
+# swift package purge-cache
+
+Purge the global repository cache.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageReset.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageReset.md
@@ -1,0 +1,15 @@
+# swift package reset
+
+Reset the complete cache/build directory.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageResolve.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageResolve.md
@@ -1,0 +1,15 @@
+# swift package resolve
+
+Resolve package dependencies.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageShowDependencies.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageShowDependencies.md
@@ -1,0 +1,15 @@
+# swift package show-dependencies
+
+Print the resolved dependency graph.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageShowExecutables.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageShowExecutables.md
@@ -1,0 +1,17 @@
+# swift package show-executables
+
+List the available executables from this package.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+<!-- new with Swift 6.1 -->
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageToolsVersion.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageToolsVersion.md
@@ -1,0 +1,15 @@
+# swift package tools-version
+
+Manipulate tools version of the current package.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageUnedit.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageUnedit.md
@@ -1,0 +1,15 @@
+# swift package unedit
+
+Remove a package from editable mode.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageUpdate.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageUpdate.md
@@ -1,0 +1,15 @@
+# swift package update
+
+Update package dependencies.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionAdd.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionAdd.md
@@ -1,0 +1,15 @@
+# swift package-collection add
+
+Add a new collection.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionDescribe.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionDescribe.md
@@ -1,0 +1,15 @@
+# swift package-collection describe
+
+Get metadata for a collection or a package included in an imported collection.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionList.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionList.md
@@ -1,0 +1,15 @@
+# swift package-collection list
+
+List configured collections.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionRefresh.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionRefresh.md
@@ -1,0 +1,15 @@
+# swift package-collection refresh
+
+Refresh configured collections.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionRemove.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionRemove.md
@@ -1,0 +1,15 @@
+# swift package-collection remove
+
+Remove a configured collection.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionSearch.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionSearch.md
@@ -1,0 +1,15 @@
+# swift package-collection search
+
+Search for packages by keywords or module names.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryLogin.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryLogin.md
@@ -1,0 +1,15 @@
+# swift package-registry login
+
+Log in to a registry.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryLogout.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryLogout.md
@@ -1,0 +1,15 @@
+# swift package-registry logout
+
+Log out from a registry.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryPublish.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryPublish.md
@@ -1,0 +1,15 @@
+# swift package-registry publish
+
+Publish to a registry.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistrySet.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistrySet.md
@@ -1,0 +1,15 @@
+# swift package-registry set
+
+Set a custom registry.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryUnset.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryUnset.md
@@ -1,0 +1,15 @@
+# swift package-registry unset
+
+Remove a configured registry.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigurationReset.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigurationReset.md
@@ -1,0 +1,17 @@
+# swift sdk configuration reset
+
+Resets configuration properties currently applied to a given Swift SDK and target triple. 
+
+If no specific property is specified, all of them are reset for the Swift SDK.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigurationSet.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigurationSet.md
@@ -1,0 +1,15 @@
+# swift sdk configuration reset
+
+Sets configuration options for installed Swift SDKs.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigurationShow.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigurationShow.md
@@ -1,0 +1,15 @@
+# swift sdk configuration show
+
+Prints all configuration properties currently applied to a given Swift SDK and target triple.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigure.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigure.md
@@ -1,0 +1,15 @@
+# swift sdk configure
+
+Manages configuration options for installed Swift SDKs.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKInstall.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKInstall.md
@@ -1,0 +1,17 @@
+# swift sdk install
+
+Installs a given Swift SDK bundle to a location discoverable by SwiftPM. 
+
+If the artifact bundle is at a remote location, it's downloaded to local filesystem first.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKList.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKList.md
@@ -1,0 +1,15 @@
+# swift sdk list
+
+Print a list of IDs of available Swift SDKs available on the filesystem.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKRemove.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKRemove.md
@@ -1,0 +1,15 @@
+# swift sdk remove
+
+Removes a previously installed Swift SDK bundle from the filesystem.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftBuild.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftBuild.md
@@ -1,0 +1,15 @@
+# swift build
+
+Compile the contents of your package.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageCollectionCommands.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageCollectionCommands.md
@@ -1,0 +1,32 @@
+# swift package-collection
+
+Interact with package collections.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+Overview of package manager commands here...
+
+<!-- reference content for the CLI commands `swift package ...` -->
+
+## Topics 
+
+### Adding a package colleciton
+- <doc:PackageCollectionAdd>
+
+### Finding package collections
+- <doc:PackageCollectionSearch>
+
+### Updating package collection
+- <doc:PackageCollectionRefresh>
+
+### Inspecting package collections
+- <doc:PackageCollectionList>
+- <doc:PackageCollectionDescribe>
+
+### Removing a package collection
+- <doc:PackageCollectionRemove>
+

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageCommands.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageCommands.md
@@ -1,0 +1,57 @@
+# SwiftPackageCommands
+
+A command-line utility to update and inspect your Swift package.
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+<!-- reference content for the CLI commands `swift package ...` -->
+
+### Creating packages
+- <doc:PackageInit>
+
+### Updating and resolving dependencies
+- <doc:PackageUpdate>
+- <doc:PackageResolve>
+
+### Editing packages
+- <doc:PackageAddDependency>
+- <doc:PackageAddProduct>
+- <doc:PackageAddTarget>
+- <doc:PackageAddTargetDependency>
+- <doc:PackageEdit>
+- <doc:PackageUnedit>
+
+### Using package manager plugins
+- <doc:PackagePlugin>
+- <doc:PackageDiagnoseAPIBreakingChange>
+<!-- ref to swift-format -->
+<!-- ref to swift-docc-plugin -->
+
+### Inspecting packages
+- <doc:PackageDescribe>
+- <doc:PackageShowDependencies>
+- <doc:PackageShowExecutables>
+- <doc:PackageToolsVersion>
+- <doc:PackageDumpSymbolGraph>
+
+### Cleaning builds and caches
+- <doc:PackageClean>
+- <doc:PackageReset>
+- <doc:PackagePurgeCache>
+
+### Archiving packages
+- <doc:PackageArchiveSource>
+- <doc:PackageComputeChecksum>
+
+### Integrating Package Manager into your shell
+- <doc:PackageCompletionTool>
+
+### Configuring package manager
+- <doc:PackageConfig>
+- <doc:PackageConfigSetMirror>
+- <doc:PackageConfigUnsetMirror>
+- <doc:PackageConfigGetMirror>
+
+

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageCommands.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageCommands.md
@@ -1,12 +1,18 @@
-# SwiftPackageCommands
+# swift package
 
-A command-line utility to update and inspect your Swift package.
+Subcommands to update and inspect your Swift package.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
 
 ## Overview
 
-<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+Overview of package manager commands here...
 
 <!-- reference content for the CLI commands `swift package ...` -->
+
+## Topics 
 
 ### Creating packages
 - <doc:PackageInit>
@@ -34,6 +40,7 @@ A command-line utility to update and inspect your Swift package.
 - <doc:PackageShowDependencies>
 - <doc:PackageShowExecutables>
 - <doc:PackageToolsVersion>
+- <doc:PackageDumpPackage>
 - <doc:PackageDumpSymbolGraph>
 
 ### Cleaning builds and caches
@@ -48,8 +55,7 @@ A command-line utility to update and inspect your Swift package.
 ### Integrating Package Manager into your shell
 - <doc:PackageCompletionTool>
 
-### Configuring package manager
-- <doc:PackageConfig>
+### Configuring Mirrors
 - <doc:PackageConfigSetMirror>
 - <doc:PackageConfigUnsetMirror>
 - <doc:PackageConfigGetMirror>

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageManager.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageManager.md
@@ -8,7 +8,19 @@ Organize, manage, and edit Swift packages.
 
 ## Overview
 
-The Swift Package Manager is a tool for managing distribution of source code, aimed at making it easy to share your code and reuse others’ code. The tool directly addresses the challenges of compiling and linking Swift packages, managing dependencies, versioning, and supporting flexible distribution and collaboration models.
+The Swift Package Manager leets you share your code as a package, depend on and use other share packages, as well as build, test, document, and run your code.
 
 ## Topics
 
+### Essentials
+
+- <doc:GettingStarted>
+- <doc:IntroducingPackages>
+
+### Swift Commands
+<!-- reference content for the CLI commands `swift ...` -->
+- <doc:SwiftPackageCommands>
+- <doc:SwiftBuild>
+- <doc:SwiftTest>
+- <doc:SwiftRepl>
+- <doc:SwiftRun>

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageManager.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageManager.md
@@ -28,7 +28,7 @@ The Swift Package Manager leets you share your code as a package, depend on and 
 
 <!-- ### Reference -->
 <!-- link to PackageDescription API reference docc -->
-<!-- link to Command API reference docc - the DocC Plugin API -->
+<!-- link to Command API reference docc - the DocC Plugin API (PackagePlugin) -->
 
 <!-- reference content for the CLI commands `swift ...` -->
 ### Swift Commands

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageManager.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageManager.md
@@ -14,13 +14,14 @@ The Swift Package Manager leets you share your code as a package, depend on and 
 
 ### Essentials
 
-- <doc:GettingStarted>
-- <doc:IntroducingPackages>
+- <doc:GettingStarted>      <!-- tutorial or article based walk through -->
+- <doc:IntroducingPackages> <!-- content from Documentation/README -->
 
-### Swift Commands
 <!-- reference content for the CLI commands `swift ...` -->
-- <doc:SwiftPackageCommands>
+### Swift Commands
+
 - <doc:SwiftBuild>
 - <doc:SwiftTest>
+- <doc:SwiftPackageCommands>
 - <doc:SwiftRepl>
 - <doc:SwiftRun>

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageManager.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageManager.md
@@ -17,11 +17,27 @@ The Swift Package Manager leets you share your code as a package, depend on and 
 - <doc:GettingStarted>      <!-- tutorial or article based walk through -->
 - <doc:IntroducingPackages> <!-- content from Documentation/README -->
 
+<!-- ### Guides -->
+<!-- placeholder location for articles (to be written or copy/updated from existing content -->
+
+<!-- ### Command Plugins -->
+<!-- placeholder for content about swift package manager extensions - command plugins -->
+<!-- - <doc:swift-format> -->
+<!-- - <doc:swift-docc-plugin> -->
+<!-- - <doc:swift-container-plugin> -->
+
+<!-- ### Reference -->
+<!-- link to PackageDescription API reference docc -->
+<!-- link to Command API reference docc - the DocC Plugin API -->
+
 <!-- reference content for the CLI commands `swift ...` -->
 ### Swift Commands
 
 - <doc:SwiftBuild>
 - <doc:SwiftTest>
 - <doc:SwiftPackageCommands>
+- <doc:SwiftSDKCommands>
+- <doc:SwiftPackageRegistryCommands>
+- <doc:SwiftPackageCollectionCommands>
 - <doc:SwiftRepl>
 - <doc:SwiftRun>

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageRegistryCommands.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageRegistryCommands.md
@@ -1,0 +1,24 @@
+# swift package-registry
+
+Interact with package registry and manage related configuration.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+Overview of package manager commands here...
+
+<!-- reference content for the CLI commands `swift package-registry ...` -->
+
+## Topics 
+
+### Adding and Removing Registries
+- <doc:PackageRegistrySet>
+- <doc:PackageRegistryUnset>
+
+### Accessing Registries
+- <doc:PackageRegistryLogin>
+- <doc:PackageRegistryPublish>
+- <doc:PackageRegistryLogout>

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftRepl.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftRepl.md
@@ -1,0 +1,15 @@
+# swift repl
+
+Run Swift code interactively with LLDB.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftRun.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftRun.md
@@ -1,0 +1,15 @@
+# swift run
+
+Run an executable product in your package.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftSDKCommands.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftSDKCommands.md
@@ -1,0 +1,33 @@
+# swift sdk
+
+Perform operations on Swift SDKs.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+Overview of package manager commands here...
+
+<!-- reference content for the CLI commands `swift package ...` -->
+
+## Topics 
+
+### Installing an SDK
+- <doc:SDKInstall>
+
+### Listing SDKs
+- <doc:SDKList>
+
+### Removing an SDK
+- <doc:SDKRemove>
+
+### Configuring an SDK
+- <doc:SDKConfigure>
+
+### Deprecated Commands
+- <doc:SDKConfigurationSet>
+- <doc:SDKConfigurationReset>
+- <doc:SDKConfigurationShow>
+

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftTest.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftTest.md
@@ -1,0 +1,15 @@
+# swift test
+
+Build and run tests in your package.
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+}
+
+## Overview
+
+overview content here....
+
+### First Section
+
+First section content

--- a/Sources/PackageManagerDocs/EmptyFile.swift
+++ b/Sources/PackageManagerDocs/EmptyFile.swift
@@ -1,0 +1,4 @@
+// This is an empty placeholder swift file for the documentation target.
+
+// You can preview the documentation here by running the following command:
+// swift package --disable-sandbox preview-documentation --target PackageManagerDocs


### PR DESCRIPTION
Placeholder structure for DocC content to lay out an initial area to build into. 

### Motivation:

@bripeticca and I wanted to have something in place to merge into and a general plan of attack for shifting current content from the `/documentation` directory into DocC format. This provides a bit more structure over the bare docc catalog, and puts in placeholders for the CLI documentation as well.

We'll be creating issues for each of the existing markdown files in `/documentation`, and one for each cluster of CLI commands (grouped by top-level subcommand) to track progress.

### Modifications:

This drops in place some light DocC content, with no real depth, to set up an initial structure to merge content into. This isn't merging any existing documentation

### Result:

The PackageManagerDocs target has more concrete content layout structure to it, with placeholders for CLI commands and where to expand to build out article sets based on existing documentation.

Use `swift package --disable-sandbox preview-documentation --target PackageManagerDocs` with this PR to get a sense of the layout.

<img width="1416" alt="Screenshot 2025-04-29 at 2 19 10 PM" src="https://github.com/user-attachments/assets/47875e36-c085-4bda-89a0-dcdde30f27c6" />
