### PR TITLE
Tests: Convert more tests to Swift Testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -824,7 +824,12 @@ let package = Package(
 
         .testTarget(
             name: "BasicsTests",
-            dependencies: ["Basics", "_InternalTestSupport", "tsan_utils"],
+            dependencies: [
+                "Basics",
+                "_InternalTestSupport",
+                "tsan_utils",
+                .product(name: "Numerics", package: "swift-numerics"),
+            ],
             exclude: [
                 "Archiver/Inputs/archive.tar.gz",
                 "Archiver/Inputs/archive.zip",
@@ -1077,6 +1082,9 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/swiftlang/swift-toolchain-sqlite.git", from: "1.0.0"),
         // For use in previewing documentation
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
+
+        // Test dependency
+        .package(url: "https://github.com/apple/swift-numerics.git", from: "1.0.3"),
     ]
 } else {
     package.dependencies += [
@@ -1089,6 +1097,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-collections"),
         .package(path: "../swift-certificates"),
         .package(path: "../swift-toolchain-sqlite"),
+        .package(path: "../swift-numerics"),
     ]
 }
 

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -9,225 +9,17 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @testable import Basics
 import _Concurrency
 import _InternalTestSupport
+import Testing
 import XCTest
 
-final class HTTPClientTests: XCTestCase {
-    func testHead() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseStatus = Int.random(in: 201 ..< 500)
-        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody: Data? = nil
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertEqual(request.url, url, "url should match")
-            XCTAssertEqual(request.method, .head, "method should match")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
-        }
-
-        let response = try await httpClient.head(url, headers: requestHeaders)
-        XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
-        assertResponseHeaders(response.headers, expected: responseHeaders)
-        XCTAssertEqual(response.body, responseBody, "body should match")
-    }
-
-    func testGet() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseStatus = Int.random(in: 201 ..< 500)
-        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = Data(UUID().uuidString.utf8)
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertEqual(request.url, url, "url should match")
-            XCTAssertEqual(request.method, .get, "method should match")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
-        }
-
-        let response = try await httpClient.get(url, headers: requestHeaders)
-        XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
-        assertResponseHeaders(response.headers, expected: responseHeaders)
-        XCTAssertEqual(response.body, responseBody, "body should match")
-    }
-
-    func testPost() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestBody = Data(UUID().uuidString.utf8)
-        let responseStatus = Int.random(in: 201 ..< 500)
-        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = Data(UUID().uuidString.utf8)
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertEqual(request.url, url, "url should match")
-            XCTAssertEqual(request.method, .post, "method should match")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            XCTAssertEqual(request.body, requestBody, "body should match")
-            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
-        }
-
-        let response = try await httpClient.post(url, body: requestBody, headers: requestHeaders)
-        XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
-        assertResponseHeaders(response.headers, expected: responseHeaders)
-        XCTAssertEqual(response.body, responseBody, "body should match")
-    }
-
-    func testPut() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestBody = Data(UUID().uuidString.utf8)
-        let responseStatus = Int.random(in: 201 ..< 500)
-        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = Data(UUID().uuidString.utf8)
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertEqual(request.url, url, "url should match")
-            XCTAssertEqual(request.method, .put, "method should match")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            XCTAssertEqual(request.body, requestBody, "body should match")
-            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
-        }
-
-        let response = try await httpClient.put(url, body: requestBody, headers: requestHeaders)
-        XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
-        assertResponseHeaders(response.headers, expected: responseHeaders)
-        XCTAssertEqual(response.body, responseBody, "body should match")
-    }
-
-    func testDelete() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseStatus = Int.random(in: 201 ..< 500)
-        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = Data(UUID().uuidString.utf8)
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertEqual(request.url, url, "url should match")
-            XCTAssertEqual(request.method, .delete, "method should match")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
-        }
-
-        let response = try await httpClient.delete(url, headers: requestHeaders)
-        XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
-        assertResponseHeaders(response.headers, expected: responseHeaders)
-        XCTAssertEqual(response.body, responseBody, "body should match")
-    }
-
-    func testExtraHeaders() async throws {
-        let url = URL("http://test")
-        let globalHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-
-        let httpClient = HTTPClient(configuration: .init(requestHeaders: globalHeaders)) { request, _ in
-            var expectedHeaders = globalHeaders
-            expectedHeaders.merge(requestHeaders)
-            assertRequestHeaders(request.headers, expected: expectedHeaders)
-            return .init(statusCode: 200)
-        }
-
-        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
-        request.options.addUserAgent = true
-
-        let response = try await httpClient.execute(request)
-        XCTAssertEqual(response.statusCode, 200, "statusCode should match")
-    }
-
-    func testUserAgent() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertTrue(request.headers.contains("User-Agent"), "expecting User-Agent")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            return .init(statusCode: 200)
-        }
-        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
-        request.options.addUserAgent = true
-
-        let response = try await httpClient.execute(request)
-        XCTAssertEqual(response.statusCode, 200, "statusCode should match")
-    }
-
-    func testNoUserAgent() async throws {
-        let url = URL("http://test")
-        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-
-        let httpClient = HTTPClient { request, _ in
-            XCTAssertFalse(request.headers.contains("User-Agent"), "expecting User-Agent")
-            assertRequestHeaders(request.headers, expected: requestHeaders)
-            return .init(statusCode: 200)
-        }
-
-        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
-        request.options.addUserAgent = false
-
-        let response = try await httpClient.execute(request)
-        XCTAssertEqual(response.statusCode, 200, "statusCode should match")
-    }
-
-    func testAuthorization() async throws {
-        let url = URL("http://test")
-
-        do {
-            let authorization = UUID().uuidString
-
-            let httpClient = HTTPClient { request, _ in
-                XCTAssertTrue(request.headers.contains("Authorization"), "expecting Authorization")
-                XCTAssertEqual(request.headers.get("Authorization").first, authorization, "expecting Authorization to match")
-                return .init(statusCode: 200)
-            }
-
-            var request = HTTPClient.Request(method: .get, url: url)
-            request.options.authorizationProvider = { requestUrl in
-                requestUrl == url ? authorization : nil
-            }
-
-            let response = try await httpClient.execute(request)
-            XCTAssertEqual(response.statusCode, 200, "statusCode should match")
-        }
-
-        do {
-            let httpClient = HTTPClient { request, _ in
-                XCTAssertFalse(request.headers.contains("Authorization"), "not expecting Authorization")
-                return .init(statusCode: 200)
-            }
-
-            var request = HTTPClient.Request(method: .get, url: url)
-            request.options.authorizationProvider = { _ in "" }
-
-            let response = try await httpClient.execute(request)
-            XCTAssertEqual(response.statusCode, 200, "statusCode should match")
-        }
-    }
-
-    func testValidResponseCodes() async throws {
-        let statusCode = Int.random(in: 201 ..< 500)
-
-        let httpClient = HTTPClient { _, _ in
-            throw HTTPClientError.badResponseStatusCode(statusCode)
-        }
-
-        var request = HTTPClient.Request(method: .get, url: "http://test")
-        request.options.validResponseCodes = [200]
-
-        do {
-            let response = try await httpClient.execute(request)
-            XCTFail("unexpected success \(response)")
-        } catch {
-            XCTAssertEqual(error as? HTTPClientError, .badResponseStatusCode(statusCode), "expected error to match")
-        }
-    }
-
-    func testExponentialBackoff() async throws {
+class HTTPClientXCTest: XCTestCase {
+    func testEponentialBackoff() async throws {
         try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8501")
-
         let counter = SendableBox(0)
         let lastCall = SendableBox<Date>()
         let maxAttempts = 5
@@ -252,8 +44,231 @@ final class HTTPClientTests: XCTestCase {
         let count = await counter.value
         XCTAssertEqual(count, maxAttempts, "retries should match")
     }
+}
 
-    func testHostCircuitBreaker() async throws {
+
+struct HTTPClientTests {
+    @Test
+    func head() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody: Data? = nil
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(request.url == url)
+            #expect(request.method == .head)
+            self.expectRequestHeaders(request.headers, expected: requestHeaders)
+            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let response = try await httpClient.head(url, headers: requestHeaders)
+        #expect(response.statusCode == responseStatus)
+        self.expectResponseHeaders(response.headers, expected: responseHeaders)
+        #expect(response.body == responseBody)
+    }
+
+    @Test
+    func testGet() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody = Data(UUID().uuidString.utf8)
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(request.url == url)
+            #expect(request.method == .get)
+            self.expectRequestHeaders(request.headers, expected: requestHeaders)
+            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let response = try await httpClient.get(url, headers: requestHeaders)
+        #expect(response.statusCode == responseStatus)
+        self.expectResponseHeaders(response.headers, expected: responseHeaders)
+        #expect(response.body == responseBody)
+    }
+
+    @Test
+    func post() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let requestBody = Data(UUID().uuidString.utf8)
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody = Data(UUID().uuidString.utf8)
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(request.url == url)
+            #expect(request.method == .post)
+            self.expectRequestHeaders(request.headers, expected: requestHeaders)
+            #expect(request.body == requestBody)
+            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let response = try await httpClient.post(url, body: requestBody, headers: requestHeaders)
+        #expect(response.statusCode == responseStatus)
+        self.expectResponseHeaders(response.headers, expected: responseHeaders)
+        #expect(response.body == responseBody)
+    }
+
+    @Test
+    func put() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let requestBody = Data(UUID().uuidString.utf8)
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody = Data(UUID().uuidString.utf8)
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(request.url == url)
+            #expect(request.method == .put)
+            self.expectRequestHeaders(request.headers, expected: requestHeaders)
+            #expect(request.body == requestBody)
+            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let response = try await httpClient.put(url, body: requestBody, headers: requestHeaders)
+        #expect(response.statusCode == responseStatus)
+        self.expectResponseHeaders(response.headers, expected: responseHeaders)
+        #expect(response.body == responseBody)
+    }
+
+    @Test
+    func delete() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody = Data(UUID().uuidString.utf8)
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(request.url == url)
+            #expect(request.method == .delete)
+            self.expectRequestHeaders(request.headers, expected: requestHeaders)
+            return .init(statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let response = try await httpClient.delete(url, headers: requestHeaders)
+        #expect(response.statusCode == responseStatus)
+        self.expectResponseHeaders(response.headers, expected: responseHeaders)
+        #expect(response.body == responseBody)
+    }
+
+    @Test
+    func extraHeaders() async throws {
+        let url = URL("http://test")
+        let globalHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+
+        let httpClient = HTTPClient(configuration: .init(requestHeaders: globalHeaders)) { request, _ in
+            var expectedHeaders = globalHeaders
+            expectedHeaders.merge(requestHeaders)
+            self.expectRequestHeaders(request.headers, expected: expectedHeaders)
+            return .init(statusCode: 200)
+        }
+
+        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
+        request.options.addUserAgent = true
+
+        let response = try await httpClient.execute(request)
+        #expect(response.statusCode == 200)
+    }
+
+    @Test
+    func userAgent() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(request.headers.contains("User-Agent"), "expecting User-Agent")
+            self.expectRequestHeaders(request.headers, expected: requestHeaders)
+            return .init(statusCode: 200)
+        }
+        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
+        request.options.addUserAgent = true
+
+        let response = try await httpClient.execute(request)
+        #expect(response.statusCode == 200)
+    }
+
+    @Test
+    func noUserAgent() async throws {
+        let url = URL("http://test")
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+
+        let httpClient = HTTPClient { request, _ in
+            #expect(!request.headers.contains("User-Agent"), "expecting User-Agent")
+            self.expectRequestHeaders(request.headers, expected: requestHeaders)
+            return .init(statusCode: 200)
+        }
+
+        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
+        request.options.addUserAgent = false
+
+        let response = try await httpClient.execute(request)
+        #expect(response.statusCode == 200)
+    }
+
+    @Test
+    func authorization() async throws {
+        let url = URL("http://test")
+
+        do {
+            let authorization = UUID().uuidString
+
+            let httpClient = HTTPClient { request, _ in
+                #expect(request.headers.contains("Authorization"), "expecting Authorization")
+                #expect(request.headers.get("Authorization").first == authorization)
+                return .init(statusCode: 200)
+            }
+
+            var request = HTTPClient.Request(method: .get, url: url)
+            request.options.authorizationProvider = { requestUrl in
+                requestUrl == url ? authorization : nil
+            }
+
+            let response = try await httpClient.execute(request)
+            #expect(response.statusCode == 200)
+        }
+
+        do {
+            let httpClient = HTTPClient { request, _ in
+                #expect(!request.headers.contains("Authorization"), "not expecting Authorization")
+                return .init(statusCode: 200)
+            }
+
+            var request = HTTPClient.Request(method: .get, url: url)
+            request.options.authorizationProvider = { _ in "" }
+
+            let response = try await httpClient.execute(request)
+            #expect(response.statusCode == 200)
+        }
+    }
+
+    @Test
+    func validResponseCodes() async throws {
+        let statusCode = Int.random(in: 201 ..< 500)
+
+        let httpClient = HTTPClient { _, _ in
+            throw HTTPClientError.badResponseStatusCode(statusCode)
+        }
+
+        var request = HTTPClient.Request(method: .get, url: "http://test")
+        request.options.validResponseCodes = [200]
+
+        do {
+            let response = try await httpClient.execute(request)
+            Issue.record("unexpected success \(response)")
+        } catch {
+            #expect(error as? HTTPClientError == .badResponseStatusCode(statusCode))
+        }
+    }
+
+    @Test
+    func hostCircuitBreaker() async throws {
         let maxErrors = 5
         let errorCode = Int.random(in: 500 ..< 600)
         let age = SendableTimeInterval.seconds(5)
@@ -261,7 +276,7 @@ final class HTTPClientTests: XCTestCase {
         let host = "http://tes-\(UUID().uuidString).com"
         let configuration = HTTPClientConfiguration(circuitBreakerStrategy: .hostErrors(maxErrors: maxErrors, age: age))
         let httpClient = HTTPClient(configuration: configuration) { _, _ in
-            .init(statusCode: errorCode)
+                .init(statusCode: errorCode)
         }
 
         // make the initial errors
@@ -270,10 +285,10 @@ final class HTTPClientTests: XCTestCase {
             for index in (0 ..< maxErrors) {
                 let response = try await httpClient.get(URL("\(host)/\(index)/foo"))
                 await counter.increment()
-                XCTAssertEqual(response.statusCode, errorCode)
+                #expect(response.statusCode == errorCode)
             }
             let count = await counter.value
-            XCTAssertEqual(count, maxErrors, "expected results count to match")
+            #expect(count == maxErrors)
         }
 
         // these should all circuit break
@@ -282,19 +297,20 @@ final class HTTPClientTests: XCTestCase {
         for index in (0 ..< total) {
             do {
                 let response = try await httpClient.get(URL("\(host)/\(index)/foo"))
-                XCTFail("unexpected success \(response)")
+                Issue.record("unexpected success \(response)")
             } catch {
-                XCTAssertEqual(error as? HTTPClientError, .circuitBreakerTriggered, "expected error to match")
+                #expect(error as? HTTPClientError == .circuitBreakerTriggered)
             }
 
             await counter.increment()
         }
 
         let count = await counter.value
-        XCTAssertEqual(count, total, "expected results count to match")
+        #expect(count == total)
     }
 
-    func testHostCircuitBreakerAging() async throws {
+    @Test
+    func hostCircuitBreakerAging() async throws {
         let maxErrors = 5
         let errorCode = Int.random(in: 500 ..< 600)
         let ageInMilliseconds = 100
@@ -322,10 +338,10 @@ final class HTTPClientTests: XCTestCase {
             for index in (0 ..< maxErrors) {
                 let response = try await httpClient.get(URL("\(host)/\(index)/error"))
                 await counter.increment()
-                XCTAssertEqual(response.statusCode, errorCode)
+                #expect(response.statusCode == errorCode)
             }
             let count = await counter.value
-            XCTAssertEqual(count, maxErrors, "expected results count to match")
+            #expect(count == maxErrors)
         }
 
         // these should not circuit break since they are deliberately aged
@@ -338,49 +354,51 @@ final class HTTPClientTests: XCTestCase {
             try await Task.sleep(nanoseconds: UInt64(sleepInterval.nanoseconds()!))
             let response = try await httpClient.get("\(host)/\(index)/okay")
             count.increment()
-            XCTAssertEqual(response.statusCode, 200, "expected status code to match")
+            #expect(response.statusCode == 200)
         }
 
-        XCTAssertEqual(count.get(), total, "expected results count to match")
+        #expect(count.get() == total)
     }
 
-    func testHTTPClientHeaders() async throws {
+    @Test
+    func hTTPClientHeaders() async throws {
         var headers = HTTPClientHeaders()
 
         let items = (1 ... Int.random(in: 10 ... 20)).map { index in HTTPClientHeaders.Item(name: "header-\(index)", value: UUID().uuidString) }
         headers.add(items)
 
-        XCTAssertEqual(headers.count, items.count, "headers count should match")
+        #expect(headers.count == items.count)
         items.forEach { item in
-            XCTAssertEqual(headers.get(item.name).first, item.value, "headers value should match")
+            #expect(headers.get(item.name).first == item.value)
         }
 
         headers.add(items.first!)
-        XCTAssertEqual(headers.count, items.count, "headers count should match (no duplicates)")
+        #expect(headers.count == items.count)
 
         let name = UUID().uuidString
         let values = (1 ... Int.random(in: 10 ... 20)).map { "value-\($0)" }
         values.forEach { value in
             headers.add(name: name, value: value)
         }
-        XCTAssertEqual(headers.count, items.count + 1, "headers count should match (no duplicates)")
-        XCTAssertEqual(values, headers.get(name), "multiple headers value should match")
+        #expect(headers.count == items.count + 1)
+        #expect(values == headers.get(name))
     }
 
-    func testExceedsDownloadSizeLimitProgress() async throws {
+    @Test
+    func exceedsDownloadSizeLimitProgress() async throws {
         let maxSize: Int64 = 50
 
         let httpClient = HTTPClient { request, progress in
             switch request.method {
-            case .head:
-                return .init(
-                    statusCode: 200,
-                    headers: .init([.init(name: "Content-Length", value: "0")])
-                )
-            case .get:
-                try progress?(Int64(maxSize * 2), 0)
-            default:
-                XCTFail("method should match")
+                case .head:
+                    return .init(
+                        statusCode: 200,
+                        headers: .init([.init(name: "Content-Length", value: "0")])
+                    )
+                case .get:
+                    try progress?(Int64(maxSize * 2), 0)
+                default:
+                    Issue.record("method should match")
             }
 
             fatalError("unreachable")
@@ -391,13 +409,14 @@ final class HTTPClientTests: XCTestCase {
 
         do {
             let response = try await httpClient.execute(request)
-            XCTFail("unexpected success \(response)")
+            Issue.record("unexpected success \(response)")
         } catch {
-            XCTAssertEqual(error as? HTTPClientError, .responseTooLarge(maxSize * 2), "expected error to match")
+            #expect(error as? HTTPClientError == .responseTooLarge(maxSize * 2))
         }
     }
 
-    func testMaxConcurrency() async throws {
+    @Test
+    func maxConcurrency() async throws {
         let maxConcurrentRequests = 2
         let concurrentRequests = SendableBox(0)
 
@@ -407,7 +426,7 @@ final class HTTPClientTests: XCTestCase {
             await concurrentRequests.increment()
 
             if await concurrentRequests.value! > maxConcurrentRequests {
-                XCTFail("too many concurrent requests \(concurrentRequests), expected \(maxConcurrentRequests)")
+                Issue.record("too many concurrent requests \(concurrentRequests), expected \(maxConcurrentRequests)")
             }
 
             await concurrentRequests.decrement()
@@ -428,20 +447,21 @@ final class HTTPClientTests: XCTestCase {
                 results.append(result)
             }
 
-            XCTAssertEqual(results.count, total, "expected number of results to match")
+            #expect(results.count == total)
 
             for result in results {
-                XCTAssertEqual(result.statusCode, 200, "expected '200 okay' response")
+                #expect(result.statusCode == 200)
             }
         }
     }
-}
 
-private func assertRequestHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {
-    let noAgent = HTTPClientHeaders(headers.filter { $0.name != "User-Agent" })
-    XCTAssertEqual(noAgent, expected, "expected headers to match")
-}
+    private func expectRequestHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders, sourceLocation: SourceLocation = #_sourceLocation) {
+        let noAgent = HTTPClientHeaders(headers.filter { $0.name != "User-Agent" })
+        #expect(noAgent == expected, sourceLocation: sourceLocation)
+    }
 
-private func assertResponseHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {
-    XCTAssertEqual(headers, expected, "expected headers to match")
+    private func expectResponseHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders, sourceLocation: SourceLocation = #_sourceLocation) {
+        #expect(headers == expected, sourceLocation: sourceLocation)
+    }
+
 }

--- a/Tests/BasicsTests/SQLiteBackedCacheTests.swift
+++ b/Tests/BasicsTests/SQLiteBackedCacheTests.swift
@@ -2,25 +2,31 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @testable import Basics
 import _InternalTestSupport
 import tsan_utils
-import XCTest
+import Testing
 
-final class SQLiteBackedCacheTests: XCTestCase {
-    func testHappyCase() throws {
+struct SQLiteBackedCacheTests {
+    @Test
+    func happyCase() throws {
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending("test.db")
             let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)
-            defer { XCTAssertNoThrow(try cache.close()) }
+            defer {
+                #expect(throws: Never.self) {
+                    try cache.close()
+                }
+            }
 
             let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath)
             try mockData.forEach { key, value in
@@ -29,38 +35,42 @@ final class SQLiteBackedCacheTests: XCTestCase {
 
             try mockData.forEach { key, _ in
                 let result = try cache.get(key: key)
-                XCTAssertEqual(mockData[key], result)
+                #expect(mockData[key] == result)
             }
 
             let key = mockData.first!.key
 
             _ = try cache.put(key: key, value: "foobar", replace: false)
-            XCTAssertEqual(mockData[key], try cache.get(key: key))
+            #expect(try cache.get(key: key) == mockData[key], "Actual is not as expected")
 
             _ = try cache.put(key: key, value: "foobar", replace: true)
-            XCTAssertEqual("foobar", try cache.get(key: key))
+            #expect(try cache.get(key: key) == "foobar", "Actual is not as expected")
 
             try cache.remove(key: key)
-            XCTAssertNil(try cache.get(key: key))
+            #expect(try cache.get(key: key) == nil, "Actual is not as expected")
 
             guard case .path(let cachePath) = cache.location else {
-                return XCTFail("invalid location \(cache.location)")
+                Issue.record("invalid location \(cache.location)")
+                return
             }
 
-            XCTAssertTrue(cache.fileSystem.exists(cachePath), "expected file to be written")
+            #expect(cache.fileSystem.exists(cachePath), "expected file to be written")
         }
     }
 
-    func testFileDeleted() throws {
-#if os(Windows)
-        try XCTSkipIf(true, "open file cannot be deleted on Windows")
-#endif
-        try XCTSkipIf(is_tsan_enabled())
-
+    @Test(
+        .disabled(if: (ProcessInfo.hostOperatingSystem == .windows), "open file cannot be deleted on Windows"),
+        .disabled(if: is_tsan_enabled(), "Disabling as tsan is enabled")
+    )
+    func fileDeleted() throws {
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending("test.db")
             let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)
-            defer { XCTAssertNoThrow(try cache.close()) }
+            defer {
+                #expect(throws: Never.self) {
+                    try cache.close()
+                }
+            }
 
             let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath)
             try mockData.forEach { key, value in
@@ -69,40 +79,49 @@ final class SQLiteBackedCacheTests: XCTestCase {
 
             try mockData.forEach { key, _ in
                 let result = try cache.get(key: key)
-                XCTAssertEqual(mockData[key], result)
+                #expect(mockData[key] == result)
             }
 
             guard case .path(let cachePath) = cache.location else {
-                return XCTFail("invalid location \(cache.location)")
+                Issue.record("invalid location \(cache.location)")
+                return
             }
 
-            XCTAssertTrue(cache.fileSystem.exists(cachePath), "expected file to exist at \(cachePath)")
+            #expect(cache.fileSystem.exists(cachePath), "expected file to exist at \(cachePath)")
             try cache.fileSystem.removeFileTree(cachePath)
 
             let key = mockData.first!.key
 
             do {
                 let result = try cache.get(key: key)
-                XCTAssertNil(result)
+                #expect(result == nil)
             }
 
             do {
-                XCTAssertNoThrow(try cache.put(key: key, value: mockData[key]!))
+                #expect(throws: Never.self) {
+                    try cache.put(key: key, value: mockData[key]!)
+                }
                 let result = try cache.get(key: key)
-                XCTAssertEqual(mockData[key], result)
+                #expect(mockData[key] == result)
             }
 
-            XCTAssertTrue(cache.fileSystem.exists(cachePath), "expected file to exist at \(cachePath)")
+            #expect(cache.fileSystem.exists(cachePath), "expected file to exist at \(cachePath)")
         }
     }
 
-    func testFileCorrupt() throws {
-        try XCTSkipIf(is_tsan_enabled())
+    @Test(
+        .disabled(if: is_tsan_enabled(), "Disabling as tsan is enabled")
+    )
+    func fileCorrupt() throws {
 
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending("test.db")
             let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)
-            defer { XCTAssertNoThrow(try cache.close()) }
+            defer {
+                #expect(throws: Never.self) {
+                    try cache.close()
+                }
+            }
 
             let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath)
             try mockData.forEach { key, value in
@@ -111,36 +130,46 @@ final class SQLiteBackedCacheTests: XCTestCase {
 
             try mockData.forEach { key, _ in
                 let result = try cache.get(key: key)
-                XCTAssertEqual(mockData[key], result)
+                #expect(mockData[key] == result)
             }
 
             guard case .path(let cachePath) = cache.location else {
-                return XCTFail("invalid location \(cache.location)")
+                Issue.record("invalid location \(cache.location)")
+                return
             }
 
             try cache.close()
 
-            XCTAssertTrue(cache.fileSystem.exists(cachePath), "expected file to exist at \(path)")
+            #expect(cache.fileSystem.exists(cachePath), "expected file to exist at \(path)")
             try cache.fileSystem.writeFileContents(cachePath, string: "blah")
 
-            XCTAssertThrowsError(try cache.get(key: mockData.first!.key), "expected error") { error in
-                XCTAssert("\(error)".contains("is not a database"), "Expected file is not a database error")
+            #expect {
+                try cache.get(key: mockData.first!.key)
+            } throws: { error in
+                return "\(error)".contains("is not a database")
             }
 
-            XCTAssertThrowsError(try cache.put(key: mockData.first!.key, value: mockData.first!.value), "expected error") { error in
-                XCTAssert("\(error)".contains("is not a database"), "Expected file is not a database error")
+            #expect {
+                try cache.put(key: mockData.first!.key, value: mockData.first!.value)
+            } throws: { error in
+                return "\(error)".contains("is not a database")
             }
         }
     }
 
-    func testMaxSizeNotHandled() throws {
+    @Test
+    func maxSizeNotHandled() throws {
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending("test.db")
             var configuration = SQLiteBackedCacheConfiguration()
             configuration.maxSizeInBytes = 1024 * 3
             configuration.truncateWhenFull = false
             let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path, configuration: configuration)
-            defer { XCTAssertNoThrow(try cache.close()) }
+            defer {
+                #expect(throws: Never.self) {
+                    try cache.close()
+                }
+            }
 
             func create() throws {
                 let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath, count: 500)
@@ -149,20 +178,28 @@ final class SQLiteBackedCacheTests: XCTestCase {
                 }
             }
 
-            XCTAssertThrowsError(try create(), "expected error") { error in
-                XCTAssertEqual(error as? SQLite.Errors, .databaseFull, "Expected 'databaseFull' error")
+            #expect {
+                try create()
+            } throws: { error in
+                let error = try #require(error as? SQLite.Errors)
+                return error == .databaseFull
             }
         }
     }
 
