### PR TITLE
Support Swift SDKs w/ many metadata files in same directory

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
@@ -370,9 +370,13 @@ public final class SwiftSDKBundleStore {
             var variants = [SwiftSDKBundle.Variant]()
 
             for variantMetadata in artifactMetadata.variants {
-                let variantConfigurationPath = bundlePath
+                var variantConfigurationPath = bundlePath
                     .appending(variantMetadata.path)
-                    .appending("swift-sdk.json")
+
+                if variantConfigurationPath.extension != ".json" &&
+                        self.fileSystem.isDirectory(variantConfigurationPath) {
+                    variantConfigurationPath = variantConfigurationPath.appending("swift-sdk.json")
+                }
 
                 guard self.fileSystem.exists(variantConfigurationPath) else {
                     self.observabilityScope.emit(

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -75,7 +75,7 @@ private func generateBundleFiles(bundle: MockBundle) throws -> [(String, ByteStr
         let toolsetPath = if artifact.metadataPath != nil {
             "\(bundle.path)/toolset.json"
         } else {
-            "\(bundle.path)/\(artifact.id)/\(targetTriple.triple)/toolset"
+            "\(bundle.path)/\(artifact.id)/\(targetTriple.triple)/toolset.json"
         }
         return artifact.toolsetRootPath.map { path in
             (

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -27,20 +27,26 @@ private let targetTriple = try! Triple("aarch64-unknown-linux")
 private let jsonEncoder = JSONEncoder()
 
 private func generateBundleFiles(bundle: MockBundle) throws -> [(String, ByteString)] {
-    try [
+    return try [
         (
             "\(bundle.path)/info.json",
             ByteString(json: """
             {
                 "artifacts" : {
                     \(bundle.artifacts.map {
-                            """
+                            let path = if let metadataPath = $0.metadataPath {
+                                metadataPath.pathString
+                            } else {
+                                "\($0.id)/\(targetTriple.triple)"
+                            }
+
+                            return """
                             "\($0.id)" : {
                                 "type" : "swiftSDK",
                                 "version" : "0.0.1",
                                 "variants" : [
                                     {
-                                        "path" : "\($0.id)/\(targetTriple.triple)",
+                                        "path" : "\(path)",
                                         "supportedTriples" : \($0.supportedTriples.map(\.tripleString))
                                     }
                                 ]
@@ -55,14 +61,25 @@ private func generateBundleFiles(bundle: MockBundle) throws -> [(String, ByteStr
         ),
 
     ] + bundle.artifacts.map {
-        (
-            "\(bundle.path)/\($0.id)/\(targetTriple.tripleString)/swift-sdk.json",
+        let path = if let metadataPath = $0.metadataPath {
+            "\(bundle.path)/\(metadataPath.pathString)"
+        } else {
+            "\(bundle.path)/\($0.id)/\(targetTriple.triple)/swift-sdk.json"
+        }
+
+        return (
+            path,
             ByteString(json: try generateSwiftSDKMetadata(jsonEncoder, createToolset: $0.toolsetRootPath != nil))
         )
     } + bundle.artifacts.compactMap { artifact in
-        artifact.toolsetRootPath.map { path in
+        let toolsetPath = if artifact.metadataPath != nil {
+            "\(bundle.path)/toolset.json"
+        } else {
+            "\(bundle.path)/\(artifact.id)/\(targetTriple.triple)/toolset"
+        }
+        return artifact.toolsetRootPath.map { path in
             (
-                "\(bundle.path)/\(artifact.id)/\(targetTriple.tripleString)/toolset.json",
+                "\(toolsetPath)",
                 ByteString(json: """
                 {
                     "schemaVersion": "1.0",
@@ -101,15 +118,17 @@ private struct MockBundle {
 private struct MockArtifact {
     let id: String
     let supportedTriples: [Triple]
+    var metadataPath: RelativePath?
     var toolsetRootPath: AbsolutePath?
 }
 
-private func generateTestFileSystem(bundleArtifacts: [MockArtifact]) throws -> (some FileSystem, [MockBundle], AbsolutePath) {
+private func generateTestFileSystem(
+    bundleArtifacts: [MockArtifact]
+) throws -> (some FileSystem, [MockBundle], AbsolutePath) {
     let bundles = bundleArtifacts.enumerated().map { (i, artifacts) in
         let bundleName = "test\(i).\(artifactBundleExtension)"
         return MockBundle(name: "test\(i).\(artifactBundleExtension)", path: "/\(bundleName)", artifacts: [artifacts])
     }
-
 
     let fileSystem = try InMemoryFileSystem(
         files: Dictionary(
@@ -474,5 +493,55 @@ final class SwiftSDKBundleTests: XCTestCase {
                 [customCompileToolchain.appending(components: ["usr", "bin"])] + hostSwiftSDK.toolset.rootPaths
             )
         }
+    }
+
+    func testMetadataJSONPaths() async throws {
+        let toolsetRootPath = AbsolutePath("/path/to/toolpath")
+        let (fileSystem, bundles, swiftSDKsDirectory) = try generateTestFileSystem(
+            bundleArtifacts: [
+                .init(
+                    id: "\(testArtifactID)1",
+                    supportedTriples: [arm64Triple],
+                    metadataPath: "metadata1.json"
+                ),
+                .init(
+                    id: "\(testArtifactID)2",
+                    supportedTriples: [i686Triple],
+                    metadataPath: "metadata2.json",
+                    toolsetRootPath: toolsetRootPath
+                ),
+            ]
+        )
+        let system = ObservabilitySystem.makeForTesting()
+        let archiver = MockArchiver()
+        
+        var output = [SwiftSDKBundleStore.Output]()
+        let store = SwiftSDKBundleStore(
+            swiftSDKsDirectory: swiftSDKsDirectory,
+            fileSystem: fileSystem,
+            observabilityScope: system.topScope,
+            outputHandler: { output.append($0) }
+        )
+
+        for bundle in bundles {
+            try await store.install(bundlePathOrURL: bundle.path, archiver)
+        }
+
+        let validBundles = try store.allValidBundles
+
+        XCTAssertEqual(validBundles.count, bundles.count)
+
+        XCTAssertEqual(validBundles.sortedArtifactIDs, ["\(testArtifactID)1", "\(testArtifactID)2"])
+        XCTAssertEqual(output.count, 2)
+        XCTAssertEqual(output, [
+            .installationSuccessful(
+                bundlePathOrURL: bundles[0].path,
+                bundleName: AbsolutePath(bundles[0].path).components.last!
+            ),
+            .installationSuccessful(
+                bundlePathOrURL: bundles[1].path,
+                bundleName: AbsolutePath(bundles[1].path).components.last!
+            ),
+        ])
     }
 }


### PR DESCRIPTION
### Motivation:

Swift SDK artifact bundle for WASI now supports both embedded and non-embedded modes. Majority of their content is overlapping, thus to avoid duplication they live in the same source tree.

Currently, SwiftPM requires that Swift SDKs are located in separate directories, with `swift-sdk.json` metadata at the root of each directory.

### Modification:

SwiftPM can now parse Swift SDK metadata that points directly to metadata JSON files instead of their root directories.

### Result:

We can avoid changing file system layout in the artifact bundles for WASI and just place sibling `nonembedded.json` and `embedded.json` Swift SDK metadata files in the same directory in their existing layout.

The change is transparent to Swift SDK users and is an optional and incremental addition for Swift SDK authors.

As Swift SDKs are required to exactly match the version of the host toolchain, there are no backward compatibility concerns with this change.