### PR TITLE
[Commands] Adjust `swift package migrate` to only apply fix-its to th…

### DIFF
--- a/Fixtures/SwiftMigrate/ExistentialAnyMigration/Sources/Fixed/Test.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyMigration/Sources/Fixed/Test.swift
@@ -10,3 +10,7 @@ func test2(_: (any P).Protocol) {
 func test3() {
     let _: [(any P)?] = []
 }
+
+func test4() {
+    var x = 42
+}

--- a/Fixtures/SwiftMigrate/ExistentialAnyMigration/Sources/Test.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyMigration/Sources/Test.swift
@@ -10,3 +10,7 @@ func test2(_: P.Protocol) {
 func test3() {
     let _: [P?] = []
 }
+
+func test4() {
+    var x = 42
+}

--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -126,6 +126,7 @@ extension SwiftPackageCommand {
             for module in modules {
                 let fixit = try SwiftFixIt(
                     diagnosticFiles: module.diagnosticFiles,
+                    categories: Set(features.map(\.name)),
                     fileSystem: swiftCommandState.fileSystem
                 )
                 try fixit.applyFixIts()


### PR DESCRIPTION
…e selected features

### Motivation:

Use new ability of `SwiftFixIt` to filter by category, to make sure that the command only applies fix-its that are related to the selected features and nothing else.

### Modifications:

- `swift package migrate` - Add an argument to `SwiftFixIt` API that lists all of the features selected by the user.

### Result:

Even if there are other warnings with a single fix-it the command is not going to apply them i.e. for `var` -> `let` or `<name>` to `_`.