-    func testMaxSizeHandled() throws {
+    @Test
+    func maxSizeHandled() throws {
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending("test.db")
             var configuration = SQLiteBackedCacheConfiguration()
             configuration.maxSizeInBytes = 1024 * 3
             configuration.truncateWhenFull = true
             let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path, configuration: configuration)
-            defer { XCTAssertNoThrow(try cache.close()) }
+            defer {
+                #expect(throws: Never.self) {
+                    try cache.close()
+                }
+            }
 
             var keys = [String]()
             let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath, count: 500)
@@ -173,17 +210,18 @@ final class SQLiteBackedCacheTests: XCTestCase {
 
             do {
                 let result = try cache.get(key: mockData.first!.key)
-                XCTAssertNil(result)
+                #expect(result == nil)
             }
 
             do {
                 let result = try cache.get(key: keys.last!)
-                XCTAssertEqual(mockData[keys.last!], result)
+                #expect(mockData[keys.last!] == result)
             }
         }
     }
 
-    func testInitialFileCreation() throws {
+    @Test
+    func initialFileCreation() throws {
         try testWithTemporaryDirectory { tmpPath in
             let paths = [
                 tmpPath.appending("foo", "test.db"),
@@ -194,9 +232,13 @@ final class SQLiteBackedCacheTests: XCTestCase {
             for path in paths {
                 let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)
                 // Put an entry to ensure the file is created.
-                XCTAssertNoThrow(try cache.put(key: "foo", value: "bar"))
-                XCTAssertNoThrow(try cache.close())
-                XCTAssertTrue(localFileSystem.exists(path), "expected file to be created at \(path)")
+                #expect(throws: Never.self) {
+                    try cache.put(key: "foo", value: "bar")
+                }
+                #expect(throws: Never.self) {
+                    try cache.close()
+                }
+                #expect(localFileSystem.exists(path), "expected file to be created at \(path)")
             }
         }
     }

