### PR TITLE
Add missing file to SwiftBuildSupport/CMakeLists.txt

### DIFF
--- a/Sources/SwiftBuildSupport/CMakeLists.txt
+++ b/Sources/SwiftBuildSupport/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_library(SwiftBuildSupport STATIC
   BuildSystem.swift
+  DotPIFSerializer.swift
   PackagePIFBuilder.swift
   PackagePIFBuilder+Helpers.swift
   PackagePIFBuilder+Plugins.swift


### PR DESCRIPTION
### Motivation:

Fix a minor `cmake` build issue I introduced in #8539. 

### Modifications:

Add missing `.swift` file to `SwiftBuildSupport/CMakeLists.txt`.