### PR TITLE
SwiftBuild: Fix executable can't find dynamic lib runtime error

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -769,21 +769,19 @@ extension PackagePIFProjectBuilder {
         //   A (executable) -> B (dynamicLibrary) -> C (objectFile)
         //
         // An imparted build setting on C will propagate back to both B and A.
-        let additionalRunPaths = if productType == .framework {
-            ["$(BUILT_PRODUCTS_DIR)/PackageFrameworks"]
-        } else {
-            ["@loader_path"]
-        }
         impartedSettings[.LD_RUNPATH_SEARCH_PATHS] =
-            additionalRunPaths +
+            ["@loader_path"] +
             (impartedSettings[.LD_RUNPATH_SEARCH_PATHS] ?? ["$(inherited)"])
+
+        var impartedDebugSettings = impartedSettings
+        impartedDebugSettings[.LD_RUNPATH_SEARCH_PATHS]! += ["$(BUILT_PRODUCTS_DIR)/PackageFrameworks"]
 
         self.project[keyPath: sourceModuleTargetKeyPath].common.addBuildConfig { id in
             BuildConfig(
                 id: id,
                 name: "Debug",
                 settings: debugSettings,
-                impartedBuildSettings: impartedSettings
+                impartedBuildSettings: impartedDebugSettings
             )
         }
         self.project[keyPath: sourceModuleTargetKeyPath].common.addBuildConfig { id in

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -227,7 +227,7 @@ extension PackagePIFProjectBuilder {
         case macro
     }
 
-    /// Constructs a *PIF target* for building a *module* target as a particular type.
+    /// Constructs a *PIF target* for building a *module* as a particular type.
     /// An optional target identifier suffix is passed when building variants of a target.
     @discardableResult
     private mutating func buildSourceModule(
@@ -245,7 +245,8 @@ extension PackagePIFProjectBuilder {
 
         switch desiredModuleType {
         case .dynamicLibrary:
-            if pifBuilder.createDylibForDynamicProducts { // We are re-using this default for dynamic targets as well.
+            // We are re-using this default for dynamic targets as well.
+            if pifBuilder.createDylibForDynamicProducts {
                 pifProductName = "lib\(sourceModule.name).dylib"
                 executableName = pifProductName
                 productType = .dynamicLibrary


### PR DESCRIPTION
Update `LD_RUNPATH_SEARCH_PATHS` of executable built using the new Swift Build backend.

### Motivation:

For the **Swift Build** backend, fix a runtime issue when building & running an executable linked against a dynamic library. Given the following packages:

#### Package App
```swift
let package = Package(
    name: "App",
    dependencies: [
        .package(path: "../Lib")
    ],
    targets: [
        .executableTarget(
            name: "App",
            dependencies: [
                .product(name: "Utils", package: "Lib")
            ]
        )
    ]
)
```

#### Package Lib
```swift
let package = Package(
    name: "Lib",
    products: [
        .library(
            name: "Utils",
            type: .dynamic,
            targets: ["Utils"]
        )
    ],
    targets: [
        .target(name: "Utils")
    ]
)
```

This the error that I get:
```shell
$ swift run --package-path /App --build-system swiftbuild

dyld[89079]: Library not loaded: @rpath/libUtils.dylib
Referenced from: 
<98AF2F50-2C62-318C-8430-C6326D8468F1> /App/.build/arm64-apple-macosx/Products/Debug/App
Reason: tried: 
'/usr/lib/swift/libUtils.dylib' (no such file, not in dyld cache), 
'/App/.build/arm64-apple-macosx/Products/Debug/PackageFrameworks/libUtils.dylib' (no such file),
'/System/Volumes/Preboot/Cryptexes/OS/usr/lib/swift/libUtils.dylib' (no such file), 
'/System/Volumes/Preboot/Cryptexes/OS/App/.build/arm64-apple-macosx/Products/Debug/PackageFrameworks/libUtils.dylib' (no such file),
```
...but works just fine when using `--build-system native`.

When comparing the *runpath*, we get this:
```shell
# Swift Build
.build/arm64-apple-macosx/Products/Debug/App
/usr/lib/swift
/Users/pmattos/SamplePackages/App+DynamicLib/App/.build/arm64-apple-macosx/Products/Debug/PackageFrameworks

# Native
.build/arm64-apple-macosx/debug/App
/usr/lib/swift
@loader_path
/Applications/Xcode_17A233.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx
```

PS. To get the runpath, run `otool -l path/to/bin | awk '/LC_RPATH/ {getline; getline; print $2}'`.

### Modifications:

Update the build setting `LD_RUNPATH_SEARCH_PATHS` for executables, appending `@loader_path`. This is actually an "imparted" build setting coming from dynamic libraries targets, so that's where I made the change.

### Result:

Now both configurations are capable of running the built `App`:
```shell
$ swift run --package-path /App --build-system swiftbuild --configuration debug
Hello from Lib

$ swift run --package-path /App --build-system swiftbuild --configuration release
Hello from Lib
```

For reference, this is the PIF for the sample package `App` above. Note my change affects the bottom `PACKAGE-TARGET:Utils` target only. The build setting is then "imparted" on the top `PACKAGE-PRODUCT:App` target.

<img src="https://github.com/user-attachments/assets/39d45e51-c329-4312-b56a-8c7e0b08f661" width=650/>