### PR TITLE
Bump iOS deployment target to 17 to match dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -104,7 +104,7 @@ let package = Package(
     name: "SwiftPM",
     platforms: [
         .macOS(.v13),
-        .iOS(.v16),
+        .iOS(.v17),
         .macCatalyst(.v17),
     ],
     products:


### PR DESCRIPTION
Swift Build requires iOS 17