### PR TITLE
Minor improvement in SwiftBuildSupport helpers

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -461,7 +461,7 @@ extension PIFGenerationError: CustomStringConvertible {
 
 // MARK: - Helpers
 
-public extension PIFBuilderParameters {
+extension PIFBuilderParameters {
     init(_ buildParameters: BuildParameters, supportedSwiftVersions: [SwiftLanguageVersion]) {
         self.init(
             triple: buildParameters.triple,

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -458,3 +458,20 @@ extension PIFGenerationError: CustomStringConvertible {
         }
     }
 }
+
+// MARK: - Helpers
+
+public extension PIFBuilderParameters {
+    init(_ buildParameters: BuildParameters, supportedSwiftVersions: [SwiftLanguageVersion]) {
+        self.init(
+            triple: buildParameters.triple,
+            isPackageAccessModifierSupported: buildParameters.driverParameters.isPackageAccessModifierSupported,
+            enableTestability: buildParameters.enableTestability,
+            shouldCreateDylibForDynamicProducts: buildParameters.shouldCreateDylibForDynamicProducts,
+            toolchainLibDir: (try? buildParameters.toolchain.toolchainLibDir) ?? .root,
+            pkgConfigDirectories: buildParameters.pkgConfigDirectories,
+            sdkRootPath: buildParameters.toolchain.sdkRootPath,
+            supportedSwiftVersions: supportedSwiftVersions
+        )
+    }
+}

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -539,21 +539,6 @@ extension String {
     }
 }
 
-extension PIFBuilderParameters {
-    public init(_ buildParameters: BuildParameters, supportedSwiftVersions: [SwiftLanguageVersion]) {
-        self.init(
-            triple: buildParameters.triple,
-            isPackageAccessModifierSupported: buildParameters.driverParameters.isPackageAccessModifierSupported,
-            enableTestability: buildParameters.enableTestability,
-            shouldCreateDylibForDynamicProducts: buildParameters.shouldCreateDylibForDynamicProducts,
-            toolchainLibDir: (try? buildParameters.toolchain.toolchainLibDir) ?? .root,
-            pkgConfigDirectories: buildParameters.pkgConfigDirectories,
-            sdkRootPath: buildParameters.toolchain.sdkRootPath,
-            supportedSwiftVersions: supportedSwiftVersions
-        )
-    }
-}
-
 extension Basics.Diagnostic.Severity {
     var isVerbose: Bool {
         self <= .info


### PR DESCRIPTION
### Motivation:

Just a minor cleanup in `SwiftBuildSupport/SwiftBuildSystem.swift` file.

### Modifications:

Move the `extension PIFBuilderParameters` helper to `PIFBuilder.swift` instead.