### PR TITLE
[cmake] Turn `SwiftFixIt` into a static library

### DIFF
--- a/Sources/SwiftFixIt/CMakeLists.txt
+++ b/Sources/SwiftFixIt/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(SwiftFixIt
+add_library(SwiftFixIt STATIC
   SwiftFixIt.swift)
 target_link_libraries(SwiftFixIt PUBLIC
   Basics
@@ -22,9 +22,3 @@ target_link_libraries(SwiftFixIt PUBLIC
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(SwiftFixIt PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-
-install(TARGETS SwiftFixIt
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS SwiftFixIt)


### PR DESCRIPTION
This is currently only intended to be used by a few commands and shouldn't be vended.