### PR TITLE
Tests: Conditionally skip the Archiver tests

### DIFF
--- a/Sources/Basics/Archiver/TarArchiver.swift
+++ b/Sources/Basics/Archiver/TarArchiver.swift
@@ -25,7 +25,7 @@ public struct TarArchiver: Archiver {
     private let cancellator: Cancellator
 
     /// The underlying command
-    private let tarCommand: String
+    internal let tarCommand: String
 
     /// Creates a `TarArchiver`.
     ///

--- a/Sources/_InternalTestSupport/XCTAssertHelpers.swift
+++ b/Sources/_InternalTestSupport/XCTAssertHelpers.swift
@@ -76,6 +76,31 @@ public func XCTSkipOnWindows(because reason: String? = nil, skipPlatformCi: Bool
     #endif
 }
 
+public func _requiresTools(_ executable: String) throws {
+    func getAsyncProcessArgs(_ executable: String) -> [String] {
+        #if os(Windows)
+            let args = ["cmd.exe", "/c", "where.exe", executable]
+        #else
+            let args = ["which", executable]
+        #endif
+        return args
+    }
+    try AsyncProcess.checkNonZeroExit(arguments: getAsyncProcessArgs(executable))
+}
+public func XCTRequires(
+    executable: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
+
+    do {
+        try _requiresTools(executable)
+    } catch (let AsyncProcessResult.Error.nonZeroExit(result)) {
+        throw XCTSkip(
+            "Skipping as tool \(executable) is not found in the path. (\(result.description))")
+    }
+}
+
 /// An `async`-friendly replacement for `XCTAssertThrowsError`.
 public func XCTAssertAsyncThrowsError<T>(
     _ expression: @autoclosure () async throws -> T,

--- a/Tests/BasicsTests/Archiver/TarArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/TarArchiverTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+@testable import struct Basics.TarArchiver
 import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported
 import _InternalTestSupport
 import XCTest
@@ -18,6 +19,11 @@ import XCTest
 import struct TSCBasic.FileSystemError
 
 final class TarArchiverTests: XCTestCase {
+    override func setUp() async throws {
+        let archiver = TarArchiver(fileSystem: localFileSystem)
+        try XCTRequires(executable: archiver.tarCommand)
+    }
+
     func testSuccess() async throws {
         try await testWithTemporaryDirectory { tmpdir in
             let archiver = TarArchiver(fileSystem: localFileSystem)

--- a/Tests/BasicsTests/Archiver/UniversalArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/UniversalArchiverTests.swift
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+@testable import struct Basics.TarArchiver
+@testable import struct Basics.ZipArchiver
 import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported
 import _InternalTestSupport
 import XCTest
@@ -18,6 +20,22 @@ import XCTest
 import struct TSCBasic.FileSystemError
 
 final class UniversalArchiverTests: XCTestCase {
+    override func setUp() async throws {
+        let zipAchiver = ZipArchiver(fileSystem: localFileSystem)
+        #if os(Windows)
+            try XCTRequires(executable: zipAchiver.windowsTar)
+        #else
+            try XCTRequires(executable: zipAchiver.unzip)
+            try XCTRequires(executable: zipAchiver.zip)
+        #endif
+        #if os(FreeBSD)
+            try XCTRequires(executable: zipAchiver.tar)
+        #endif
+
+        let tarAchiver = TarArchiver(fileSystem: localFileSystem)
+        try XCTRequires(executable: tarAchiver.tarCommand)
+    }
+
     func testSuccess() async throws {
         try await testWithTemporaryDirectory { tmpdir in
             let archiver = UniversalArchiver(localFileSystem)

--- a/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+@testable import struct Basics.ZipArchiver
 import _InternalTestSupport
 import XCTest
 import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported
@@ -18,6 +19,19 @@ import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported
 import struct TSCBasic.FileSystemError
 
 final class ZipArchiverTests: XCTestCase {
+    override func setUp() async throws {
+        let archiver = ZipArchiver(fileSystem: localFileSystem)
+        #if os(Windows)
+            try XCTRequires(executable: archiver.windowsTar)
+        #else
+            try XCTRequires(executable: archiver.unzip)
+            try XCTRequires(executable: archiver.zip)
+        #endif
+        #if os(FreeBSD)
+            try XCTRequires(executable: archiver.tar)
+        #endif
+    }
+
     func testZipArchiverSuccess() async throws {
         try await testWithTemporaryDirectory { tmpdir in
             let archiver = ZipArchiver(fileSystem: localFileSystem)

--- a/Tests/_InternalTestSupportTests/Misc.swift
+++ b/Tests/_InternalTestSupportTests/Misc.swift
@@ -1,3 +1,14 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
 import SPMBuildCore
 import _InternalTestSupport
 import XCTest

--- a/Tests/_InternalTestSupportTests/XCTAssertHelpersTests.swift
+++ b/Tests/_InternalTestSupportTests/XCTAssertHelpersTests.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import XCTest
+import func _InternalTestSupport.XCTAssertThrows
+import func _InternalTestSupport._requiresTools
+
+final class TestRequiresTool: XCTestCase {
+    func testErrorIsThrownIfExecutableIsNotFoundOnThePath() throws {
+        XCTAssertThrows(
+            try _requiresTools("doesNotExists")
+        ) { (error: AsyncProcessResult.Error) in
+            return true
+        }
+    }
+
+    func testErrorIsNotThrownIfExecutableIsOnThePath() throws {
+        // Essentially call either "which which" or "where.exe where.exe"
+        #if os(Window)
+        let executable = "where.exe"
+        #else
+        let executable = "which"
+        #endif
+        XCTAssertNoThrow(
+            try _requiresTools(executable)
+        )
+    }
+}


### PR DESCRIPTION
The Archiver tests has a dependency on a system binary being available on the host.  Update the archiver test to skip the test is the required executable is not available on the system.

Fixes: #8586
Issue: rdar://150414402
Required for: https://github.com/swiftlang/swift/pull/80405