### PR TITLE
Rename remaining occurrences of the old helper.

### DIFF
--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -16145,7 +16145,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testInvalidTrait_WhenParentPackageEnablesTraits() async throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: #"\tmp\ws doesn't exist in file system"#)
+        try XCTSkipOnWindows(because: #"\tmp\ws doesn't exist in file system"#)
 
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
@@ -16208,7 +16208,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testInvalidTraitConfiguration_ForRootPackage() async throws {
-        try skipOnWindowsAsTestCurrentlyFails(because: #"\tmp\ws doesn't exist in file system"#)
+        try XCTSkipOnWindows(because: #"\tmp\ws doesn't exist in file system"#)
 
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()


### PR DESCRIPTION
Rename remaining occurrences of the old helper.

### Motivation:

My local test failed to build after #8569 with

```
…/Tests/WorkspaceTests/WorkspaceTests.swift:16148:13: error: cannot find 'skipOnWindowsAsTestCurrentlyFails' in scope
16146 | 
16147 |     func testInvalidTrait_WhenParentPackageEnablesTraits() async throws {
16148 |         try skipOnWindowsAsTestCurrentlyFails(because: #"\tmp\ws doesn't exist in file system"#)
      |             `- error: cannot find 'skipOnWindowsAsTestCurrentlyFails' in scope
16149 | 
16150 |         let sandbox = AbsolutePath("/tmp/ws/")
```

I checked, and it appears to be leftovers after  #8569:

```
% rg skipOnWindowsAsTestCurrentlyFails
Tests/WorkspaceTests/WorkspaceTests.swift
16148:        try skipOnWindowsAsTestCurrentlyFails(because: #"\tmp\ws doesn't exist in file system"#)
16211:        try skipOnWindowsAsTestCurrentlyFails(because: #"\tmp\ws doesn't exist in file system"#)
```

### Modifications:

Renamed `skipOnWindowsAsTestCurrentlyFails` to `XCTSkipOnWindows`.

### Result:

Tests build and pass.
