### PR TITLE
Revert "Tests: Convert Environment/Graph and other suites to ST"

### DIFF
--- a/Sources/_InternalTestSupport/Observability.swift
+++ b/Sources/_InternalTestSupport/Observability.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -18,7 +18,6 @@ import func XCTest.XCTFail
 import struct TSCBasic.StringError
 
 import TSCTestSupport
-import Testing
 
 extension ObservabilitySystem {
     public static func makeForTesting(verbose: Bool = true) -> TestingObservability {
@@ -140,37 +139,6 @@ public func testDiagnostics(
     }
 }
 
-public func expectDiagnostics(
-    _ diagnostics: [Basics.Diagnostic],
-    problemsOnly: Bool = true,
-    sourceLocation: SourceLocation = #_sourceLocation,
-    handler: (DiagnosticsTestResult) throws -> Void
-) throws {
-    try expectDiagnostics(
-        diagnostics,
-        minSeverity: problemsOnly ? .warning : .debug,
-        sourceLocation: sourceLocation,
-        handler: handler
-    )
-}
-
-
-public func expectDiagnostics(
-    _ diagnostics: [Basics.Diagnostic],
-    minSeverity: Basics.Diagnostic.Severity,
-    sourceLocation: SourceLocation = #_sourceLocation,
-    handler: (DiagnosticsTestResult) throws -> Void
-) throws {
-    let diagnostics = diagnostics.filter { $0.severity >= minSeverity }
-    let testResult = DiagnosticsTestResult(diagnostics)
-
-    try handler(testResult)
-
-    if !testResult.uncheckedDiagnostics.isEmpty {
-        Issue.record("unchecked diagnostics \(testResult.uncheckedDiagnostics)", sourceLocation: sourceLocation)
-     }
-}
- 
 public func testPartialDiagnostics(
     _ diagnostics: [Basics.Diagnostic],
     minSeverity: Basics.Diagnostic.Severity,

--- a/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
@@ -2,100 +2,91 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import Foundation
 
 @testable import Basics
-import Testing
+import XCTest
 
-struct EnvironmentKeyTests {
-    @Test
-    func comparable() {
+final class EnvironmentKeyTests: XCTestCase {
+    func test_comparable() {
         let key0 = EnvironmentKey("Test")
         let key1 = EnvironmentKey("Test1")
-        #expect(key0 < key1)
+        XCTAssertLessThan(key0, key1)
 
         let key2 = EnvironmentKey("test")
-        #expect(key0 < key2)
+        XCTAssertLessThan(key0, key2)
     }
 
-    @Test
-    func customStringConvertible() {
+    func test_customStringConvertible() {
         let key = EnvironmentKey("Test")
-        #expect(key.description == "Test")
+        XCTAssertEqual(key.description, "Test")
     }
 
-    @Test
-    func encodable() throws {
+    func test_encodable() throws {
         let key = EnvironmentKey("Test")
         let data = try JSONEncoder().encode(key)
         let string = String(data: data, encoding: .utf8)
-        #expect(string == #""Test""#)
+        XCTAssertEqual(string, #""Test""#)
     }
 
-    @Test
-    func equatable() {
+    func test_equatable() {
         let key0 = EnvironmentKey("Test")
         let key1 = EnvironmentKey("Test")
-        #expect(key0 == key1)
+        XCTAssertEqual(key0, key1)
 
         let key2 = EnvironmentKey("Test2")
-        #expect(key0 != key2)
+        XCTAssertNotEqual(key0, key2)
 
         #if os(Windows)
         // Test case insensitivity on windows
         let key3 = EnvironmentKey("teSt")
-            #expect(key0 == key3)
+        XCTAssertEqual(key0, key3)
         #endif
     }
 
-    @Test
-    func expressibleByStringLiteral() {
+    func test_expressibleByStringLiteral() {
         let key0 = EnvironmentKey("Test")
-        #expect(key0 == "Test")
+        XCTAssertEqual(key0, "Test")
     }
 
-    @Test
-    func decodable() throws {
+    func test_decodable() throws {
         let jsonString = #""Test""#
         let data = jsonString.data(using: .utf8)!
         let key = try JSONDecoder().decode(EnvironmentKey.self, from: data)
-        #expect(key.rawValue == "Test")
+        XCTAssertEqual(key.rawValue, "Test")
     }
 
-    @Test
-    func hashable() {
+    func test_hashable() {
         var set = Set<EnvironmentKey>()
         let key0 = EnvironmentKey("Test")
-        #expect(set.insert(key0).inserted)
+        XCTAssertTrue(set.insert(key0).inserted)
 
         let key1 = EnvironmentKey("Test")
-        #expect(set.contains(key1))
-        #expect(!set.insert(key1).inserted)
+        XCTAssertTrue(set.contains(key1))
+        XCTAssertFalse(set.insert(key1).inserted)
 
         let key2 = EnvironmentKey("Test2")
-        #expect(!set.contains(key2))
-        #expect(set.insert(key2).inserted)
+        XCTAssertFalse(set.contains(key2))
+        XCTAssertTrue(set.insert(key2).inserted)
 
         #if os(Windows)
         // Test case insensitivity on windows
         let key3 = EnvironmentKey("teSt")
-            #expect(set.contains(key3))
-            #expect(!set.insert(key3).inserted)
+        XCTAssertTrue(set.contains(key3))
+        XCTAssertFalse(set.insert(key3).inserted)
         #endif
 
-        #expect(set == ["Test", "Test2"])
+        XCTAssertEqual(set, ["Test", "Test2"])
     }
 
-    @Test
-    func rawRepresentable() {
+    func test_rawRepresentable() {
         let key = EnvironmentKey(rawValue: "Test")
-        #expect(key?.rawValue == "Test")
+        XCTAssertEqual(key?.rawValue, "Test")
     }
 }

--- a/Tests/BasicsTests/Graph/AdjacencyMatrixTests.swift
+++ b/Tests/BasicsTests/Graph/AdjacencyMatrixTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -11,30 +11,28 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Basics
-import Testing
+import XCTest
 
-struct AdjacencyMatrixTests {
-    @Test
-    func empty() {
+final class AdjacencyMatrixTests: XCTestCase {
+    func testEmpty() {
         var matrix = AdjacencyMatrix(rows: 0, columns: 0)
-        #expect(matrix.bitCount == 0)
+        XCTAssertEqual(matrix.bitCount, 0)
 
         matrix = AdjacencyMatrix(rows: 0, columns: 42)
-        #expect(matrix.bitCount == 0)
+        XCTAssertEqual(matrix.bitCount, 0)
 
         matrix = AdjacencyMatrix(rows: 42, columns: 0)
-        #expect(matrix.bitCount == 0)
+        XCTAssertEqual(matrix.bitCount, 0)
     }
 
-    @Test
-    func bits() {
+    func testBits() {
         for count in 1..<10 {
             var matrix = AdjacencyMatrix(rows: count, columns: count)
             for row in 0..<count {
                 for column in 0..<count {
-                    #expect(!matrix[row, column])
+                    XCTAssertFalse(matrix[row, column])
                     matrix[row, column] = true
-                    #expect(matrix[row, column])
+                    XCTAssertTrue(matrix[row, column])
                 }
             }
         }

--- a/Tests/BasicsTests/Graph/DirectedGraphTests.swift
+++ b/Tests/BasicsTests/Graph/DirectedGraphTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -13,22 +13,21 @@
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 import Basics
 
-import Testing
+import XCTest
 
-struct DirectedGraphTests {
-    @Test
-    func nodesConnection() {
+final class DirectedGraphTests: XCTestCase {
+    func testNodesConnection() {
         var graph = DirectedGraph(nodes: ["app1", "lib1", "lib2", "app2", "lib3"])
         graph.addEdge(source: 0, destination: 1)
         graph.addEdge(source: 1, destination: 2)
-        #expect(graph.areNodesConnected(source: 0, destination: 2))
-        #expect(!graph.areNodesConnected(source: 2, destination: 0))
+        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 2))
+        XCTAssertFalse(graph.areNodesConnected(source: 2, destination: 0))
 
         graph.addEdge(source: 0, destination: 4)
         graph.addEdge(source: 3, destination: 4)
-        #expect(graph.areNodesConnected(source: 3, destination: 4))
-        #expect(graph.areNodesConnected(source: 0, destination: 4))
-        #expect(!graph.areNodesConnected(source: 1, destination: 4))
-        #expect(graph.areNodesConnected(source: 0, destination: 4))
+        XCTAssertTrue(graph.areNodesConnected(source: 3, destination: 4))
+        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 4))
+        XCTAssertFalse(graph.areNodesConnected(source: 1, destination: 4))
+        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 4))
     }
 }

--- a/Tests/BasicsTests/Graph/UndirectedGraphTests.swift
+++ b/Tests/BasicsTests/Graph/UndirectedGraphTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -13,29 +13,28 @@
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 import Basics
 
-import Testing
+import XCTest
 
-struct UndirectedGraphTests {
-    @Test
-    func nodesConnection() {
+final class UndirectedGraphTests: XCTestCase {
+    func testNodesConnection() {
         var graph = UndirectedGraph(nodes: ["app1", "lib1", "lib2", "app2", "lib3", "app3"])
         graph.addEdge(source: 0, destination: 1)
         graph.addEdge(source: 1, destination: 2)
-        #expect(graph.areNodesConnected(source: 0, destination: 2))
-        #expect(graph.areNodesConnected(source: 2, destination: 0))
+        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 2))
+        XCTAssertTrue(graph.areNodesConnected(source: 2, destination: 0))
 
         graph.addEdge(source: 0, destination: 4)
         graph.addEdge(source: 3, destination: 4)
-        #expect(graph.areNodesConnected(source: 3, destination: 4))
-        #expect(graph.areNodesConnected(source: 4, destination: 3))
-        #expect(graph.areNodesConnected(source: 0, destination: 4))
-        #expect(graph.areNodesConnected(source: 4, destination: 0))
-        #expect(graph.areNodesConnected(source: 1, destination: 4))
-        #expect(graph.areNodesConnected(source: 4, destination: 1))
+        XCTAssertTrue(graph.areNodesConnected(source: 3, destination: 4))
+        XCTAssertTrue(graph.areNodesConnected(source: 4, destination: 3))
+        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 4))
+        XCTAssertTrue(graph.areNodesConnected(source: 4, destination: 0))
+        XCTAssertTrue(graph.areNodesConnected(source: 1, destination: 4))
+        XCTAssertTrue(graph.areNodesConnected(source: 4, destination: 1))
 
         for i in 0...4 {
-            #expect(!graph.areNodesConnected(source: i, destination: 5))
-            #expect(!graph.areNodesConnected(source: 5, destination: i))
+            XCTAssertFalse(graph.areNodesConnected(source: i, destination: 5))
+            XCTAssertFalse(graph.areNodesConnected(source: 5, destination: i))
         }
     }
 }

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -2,25 +2,23 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020-2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import Foundation
 
 @testable import Basics
 import _InternalTestSupport
-import Testing
+import XCTest
 
 // TODO: remove when transition to new diagnostics system is complete
 typealias Diagnostic = Basics.Diagnostic
 
-struct ObservabilitySystemTest {
-    @Test
-    func scopes() throws {
+final class ObservabilitySystemTest: XCTestCase {
+    func testScopes() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)
 
@@ -35,19 +33,16 @@ struct ObservabilitySystemTest {
         let emitter1 = childScope1.makeDiagnosticsEmitter()
         emitter1.emit(error: "error 1.5")
 
-        try expectDiagnostics(collector.diagnostics) { result in
-            let diagnostic1 = try #require(result.check(diagnostic: "error 1", severity: .error))
-            let diagnostic1_metadata = try #require(diagnostic1.metadata)
-            #expect(diagnostic1_metadata.testKey1 == metadata1.testKey1)
-            #expect(diagnostic1_metadata.testKey2 == metadata1.testKey2)
-            #expect(diagnostic1_metadata.testKey3 == metadata1.testKey3)
+        testDiagnostics(collector.diagnostics) { result in
+            let diagnostic1 = result.check(diagnostic: "error 1", severity: .error)
+            XCTAssertEqual(diagnostic1?.metadata?.testKey1, metadata1.testKey1)
+            XCTAssertEqual(diagnostic1?.metadata?.testKey2, metadata1.testKey2)
+            XCTAssertEqual(diagnostic1?.metadata?.testKey3, metadata1.testKey3)
 
-            let diagnostic1_5 = try #require(result.check(diagnostic: "error 1.5", severity: .error))
-            let diagnostic1_5_metadata = try #require(diagnostic1_5.metadata)
-
-            #expect(diagnostic1_5_metadata.testKey1 == metadata1.testKey1)
-            #expect(diagnostic1_5_metadata.testKey2 == metadata1.testKey2)
-            #expect(diagnostic1_5_metadata.testKey3 == metadata1.testKey3)
+            let diagnostic1_5 = result.check(diagnostic: "error 1.5", severity: .error)
+            XCTAssertEqual(diagnostic1_5?.metadata?.testKey1, metadata1.testKey1)
+            XCTAssertEqual(diagnostic1_5?.metadata?.testKey2, metadata1.testKey2)
+            XCTAssertEqual(diagnostic1_5?.metadata?.testKey3, metadata1.testKey3)
         }
 
         collector.clear()
@@ -57,9 +52,9 @@ struct ObservabilitySystemTest {
         metadata2.testKey2 = Int.random(in: Int.min..<Int.max)
 
         let mergedMetadata2 = metadata1.merging(metadata2)
-        #expect(mergedMetadata2.testKey1 == metadata2.testKey1)
-        #expect(mergedMetadata2.testKey2 == metadata2.testKey2)
-        #expect(mergedMetadata2.testKey3 == metadata1.testKey3)
+        XCTAssertEqual(mergedMetadata2.testKey1, metadata2.testKey1)
+        XCTAssertEqual(mergedMetadata2.testKey2, metadata2.testKey2)
+        XCTAssertEqual(mergedMetadata2.testKey3, metadata1.testKey3)
 
         let childScope2 = childScope1.makeChildScope(description: "child 2", metadata: metadata2)
         childScope2.emit(error: "error 2")
@@ -67,18 +62,16 @@ struct ObservabilitySystemTest {
         let emitter2 = childScope2.makeDiagnosticsEmitter()
         emitter2.emit(error: "error 2.5")
 
-        try expectDiagnostics(collector.diagnostics) { result in
-            let diagnostic2 = try #require(result.check(diagnostic: "error 2", severity: .error))
-            let diagnostic2_metadata = try #require(diagnostic2.metadata)
-            #expect(diagnostic2_metadata.testKey1 == mergedMetadata2.testKey1)
-            #expect(diagnostic2_metadata.testKey2 == mergedMetadata2.testKey2)
-            #expect(diagnostic2_metadata.testKey3 == mergedMetadata2.testKey3)
+        testDiagnostics(collector.diagnostics) { result in
+            let diagnostic2 = result.check(diagnostic: "error 2", severity: .error)!
+            XCTAssertEqual(diagnostic2.metadata?.testKey1, mergedMetadata2.testKey1)
+            XCTAssertEqual(diagnostic2.metadata?.testKey2, mergedMetadata2.testKey2)
+            XCTAssertEqual(diagnostic2.metadata?.testKey3, mergedMetadata2.testKey3)
 
-            let diagnostic2_5 = try #require(result.check(diagnostic: "error 2.5", severity: .error))
-            let diagnostic2_5_metadata = try #require(diagnostic2.metadata)
-            #expect(diagnostic2_5_metadata.testKey1 == mergedMetadata2.testKey1)
-            #expect(diagnostic2_5_metadata.testKey2 == mergedMetadata2.testKey2)
-            #expect(diagnostic2_5_metadata.testKey3 == mergedMetadata2.testKey3)
+            let diagnostic2_5 = result.check(diagnostic: "error 2.5", severity: .error)
+            XCTAssertEqual(diagnostic2_5?.metadata?.testKey1, mergedMetadata2.testKey1)
+            XCTAssertEqual(diagnostic2_5?.metadata?.testKey2, mergedMetadata2.testKey2)
+            XCTAssertEqual(diagnostic2_5?.metadata?.testKey3, mergedMetadata2.testKey3)
         }
 
         collector.clear()
@@ -87,9 +80,9 @@ struct ObservabilitySystemTest {
         metadata3.testKey1 = UUID().uuidString
 
         let mergedMetadata3 = metadata1.merging(metadata2).merging(metadata3)
-        #expect(mergedMetadata3.testKey1 == metadata3.testKey1)
-        #expect(mergedMetadata3.testKey2 == metadata2.testKey2)
-        #expect(mergedMetadata3.testKey3 == metadata1.testKey3)
+        XCTAssertEqual(mergedMetadata3.testKey1, metadata3.testKey1)
+        XCTAssertEqual(mergedMetadata3.testKey2, metadata2.testKey2)
+        XCTAssertEqual(mergedMetadata3.testKey3, metadata1.testKey3)
 
         let childScope3 = childScope2.makeChildScope(description: "child 3", metadata: metadata3)
         childScope3.emit(error: "error 3")
@@ -98,30 +91,27 @@ struct ObservabilitySystemTest {
         metadata3_5.testKey1 = UUID().uuidString
 
         let mergedMetadata3_5 = metadata1.merging(metadata2).merging(metadata3).merging(metadata3_5)
-        #expect(mergedMetadata3_5.testKey1 == metadata3_5.testKey1)
-        #expect(mergedMetadata3_5.testKey2 == metadata2.testKey2)
-        #expect(mergedMetadata3_5.testKey3 == metadata1.testKey3)
+        XCTAssertEqual(mergedMetadata3_5.testKey1, metadata3_5.testKey1)
+        XCTAssertEqual(mergedMetadata3_5.testKey2, metadata2.testKey2)
+        XCTAssertEqual(mergedMetadata3_5.testKey3, metadata1.testKey3)
 
         let emitter3 = childScope3.makeDiagnosticsEmitter(metadata: metadata3_5)
         emitter3.emit(error: "error 3.5")
 
-        try expectDiagnostics(collector.diagnostics) { result in
-            let diagnostic3 = try #require(result.check(diagnostic: "error 3", severity: .error))
-            let diagnostic3_metadata = try #require(diagnostic3.metadata)
-            #expect(diagnostic3_metadata.testKey1 == mergedMetadata3.testKey1)
-            #expect(diagnostic3_metadata.testKey2 == mergedMetadata3.testKey2)
-            #expect(diagnostic3_metadata.testKey3 == mergedMetadata3.testKey3)
+        testDiagnostics(collector.diagnostics) { result in
+            let diagnostic3 = result.check(diagnostic: "error 3", severity: .error)
+            XCTAssertEqual(diagnostic3?.metadata?.testKey1, mergedMetadata3.testKey1)
+            XCTAssertEqual(diagnostic3?.metadata?.testKey2, mergedMetadata3.testKey2)
+            XCTAssertEqual(diagnostic3?.metadata?.testKey3, mergedMetadata3.testKey3)
 
-            let diagnostic3_5 = try #require(result.check(diagnostic: "error 3.5", severity: .error))
-            let diagnostic3_5_metadata = try #require(diagnostic3_5.metadata)
-            #expect(diagnostic3_5_metadata.testKey1 == mergedMetadata3_5.testKey1)
-            #expect(diagnostic3_5_metadata.testKey2 == mergedMetadata3_5.testKey2)
-            #expect(diagnostic3_5_metadata.testKey3 == mergedMetadata3_5.testKey3)
+            let diagnostic3_5 = result.check(diagnostic: "error 3.5", severity: .error)
+            XCTAssertEqual(diagnostic3_5?.metadata?.testKey1, mergedMetadata3_5.testKey1)
+            XCTAssertEqual(diagnostic3_5?.metadata?.testKey2, mergedMetadata3_5.testKey2)
+            XCTAssertEqual(diagnostic3_5?.metadata?.testKey3, mergedMetadata3_5.testKey3)
         }
     }
 
-    @Test
-    func basicDiagnostics() throws {
+    func testBasicDiagnostics() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)
 
@@ -140,58 +130,48 @@ struct ObservabilitySystemTest {
         emitter.emit(debug: "debug")
         emitter.emit(.debug("debug 2"))
 
-        try expectDiagnostics(collector.diagnostics, problemsOnly: false) { result in
+        testDiagnostics(collector.diagnostics, problemsOnly: false) { result in
             do {
-                let diagnostic = try #require(result.check(diagnostic: "error", severity: .error))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
+                let diagnostic = result.check(diagnostic: "error", severity: .error)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "error 2", severity: .error))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
+                let diagnostic = result.check(diagnostic: "error 2", severity: .error)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "error 3", severity: .error))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
-                #expect(diagnostic_metadata.underlyingError as? StringError == StringError("error 3"))
+                let diagnostic = result.check(diagnostic: "error 3", severity: .error)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? StringError, StringError("error 3"))
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "warning", severity: .warning))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
+                let diagnostic = result.check(diagnostic: "warning", severity: .warning)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "warning 2", severity: .warning))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
+                let diagnostic = result.check(diagnostic: "warning 2", severity: .warning)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "info", severity: .info))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
+                let diagnostic = result.check(diagnostic: "info", severity: .info)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "info 2", severity: .info))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
+                let diagnostic = result.check(diagnostic: "info 2", severity: .info)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "debug", severity: .error))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
+                let diagnostic = result.check(diagnostic: "debug", severity: .debug)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "debug 2", severity: .debug))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
+                let diagnostic = result.check(diagnostic: "debug 2", severity: .debug)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
             }
         }
     }
 
-    @Test
-    func diagnosticsErrorDescription() throws {
+    func testDiagnosticsErrorDescription() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)
 
@@ -201,29 +181,26 @@ struct ObservabilitySystemTest {
         observabilitySystem.topScope.emit(MyDescribedError(description: "error 4"))
         observabilitySystem.topScope.emit(MyLocalizedError(errorDescription: "error 5"))
 
-        try expectDiagnostics(collector.diagnostics, problemsOnly: false) { result in
+        testDiagnostics(collector.diagnostics, problemsOnly: false) { result in
             do {
-                let diagnostic = try #require(result.check(diagnostic: "error", severity: .error))
-                #expect(diagnostic.metadata?.underlyingError == nil)
+                let diagnostic = result.check(diagnostic: "error", severity: .error)
+                XCTAssertNil(diagnostic?.metadata?.underlyingError)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "error 2", severity: .error))
-                #expect(diagnostic.metadata?.underlyingError == nil)
+                let diagnostic = result.check(diagnostic: "error 2", severity: .error)
+                XCTAssertNil(diagnostic?.metadata?.underlyingError)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "MyError(description: \"error 3\")", severity: .error))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.underlyingError as? MyError == MyError(description: "error 3"))
+                let diagnostic = result.check(diagnostic: "MyError(description: \"error 3\")", severity: .error)
+                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? MyError, MyError(description: "error 3"))
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "error 4", severity: .error))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.underlyingError as? MyDescribedError == MyDescribedError(description: "error 4"))
+                let diagnostic = result.check(diagnostic: "error 4", severity: .error)
+                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? MyDescribedError, MyDescribedError(description: "error 4"))
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "error 5", severity: .error))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.underlyingError as? MyLocalizedError == MyLocalizedError(errorDescription: "error 5"))
+                let diagnostic = result.check(diagnostic: "error 5", severity: .error)
+                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? MyLocalizedError, MyLocalizedError(errorDescription: "error 5"))
             }
         }
 
