### PR TITLE
Some PIF delegate fixes for Swift Build 

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -278,7 +278,7 @@ fileprivate final class PackagePIFBuilderDelegate: PackagePIFBuilder.BuildDelega
         []
     }
     
-    func addCustomTargets(pifProject: SwiftBuild.ProjectModel.Project) throws -> [PackagePIFBuilder.ModuleOrProduct] {
+    func addCustomTargets(pifProject: inout SwiftBuild.ProjectModel.Project) throws -> [PackagePIFBuilder.ModuleOrProduct] {
         return []
     }
     
@@ -292,6 +292,7 @@ fileprivate final class PackagePIFBuilderDelegate: PackagePIFBuilder.BuildDelega
     
     func configureLibraryProduct(
         product: PackageModel.Product,
+        project: inout ProjectModel.Project,
         target: WritableKeyPath<ProjectModel.Project, ProjectModel.Target>,
         additionalFiles: WritableKeyPath<ProjectModel.Group, ProjectModel.Group>
     ) {

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -122,7 +122,7 @@ public final class PackagePIFBuilder {
         func customSDKOptions(forPlatform: PackageModel.Platform) -> [String]
 
         /// Create additional custom PIF targets after all targets have been built.
-        func addCustomTargets(pifProject: ProjectModel.Project) throws -> [PackagePIFBuilder.ModuleOrProduct]
+        func addCustomTargets(pifProject: inout ProjectModel.Project) throws -> [PackagePIFBuilder.ModuleOrProduct]
 
         /// Should we suppresses the specific product dependency, updating the provided build settings if necessary?
         /// The specified product may be in the same package or a different one.
@@ -139,6 +139,7 @@ public final class PackagePIFBuilder {
         /// Provides additional configuration and files for the specified library product.
         func configureLibraryProduct(
             product: PackageModel.Product,
+            project: inout ProjectModel.Project,
             target: WritableKeyPath<ProjectModel.Project, ProjectModel.Target>,
             additionalFiles: WritableKeyPath<ProjectModel.Group, ProjectModel.Group>
         )
@@ -467,7 +468,7 @@ public final class PackagePIFBuilder {
             }
         }
 
-        let customModulesAndProducts = try delegate.addCustomTargets(pifProject: projectBuilder.project)
+        let customModulesAndProducts = try delegate.addCustomTargets(pifProject: &projectBuilder.project)
         projectBuilder.builtModulesAndProducts.append(contentsOf: customModulesAndProducts)
 
         self._pifProject = projectBuilder.project

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -703,6 +703,7 @@ extension PackagePIFProjectBuilder {
         // Additional configuration and files for this library product.
         pifBuilder.delegate.configureLibraryProduct(
             product: product.underlying,
+            project: &self.project,
             target: librayUmbrellaTargetKeyPath,
             additionalFiles: additionalFilesGroupKeyPath
         )


### PR DESCRIPTION
### Motivation:

Fixes a few issues introduced by #8441, where the PIF model transitioned from *reference types* to *value types* (i.e., the new `SwiftBuild.ProjectModel` API.)

### Modifications:

Just a couple of changes in the `PackagePIFBuilder.BuildDelegate` protocol, ensuring we can actually mutate the `ProjectModel.Project` value.
