### PR TITLE
Use correct FileSystem in the PIF builder for Swift Build

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -164,6 +164,7 @@ public final class PIFBuilder {
                     buildToolPluginResultsByTargetName: [:],
                     createDylibForDynamicProducts: self.parameters.shouldCreateDylibForDynamicProducts,
                     packageDisplayVersion: package.manifest.displayName,
+                    fileSystem: self.fileSystem,
                     observabilityScope: self.observabilityScope
                 )
                 

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -110,7 +110,7 @@ public final class PIFBuilder {
             encoder.userInfo[.encodeForSwiftBuild] = true
         }
 
-        let topLevelObject = try self.construct(buildParameters: buildParameters)
+        let topLevelObject = try self.constructPIF(buildParameters: buildParameters)
 
         // Sign the PIF objects before encoding it for Swift Build.
         try PIF.sign(workspace: topLevelObject.workspace)
@@ -139,7 +139,7 @@ public final class PIFBuilder {
     private var cachedPIF: PIF.TopLevelObject?
 
     /// Constructs a `PIF.TopLevelObject` representing the package graph.
-    private func construct(buildParameters: BuildParameters) throws -> PIF.TopLevelObject {
+    private func constructPIF(buildParameters: BuildParameters) throws -> PIF.TopLevelObject {
         try memoize(to: &self.cachedPIF) {
             guard let rootPackage = self.graph.rootPackages.only else {
                 if self.graph.rootPackages.isEmpty {

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Plugins.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Plugins.swift
@@ -12,9 +12,10 @@
 
 import Foundation
 
-import struct Basics.AbsolutePath
-import let Basics.localFileSystem
+import protocol TSCBasic.FileSystem
+
 import enum Basics.Sandbox
+import struct Basics.AbsolutePath
 import struct Basics.SourceControlURL
 
 #if canImport(SwiftBuild)
@@ -123,10 +124,10 @@ extension PackagePIFBuilder {
         }
 
         /// Applies the sandbox profile to the given command line, and return the modified command line.
-        public func apply(to command: [String]) throws -> [String] {
+        public func apply(to command: [String], fileSystem: FileSystem) throws -> [String] {
             try Sandbox.apply(
                 command: command,
-                fileSystem: localFileSystem,
+                fileSystem: fileSystem,
                 strictness: self.strictness,
                 writableDirectories: self.writableDirectories,
                 readOnlyDirectories: self.readOnlyDirectories

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -12,20 +12,22 @@
 
 import Foundation
 
+import protocol TSCBasic.FileSystem
+
 import struct Basics.AbsolutePath
 import struct Basics.SourceControlURL
-
-import class PackageModel.Manifest
-import class PackageModel.Package
-import struct PackageModel.Platform
-import struct PackageModel.PlatformVersion
-import class PackageModel.Product
-import enum PackageModel.ProductType
-import struct PackageModel.Resource
-
 import struct Basics.Diagnostic
 import struct Basics.ObservabilityMetadata
 import class Basics.ObservabilityScope
+
+import class PackageModel.Manifest
+import class PackageModel.Package
+import class PackageModel.Product
+import struct PackageModel.Platform
+import struct PackageModel.PlatformVersion
+import struct PackageModel.Resource
+import enum PackageModel.ProductType
+
 import struct PackageGraph.ModulesGraph
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
@@ -169,6 +171,9 @@ public final class PackagePIFBuilder {
     /// Package display version, if any (i.e., it can be a version, branch or a git ref).
     let packageDisplayVersion: String?
 
+    /// The file system to read from.
+    let fileSystem: FileSystem
+
     /// Whether to suppress warnings from compilers, linkers, and other build tools for package dependencies.
     private var suppressWarningsForPackageDependencies: Bool {
         UserDefaults.standard.bool(forKey: "SuppressWarningsForPackageDependencies", defaultValue: true)
@@ -191,6 +196,7 @@ public final class PackagePIFBuilder {
         buildToolPluginResultsByTargetName: [String: BuildToolPluginInvocationResult],
         createDylibForDynamicProducts: Bool = false,
         packageDisplayVersion: String?,
+        fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
     ) {
         self.package = resolvedPackage
@@ -200,6 +206,7 @@ public final class PackagePIFBuilder {
         self.buildToolPluginResultsByTargetName = buildToolPluginResultsByTargetName
         self.createDylibForDynamicProducts = createDylibForDynamicProducts
         self.packageDisplayVersion = packageDisplayVersion
+        self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
     }
 

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -377,7 +377,7 @@ extension PackagePIFProjectBuilder {
 
             // We only need to impart this to C clients.
             impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(moduleMapFile)", "$(inherited)"]
-        } else if sourceModule.moduleMapFileRelativePath == nil {
+        } else if sourceModule.moduleMapFileRelativePath(fileSystem: self.pifBuilder.fileSystem) == nil {
             // Otherwise, this is a C library module and we generate a modulemap if one is already not provided.
             if case .umbrellaHeader(let path) = sourceModule.moduleMapType {
                 log(.debug, "\(package.name).\(sourceModule.name) generated umbrella header")
@@ -824,6 +824,7 @@ extension PackagePIFProjectBuilder {
         let settings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
         let pkgConfig = try systemLibrary.pkgConfig(
             package: self.package,
+            fileSystem: self.pifBuilder.fileSystem,
             observabilityScope: pifBuilder.observabilityScope
         )
 

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -460,7 +460,7 @@ struct PackagePIFProjectBuilder {
     ) {
         var commandLine = [command.executable] + command.arguments
         if let sandbox = command.sandboxProfile, !pifBuilder.delegate.isPluginExecutionSandboxingDisabled {
-            commandLine = try! sandbox.apply(to: commandLine)
+            commandLine = try! sandbox.apply(to: commandLine, fileSystem: self.pifBuilder.fileSystem)
         }
 
         self.project[keyPath: targetKeyPath].customTasks.append(


### PR DESCRIPTION
### Motivation:

Ensure the PIF builder follows the same `FileSystem` as the remaining code in the `SwiftBuildSupport` target.

### Modifications:

Keep around a file system reference in `PackagePIFBuilder` and use that across the PIF builder.

### Result:

All code in `SwiftBuildSupport` is now based on the same `FileSystem`.