@@ -241,8 +218,7 @@ struct ObservabilitySystemTest {
         }
     }
 
-    @Test
-    func diagnosticsMetadataMerge() throws {
+    func testDiagnosticsMetadataMerge() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)
 
@@ -258,9 +234,9 @@ struct ObservabilitySystemTest {
         emitterMetadata.testKey2 = Int.random(in: Int.min..<Int.max)
 
         let emitterMergedMetadata = scopeMetadata.merging(emitterMetadata)
-        #expect(emitterMergedMetadata.testKey1 == emitterMetadata.testKey1)
-        #expect(emitterMergedMetadata.testKey2 == emitterMetadata.testKey2)
-        #expect(emitterMergedMetadata.testKey3 == scopeMetadata.testKey3)
+        XCTAssertEqual(emitterMergedMetadata.testKey1, emitterMetadata.testKey1)
+        XCTAssertEqual(emitterMergedMetadata.testKey2, emitterMetadata.testKey2)
+        XCTAssertEqual(emitterMergedMetadata.testKey3, scopeMetadata.testKey3)
 
         let emitter = scope.makeDiagnosticsEmitter(metadata: emitterMetadata)
         emitter.emit(error: "error")
@@ -269,26 +245,24 @@ struct ObservabilitySystemTest {
         diagnosticMetadata.testKey1 = UUID().uuidString
 
         let diagnosticMergedMetadata = scopeMetadata.merging(emitterMetadata).merging(diagnosticMetadata)
-        #expect(diagnosticMergedMetadata.testKey1 == diagnosticMetadata.testKey1)
-        #expect(diagnosticMergedMetadata.testKey2 == emitterMetadata.testKey2)
-        #expect(diagnosticMergedMetadata.testKey3 == scopeMetadata.testKey3)
+        XCTAssertEqual(diagnosticMergedMetadata.testKey1, diagnosticMetadata.testKey1)
+        XCTAssertEqual(diagnosticMergedMetadata.testKey2, emitterMetadata.testKey2)
+        XCTAssertEqual(diagnosticMergedMetadata.testKey3, scopeMetadata.testKey3)
 
         emitter.emit(warning: "warning", metadata: diagnosticMetadata)
 
-        try expectDiagnostics(collector.diagnostics) { result in
+        testDiagnostics(collector.diagnostics) { result in
             do {
-                let diagnostic = try #require(result.check(diagnostic: "error", severity: .error))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.testKey1 == emitterMergedMetadata.testKey1)
-                #expect(diagnostic_metadata.testKey2 == emitterMergedMetadata.testKey2)
-                #expect(diagnostic_metadata.testKey3 == emitterMergedMetadata.testKey3)
+                let diagnostic = result.check(diagnostic: "error", severity: .error)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, emitterMergedMetadata.testKey1)
+                XCTAssertEqual(diagnostic?.metadata?.testKey2, emitterMergedMetadata.testKey2)
+                XCTAssertEqual(diagnostic?.metadata?.testKey3, emitterMergedMetadata.testKey3)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "warning", severity: .warning))
-                let diagnostic_metadata = try #require(diagnostic.metadata)
-                #expect(diagnostic_metadata.testKey1 == diagnosticMergedMetadata.testKey1)
-                #expect(diagnostic_metadata.testKey2 == diagnosticMergedMetadata.testKey2)
-                #expect(diagnostic_metadata.testKey3 == diagnosticMergedMetadata.testKey3)
+                let diagnostic = result.check(diagnostic: "warning", severity: .warning)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, diagnosticMergedMetadata.testKey1)
+                XCTAssertEqual(diagnostic?.metadata?.testKey2, diagnosticMergedMetadata.testKey2)
+                XCTAssertEqual(diagnostic?.metadata?.testKey3, diagnosticMergedMetadata.testKey3)
             }
         }
     }

