### PR TITLE
Display PID of other running SwiftPM processes

### DIFF
--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -1069,19 +1069,19 @@ public final class SwiftCommandState {
         } catch ProcessLockError.unableToAquireLock(let errno) {
             if errno == EWOULDBLOCK {
                 let lockingPID = try? String(contentsOfFile: self.scratchDirectory.appending(".lock").pathString, encoding: .utf8)
-                let pidInfo = lockingPID.map { "(PID: \($0))" } ?? ""
+                let pidInfo = lockingPID.map { "(PID: \($0)) " } ?? ""
                 
                 if self.options.locations.ignoreLock {
                     self.outputStream
                         .write(
-                            "Another instance of SwiftPM \(pidInfo) is already running using '\(self.scratchDirectory)', but this will be ignored since `--ignore-lock` has been passed"
+                            "Another instance of SwiftPM \(pidInfo)is already running using '\(self.scratchDirectory)', but this will be ignored since `--ignore-lock` has been passed"
                                 .utf8
                         )
                     self.outputStream.flush()
                 } else {
                     self.outputStream
                         .write(
-                            "Another instance of SwiftPM \(pidInfo) is already running using '\(self.scratchDirectory)', waiting until that process has finished execution..."
+                            "Another instance of SwiftPM \(pidInfo)is already running using '\(self.scratchDirectory)', waiting until that process has finished execution..."
                                 .utf8
                         )
                     self.outputStream.flush()

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -1066,7 +1066,7 @@ public final class SwiftCommandState {
         do {
             try workspaceLock.lock(type: .exclusive, blocking: false)
             let pid = ProcessInfo.processInfo.processIdentifier
-            try String(pid).write(toFile: lockFile, atomically: true, encoding: .utf8)
+            try? String(pid).write(toFile: lockFile, atomically: true, encoding: .utf8)
         } catch ProcessLockError.unableToAquireLock(let errno) {
             if errno == EWOULDBLOCK {
                 let lockingPID = try? String(contentsOfFile: lockFile, encoding: .utf8)
@@ -1091,7 +1091,7 @@ public final class SwiftCommandState {
                     try workspaceLock.lock(type: .exclusive, blocking: true)
 
                     let pid = ProcessInfo.processInfo.processIdentifier
-                    try String(pid).write(toFile: lockFile, atomically: true, encoding: .utf8)
+                    try? String(pid).write(toFile: lockFile, atomically: true, encoding: .utf8)
                 }
             }
         }


### PR DESCRIPTION
Displays the PID of the other SwiftPM instance currently holding the lock

### Motivation:
- Fixes #8528 

When we try to run different SwiftPM processes we already see notes like 

```
Another instance of swiftPM is already running using '/Users/louissssss/swift-package-manager/.build', waiting until that process has finished execution...
```

I'll be nice to also have info about PID so I can choose to terminate it or wait for it to finish, so it might display smt like:
```
Another instance of SwiftPM (PID: 3404) is already running using '/Users/louissssss/swift-package-manager/.build', waiting until that process has finished execution...
```

### Modifications:

My approach was trying to write process id from the process that acquires the lock to the lock file and then let other processes read from it and get the pid.

### Result:

If another SwiftPM process is currently running, it now displays:
```
Another instance of SwiftPM (PID: 3404) is already running using '/Users/louissssss/swift-package-manager/.build', waiting until that process has finished execution...
```