### PR TITLE
Tests: Convert more BasicTests to Swift Testing

### DIFF
--- a/Tests/BasicsTests/ByteStringExtensionsTests.swift
+++ b/Tests/BasicsTests/ByteStringExtensionsTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -11,16 +11,17 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-import XCTest
+import Testing
 
 import struct TSCBasic.ByteString
 
-final class ByteStringExtensionsTests: XCTestCase {
-    func testSHA256Checksum() {
+struct ByteStringExtensionsTests {
+    @Test
+    func sHA256Checksum() {
         let byteString = ByteString(encodingAsUTF8: "abc")
-        XCTAssertEqual(byteString.contents, [0x61, 0x62, 0x63])
+        #expect(byteString.contents == [0x61, 0x62, 0x63])
 
         // See https://csrc.nist.gov/csrc/media/projects/cryptographic-standards-and-guidelines/documents/examples/sha_all.pdf
-        XCTAssertEqual(byteString.sha256Checksum, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+        #expect(byteString.sha256Checksum == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
     }
 }

--- a/Tests/BasicsTests/ConcurrencyHelpersTests.swift
+++ b/Tests/BasicsTests/ConcurrencyHelpersTests.swift
@@ -2,22 +2,24 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @testable import Basics
 import TSCTestSupport
-import XCTest
+import Testing
 
-final class ConcurrencyHelpersTest: XCTestCase {
+struct ConcurrencyHelpersTest {
     let queue = DispatchQueue(label: "ConcurrencyHelpersTest", attributes: .concurrent)
 
-    func testThreadSafeKeyValueStore() {
+    @Test
+    func threadSafeKeyValueStore() throws {
         for _ in 0 ..< 100 {
             let sync = DispatchGroup()
 
@@ -41,18 +43,15 @@ final class ConcurrencyHelpersTest: XCTestCase {
                 }
             }
 
-            switch sync.wait(timeout: .now() + .seconds(2)) {
-            case .timedOut:
-                XCTFail("timeout")
-            case .success:
-                expected.forEach { key, value in
-                    XCTAssertEqual(cache[key], value)
-                }
+            try #require(sync.wait(timeout: .now() + .seconds(2)) == .success)
+            expected.forEach { key, value in
+                #expect(cache[key] == value)
             }
         }
     }
 
-    func testThreadSafeArrayStore() {
+    @Test
+    func threadSafeArrayStore() throws {
         for _ in 0 ..< 100 {
             let sync = DispatchGroup()
 
@@ -71,18 +70,15 @@ final class ConcurrencyHelpersTest: XCTestCase {
                 }
             }
 
-            switch sync.wait(timeout: .now() + .seconds(2)) {
-            case .timedOut:
-                XCTFail("timeout")
-            case .success:
-                let expectedSorted = expected.sorted()
-                let resultsSorted = cache.get().sorted()
-                XCTAssertEqual(expectedSorted, resultsSorted)
-            }
+            try #require(sync.wait(timeout: .now() + .seconds(2)) == .success)
+            let expectedSorted = expected.sorted()
+            let resultsSorted = cache.get().sorted()
+            #expect(expectedSorted == resultsSorted)
         }
     }
 
-    func testThreadSafeBox() {
+    @Test
+    func threadSafeBox() throws {
         for _ in 0 ..< 100 {
             let sync = DispatchGroup()
 
@@ -108,12 +104,8 @@ final class ConcurrencyHelpersTest: XCTestCase {
                 }
             }
 
-            switch sync.wait(timeout: .now() + .seconds(2)) {
-            case .timedOut:
-                XCTFail("timeout")
-            case .success:
-                XCTAssertEqual(cache.get(), winner)
-            }
+            try #require(sync.wait(timeout: .now() + .seconds(2)) == .success)
+            #expect(cache.get() == winner)
         }
     }
 }

--- a/Tests/BasicsTests/DictionaryTest.swift
+++ b/Tests/BasicsTests/DictionaryTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -11,26 +11,27 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Basics
-import XCTest
+import Testing
 
-final class DictionaryTests: XCTestCase {
-    func testThrowingUniqueKeysWithValues() throws {
+struct DictionaryTests {
+    @Test
+    func throwingUniqueKeysWithValues() throws {
         do {
             let keysWithValues = [("key1", "value1"), ("key2", "value2")]
             let dictionary = try Dictionary(throwingUniqueKeysWithValues: keysWithValues)
-            XCTAssertEqual(dictionary["key1"], "value1")
-            XCTAssertEqual(dictionary["key2"], "value2")
+            #expect(dictionary["key1"] == "value1")
+            #expect(dictionary["key2"] == "value2")
         }
         do {
             let keysWithValues = [("key1", "value"), ("key2", "value")]
             let dictionary = try Dictionary(throwingUniqueKeysWithValues: keysWithValues)
-            XCTAssertEqual(dictionary["key1"], "value")
-            XCTAssertEqual(dictionary["key2"], "value")
+            #expect(dictionary["key1"] == "value")
+            #expect(dictionary["key2"] == "value")
         }
         do {
             let keysWithValues = [("key", "value1"), ("key", "value2")]
-            XCTAssertThrowsError(try Dictionary(throwingUniqueKeysWithValues: keysWithValues)) { error in
-                XCTAssertEqual(error as? StringError, StringError("duplicate key found: 'key'"))
+            #expect(throws: StringError("duplicate key found: 'key'")) {
+                try Dictionary(throwingUniqueKeysWithValues: keysWithValues)
             }
         }
     }

--- a/Tests/BasicsTests/DispatchTimeTests.swift
+++ b/Tests/BasicsTests/DispatchTimeTests.swift
@@ -2,37 +2,40 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import Basics
-import XCTest
+import Testing
 
-final class DispatchTimeTests: XCTestCase {
-    func testDifferencePositive() {
+struct DispatchTimeTests {
+    @Test
+    func differencePositive() {
         let point: DispatchTime = .now()
         let future: DispatchTime = point + .seconds(10)
 
         let diff1: DispatchTimeInterval = point.distance(to: future)
-        XCTAssertEqual(diff1.seconds(), 10)
+        #expect(diff1.seconds() == 10)
 
         let diff2: DispatchTimeInterval = future.distance(to: point)
-        XCTAssertEqual(diff2.seconds(), -10)
+        #expect(diff2.seconds() == -10)
     }
 
-    func testDifferenceNegative() {
+    @Test
+    func differenceNegative() {
         let point: DispatchTime = .now()
         let past: DispatchTime = point - .seconds(10)
 
         let diff1: DispatchTimeInterval = point.distance(to: past)
-        XCTAssertEqual(diff1.seconds(), -10)
+        #expect(diff1.seconds() == -10)
 
         let diff2: DispatchTimeInterval = past.distance(to: point)
-        XCTAssertEqual(diff2.seconds(), 10)
+        #expect(diff2.seconds() == 10)
     }
 }

--- a/Tests/BasicsTests/NetrcTests.swift
+++ b/Tests/BasicsTests/NetrcTests.swift
@@ -9,32 +9,35 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import Basics
-import XCTest
+import Testing
 
-class NetrcTests: XCTestCase {
+struct NetrcTests {
     /// should load machines for a given inline format
-    func testLoadMachinesInline() throws {
+    @Test
+    func loadMachinesInline() throws {
         let content = "machine example.com login anonymous password qwerty"
 
         let netrc = try NetrcParser.parse(content)
-        XCTAssertEqual(netrc.machines.count, 1)
+        #expect(netrc.machines.count == 1)
 
-        let machine = netrc.machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qwerty")
+        let machine = try #require(netrc.machines.first)
+        #expect(machine.name == "example.com")
+        #expect(machine.login == "anonymous")
+        #expect(machine.password == "qwerty")
 
         let authorization = netrc.authorization(for: "http://example.com/resource.zip")
-        XCTAssertEqual(authorization, Netrc.Authorization(login: "anonymous", password: "qwerty"))
+        #expect(authorization == Netrc.Authorization(login: "anonymous", password: "qwerty"))
 
-        XCTAssertNil(netrc.authorization(for: "http://example2.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "http://www.example2.com/resource.zip"))
+        #expect(netrc.authorization(for: "http://example2.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "http://www.example2.com/resource.zip") == nil)
     }
 
     /// should load machines for a given multi-line format
-    func testLoadMachinesMultiLine() throws {
+    @Test
+    func loadMachinesMultiLine() throws {
         let content = """
                     machine example.com
                     login anonymous
@@ -42,22 +45,23 @@ class NetrcTests: XCTestCase {
                     """
 
         let netrc = try NetrcParser.parse(content)
-        XCTAssertEqual(netrc.machines.count, 1)
+        #expect(netrc.machines.count == 1)
 
-        let machine = netrc.machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qwerty")
+        let machine = try #require(netrc.machines.first)
+        #expect(machine.name == "example.com")
+        #expect(machine.login == "anonymous")
+        #expect(machine.password == "qwerty")
 
         let authorization = netrc.authorization(for: "http://example.com/resource.zip")
-        XCTAssertEqual(authorization, Netrc.Authorization(login: "anonymous", password: "qwerty"))
+        #expect(authorization == Netrc.Authorization(login: "anonymous", password: "qwerty"))
 
-        XCTAssertNil(netrc.authorization(for: "http://example2.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "http://www.example2.com/resource.zip"))
+        #expect(netrc.authorization(for: "http://example2.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "http://www.example2.com/resource.zip") == nil)
     }
 
     /// Should fall back to default machine when not matching host
-    func testLoadDefaultMachine() throws {
+    @Test
+    func loadDefaultMachine() throws {
         let content = """
                     machine example.com
                     login anonymous
@@ -69,23 +73,24 @@ class NetrcTests: XCTestCase {
                     """
 
         let netrc = try NetrcParser.parse(content)
-        XCTAssertEqual(netrc.machines.count, 2)
+        #expect(netrc.machines.count == 2)
 
-        let machine = netrc.machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qwerty")
+        let machine = try #require(netrc.machines.first)
+        #expect(machine.name == "example.com")
+        #expect(machine.login == "anonymous")
+        #expect(machine.password == "qwerty")
 
-        let machine2 = netrc.machines.last
-        XCTAssertEqual(machine2?.name, "default")
-        XCTAssertEqual(machine2?.login, "id")
-        XCTAssertEqual(machine2?.password, "secret")
+        let machine2 = try #require(netrc.machines.last)
+        #expect(machine2.name == "default")
+        #expect(machine2.login == "id")
+        #expect(machine2.password == "secret")
 
         let authorization = netrc.authorization(for: "http://example2.com/resource.zip")
-        XCTAssertEqual(authorization, Netrc.Authorization(login: "id", password: "secret"))
+        #expect(authorization == Netrc.Authorization(login: "id", password: "secret"))
     }
 
-    func testRegexParsing() throws {
+    @Test
+    func regexParsing() throws {
         let content = """
                     machine machine
                     login login
@@ -109,25 +114,26 @@ class NetrcTests: XCTestCase {
                     """
 
         let netrc = try NetrcParser.parse(content)
-        XCTAssertEqual(netrc.machines.count, 3)
+        #expect(netrc.machines.count == 3)
 
-        XCTAssertEqual(netrc.machines[0].name, "machine")
-        XCTAssertEqual(netrc.machines[0].login, "login")
-        XCTAssertEqual(netrc.machines[0].password, "password")
+        #expect(netrc.machines[0].name == "machine")
+        #expect(netrc.machines[0].login == "login")
+        #expect(netrc.machines[0].password == "password")
 
-        XCTAssertEqual(netrc.machines[1].name, "login")
-        XCTAssertEqual(netrc.machines[1].login, "password")
-        XCTAssertEqual(netrc.machines[1].password, "machine")
+        #expect(netrc.machines[1].name == "login")
+        #expect(netrc.machines[1].login == "password")
+        #expect(netrc.machines[1].password == "machine")
 
-        XCTAssertEqual(netrc.machines[2].name, "default")
-        XCTAssertEqual(netrc.machines[2].login, "id")
-        XCTAssertEqual(netrc.machines[2].password, "secret")
+        #expect(netrc.machines[2].name == "default")
+        #expect(netrc.machines[2].login == "id")
+        #expect(netrc.machines[2].password == "secret")
 
         let authorization = netrc.authorization(for: "http://example2.com/resource.zip")
-        XCTAssertEqual(authorization, Netrc.Authorization(login: "id", password: "secret"))
+        #expect(authorization == Netrc.Authorization(login: "id", password: "secret"))
     }
 
-    func testOutOfOrderDefault() {
+    @Test
+    func outOfOrderDefault() {
         let content = """
                     machine machine
                     login login
@@ -146,12 +152,13 @@ class NetrcTests: XCTestCase {
                     password secret
                     """
 
-        XCTAssertThrowsError(try NetrcParser.parse(content)) { error in
-            XCTAssertEqual(error as? NetrcError, .invalidDefaultMachinePosition)
+        #expect(throws: NetrcError.invalidDefaultMachinePosition) {
+            try NetrcParser.parse(content)
         }
     }
 
-    func testErrorOnMultipleDefault() {
+    @Test
+    func errorOnMultipleDefault() {
         let content = """
                     machine machine
                     login login
@@ -174,13 +181,14 @@ class NetrcTests: XCTestCase {
                     password terces
                     """
 
-        XCTAssertThrowsError(try NetrcParser.parse(content)) { error in
-            XCTAssertEqual(error as? NetrcError, .invalidDefaultMachinePosition)
+        #expect(throws: NetrcError.invalidDefaultMachinePosition) {
+            try NetrcParser.parse(content)
         }
     }
 
     /// should load machines for a given multi-line format with comments
-    func testLoadMachinesMultilineComments() throws {
+    @Test
+    func loadMachinesMultilineComments() throws {
         let content = """
                     ## This is a comment
                     # This is another comment
@@ -190,48 +198,51 @@ class NetrcTests: XCTestCase {
                     """
 
         let machines = try NetrcParser.parse(content).machines
-        XCTAssertEqual(machines.count, 1)
+        #expect(machines.count == 1)
 
-        let machine = machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qwerty")
+        let machine = try #require(machines.first)
+        #expect(machine.name == "example.com")
+        #expect(machine.login == "anonymous")
+        #expect(machine.password == "qwerty")
     }
 
     /// should load machines for a given multi-line + whitespaces format
-    func testLoadMachinesMultilineWhitespaces() throws {
+    @Test
+    func loadMachinesMultilineWhitespaces() throws {
         let content = """
                     machine  example.com login     anonymous
                     password                  qwerty
                     """
 
         let machines = try NetrcParser.parse(content).machines
-        XCTAssertEqual(machines.count, 1)
+        #expect(machines.count == 1)
 
-        let machine = machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qwerty")
+        let machine = try #require(machines.first)
+        #expect(machine.name == "example.com")
+        #expect(machine.login == "anonymous")
+        #expect(machine.password == "qwerty")
     }
 
     /// should load multiple machines for a given inline format
-    func testLoadMultipleMachinesInline() throws {
+    @Test
+    func loadMultipleMachinesInline() throws {
         let content = "machine example.com login anonymous password qwerty machine example2.com login anonymous2 password qwerty2"
 
         let netrc = try NetrcParser.parse(content)
-        XCTAssertEqual(netrc.machines.count, 2)
+        #expect(netrc.machines.count == 2)
 
-        XCTAssertEqual(netrc.machines[0].name, "example.com")
-        XCTAssertEqual(netrc.machines[0].login, "anonymous")
-        XCTAssertEqual(netrc.machines[0].password, "qwerty")
+        #expect(netrc.machines[0].name == "example.com")
+        #expect(netrc.machines[0].login == "anonymous")
+        #expect(netrc.machines[0].password == "qwerty")
 
-        XCTAssertEqual(netrc.machines[1].name, "example2.com")
-        XCTAssertEqual(netrc.machines[1].login, "anonymous2")
-        XCTAssertEqual(netrc.machines[1].password, "qwerty2")
+        #expect(netrc.machines[1].name == "example2.com")
+        #expect(netrc.machines[1].login == "anonymous2")
+        #expect(netrc.machines[1].password == "qwerty2")
     }
 
     /// should load multiple machines for a given multi-line format
-    func testLoadMultipleMachinesMultiline() throws {
+    @Test
+    func loadMultipleMachinesMultiline() throws {
         let content = """
                     machine  example.com login     anonymous
                     password                  qwerty
@@ -241,90 +252,98 @@ class NetrcTests: XCTestCase {
                     """
 
         let machines = try NetrcParser.parse(content).machines
-        XCTAssertEqual(machines.count, 2)
+        #expect(machines.count == 2)
 
         var machine = machines[0]
-        XCTAssertEqual(machine.name, "example.com")
-        XCTAssertEqual(machine.login, "anonymous")
-        XCTAssertEqual(machine.password, "qwerty")
+        #expect(machine.name == "example.com")
+        #expect(machine.login == "anonymous")
+        #expect(machine.password == "qwerty")
 
         machine = machines[1]
-        XCTAssertEqual(machine.name, "example2.com")
-        XCTAssertEqual(machine.login, "anonymous2")
-        XCTAssertEqual(machine.password, "qwerty2")
+        #expect(machine.name == "example2.com")
+        #expect(machine.login == "anonymous2")
+        #expect(machine.password == "qwerty2")
     }
 
     /// should throw error when machine parameter is missing
-    func testErrorMachineParameterMissing() throws {
+    @Test
+    func errorMachineParameterMissing() throws {
         let content = "login anonymous password qwerty"
 
-        XCTAssertThrowsError(try NetrcParser.parse(content)) { error in
-            XCTAssertEqual(error as? NetrcError, .machineNotFound)
+        #expect(throws: NetrcError.machineNotFound) {
+            try NetrcParser.parse(content)
         }
     }
 
     /// should throw error for an empty machine values
-    func testErrorEmptyMachineValue() throws {
+    @Test
+    func errorEmptyMachineValue() throws {
         let content = "machine"
 
-        XCTAssertThrowsError(try NetrcParser.parse(content)) { error in
-            XCTAssertEqual(error as? NetrcError, .machineNotFound)
+        #expect(throws: NetrcError.machineNotFound) {
+            try NetrcParser.parse(content)
         }
     }
 
     /// should throw error for an empty machine values
-    func testEmptyMachineValueFollowedByDefaultNoError() throws {
+    @Test
+    func emptyMachineValueFollowedByDefaultNoError() throws {
         let content = "machine default login id password secret"
         let netrc = try NetrcParser.parse(content)
         let authorization = netrc.authorization(for: "http://example.com/resource.zip")
-        XCTAssertEqual(authorization, Netrc.Authorization(login: "id", password: "secret"))
+        #expect(authorization == Netrc.Authorization(login: "id", password: "secret"))
     }
 
     /// should return authorization when config contains a given machine
-    func testReturnAuthorizationForMachineMatch() throws {
+    @Test
+    func returnAuthorizationForMachineMatch() throws {
         let content = "machine example.com login anonymous password qwerty"
 
         let netrc = try NetrcParser.parse(content)
         let authorization = netrc.authorization(for: "http://example.com/resource.zip")
-        XCTAssertEqual(authorization, Netrc.Authorization(login: "anonymous", password: "qwerty"))
+        #expect(authorization == Netrc.Authorization(login: "anonymous", password: "qwerty"))
     }
 
-    func testReturnNoAuthorizationForUnmatched() throws {
+    @Test
+    func returnNoAuthorizationForUnmatched() throws {
         let content = "machine example.com login anonymous password qwerty"
         let netrc = try NetrcParser.parse(content)
-        XCTAssertNil(netrc.authorization(for: "http://www.example.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "ftp.example.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "http://example2.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "http://www.example2.com/resource.zip"))
+        #expect(netrc.authorization(for: "http://www.example.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "ftp.example.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "http://example2.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "http://www.example2.com/resource.zip") == nil)
     }
 
     /// should not return authorization when config does not contain a given machine
-    func testNoReturnAuthorizationForNoMachineMatch() throws {
+    @Test
+    func noReturnAuthorizationForNoMachineMatch() throws {
         let content = "machine example.com login anonymous password qwerty"
 
         let netrc = try NetrcParser.parse(content)
-        XCTAssertNil(netrc.authorization(for: "https://example99.com"))
-        XCTAssertNil(netrc.authorization(for: "http://www.example.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "ftp.example.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "http://example2.com/resource.zip"))
-        XCTAssertNil(netrc.authorization(for: "http://www.example2.com/resource.zip"))
+        #expect(netrc.authorization(for: "https://example99.com") == nil)
+        #expect(netrc.authorization(for: "http://www.example.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "ftp.example.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "http://example2.com/resource.zip") == nil)
+        #expect(netrc.authorization(for: "http://www.example2.com/resource.zip") == nil)
     }
 
     /// Test case: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/filesreference/netrc.html
-    func testIBMDocumentation() throws {
+    @Test
+    func iBMDocumentation() throws {
         let content = "machine host1.austin.century.com login fred password bluebonnet"
 
         let netrc = try NetrcParser.parse(content)
 
-        let machine = netrc.machines.first
-        XCTAssertEqual(machine?.name, "host1.austin.century.com")
-        XCTAssertEqual(machine?.login, "fred")
-        XCTAssertEqual(machine?.password, "bluebonnet")
+        let machine = try #require(netrc.machines.first)
+        #expect(machine.name == "host1.austin.century.com")
+        #expect(machine.login == "fred")
+        #expect(machine.password == "bluebonnet")
     }
 
     /// Should not fail on presence of `account`, `macdef`, `default`
     /// test case: https://gist.github.com/tpope/4247721
-    func testNoErrorTrailingAccountMacdefDefault() throws {
+    @Test
+    func noErrorTrailingAccountMacdefDefault() throws {
         let content = """
             machine api.heroku.com
               login my@email.com
@@ -341,28 +360,29 @@ class NetrcTests: XCTestCase {
 
         let netrc = try NetrcParser.parse(content)
 
-        XCTAssertEqual(netrc.machines.count, 4)
+        #expect(netrc.machines.count == 4)
 
-        XCTAssertEqual(netrc.machines[0].name, "api.heroku.com")
-        XCTAssertEqual(netrc.machines[0].login, "my@email.com")
-        XCTAssertEqual(netrc.machines[0].password, "01230123012301230123012301230123")
+        #expect(netrc.machines[0].name == "api.heroku.com")
+        #expect(netrc.machines[0].login == "my@email.com")
+        #expect(netrc.machines[0].password == "01230123012301230123012301230123")
 
-        XCTAssertEqual(netrc.machines[1].name, "api.github.com")
-        XCTAssertEqual(netrc.machines[1].login, "somebody")
-        XCTAssertEqual(netrc.machines[1].password, "something")
+        #expect(netrc.machines[1].name == "api.github.com")
+        #expect(netrc.machines[1].login == "somebody")
+        #expect(netrc.machines[1].password == "something")
 
-        XCTAssertEqual(netrc.machines[2].name, "ftp.server")
-        XCTAssertEqual(netrc.machines[2].login, "abc")
-        XCTAssertEqual(netrc.machines[2].password, "def")
+        #expect(netrc.machines[2].name == "ftp.server")
+        #expect(netrc.machines[2].login == "abc")
+        #expect(netrc.machines[2].password == "def")
 
-        XCTAssertEqual(netrc.machines[3].name, "default")
-        XCTAssertEqual(netrc.machines[3].login, "anonymous")
-        XCTAssertEqual(netrc.machines[3].password, "my@email.com")
+        #expect(netrc.machines[3].name == "default")
+        #expect(netrc.machines[3].login == "anonymous")
+        #expect(netrc.machines[3].password == "my@email.com")
     }
 
     /// Should not fail on presence of `account`, `macdef`, `default`
     /// test case: https://gist.github.com/tpope/4247721
-    func testNoErrorMixedAccount() throws {
+    @Test
+    func noErrorMixedAccount() throws {
         let content = """
             machine api.heroku.com
               login my@email.com
@@ -379,28 +399,29 @@ class NetrcTests: XCTestCase {
 
         let netrc = try NetrcParser.parse(content)
 
-        XCTAssertEqual(netrc.machines.count, 4)
+        #expect(netrc.machines.count == 4)
 
-        XCTAssertEqual(netrc.machines[0].name, "api.heroku.com")
-        XCTAssertEqual(netrc.machines[0].login, "my@email.com")
-        XCTAssertEqual(netrc.machines[0].password, "01230123012301230123012301230123")
+        #expect(netrc.machines[0].name == "api.heroku.com")
+        #expect(netrc.machines[0].login == "my@email.com")
+        #expect(netrc.machines[0].password == "01230123012301230123012301230123")
 
-        XCTAssertEqual(netrc.machines[1].name, "api.github.com")
-        XCTAssertEqual(netrc.machines[1].login, "somebody")
-        XCTAssertEqual(netrc.machines[1].password, "something")
+        #expect(netrc.machines[1].name == "api.github.com")
+        #expect(netrc.machines[1].login == "somebody")
+        #expect(netrc.machines[1].password == "something")
 
-        XCTAssertEqual(netrc.machines[2].name, "ftp.server")
-        XCTAssertEqual(netrc.machines[2].login, "abc")
-        XCTAssertEqual(netrc.machines[2].password, "def")
+        #expect(netrc.machines[2].name == "ftp.server")
+        #expect(netrc.machines[2].login == "abc")
+        #expect(netrc.machines[2].password == "def")
 
-        XCTAssertEqual(netrc.machines[3].name, "default")
-        XCTAssertEqual(netrc.machines[3].login, "anonymous")
-        XCTAssertEqual(netrc.machines[3].password, "my@email.com")
+        #expect(netrc.machines[3].name == "default")
+        #expect(netrc.machines[3].login == "anonymous")
+        #expect(netrc.machines[3].password == "my@email.com")
     }
 
     /// Should not fail on presence of `account`, `macdef`, `default`
     /// test case: https://renenyffenegger.ch/notes/Linux/fhs/home/username/_netrc
-    func testNoErrorMultipleMacdefAndComments() throws {
+    @Test
+    func noErrorMultipleMacdefAndComments() throws {
         let content = """
             machine  ftp.foobar.baz
             login    john
@@ -421,18 +442,19 @@ class NetrcTests: XCTestCase {
 
         let netrc = try NetrcParser.parse(content)
 
-        XCTAssertEqual(netrc.machines.count, 2)
+        #expect(netrc.machines.count == 2)
 
-        XCTAssertEqual(netrc.machines[0].name, "ftp.foobar.baz")
-        XCTAssertEqual(netrc.machines[0].login, "john")
-        XCTAssertEqual(netrc.machines[0].password, "5ecr3t")
+        #expect(netrc.machines[0].name == "ftp.foobar.baz")
+        #expect(netrc.machines[0].login == "john")
+        #expect(netrc.machines[0].password == "5ecr3t")
 
-        XCTAssertEqual(netrc.machines[1].name, "other.server.org")
-        XCTAssertEqual(netrc.machines[1].login, "fred")
-        XCTAssertEqual(netrc.machines[1].password, "sunshine4ever")
+        #expect(netrc.machines[1].name == "other.server.org")
+        #expect(netrc.machines[1].login == "fred")
+        #expect(netrc.machines[1].password == "sunshine4ever")
     }
 
-    func testComments() throws {
+    @Test
+    func comments() throws {
         let content = """
             # A comment at the beginning of the line
             machine example.com # Another comment
@@ -442,62 +464,60 @@ class NetrcTests: XCTestCase {
 
         let netrc = try NetrcParser.parse(content)
 
-        let machine = netrc.machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qw#erty")
+        let machine = try #require(netrc.machines.first)
+        #expect(machine.name == "example.com")
+        #expect(machine.login == "anonymous")
+        #expect(machine.password == "qw#erty")
     }
 
-    // TODO: These permutation tests would be excellent swift-testing parameterized tests.
-    func testAllHashQuotingPermutations() throws {
-        let cases = [
-            ("qwerty", "qwerty"),
-            ("qwe#rty", "qwe#rty"),
-            ("\"qwe#rty\"", "qwe#rty"),
-            ("\"qwe #rty\"", "qwe #rty"),
-            ("\"qwe# rty\"", "qwe# rty"),
+    @Test(
+        arguments: [
+            (testCase: "qwerty", expected: "qwerty"),
+            (testCase: "qwe#rty", expected: "qwe#rty"),
+            (testCase: "\"qwe#rty\"", expected: "qwe#rty"),
+            (testCase: "\"qwe #rty\"", expected: "qwe #rty"),
+            (testCase: "\"qwe# rty\"", expected: "qwe# rty")
         ]
+    )
+    func allHashQuotingPermutations(testCase: String, expected: String) throws {
+        let content = """
+            machine example.com
+            login \(testCase)
+            password \(testCase)
+            """
+        let netrc = try NetrcParser.parse(content)
 
-        for (testCase, expected) in cases {
-            let content = """
-                machine example.com
-                login \(testCase)
-                password \(testCase)
-                """
-            let netrc = try NetrcParser.parse(content)
-
-            let machine = netrc.machines.first
-            XCTAssertEqual(machine?.name, "example.com")
-            XCTAssertEqual(machine?.login, expected, "Expected login \(testCase) to parse as \(expected)")
-            XCTAssertEqual(machine?.password, expected, "Expected \(testCase) to parse as \(expected)")
-        }
+        let machine = try #require(netrc.machines.first)
+        #expect(machine.name == "example.com")
+        #expect(machine.login == expected)
+        #expect(machine.password == expected)
     }
 
-    func testAllCommentPermutations() throws {
-        let cases = [
-            ("qwerty   # a comment", "qwerty"),
-            ("qwe#rty   # a comment", "qwe#rty"),
-            ("\"qwe#rty\"   # a comment", "qwe#rty"),
-            ("\"qwe #rty\"   # a comment", "qwe #rty"),
-            ("\"qwe# rty\"   # a comment", "qwe# rty"),
+    @Test(
+        arguments: [
+            (testCase: "qwerty   # a comment", expected: "qwerty"),
+            (testCase: "qwe#rty   # a comment", expected: "qwe#rty"),
+            (testCase: "\"qwe#rty\"   # a comment", expected: "qwe#rty"),
+            (testCase: "\"qwe #rty\"   # a comment", expected: "qwe #rty"),
+            (testCase: "\"qwe# rty\"   # a comment", expected: "qwe# rty")
         ]
+    )
+    func allCommentPermutations(testCase: String, expected: String) throws {
+        let content = """
+            machine example.com
+            login \(testCase)
+            password \(testCase)
+            """
+        let netrc = try NetrcParser.parse(content)
 
-        for (testCase, expected) in cases {
-            let content = """
-                machine example.com
-                login \(testCase)
-                password \(testCase)
-                """
-            let netrc = try NetrcParser.parse(content)
-
-            let machine = netrc.machines.first
-            XCTAssertEqual(machine?.name, "example.com")
-            XCTAssertEqual(machine?.login, expected, "Expected login \(testCase) to parse as \(expected)")
-            XCTAssertEqual(machine?.password, expected, "Expected password \(testCase) to parse as \(expected)")
-        }
+        let machine = try #require(netrc.machines.first)
+        #expect(machine.name == "example.com")
+        #expect(machine.login == expected)
+        #expect(machine.password == expected)
     }
 
-    func testQuotedMachine() throws {
+    @Test
+    func quotedMachine() throws {
         let content = """
             machine "example.com"
             login anonymous
@@ -506,9 +526,9 @@ class NetrcTests: XCTestCase {
 
         let netrc = try NetrcParser.parse(content)
 
-        let machine = netrc.machines.first
-        XCTAssertEqual(machine?.name, "example.com")
-        XCTAssertEqual(machine?.login, "anonymous")
-        XCTAssertEqual(machine?.password, "qwerty")
+        let machine = try #require(netrc.machines.first)
+        #expect(machine.name == "example.com")
+        #expect(machine.login == "anonymous")
+        #expect(machine.password == "qwerty")
     }
 }

--- a/Tests/BasicsTests/PhonyTest.swift
+++ b/Tests/BasicsTests/PhonyTest.swift
@@ -1,7 +1,0 @@
-import Testing
-
-// This test exists to force xunit to report at least one test pass
-// for systems that require the output to report something.
-struct PhonyTest {
-    @Test func phonyPass() {}
-}

--- a/Tests/BasicsTests/SampleTests.swift
+++ b/Tests/BasicsTests/SampleTests.swift
@@ -1,9 +1,0 @@
-import Testing
-
-struct Foo {
-
-    @Test
-    func myTest() {
-        #expect(Bool(true))
-    }
-}

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -2,244 +2,365 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import Basics
-import XCTest
+import Testing
 
-final class TripleTests: XCTestCase {
-    func testIsAppleIsDarwin() {
-        func XCTAssertTriple(
-            _ triple: String,
-            isApple: Bool,
-            isDarwin: Bool,
-            file: StaticString = #filePath,
-            line: UInt = #line
-        ) {
-            guard let triple = try? Triple(triple) else {
-                XCTFail(
-                    "Unknown triple '\(triple)'.",
-                    file: file,
-                    line: line)
-                return
-            }
-            XCTAssert(
-                isApple == triple.isApple(),
-                """
-                Expected triple '\(triple.tripleString)' \
-                \(isApple ? "" : " not") to be an Apple triple.
-                """,
-                file: file,
-                line: line)
-            XCTAssert(
-                isDarwin == triple.isDarwin(),
-                """
-                Expected triple '\(triple.tripleString)' \
-                \(isDarwin ? "" : " not") to be a Darwin triple.
-                """,
-                file: file,
-                line: line)
-        }
-
-        XCTAssertTriple("x86_64-pc-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("x86_64-pc-linux-musl", isApple: false, isDarwin: false)
-        XCTAssertTriple("powerpc-bgp-linux", isApple: false, isDarwin: false)
-        XCTAssertTriple("arm-none-none-eabi", isApple: false, isDarwin: false)
-        XCTAssertTriple("arm-none-linux-musleabi", isApple: false, isDarwin: false)
-        XCTAssertTriple("wasm32-unknown-wasi", isApple: false, isDarwin: false)
-        XCTAssertTriple("riscv64-unknown-linux", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips-mti-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("mipsel-img-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips64-mti-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips64el-img-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips64el-img-linux-gnuabin32", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips64-unknown-linux-gnuabi64", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips64-unknown-linux-gnuabin32", isApple: false, isDarwin: false)
-        XCTAssertTriple("mipsel-unknown-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("mips-unknown-linux-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("arm-oe-linux-gnueabi", isApple: false, isDarwin: false)
-        XCTAssertTriple("aarch64-oe-linux", isApple: false, isDarwin: false)
-        XCTAssertTriple("armv7em-unknown-none-macho", isApple: false, isDarwin: false)
-        XCTAssertTriple("armv7em-apple-none-macho", isApple: true, isDarwin: false)
-        XCTAssertTriple("armv7em-apple-none", isApple: true, isDarwin: false)
-        XCTAssertTriple("aarch64-apple-macosx", isApple: true, isDarwin: true)
-        XCTAssertTriple("x86_64-apple-macosx", isApple: true, isDarwin: true)
-        XCTAssertTriple("x86_64-apple-macosx10.15", isApple: true, isDarwin: true)
-        XCTAssertTriple("x86_64h-apple-darwin", isApple: true, isDarwin: true)
-        XCTAssertTriple("i686-pc-windows-msvc", isApple: false, isDarwin: false)
-        XCTAssertTriple("i686-pc-windows-gnu", isApple: false, isDarwin: false)
-        XCTAssertTriple("i686-pc-windows-cygnus", isApple: false, isDarwin: false)
+struct TripleTests {
+    @Test(
+        "Triple is Apple and is Darwin",
+        arguments: [
+            (tripleName: "x86_64-pc-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName: "x86_64-pc-linux-musl", isApple: false, isDarwin: false),
+            (tripleName: "powerpc-bgp-linux", isApple: false, isDarwin: false),
+            (tripleName: "arm-none-none-eabi", isApple: false, isDarwin: false),
+            (tripleName: "arm-none-linux-musleabi", isApple: false, isDarwin: false),
+            (tripleName: "wasm32-unknown-wasi", isApple: false, isDarwin: false),
+            (tripleName: "riscv64-unknown-linux", isApple: false, isDarwin: false),
+            (tripleName: "mips-mti-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName: "mipsel-img-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName: "mips64-mti-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName: "mips64el-img-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName: "mips64el-img-linux-gnuabin32", isApple: false, isDarwin: false),
+            (tripleName: "mips64-unknown-linux-gnuabi64", isApple: false, isDarwin: false),
+            (tripleName: "mips64-unknown-linux-gnuabin32", isApple: false, isDarwin: false),
+            (tripleName: "mipsel-unknown-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName: "mips-unknown-linux-gnu", isApple: false, isDarwin: false),
+            (tripleName: "arm-oe-linux-gnueabi", isApple: false, isDarwin: false),
+            (tripleName: "aarch64-oe-linux", isApple: false, isDarwin: false),
+            (tripleName: "armv7em-unknown-none-macho", isApple: false, isDarwin: false),
+            (tripleName: "armv7em-apple-none-macho", isApple: true, isDarwin: false),
+            (tripleName: "armv7em-apple-none", isApple: true, isDarwin: false),
+            (tripleName: "aarch64-apple-macosx", isApple: true, isDarwin: true),
+            (tripleName: "x86_64-apple-macosx", isApple: true, isDarwin: true),
+            (tripleName: "x86_64-apple-macosx10.15", isApple: true, isDarwin: true),
+            (tripleName: "x86_64h-apple-darwin", isApple: true, isDarwin: true),
+            (tripleName: "i686-pc-windows-msvc", isApple: false, isDarwin: false),
+            (tripleName: "i686-pc-windows-gnu", isApple: false, isDarwin: false),
+            (tripleName: "i686-pc-windows-cygnus", isApple: false, isDarwin: false),
+        ],
+    )
+    func isAppleIsDarwin(_ tripleName: String, _ isApple: Bool, _ isDarwin: Bool) throws {
+        let triple = try #require(try Triple(tripleName), "Unknown triple '\(tripleName)'.")
+        #expect(
+            isApple == triple.isApple(),
+            """
+            Expected triple '\(triple.tripleString)' \
+            \(isApple ? "" : " not") to be an Apple triple.
+            """,
+        )
+        #expect(
+            isDarwin == triple.isDarwin(),
+            """
+            Expected triple '\(triple.tripleString)' \
+            \(isDarwin ? "" : " not") to be a Darwin triple.
+            """,
+        )
     }
 
-    func testDescription() throws {
+    @Test
+    func description() throws {
         let triple = try Triple("x86_64-pc-linux-gnu")
-        XCTAssertEqual("foo \(triple) bar", "foo x86_64-pc-linux-gnu bar")
+        #expect("foo \(triple) bar" == "foo x86_64-pc-linux-gnu bar")
     }
 
-    func testTripleStringForPlatformVersion() throws {
-        func XCTAssertTriple(
-            _ triple: String,
-            forPlatformVersion version: String,
-            is expectedTriple: String,
-            file: StaticString = #filePath,
-            line: UInt = #line
-        ) {
-            guard let triple = try? Triple(triple) else {
-                XCTFail("Unknown triple '\(triple)'.", file: file, line: line)
-                return
-            }
-            let actualTriple = triple.tripleString(forPlatformVersion: version)
-            XCTAssert(
-                actualTriple == expectedTriple,
-                """
-                Actual triple '\(actualTriple)' did not match expected triple \
-                '\(expectedTriple)' for platform version '\(version)'.
-                """,
-                file: file,
-                line: line)
-        }
+    @Test(
+        "Triple String for Platform Version",
+        arguments: [
+            (
+                tripleName: "x86_64-apple-macosx",
+                version: "",
+                expectedTriple: "x86_64-apple-macosx",
+            ),
+            (
+                tripleName: "x86_64-apple-macosx",
+                version: "13.0",
+                expectedTriple: "x86_64-apple-macosx13.0",
+            ),
+            (
+                tripleName: "armv7em-apple-macosx10.12",
+                version: "",
+                expectedTriple: "armv7em-apple-macosx",
+            ),
+            (
+                tripleName: "armv7em-apple-macosx10.12",
+                version: "13.0",
+                expectedTriple: "armv7em-apple-macosx13.0",
+            ),
+            (
+                tripleName: "powerpc-apple-macos",
+                version: "",
+                expectedTriple: "powerpc-apple-macos",
+            ),
+            (
+                tripleName: "powerpc-apple-macos",
+                version: "13.0",
+                expectedTriple: "powerpc-apple-macos13.0",
+            ),
+            (
+                tripleName: "i686-apple-macos10.12.0",
+                version: "",
+                expectedTriple: "i686-apple-macos",
+            ),
+            (
+                tripleName: "i686-apple-macos10.12.0",
+                version: "13.0",
+                expectedTriple: "i686-apple-macos13.0",
+            ),
+            (
+                tripleName: "riscv64-apple-darwin",
+                version: "",
+                expectedTriple: "riscv64-apple-darwin",
+            ),
+            (
+                tripleName: "riscv64-apple-darwin",
+                version: "22",
+                expectedTriple: "riscv64-apple-darwin22",
+            ),
+            (
+                tripleName: "mips-apple-darwin19",
+                version: "",
+                expectedTriple: "mips-apple-darwin",
+            ),
+            (
+                tripleName: "mips-apple-darwin19",
+                version: "22",
+                expectedTriple: "mips-apple-darwin22",
+            ),
+            (
+                tripleName: "arm64-apple-ios-simulator",
+                version: "",
+                expectedTriple: "arm64-apple-ios-simulator",
+            ),
+            (
+                tripleName: "arm64-apple-ios-simulator",
+                version: "13.0",
+                expectedTriple: "arm64-apple-ios13.0-simulator",
+            ),
+            (
+                tripleName: "arm64-apple-ios12-simulator",
+                version: "",
+                expectedTriple: "arm64-apple-ios-simulator",
+            ),
+            (
+                tripleName: "arm64-apple-ios12-simulator",
+                version: "13.0",
+                expectedTriple: "arm64-apple-ios13.0-simulator",
+            ),
+        ]
+    )
+    func tripleStringForPlatformVersion(
+        tripleName: String, version: String, expectedTriple: String
+    ) throws {
+        let triple = try #require(try Triple(tripleName), "Unknown triple '\(tripleName)'.")
+        let actualTriple = triple.tripleString(forPlatformVersion: version)
+        #expect(
+            actualTriple == expectedTriple,
+            """
+            Actual triple '\(actualTriple)' did not match expected triple \
+            '\(expectedTriple)' for platform version '\(version)'.
+            """,
+        )
 
-        XCTAssertTriple("x86_64-apple-macosx", forPlatformVersion: "", is: "x86_64-apple-macosx")
-        XCTAssertTriple("x86_64-apple-macosx", forPlatformVersion: "13.0", is: "x86_64-apple-macosx13.0")
-
-        XCTAssertTriple("armv7em-apple-macosx10.12", forPlatformVersion: "", is: "armv7em-apple-macosx")
-        XCTAssertTriple("armv7em-apple-macosx10.12", forPlatformVersion: "13.0", is: "armv7em-apple-macosx13.0")
-
-        XCTAssertTriple("powerpc-apple-macos", forPlatformVersion: "", is: "powerpc-apple-macos")
-        XCTAssertTriple("powerpc-apple-macos", forPlatformVersion: "13.0", is: "powerpc-apple-macos13.0")
-
-        XCTAssertTriple("i686-apple-macos10.12.0", forPlatformVersion: "", is: "i686-apple-macos")
-        XCTAssertTriple("i686-apple-macos10.12.0", forPlatformVersion: "13.0", is: "i686-apple-macos13.0")
-
-        XCTAssertTriple("riscv64-apple-darwin", forPlatformVersion: "", is: "riscv64-apple-darwin")
-        XCTAssertTriple("riscv64-apple-darwin", forPlatformVersion: "22", is: "riscv64-apple-darwin22")
-
-        XCTAssertTriple("mips-apple-darwin19", forPlatformVersion: "", is: "mips-apple-darwin")
-        XCTAssertTriple("mips-apple-darwin19", forPlatformVersion: "22", is: "mips-apple-darwin22")
-
-        XCTAssertTriple("arm64-apple-ios-simulator", forPlatformVersion: "", is: "arm64-apple-ios-simulator")
-        XCTAssertTriple("arm64-apple-ios-simulator", forPlatformVersion: "13.0", is: "arm64-apple-ios13.0-simulator")
-
-        XCTAssertTriple("arm64-apple-ios12-simulator", forPlatformVersion: "", is: "arm64-apple-ios-simulator")
-        XCTAssertTriple("arm64-apple-ios12-simulator", forPlatformVersion: "13.0", is: "arm64-apple-ios13.0-simulator")
     }
 
-    func testKnownTripleParsing() {
-        func XCTAssertTriple(
-            _ triple: String,
-            matches components: (
-                arch: Triple.Arch?,
-                subArch: Triple.SubArch?,
-                vendor: Triple.Vendor?,
-                os: Triple.OS?,
-                environment: Triple.Environment?,
-                objectFormat: Triple.ObjectFormat?),
-            file: StaticString = #filePath,
-            line: UInt = #line
-        ) {
-            guard let triple = try? Triple(triple) else {
-                XCTFail(
-                    "Unknown triple '\(triple)'.",
-                    file: file,
-                    line: line)
-                return
-            }
-            XCTAssertEqual(triple.arch, components.arch, file: file, line: line)
-            XCTAssertEqual(triple.subArch, components.subArch, file: file, line: line)
-            XCTAssertEqual(triple.vendor, components.vendor, file: file, line: line)
-            XCTAssertEqual(triple.os, components.os, file: file, line: line)
-            XCTAssertEqual(triple.environment, components.environment, file: file, line: line)
-            XCTAssertEqual(triple.objectFormat, components.objectFormat, file: file, line: line)
-        }
-        XCTAssertTriple("armv7em-apple-none-eabihf-macho", matches: (.arm, .arm(.v7em), .apple, .noneOS, .eabihf, .macho))
-        XCTAssertTriple("x86_64-apple-macosx", matches: (.x86_64, nil, .apple, .macosx, nil, .macho))
-        XCTAssertTriple("x86_64-unknown-linux-gnu", matches: (.x86_64, nil, nil, .linux, .gnu, .elf))
-        XCTAssertTriple("aarch64-unknown-linux-gnu", matches: (.aarch64, nil, nil, .linux, .gnu, .elf))
-        XCTAssertTriple("aarch64-unknown-linux-android", matches: (.aarch64, nil, nil, .linux, .android, .elf))
-        XCTAssertTriple("x86_64-unknown-windows-msvc", matches: (.x86_64, nil, nil, .win32, .msvc, .coff))
-        XCTAssertTriple("wasm32-unknown-wasi", matches: (.wasm32, nil, nil, .wasi, nil, .wasm))
-    }    
+    struct DataKnownTripleParsing {
+        var tripleName: String
+        var expectedArch: Triple.Arch?
+        var expectedSubArch: Triple.SubArch?
+        var expectedVendor: Triple.Vendor?
+        var expectedOs: Triple.OS?
+        var expectedEnvironment: Triple.Environment?
+        var expectedObjectFormat: Triple.ObjectFormat?
+    }
+    @Test(
+        "Known Triple Parsing",
+        arguments: [
+            DataKnownTripleParsing(
+                tripleName: "armv7em-apple-none-eabihf-macho",
+                expectedArch: .arm,
+                expectedSubArch : .arm(.v7em),
+                expectedVendor: .apple,
+                expectedOs: .noneOS,
+                expectedEnvironment: .eabihf,
+                expectedObjectFormat: .macho
+            ),
+            DataKnownTripleParsing(
+                tripleName: "x86_64-apple-macosx",
+                expectedArch: .x86_64,
+                expectedSubArch: nil,
+                expectedVendor: .apple,
+                expectedOs: .macosx,
+                expectedEnvironment: nil,
+                expectedObjectFormat: .macho
+            ),
+            DataKnownTripleParsing(
+                tripleName: "x86_64-unknown-linux-gnu",
+                expectedArch: .x86_64,
+                expectedSubArch: nil,
+                expectedVendor: nil,
+                expectedOs: .linux,
+                expectedEnvironment: .gnu,
+                expectedObjectFormat: .elf
+            ),
+            DataKnownTripleParsing(
+                tripleName: "aarch64-unknown-linux-gnu",
+                expectedArch: .aarch64,
+                expectedSubArch: nil,
+                expectedVendor: nil,
+                expectedOs: .linux,
+                expectedEnvironment: .gnu,
+                expectedObjectFormat: .elf
+            ),
+            DataKnownTripleParsing(
+                tripleName: "aarch64-unknown-linux-android",
+                expectedArch: .aarch64,
+                expectedSubArch: nil,
+                expectedVendor: nil,
+                expectedOs: .linux,
+                expectedEnvironment: .android,
+                expectedObjectFormat: .elf
+            ),
+            DataKnownTripleParsing(
+                tripleName: "x86_64-unknown-windows-msvc",
+                expectedArch: .x86_64,
+                expectedSubArch: nil,
+                expectedVendor: nil,
+                expectedOs: .win32,
+                expectedEnvironment: .msvc,
+                expectedObjectFormat: .coff
+            ),
+            DataKnownTripleParsing(
+                tripleName: "wasm32-unknown-wasi",
+                expectedArch: .wasm32,
+                expectedSubArch: nil,
+                expectedVendor: nil,
+                expectedOs: .wasi,
+                expectedEnvironment: nil,
+                expectedObjectFormat: .wasm
+            )
+        ]
+    )
+    func knownTripleParsing(
+        data: DataKnownTripleParsing,
+    ) throws {
+        let triple = try #require(
+            try Triple(data.tripleName), "Unknown triple '\(data.tripleName)'.")
+        #expect(triple.arch == data.expectedArch, "Actual arch not as expected")
+        #expect(triple.subArch == data.expectedSubArch, "Actual subarch is not as expected")
+        #expect(triple.vendor == data.expectedVendor, "Actual Vendor is not as expected")
+        #expect(triple.os == data.expectedOs, "Actual OS is not as expcted")
+        #expect(triple.environment == data.expectedEnvironment, "Actual environment is not as expected")
+        #expect(triple.objectFormat == data.expectedObjectFormat, "Actual object format is not as expected")
+    }
 
-    func testTriple() {
+    @Test
+    func triple() {
         let linux = try? Triple("x86_64-unknown-linux-gnu")
-        XCTAssertNotNil(linux)
-        XCTAssertEqual(linux!.os, .linux)
-        XCTAssertEqual(linux!.osVersion, Triple.Version.zero)
-        XCTAssertEqual(linux!.environment, .gnu)
+        #expect(linux != nil)
+        #expect(linux!.os == .linux)
+        #expect(linux!.osVersion == Triple.Version.zero)
+        #expect(linux!.environment == .gnu)
 
         let macos = try? Triple("x86_64-apple-macosx10.15")
-        XCTAssertNotNil(macos!)
-        XCTAssertEqual(macos!.osVersion, .init(parse: "10.15"))
+        #expect(macos! != nil)
+        #expect(macos!.osVersion == .init(parse: "10.15"))
         let newVersion = "10.12"
         let tripleString = macos!.tripleString(forPlatformVersion: newVersion)
-        XCTAssertEqual(tripleString, "x86_64-apple-macosx10.12")
+        #expect(tripleString == "x86_64-apple-macosx10.12")
         let macosNoX = try? Triple("x86_64-apple-macos12.2")
-        XCTAssertNotNil(macosNoX!)
-        XCTAssertEqual(macosNoX!.os, .macosx)
-        XCTAssertEqual(macosNoX!.osVersion, .init(parse: "12.2"))
+        #expect(macosNoX! != nil)
+        #expect(macosNoX!.os == .macosx)
+        #expect(macosNoX!.osVersion == .init(parse: "12.2"))
 
         let android = try? Triple("aarch64-unknown-linux-android24")
-        XCTAssertNotNil(android)
-        XCTAssertEqual(android!.os, .linux)
-        XCTAssertEqual(android!.environment, .android)
+        #expect(android != nil)
+        #expect(android!.os == .linux)
+        #expect(android!.environment == .android)
 
         let linuxWithABIVersion = try? Triple("x86_64-unknown-linux-gnu42")
-        XCTAssertEqual(linuxWithABIVersion!.environment, .gnu)
+        #expect(linuxWithABIVersion!.environment == .gnu)
     }
 
-    func testEquality() throws {
+    @Test
+    func equality() throws {
         let macOSTriple = try Triple("arm64-apple-macos")
         let macOSXTriple = try Triple("arm64-apple-macosx")
-        XCTAssertEqual(macOSTriple, macOSXTriple)
+        #expect(macOSTriple == macOSXTriple)
 
         let intelMacOSTriple = try Triple("x86_64-apple-macos")
-        XCTAssertNotEqual(macOSTriple, intelMacOSTriple)
+        #expect(macOSTriple != intelMacOSTriple)
 
         let linuxWithoutGNUABI = try Triple("x86_64-unknown-linux")
         let linuxWithGNUABI = try Triple("x86_64-unknown-linux-gnu")
-        XCTAssertNotEqual(linuxWithoutGNUABI, linuxWithGNUABI)
+        #expect(linuxWithoutGNUABI != linuxWithGNUABI)
     }
 
-    func testWASI() throws {
+    @Test
+    func WASI() throws {
         let wasi = try Triple("wasm32-unknown-wasi")
-
-
 
         // WASI dynamic libraries are only experimental,
         // but SwiftPM requires this property not to crash.
         _ = wasi.dynamicLibraryExtension
     }
 
-    func testNoneOSDynamicLibrary() throws {
-      // Dynamic libraries aren't actually supported for OS none, but swiftpm
-      // wants an extension to avoid crashing during build planning.
-      try XCTAssertEqual(
-          Triple("armv7em-unknown-none-coff").dynamicLibraryExtension,
-          ".coff")
-      try XCTAssertEqual(
-          Triple("armv7em-unknown-none-elf").dynamicLibraryExtension,
-          ".elf")
-      try XCTAssertEqual(
-          Triple("armv7em-unknown-none-macho").dynamicLibraryExtension,
-          ".macho")
-      try XCTAssertEqual(
-          Triple("armv7em-unknown-none-wasm").dynamicLibraryExtension,
-          ".wasm")
-      try XCTAssertEqual(
-          Triple("armv7em-unknown-none-xcoff").dynamicLibraryExtension,
-          ".xcoff")
+    @Test(
+        "Test dynamicLibraryExtesion attribute on Triple returns expected value",
+        arguments: [
+            (tripleName: "armv7em-unknown-none-coff", expected: ".coff"),
+            (tripleName: "armv7em-unknown-none-elf", expected: ".elf"),
+            (tripleName: "armv7em-unknown-none-macho", expected: ".macho"),
+            (tripleName: "armv7em-unknown-none-wasm", expected: ".wasm"),
+            (tripleName: "armv7em-unknown-none-xcoff", expected: ".xcoff"),
+            (tripleName: "wasm32-unknown-wasi", expected: ".wasm"),  // Added by bkhouri
+        ],
+    )
+    func noneOSDynamicLibrary(tripleName: String, expected: String) throws {
+        // Dynamic libraries aren't actually supported for OS none, but swiftpm
+        // wants an extension to avoid crashing during build planning.
+        let triple = try Triple(tripleName)
+        #expect(triple.dynamicLibraryExtension == expected)
     }
 
-    func testIsRuntimeCompatibleWith() throws {
-        try XCTAssertTrue(Triple("x86_64-apple-macosx").isRuntimeCompatible(with: Triple("x86_64-apple-macosx")))
-        try XCTAssertTrue(Triple("x86_64-unknown-linux").isRuntimeCompatible(with: Triple("x86_64-unknown-linux")))
-        try XCTAssertFalse(Triple("x86_64-apple-macosx").isRuntimeCompatible(with: Triple("x86_64-apple-linux")))
-        try XCTAssertTrue(Triple("x86_64-apple-macosx14.0").isRuntimeCompatible(with: Triple("x86_64-apple-macosx13.0")))
+    @Test(
+        "isRuntimeCompatibleWith returns expected value",
+        arguments: [
+            (
+                firstTripleName: "x86_64-apple-macosx",
+                secondTripleName: "x86_64-apple-macosx",
+                isCompatible: true,
+            ),
+            (
+                firstTripleName: "x86_64-unknown-linux",
+                secondTripleName: "x86_64-unknown-linux",
+                isCompatible: true,
+            ),
+            (
+                firstTripleName: "x86_64-apple-macosx",
+                secondTripleName: "x86_64-apple-linux",
+                isCompatible: false,
+            ),
+            (
+                firstTripleName: "x86_64-apple-macosx14.0",
+                secondTripleName: "x86_64-apple-macosx13.0",
+                isCompatible: true,
+            ),
+        ],
+    )
+    func isRuntimeCompatibleWith(
+        firstTripleName: String, secondTripleName: String, isCompatible: Bool,
+    ) throws {
+        let triple = try Triple(firstTripleName)
+        let other = try Triple(secondTripleName)
+        #expect(triple.isRuntimeCompatible(with: other) == isCompatible)
     }
 }


### PR DESCRIPTION
Convert the following test suites to Swift Testing

- Tests/BasicsTests/ByteStringExtensionsTests.swift
- Tests/BasicsTests/ConcurrencyHelpersTests.swift
- Tests/BasicsTests/DictionaryTest.swift
- Tests/BasicsTests/DispatchTimeTests.swift
- Tests/BasicsTests/NetrcTests.swift
- Tests/BasicsTests/TripleTests.swift

Also, remove the phony and sample Swift Testing tests, which were used to ensure we don't regress.