### PR TITLE
Add more context for validation errors for target properties.

### DIFF
--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -596,12 +596,12 @@ private enum Error: LocalizedError, Equatable {
     var errorDescription: String? {
         switch self {
         case .binaryTargetRequiresEitherPathOrURL(let targetName):
-            "binary target '\(targetName)' neither defines neither path nor URL for its artifacts"
+            "binary target '\(targetName)' must define either path or URL for its artifacts"
         case .pluginTargetRequiresPluginCapability(let targetName):
             "plugin target '\(targetName)' does not define any plugin capability"
         case .disallowedPropertyInTarget(let targetName, let targetType, let propertyName, let value):
             "target '\(targetName)' is assigned a property '\(propertyName)' which is not accepted " +
-            "for the \(targetType) target type. The current value of the property has " +
+            "for the \(targetType) target type. The current property value has " +
             "the following representation: \(value)."
         }
     }

--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -212,51 +212,237 @@ public struct TargetDescription: Hashable, Encodable, Sendable {
         checksum: String? = nil,
         pluginUsages: [PluginUsage]? = nil
     ) throws {
+        let targetType = String(describing: type)
         switch type {
         case .regular, .executable, .test:
-            if url != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "url") }
-            if pkgConfig != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pkgConfig") }
-            if providers != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "providers") }
-            if pluginCapability != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pluginCapability") }
-            if checksum != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "checksum") }
+            if url != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "url",
+                value: url ?? "<nil>"
+            ) }
+            if pkgConfig != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "pkgConfig",
+                value: pkgConfig ?? "<nil>"
+            ) }
+            if providers != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "providers",
+                value: String(describing: providers!)
+            ) }
+            if pluginCapability != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "pluginCapability",
+                value: String(describing: pluginCapability!)
+            ) }
+            if checksum != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "checksum",
+                value: checksum ?? "<nil>"
+            ) }
         case .system:
-            if !dependencies.isEmpty { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "dependencies") }
-            if !exclude.isEmpty { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "exclude") }
-            if sources != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "sources") }
-            if !resources.isEmpty { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "resources") }
-            if publicHeadersPath != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "publicHeadersPath") }
-            if pluginCapability != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pluginCapability") }
-            if !settings.isEmpty { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "settings") }
-            if checksum != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "checksum") }
-            if pluginUsages != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pluginUsages") }
+            if !dependencies.isEmpty { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "dependencies",
+                value: String(describing: dependencies)
+            ) }
+            if !exclude.isEmpty { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "exclude",
+                value: String(describing: exclude)
+            ) }
+            if sources != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "sources",
+                value: String(describing: sources!)
+            ) }
+            if !resources.isEmpty { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "resources",
+                value: String(describing: resources)
+            ) }
+            if publicHeadersPath != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "publicHeadersPath",
+                value: publicHeadersPath ?? "<nil>"
+            ) }
+            if pluginCapability != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "pluginCapability",
+                value: String(describing: pluginCapability!)
+            ) }
+            if !settings.isEmpty { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "settings",
+                value: String(describing: settings)
+            ) }
+            if checksum != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "checksum",
+                value: checksum ?? "<nil>"
+            ) }
+            if pluginUsages != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "pluginUsages",
+                value: String(describing: pluginUsages!)
+            ) }
         case .binary:
             if path == nil && url == nil { throw Error.binaryTargetRequiresEitherPathOrURL(targetName: name) }
-            if !dependencies.isEmpty { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "dependencies") }
-            if !exclude.isEmpty { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "exclude") }
-            if sources != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "sources") }
-            if !resources.isEmpty { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "resources") }
-            if publicHeadersPath != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "publicHeadersPath") }
-            if pkgConfig != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pkgConfig") }
-            if providers != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "providers") }
-            if pluginCapability != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pluginCapability") }
-            if !settings.isEmpty { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "settings") }
-            if pluginUsages != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pluginUsages") }
+            if !dependencies.isEmpty { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "dependencies",
+                value: String(describing: dependencies)
+            ) }
+            if !exclude.isEmpty { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "exclude",
+                value: String(describing: exclude)
+            ) }
+            if sources != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "sources",
+                value: String(describing: sources!)
+            ) }
+            if !resources.isEmpty { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "resources",
+                value: String(describing: resources)
+            ) }
+            if publicHeadersPath != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "publicHeadersPath",
+                value: publicHeadersPath ?? "<nil>"
+            ) }
+            if pkgConfig != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "pkgConfig",
+                value: pkgConfig ?? "<nil>"
+            ) }
+            if providers != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "providers",
+                value: String(describing: providers!)
+            ) }
+            if pluginCapability != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "pluginCapability",
+                value: String(describing: pluginCapability!)
+            ) }
+            if !settings.isEmpty { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "settings",
+                value: String(describing: settings)
+            ) }
+            if pluginUsages != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "pluginUsages",
+                value: String(describing: pluginUsages!)
+            ) }
         case .plugin:
-            if url != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "url") }
-            if !resources.isEmpty { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "resources") }
-            if publicHeadersPath != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "publicHeadersPath") }
-            if pkgConfig != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pkgConfig") }
-            if providers != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "providers") }
-            if pluginCapability == nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pluginCapability") }
-            if !settings.isEmpty { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "settings") }
-            if pluginUsages != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pluginUsages") }
+            if pluginCapability == nil { throw Error.pluginTargetRequiresPluginCapability(targetName: name) }
+            if url != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "url",
+                value: url ?? "<nil>"
+            ) }
+            if !resources.isEmpty { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "resources",
+                value: String(describing: resources)
+            ) }
+            if publicHeadersPath != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "publicHeadersPath",
+                value: publicHeadersPath ?? "<nil>"
+            ) }
+            if pkgConfig != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "pkgConfig",
+                value: pkgConfig ?? "<nil>"
+            ) }
+            if providers != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "providers",
+                value: String(describing: providers!)
+            ) }
+            if !settings.isEmpty { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "settings",
+                value: String(describing: settings)
+            ) }
+            if pluginUsages != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "pluginUsages",
+                value: String(describing: pluginUsages!)
+            ) }
         case .macro:
-            if url != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "url") }
-            if !resources.isEmpty { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "resources") }
-            if publicHeadersPath != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "publicHeadersPath") }
-            if pkgConfig != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pkgConfig") }
-            if providers != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "providers") }
-            if pluginCapability != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pluginCapability") }
+            if url != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "url",
+                value: url ?? "<nil>"
+            ) }
+            if !resources.isEmpty { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "resources",
+                value: String(describing: resources)
+            ) }
+            if publicHeadersPath != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "publicHeadersPath",
+                value: publicHeadersPath ?? "<nil>"
+            ) }
+            if pkgConfig != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "pkgConfig",
+                value: pkgConfig ?? "<nil>"
+            ) }
+            if providers != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "providers",
+                value: String(describing: providers!)
+            ) }
+            if pluginCapability != nil { throw Error.disallowedPropertyInTarget(
+                targetName: name,
+                targetType: targetType,
+                propertyName: "pluginCapability",
+                value: String(describing: pluginCapability!)
+            ) }
         }
 
         self.name = name
@@ -404,14 +590,19 @@ import protocol Foundation.LocalizedError
 
 private enum Error: LocalizedError, Equatable {
     case binaryTargetRequiresEitherPathOrURL(targetName: String)
-    case disallowedPropertyInTarget(targetName: String, propertyName: String)
-    
+    case pluginTargetRequiresPluginCapability(targetName: String)
+    case disallowedPropertyInTarget(targetName: String, targetType: String, propertyName: String, value: String)
+
     var errorDescription: String? {
         switch self {
         case .binaryTargetRequiresEitherPathOrURL(let targetName):
-            return "binary target '\(targetName)' neither defines neither path nor URL for its artifacts"
-        case .disallowedPropertyInTarget(let targetName, let propertyName):
-            return "target '\(targetName)' contains a value for disallowed property '\(propertyName)'"
+            "binary target '\(targetName)' neither defines neither path nor URL for its artifacts"
+        case .pluginTargetRequiresPluginCapability(let targetName):
+            "plugin target '\(targetName)' does not define any plugin capability"
+        case .disallowedPropertyInTarget(let targetName, let targetType, let propertyName, let value):
+            "target '\(targetName)' is assigned a property '\(propertyName)' which is not accepted " +
+            "for the \(targetType) target type. The current value of the property has " +
+            "the following representation: \(value)."
         }
     }
 }