--- a/Tests/BasicsTests/ProgressAnimationTests.swift
+++ b/Tests/BasicsTests/ProgressAnimationTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -11,14 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 import _Concurrency
-import Testing
+import XCTest
 
 @_spi(SwiftPMInternal)
 @testable
 import Basics
 import TSCBasic
 
-struct ProgressAnimationTests {
+final class ProgressAnimationTests: XCTestCase {
     class TrackingProgressAnimation: ProgressAnimationProtocol {
         var steps: [Int] = []
 
@@ -30,8 +30,7 @@ struct ProgressAnimationTests {
         func clear() {}
     }
 
-    @Test
-    func throttledPercentProgressAnimation1() {
+    func testThrottledPercentProgressAnimation() {
         do {
             let tracking = TrackingProgressAnimation()
             var now = ContinuousClock().now
@@ -47,7 +46,7 @@ struct ProgressAnimationTests {
                 now += .milliseconds(50)
             }
             animation.complete(success: true)
-            #expect(tracking.steps == [0, 2, 4, 6, 8, 10])
+            XCTAssertEqual(tracking.steps, [0, 2, 4, 6, 8, 10])
         }
 
         do {
@@ -68,10 +67,10 @@ struct ProgressAnimationTests {
             }
             // The next update is at 1000ms, but we are at 950ms,
             // so "step 9" is not sent yet.
-            #expect(tracking.steps == [0, 2, 4, 6, 8])
+            XCTAssertEqual(tracking.steps, [0, 2, 4, 6, 8])
             // After explicit "completion", the last step is flushed out.
             animation.complete(success: true)
-            #expect(tracking.steps == [0, 2, 4, 6, 8, 9])
+            XCTAssertEqual(tracking.steps, [0, 2, 4, 6, 8, 9])
         }
     }
 }

--- a/Tests/BasicsTests/StringExtensionsTests.swift
+++ b/Tests/BasicsTests/StringExtensionsTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -11,27 +11,25 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-import Testing
+import XCTest
 
-struct StringExtensionsTests {
-    @Test
-    func sHA256Checksum() {
+final class StringExtensionsTests: XCTestCase {
+    func testSHA256Checksum() {
         let string = "abc"
-        #expect(Array(string.utf8) == [0x61, 0x62, 0x63])
+        XCTAssertEqual(Array(string.utf8), [0x61, 0x62, 0x63])
 
         // See https://csrc.nist.gov/csrc/media/projects/cryptographic-standards-and-guidelines/documents/examples/sha_all.pdf
-        #expect(string.sha256Checksum == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+        XCTAssertEqual(string.sha256Checksum, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
     }
 
-    @Test
-    func dropPrefix() {
+    func testDropPrefix() {
         do {
             let string = "prefixSuffix"
-            #expect(string.spm_dropPrefix("prefix") == "Suffix")
+            XCTAssertEqual(string.spm_dropPrefix("prefix"), "Suffix")
         }
         do {
             let string = "prefixSuffix"
-            #expect(string.spm_dropPrefix("notMyPrefix") == string)
+            XCTAssertEqual(string.spm_dropPrefix("notMyPrefix"), string)
         }
     }
 }


### PR DESCRIPTION
Reverts swiftlang/swift-package-manager#8624 as https://ci.swift.org/job/swift-bootstrap-ubuntu-24_04-x86_64/129/ failed with.

```
[2025-05-09T09:18:51.687Z] /home/build-user/swiftpm/Sources/_InternalTestSupport/Observability.swift:21:8: error: no such module 'Testing'
[2025-05-09T09:18:51.687Z]  19 | 
[2025-05-09T09:18:51.687Z]  20 | import TSCTestSupport
[2025-05-09T09:18:51.687Z]  21 | import Testing
[2025-05-09T09:18:51.687Z]     |        `- error: no such module 'Testing'
[2025-05-09T09:18:51.687Z]  22 | 
[2025-05-09T09:18:51.687Z]  23 | extension ObservabilitySystem { 
```

We should update the Jenkins build presets to treat Swift Testing the same as XCTest, or maybe update SwiftPM to to build the targets meant to be use only by test targets.