### PR TITLE
Tests: Convert SPMBuildCoreTests to Swift Testing

### DIFF
--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -12,10 +12,11 @@
 
 import Basics
 import PackageModel
-import XCTest
+import Testing
 
-final class ArtifactsArchiveMetadataTests: XCTestCase {
-    func testParseMetadata() throws {
+struct ArtifactsArchiveMetadataTests {
+    @Test
+    func parseMetadata() throws {
         let fileSystem = InMemoryFileSystem()
         try fileSystem.writeFileContents(
             "/info.json",
@@ -43,7 +44,7 @@ final class ArtifactsArchiveMetadataTests: XCTestCase {
         )
 
         let metadata = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: .root)
-        XCTAssertEqual(metadata, try ArtifactsArchiveMetadata(
+        let expected = try ArtifactsArchiveMetadata(
             schemaVersion: "1.0",
             artifacts: [
                 "protocol-buffer-compiler": ArtifactsArchiveMetadata.Artifact(
@@ -61,9 +62,12 @@ final class ArtifactsArchiveMetadataTests: XCTestCase {
                     ]
                 ),
             ]
-        ))
+        )
+        #expect(metadata == expected, "Actual is not as expected")
     }
-    func testParseMetadataWithoutSupportedTriple() throws {
+
+    @Test
+    func parseMetadataWithoutSupportedTriple() throws {
         let fileSystem = InMemoryFileSystem()
         try fileSystem.writeFileContents(
             "/info.json",
@@ -90,7 +94,7 @@ final class ArtifactsArchiveMetadataTests: XCTestCase {
         )
 
         let metadata = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: .root)
-        XCTAssertEqual(metadata, ArtifactsArchiveMetadata(
+        let expected = ArtifactsArchiveMetadata(
             schemaVersion: "1.0",
             artifacts: [
                 "protocol-buffer-compiler": ArtifactsArchiveMetadata.Artifact(
@@ -108,16 +112,17 @@ final class ArtifactsArchiveMetadataTests: XCTestCase {
                     ]
                 ),
             ]
-        ))
+        )
+        #expect(metadata == expected, "Actual is not as expected")
 
         let binaryTarget = BinaryModule(
             name: "protoc", kind: .artifactsArchive, path: .root, origin: .local
         )
         // No supportedTriples with binaryTarget should be rejected
-        XCTAssertThrowsError(
+        #expect(throws: (any Error).self) {
             try binaryTarget.parseArtifactArchives(
                 for: Triple("x86_64-apple-macosx"), fileSystem: fileSystem
             )
-        )
+        }
     }
 }

--- a/Tests/SPMBuildCoreTests/BuildParametersTests.swift
+++ b/Tests/SPMBuildCoreTests/BuildParametersTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -14,18 +14,17 @@
 import Basics
 import struct PackageModel.BuildEnvironment
 import _InternalTestSupport
-import XCTest
+import Testing
 
-final class BuildParametersTests: XCTestCase {
-    func testConfigurationDependentProperties() throws {
-        // Ensure that properties that depend on the "configuration" property are
-        // correctly updated after modifying the configuration.
+struct BuildParametersTests {
+    @Test
+    func configurationDependentProperties() throws {
         var parameters = mockBuildParameters(
             destination: .host,
             environment: BuildEnvironment(platform: .linux, configuration: .debug)
         )
-        XCTAssertEqual(parameters.enableTestability, true)
+        #expect(parameters.enableTestability)
         parameters.configuration = .release
-        XCTAssertEqual(parameters.enableTestability, false)
+        #expect(!parameters.enableTestability)
     }
 }

--- a/Tests/SPMBuildCoreTests/XCFrameworkMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/XCFrameworkMetadataTests.swift
@@ -12,10 +12,11 @@
 
 import class Basics.InMemoryFileSystem
 import SPMBuildCore
-import XCTest
+import Testing
 
-final class XCFrameworkMetadataTests: XCTestCase {
-    func testParseFramework() throws {
+struct XCFrameworkMetadataTests {
+    @Test
+    func parseFramework() throws {
         let fileSystem = InMemoryFileSystem(files: [
             "/Info.plist":  """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -62,28 +63,31 @@ final class XCFrameworkMetadataTests: XCTestCase {
         ])
 
         let metadata = try XCFrameworkMetadata.parse(fileSystem: fileSystem, rootPath: .root)
-        XCTAssertEqual(metadata,
-                       XCFrameworkMetadata(libraries: [
-                           XCFrameworkMetadata.Library(
-                               libraryIdentifier: "macos-x86_64",
-                               libraryPath: "MyFramework.framework",
-                               headersPath: nil,
-                               platform: "macos",
-                               architectures: ["x86_64"],
-                               variant: nil
-                           ),
-                           XCFrameworkMetadata.Library(
-                               libraryIdentifier: "ios-arm64_x86_64-simulator",
-                               libraryPath: "MyFramework.framework",
-                               headersPath: nil,
-                               platform: "ios",
-                               architectures: ["arm64", "x86_64"],
-                               variant: "simulator"
-                           ),
-                       ]))
+        let expected = XCFrameworkMetadata(
+            libraries: [
+                XCFrameworkMetadata.Library(
+                    libraryIdentifier: "macos-x86_64",
+                    libraryPath: "MyFramework.framework",
+                    headersPath: nil,
+                    platform: "macos",
+                    architectures: ["x86_64"],
+                    variant: nil
+                ),
+                XCFrameworkMetadata.Library(
+                    libraryIdentifier: "ios-arm64_x86_64-simulator",
+                    libraryPath: "MyFramework.framework",
+                    headersPath: nil,
+                    platform: "ios",
+                    architectures: ["arm64", "x86_64"],
+                    variant: "simulator"
+                ),
+            ],
+        )
+        #expect(metadata == expected)
     }
 
-    func testParseLibrary() throws {
+    @Test
+    func parseLibrary() throws {
         let fileSystem = InMemoryFileSystem(files: [
             "/Info.plist": """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -117,17 +121,18 @@ final class XCFrameworkMetadataTests: XCTestCase {
         ])
 
         let metadata = try XCFrameworkMetadata.parse(fileSystem: fileSystem, rootPath: .root)
-        XCTAssertEqual(metadata,
-                       XCFrameworkMetadata(
-                           libraries: [
-                               XCFrameworkMetadata.Library(
-                                   libraryIdentifier: "macos-x86_64",
-                                   libraryPath: "MyLibrary.a",
-                                   headersPath: "Headers",
-                                   platform: "macos",
-                                   architectures: ["x86_64"],
-                                   variant: nil
-                               ),
-                           ]))
+        let expected = XCFrameworkMetadata(
+            libraries: [
+                XCFrameworkMetadata.Library(
+                    libraryIdentifier: "macos-x86_64",
+                    libraryPath: "MyLibrary.a",
+                    headersPath: "Headers",
+                    platform: "macos",
+                    architectures: ["x86_64"],
+                    variant: nil
+                ),
+            ],
+        )
+        #expect(metadata == expected)
     }
 }

--- a/Tests/_InternalTestSupportTests/Misc.swift
+++ b/Tests/_InternalTestSupportTests/Misc.swift
@@ -11,136 +11,123 @@
 //===----------------------------------------------------------------------===//
 import SPMBuildCore
 import _InternalTestSupport
-import XCTest
+import Testing
 
-final class TestGetNumberOfMatches: XCTestCase {
-    func testEmptyStringMatchesOnEmptyStringZeroTimes() {
-        let matchOn = ""
-        let value = ""
-        let expectedNumMatches = 0
+struct TestGetNumberOfMatches {
+    @Test(
+        arguments: [
+            (
+                matchOn: "",
+                value: "",
+                expectedNumMatches: 0,
+                id: "Empty string matches on empty string zero times",
+            ),
+            (
+                matchOn: "",
+                value: "This is a non-empty string",
+                expectedNumMatches: 0,
+                id: "Empty string matches on non-empty string zero times",
+            ),
+            (
+                matchOn: "",
+                value: "This is a non-empty string\nThis is the second line",
+                expectedNumMatches: 0,
+                id: "Empty string matches on non-empty multiline string with new line character zero times",
+            ),
+            (
+                matchOn: "",
+                value: """
+                    This is a non-empty string
+                    This is the second line
+                    This is the third line
+                    """,
+                expectedNumMatches: 0,
+                id: "Empty string matches on non-empty multiline string using triple double quotes zero times",
+            ),
+            (
+                matchOn: """
+                    This is a non-empty string
+                    This is the second line
+                    This is the third line
+                    """,
+                value: "",
+                expectedNumMatches: 0,
+                id: "non-empty string matches on empty string zero times",
+            ),
+            (
+                matchOn: "error: fatalError",
+                value: """
+                    > swift test                                                                                          25/10/24 10:44:14
+                    Building for debugging...
+                    /Users/arandomuser/Documents/personal/repro-swiftpm-6605/Tests/repro-swiftpm-6605Tests/repro_swiftpm_6605Tests.swift:7:19: error: division by zero
+                            let y = 1 / x
+                                    ^
+                    error: fatalError
 
+                    error: fatalError
+                    """,
+                expectedNumMatches: 2,
+                id: "fatal error matches on multiline with two occurrences returns two",
+            ),
+            (
+                matchOn: "\nerror: fatalError",
+                value: """
+                    > swift test                                                                                          25/10/24 10:44:14
+                    Building for debugging...
+                    /Users/arandomuser/Documents/personal/repro-swiftpm-6605/Tests/repro-swiftpm-6605Tests/repro_swiftpm_6605Tests.swift:7:19: error: division by zero
+                            let y = 1 / x
+                                    ^
+                    error: fatalError
+
+                    error: fatalError
+                    """,
+                expectedNumMatches: 2,
+                id: "fatal error with leading new line matches on multi line with two occurences returns two",
+            ),
+            (
+                matchOn: "\nerror: fatalError\n",
+                value: """
+                    > swift test                                                                                          25/10/24 10:44:14
+                    Building for debugging...
+                    /Users/arandomuser/Documents/personal/repro-swiftpm-6605/Tests/repro-swiftpm-6605Tests/repro_swiftpm_6605Tests.swift:7:19: error: division by zero
+                            let y = 1 / x
+                                    ^
+                    error: fatalError
+
+                    error: fatalError
+                    """,
+                expectedNumMatches: 1,
+                id: "fatal error with leading and trailing new line matches on multi line with two occurences returns two",
+            ),
+        ]
+    )
+    func getNumberOfMatchesReturnsExpectedValue(
+        matchOn: String,
+        value: String,
+        expectedNumMatches: Int,
+        id: String,
+    ) async throws {
         let actual = getNumberOfMatches(of: matchOn, in: value)
 
-        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
-    }
-
-    func testEmptyStringMatchesOnNonEmptySingleLineStringZeroTimes() {
-        let matchOn = ""
-        let value = "This is a non-empty string"
-        let expectedNumMatches = 0
-
-        let actual = getNumberOfMatches(of: matchOn, in: value)
-
-        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
-    }
-
-    func testEmptyStringMatchesOnNonEmptyMultilineStringWithNeLineCharacterZeroTimes() {
-        let matchOn = ""
-        let value = "This is a non-empty string\nThis is the second line"
-        let expectedNumMatches = 0
-
-        let actual = getNumberOfMatches(of: matchOn, in: value)
-
-        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
-    }
-
-    func testEmptyStringMatchesOnNonEmptyMultilineStringUsingTripleDoubleQuotesZeroTimes() {
-        let matchOn = ""
-        let value = """
-        This is a non-empty string
-        This is the second line
-        This is the third line
-        """
-        let expectedNumMatches = 0
-
-        let actual = getNumberOfMatches(of: matchOn, in: value)
-
-        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
-    }
-
-    func testNonEmptyStringMatchesOnEmptyStringReturnsZero() {
-        let matchOn = """
-        This is a non-empty string
-        This is the second line
-        This is the third line
-        """
-        let value = ""
-        let expectedNumMatches = 0
-
-        let actual = getNumberOfMatches(of: matchOn, in: value)
-
-        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
-    }
-
-    func testfatalErrorMatchesOnMultiLineWithTwoOccurencesReturnsTwo() {
-        let matchOn = "error: fatalError"
-        let value = """
-        > swift test                                                                                          25/10/24 10:44:14
-        Building for debugging...
-        /Users/arandomuser/Documents/personal/repro-swiftpm-6605/Tests/repro-swiftpm-6605Tests/repro_swiftpm_6605Tests.swift:7:19: error: division by zero
-                let y = 1 / x
-                        ^
-        error: fatalError
-
-        error: fatalError
-        """
-        let expectedNumMatches = 2
-
-        let actual = getNumberOfMatches(of: matchOn, in: value)
-
-        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
-    }
-
-    func testfatalErrorWithLeadingNewLineMatchesOnMultiLineWithTwoOccurencesReturnsTwo() {
-        let matchOn = "\nerror: fatalError"
-        let value = """
-        > swift test                                                                                          25/10/24 10:44:14
-        Building for debugging...
-        /Users/arandomuser/Documents/personal/repro-swiftpm-6605/Tests/repro-swiftpm-6605Tests/repro_swiftpm_6605Tests.swift:7:19: error: division by zero
-                let y = 1 / x
-                        ^
-        error: fatalError
-
-        error: fatalError
-        """
-        let expectedNumMatches = 2
-
-        let actual = getNumberOfMatches(of: matchOn, in: value)
-
-        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
-    }
-
-    func testfatalErrorWithLeadingAndTrailingNewLineMatchesOnMultiLineWithOneOccurencesReturnsOne() {
-        let matchOn = "\nerror: fatalError\n"
-        let value = """
-        > swift test                                                                                          25/10/24 10:44:14
-        Building for debugging...
-        /Users/arandomuser/Documents/personal/repro-swiftpm-6605/Tests/repro-swiftpm-6605Tests/repro_swiftpm_6605Tests.swift:7:19: error: division by zero
-                let y = 1 / x
-                        ^
-        error: fatalError
-
-        error: fatalError
-        """
-        let expectedNumMatches = 1
-
-        let actual = getNumberOfMatches(of: matchOn, in: value)
-
-        XCTAssertEqual(actual, expectedNumMatches, "Actual is not as expected")
+        #expect(actual == expectedNumMatches)
     }
 }
 
-final class TestGetBuildSystemArgs: XCTestCase {
-    func testNilArgumentReturnsEmptyArray() {
+struct TestGetBuildSystemArgs {
+    @Test
+    func nilArgumentReturnsEmptyArray() {
         let expected: [String] = []
         let inputUnderTest: BuildSystemProvider.Kind?  = nil
 
         let actual = getBuildSystemArgs(for: inputUnderTest)
 
-        XCTAssertEqual(actual, expected, "Actual is not as expected")
+        #expect(actual == expected)
     }
 
-    private func testValidArgumentsReturnsCorrectCommandLineArguments(_ inputValue: BuildSystemProvider.Kind) {
+    @Test(
+        arguments: BuildSystemProvider.Kind.allCases
+    )
+    func validArgumentsReturnsCorrectCommandLineArguments(_ inputValue: BuildSystemProvider.Kind) {
         let expected = [
             "--build-system",
             "\(inputValue)"
@@ -148,18 +135,6 @@ final class TestGetBuildSystemArgs: XCTestCase {
 
         let actual = getBuildSystemArgs(for: inputValue)
 
-        XCTAssertEqual(actual, expected, "Actual is not as expected")
-    }
-
-    private func testNativeReturnExpectedArray() {
-        self.testValidArgumentsReturnsCorrectCommandLineArguments(.native)
-    }
-
-    private func testNextReturnExpectedArray() {
-        self.testValidArgumentsReturnsCorrectCommandLineArguments(.swiftbuild)
-    }
-
-    private func testXcodeReturnExpectedArray() {
-        self.testValidArgumentsReturnsCorrectCommandLineArguments(.xcode)
+        #expect(actual == expected)
     }
 }


### PR DESCRIPTION
Convert the Tests/SwiftBuildCoreTests/*.swift, and Tests/_InternalTestSupport/Misc.swift to Swift Testing.