--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -598,7 +598,7 @@ private enum Error: LocalizedError, Equatable {
         case .binaryTargetRequiresEitherPathOrURL(let targetName):
             "binary target '\(targetName)' must define either path or URL for its artifacts"
         case .pluginTargetRequiresPluginCapability(let targetName):
-            "plugin target '\(targetName)' does not define any plugin capability"
+            "plugin target '\(targetName)' must define a plugin capability"
         case .disallowedPropertyInTarget(let targetName, let targetType, let propertyName, let value):
             "target '\(targetName)' is assigned a property '\(propertyName)' which is not accepted " +
             "for the \(targetType) target type. The current property value has " +

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -160,7 +160,7 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
         await XCTAssertAsyncThrowsError(try await loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
             XCTAssertEqual(error.localizedDescription,
                 "target 'Foo' is assigned a property 'settings' which is not accepted for the binary target type. " +
-                "The current value of the property has the following representation: " +
+                "The current property value has the following representation: " +
                 "[PackageModel.TargetBuildSettingDescription.Setting(" +
                 "tool: PackageModel.TargetBuildSettingDescription.Tool.linker, " +
                 "kind: PackageModel.TargetBuildSettingDescription.Kind.linkedFramework(\"AVFoundation\"), " +

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -168,6 +168,31 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
+    func testBinaryTargetRequiresPathOrUrl() async throws {
+        let content = """
+        import PackageDescription
+        var fwBinaryTarget = Target.binaryTarget(
+            name: "nickel",
+            url: "https://example.com/foo.git",
+            checksum: "bee"
+        )
+        fwBinaryTarget.url = nil
+        let package = Package(name: "foo", targets: [fwBinaryTarget])
+        """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        await XCTAssertAsyncThrowsError(
+            try await loadAndValidateManifest(
+                content, observabilityScope: observability.topScope
+            ), "expected error"
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "binary target 'nickel' must define either path or URL for its artifacts"
+            )
+        }
+    }
+
     func testBinaryTargetsValidation() async throws {
         do {
             let content = """

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -158,7 +158,13 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
 
         let observability = ObservabilitySystem.makeForTesting()
         await XCTAssertAsyncThrowsError(try await loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
-            XCTAssertEqual(error.localizedDescription, "target 'Foo' contains a value for disallowed property 'settings'")
+            XCTAssertEqual(error.localizedDescription,
+                "target 'Foo' is assigned a property 'settings' which is not accepted for the binary target type. " +
+                "The current value of the property has the following representation: " +
+                "[PackageModel.TargetBuildSettingDescription.Setting(" +
+                "tool: PackageModel.TargetBuildSettingDescription.Tool.linker, " +
+                "kind: PackageModel.TargetBuildSettingDescription.Kind.linkedFramework(\"AVFoundation\"), " +
+                "condition: nil)].")
         }
     }
 

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -98,6 +98,30 @@ final class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
     }
 
+    func testPluginTargetRequiresPluginCapability() async throws {
+        let content = """
+        import PackageDescription
+        var fwPluginTarget = Target.plugin(
+            name: "quarter",
+            capability: .buildTool
+        )
+        fwPluginTarget.pluginCapability = nil
+        let package = Package(name: "foo", targets: [fwPluginTarget])
+        """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        await XCTAssertAsyncThrowsError(
+            try await loadAndValidateManifest(
+                content, observabilityScope: observability.topScope
+            ), "expected error"
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "plugin target 'quarter' must define a plugin capability"
+            )
+        }
+    }
+
     func testPluginTargetCustomization() async throws {
         let content = """
             import PackageDescription


### PR DESCRIPTION
Add more context for validation errors for target properties.

### Motivation:

I came across a post https://forums.swift.org/t/getting-error-on-package-resolve/75419 which reports the error message to be not clear. I thought I could clarify the message.

```
error: 'xerr': target 'Penny' contains a value for disallowed property 'settings'
```

### Modifications:

I've updated the message for the error, so it includes more details to narrow down what is the culprit:
 - highlight that the property depends on the target type
 - show the value of the property, so that there's a hint what line in the Package.swift lead to the error (for example, linkerSettings or cxxSettings)

### Result:


Before:

```
error: 'xerr': target 'Penny' contains a value for disallowed property 'settings'
```

After:

```
error: 'xerr': target 'Penny' is assigned a property 'settings' which is not accepted for
the binary target type. The current value of the property has the following representation: 
[PackageModel.TargetBuildSettingDescription.Setting(
tool: PackageModel.TargetBuildSettingDescription.Tool.linker,
kind: PackageModel.TargetBuildSettingDescription.Kind.linkedFramework("AVFoundation"),
condition: nil)].
```