--- a/Tests/BuildTests/BuildPlanTraversalTests.swift
+++ b/Tests/BuildTests/BuildPlanTraversalTests.swift
@@ -9,8 +9,9 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
-import XCTest
+import Testing
 
 import Basics
 @testable import Build
@@ -20,7 +21,7 @@ import PackageGraph
 import _InternalTestSupport
 import SPMBuildCore
 
-final class BuildPlanTraversalTests: XCTestCase {
+struct BuildPlanTraversalTests {
     typealias Dest = BuildParameters.Destination
 
     struct Result {
@@ -61,7 +62,8 @@ final class BuildPlanTraversalTests: XCTestCase {
         }.sorted()
     }
 
-    func testTrivialTraversal() async throws {
+    @Test
+    func trivialTraversal() async throws {
         let destinationTriple = Triple.arm64Linux
         let toolsTriple = Triple.x86_64MacOS
 
@@ -85,12 +87,13 @@ final class BuildPlanTraversalTests: XCTestCase {
             results.append(Result(parent: $1, module: $0))
         }
 
-        XCTAssertEqual(self.getParents(in: results, for: "app"), [])
-        XCTAssertEqual(self.getParents(in: results, for: "lib"), ["app", "test"])
-        XCTAssertEqual(self.getParents(in: results, for: "test"), [])
+        #expect(self.getParents(in: results, for: "app") == [])
+        #expect(self.getParents(in: results, for: "lib") == ["app", "test"])
+        #expect(self.getParents(in: results, for: "test") == [])
     }
 
-    func testTraversalWithDifferentDestinations() async throws {
+    @Test
+    func traversalWithDifferentDestinations() async throws {
         let destinationTriple = Triple.arm64Linux
         let toolsTriple = Triple.x86_64MacOS
 
@@ -114,13 +117,14 @@ final class BuildPlanTraversalTests: XCTestCase {
             results.append(Result(parent: $1, module: $0))
         }
 
-        XCTAssertEqual(self.getParents(in: results, for: "MMIO"), ["HAL"])
-        XCTAssertEqual(self.getParents(in: results, for: "SwiftSyntax", destination: .host), ["MMIOMacros"])
-        XCTAssertEqual(self.getParents(in: results, for: "HAL", destination: .target), ["Core", "HALTests"])
-        XCTAssertEqual(self.getParents(in: results, for: "HAL", destination: .host), [])
+        #expect(self.getParents(in: results, for: "MMIO") == ["HAL"])
+        #expect(self.getParents(in: results, for: "SwiftSyntax", destination: .host) == ["MMIOMacros"])
+        #expect(self.getParents(in: results, for: "HAL", destination: .target) == ["Core", "HALTests"])
+        #expect(self.getParents(in: results, for: "HAL", destination: .host) == [])
     }
 
-    func testRecursiveDependencyTraversal() async throws {
+    @Test
+    func recursiveDependencyTraversal() async throws {
         let destinationTriple = Triple.arm64Linux
         let toolsTriple = Triple.x86_64MacOS
 
@@ -139,70 +143,74 @@ final class BuildPlanTraversalTests: XCTestCase {
             observabilityScope: scope
         )
 
-        let mmioModule = try XCTUnwrap(plan.description(for: graph.module(for: "MMIO")!, context: .target))
+        let mmioModule = try #require(plan.description(for: graph.module(for: "MMIO")!, context: .target))
 
         var moduleDependencies: [(ResolvedModule, Dest, Build.ModuleBuildDescription?)] = []
         plan.traverseDependencies(of: mmioModule) { product, destination, description in
-            XCTAssertEqual(product.name, "SwiftSyntax")
-            XCTAssertEqual(destination, .host)
-            XCTAssertNil(description)
+            #expect(product.name == "SwiftSyntax")
+            #expect(destination == .host)
+            #expect(description == nil)
         } onModule: { module, destination, description in
             moduleDependencies.append((module, destination, description))
         }
 
-        XCTAssertEqual(moduleDependencies.count, 2)
+        #expect(moduleDependencies.count == 2)
 
         // The ordering is guaranteed by the traversal
 
-        XCTAssertEqual(moduleDependencies[0].0.name, "MMIOMacros")
-        XCTAssertEqual(moduleDependencies[1].0.name, "SwiftSyntax")
+        #expect(moduleDependencies[0].0.name == "MMIOMacros")
+        #expect(moduleDependencies[1].0.name == "SwiftSyntax")
 
         for index in 0 ..< moduleDependencies.count {
-            XCTAssertEqual(moduleDependencies[index].1, .host)
-            XCTAssertNotNil(moduleDependencies[index].2)
+            #expect(moduleDependencies[index].1 == .host)
+            #expect(moduleDependencies[index].2 != nil)
         }
 
         let directDependencies = mmioModule.dependencies(using: plan)
 
-        XCTAssertEqual(directDependencies.count, 1)
+        #expect(directDependencies.count == 1)
 
-        let dependency = try XCTUnwrap(directDependencies.first)
+        let dependency = try #require(directDependencies.first)
         if case .module(let module, let description) = dependency {
-            XCTAssertEqual(module.name, "MMIOMacros")
-            try XCTAssertEqual(XCTUnwrap(description).destination, .host)
+            #expect(module.name == "MMIOMacros")
+            let desc = try #require(description)
+            #expect(desc.destination == .host)
         } else {
-            XCTFail("Expected MMIOMacros module")
+            Issue.record("Expected MMIOMacros module")
         }
 
         let dependencies = mmioModule.recursiveDependencies(using: plan)
 
-        XCTAssertEqual(dependencies.count, 3)
+        #expect(dependencies.count == 3)
 
         // MMIOMacros (module) -> SwiftSyntax (product) -> SwiftSyntax (module)
 
         if case .module(let module, let description) = dependencies[0] {
-            XCTAssertEqual(module.name, "MMIOMacros")
-            try XCTAssertEqual(XCTUnwrap(description).destination, .host)
+            #expect(module.name == "MMIOMacros")
+            let desc = try #require(description)
+            #expect(desc.destination == .host)
         } else {
-            XCTFail("Expected MMIOMacros module")
+            Issue.record("Expected MMIOMacros module")
         }
 
         if case .product(let product, let description) = dependencies[1] {
-            XCTAssertEqual(product.name, "SwiftSyntax")
-            XCTAssertNil(description)
+            #expect(product.name == "SwiftSyntax")
+            #expect(description == nil)
         } else {
-            XCTFail("Expected SwiftSyntax product")
+            Issue.record("Expected SwiftSyntax product")
         }
 
         if case .module(let module, let description) = dependencies[2] {
-            XCTAssertEqual(module.name, "SwiftSyntax")
-            try XCTAssertEqual(XCTUnwrap(description).destination, .host)
+            #expect(module.name == "SwiftSyntax")
+            let desc = try #require(description)
+            #expect(desc.destination == .host)
         } else {
-            XCTFail("Expected SwiftSyntax module")
+            Issue.record("Expected SwiftSyntax module")
         }
     }
 
-    func testRecursiveDependencyTraversalWithDuplicates() async throws {
+    @Test
+    func recursiveDependencyTraversalWithDuplicates() async throws {
         let destinationTriple = Triple.arm64Linux
         let toolsTriple = Triple.x86_64MacOS
 
@@ -221,10 +229,10 @@ final class BuildPlanTraversalTests: XCTestCase {
             observabilityScope: scope
         )
 
-        let testModule = try XCTUnwrap(plan.description(for: graph.module(for: "MMIOMacrosTests")!, context: .host))
+        let testModule = try #require(plan.description(for: graph.module(for: "MMIOMacrosTests")!, context: .host))
 
         let dependencies = testModule.recursiveDependencies(using: plan)
-        XCTAssertEqual(dependencies.count, 9)
+        #expect(dependencies.count == 9)
 
         struct ModuleResult: Hashable {
             let module: ResolvedModule
@@ -234,12 +242,10 @@ final class BuildPlanTraversalTests: XCTestCase {
         var uniqueModules = Set<ModuleResult>()
         for dependency in dependencies {
             if case .module(let module, let description) = dependency {
-                XCTAssertNotNil(description)
-                XCTAssertEqual(description!.destination, .host)
-                XCTAssertTrue(
-                    uniqueModules.insert(.init(module: module, destination: description!.destination))
-                        .inserted
-                )
+                #expect(description != nil)
+                #expect(description!.destination == .host)
+                #expect(uniqueModules.insert(.init(module: module, destination: description!.destination))
+                    .inserted)
             }
         }
     }

--- a/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
+++ b/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
@@ -9,12 +9,14 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
-import XCTest
+import Testing
 import Build
 
-class SwiftCompilerOutputParserTests: XCTestCase {
-    func testParse() throws {
+struct SwiftCompilerOutputParserTests {
+    @Test
+    func parse() throws {
         let delegate = MockSwiftCompilerOutputParserDelegate()
         let parser = SwiftCompilerOutputParser(targetName: "dummy", delegate: delegate)
 
@@ -147,7 +149,8 @@ class SwiftCompilerOutputParserTests: XCTestCase {
         ], errorDescription: nil)
     }
 
-    func testRawTextTransformsIntoUnknown() {
+    @Test
+    func rawTextTransformsIntoUnknown() {
         let delegate = MockSwiftCompilerOutputParserDelegate()
         let parser = SwiftCompilerOutputParser(targetName: "dummy", delegate: delegate)
 
@@ -174,7 +177,8 @@ class SwiftCompilerOutputParserTests: XCTestCase {
         ], errorDescription: nil)
     }
 
-    func testSignalledStopsParsing() {
+    @Test
+    func signalledStopsParsing() {
         let delegate = MockSwiftCompilerOutputParserDelegate()
         let parser = SwiftCompilerOutputParser(targetName: "dummy", delegate: delegate)
 
@@ -222,12 +226,11 @@ class MockSwiftCompilerOutputParserDelegate: SwiftCompilerOutputParserDelegate {
     func assert(
         messages: [SwiftCompilerMessage],
         errorDescription: String?,
-        file: StaticString = #file,
-        line: UInt = #line
+        sourceLocation: SourceLocation = #_sourceLocation
     ) {
-        XCTAssertEqual(messages, self.messages, file: file, line: line)
+        #expect(messages == self.messages, sourceLocation: sourceLocation)
         let errorReason = (self.error as? LocalizedError)?.errorDescription ?? error?.localizedDescription
-        XCTAssertEqual(errorDescription, errorReason, file: file, line: line)
+        #expect(errorDescription == errorReason, sourceLocation: sourceLocation)
         self.messages = []
         self.error = nil
     }

--- a/Tests/_AsyncFileSystemTests/AsyncFileSystemTests.swift
+++ b/Tests/_AsyncFileSystemTests/AsyncFileSystemTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 /*
  This source file is part of the Swift.org open source project
 
@@ -6,62 +7,64 @@
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import _AsyncFileSystem
 import _InternalTestSupport
-import XCTest
+import Testing
 import struct SystemPackage.FilePath
 
-final class AsyncFileSystemTests: XCTestCase {
-    func testMockFileSystem() async throws {
+struct AsyncFileSystemTests {
+    @Test
+    func mockFileSystem() async throws {
         let fs = MockFileSystem()
 
         let mockPath: FilePath = "/foo/bar"
 
-        await XCTAssertAsyncFalse(await fs.exists(mockPath))
+        #expect(await !fs.exists(mockPath))
 
         let mockContent = "baz".utf8
 
         try await fs.write(mockPath, bytes: mockContent)
 
-        await XCTAssertAsyncTrue(await fs.exists(mockPath))
+        #expect(await fs.exists(mockPath))
 
         // Test overwriting
         try await fs.write(mockPath, bytes: mockContent)
 
-        await XCTAssertAsyncTrue(await fs.exists(mockPath))
+        #expect(await fs.exists(mockPath))
 
         let bytes = try await fs.withOpenReadableFile(mockPath) { fileHandle in
             try await fileHandle.read().reduce(into: []) { $0.append(contentsOf: $1) }
         }
 
-        XCTAssertEqual(bytes, Array(mockContent))
+        #expect(bytes == Array(mockContent))
     }
-    func testOSFileSystem() async throws {
+    @Test
+    func oSFileSystem() async throws {
         try await testWithTemporaryDirectory { tmpDir in
             let fs = OSFileSystem()
 
             let mockPath = FilePath(tmpDir.appending("foo").pathString)
 
-            await XCTAssertAsyncFalse(await fs.exists(mockPath))
+            #expect(await !fs.exists(mockPath))
 
             let mockContent = "baz".utf8
 
             try await fs.write(mockPath, bytes: mockContent)
 
-            await XCTAssertAsyncTrue(await fs.exists(mockPath))
+            #expect(await fs.exists(mockPath))
 
             // Test overwriting
             try await fs.write(mockPath, bytes: mockContent)
 
-            await XCTAssertAsyncTrue(await fs.exists(mockPath))
+            #expect(await fs.exists(mockPath))
 
             let bytes = try await fs.withOpenReadableFile(mockPath) { fileHandle in
                 try await fileHandle.read().reduce(into: []) { $0.append(contentsOf: $1) }
             }
 
-            XCTAssertEqual(bytes, Array(mockContent))
+            #expect(bytes == Array(mockContent))
         }
     }
 }


### PR DESCRIPTION
Continue to test conversion to Swift Testing.

- Tests/BasicsTests/HTTPClientTests.swift
- Tests/BasicsTests/SQLiteBackedCacheTests.swift
- Tests/BuildTests/BuildPlanTraversalTests.swift
- Tests/BuildTests/LLBuildManifestBuilderTests.swift
- Tests/BuildTests/SwiftCompilerOutputParserTests.swift
- Tests/BuildTests/WindowsBuildPlanTests.swift
- Tests/_AsyncFileSystemTests/AsyncFileSystemTests.swift