### PR TITLE
Tests: Convert Environment/Graph and other suites to ST

### DIFF
--- a/Sources/_InternalTestSupport/Observability.swift
+++ b/Sources/_InternalTestSupport/Observability.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -18,6 +18,7 @@ import func XCTest.XCTFail
 import struct TSCBasic.StringError
 
 import TSCTestSupport
+import Testing
 
 extension ObservabilitySystem {
     public static func makeForTesting(verbose: Bool = true) -> TestingObservability {
@@ -139,6 +140,37 @@ public func testDiagnostics(
     }
 }
 
+public func expectDiagnostics(
+    _ diagnostics: [Basics.Diagnostic],
+    problemsOnly: Bool = true,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    handler: (DiagnosticsTestResult) throws -> Void
+) throws {
+    try expectDiagnostics(
+        diagnostics,
+        minSeverity: problemsOnly ? .warning : .debug,
+        sourceLocation: sourceLocation,
+        handler: handler
+    )
+}
+
+
+public func expectDiagnostics(
+    _ diagnostics: [Basics.Diagnostic],
+    minSeverity: Basics.Diagnostic.Severity,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    handler: (DiagnosticsTestResult) throws -> Void
+) throws {
+    let diagnostics = diagnostics.filter { $0.severity >= minSeverity }
+    let testResult = DiagnosticsTestResult(diagnostics)
+
+    try handler(testResult)
+
+    if !testResult.uncheckedDiagnostics.isEmpty {
+        Issue.record("unchecked diagnostics \(testResult.uncheckedDiagnostics)", sourceLocation: sourceLocation)
+     }
+}
+ 
 public func testPartialDiagnostics(
     _ diagnostics: [Basics.Diagnostic],
     minSeverity: Basics.Diagnostic.Severity,

--- a/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
@@ -2,91 +2,100 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @testable import Basics
-import XCTest
+import Testing
 
-final class EnvironmentKeyTests: XCTestCase {
-    func test_comparable() {
+struct EnvironmentKeyTests {
+    @Test
+    func comparable() {
         let key0 = EnvironmentKey("Test")
         let key1 = EnvironmentKey("Test1")
-        XCTAssertLessThan(key0, key1)
+        #expect(key0 < key1)
 
         let key2 = EnvironmentKey("test")
-        XCTAssertLessThan(key0, key2)
+        #expect(key0 < key2)
     }
 
-    func test_customStringConvertible() {
+    @Test
+    func customStringConvertible() {
         let key = EnvironmentKey("Test")
-        XCTAssertEqual(key.description, "Test")
+        #expect(key.description == "Test")
     }
 
-    func test_encodable() throws {
+    @Test
+    func encodable() throws {
         let key = EnvironmentKey("Test")
         let data = try JSONEncoder().encode(key)
         let string = String(data: data, encoding: .utf8)
-        XCTAssertEqual(string, #""Test""#)
+        #expect(string == #""Test""#)
     }
 
-    func test_equatable() {
+    @Test
+    func equatable() {
         let key0 = EnvironmentKey("Test")
         let key1 = EnvironmentKey("Test")
-        XCTAssertEqual(key0, key1)
+        #expect(key0 == key1)
 
         let key2 = EnvironmentKey("Test2")
-        XCTAssertNotEqual(key0, key2)
+        #expect(key0 != key2)
 
         #if os(Windows)
         // Test case insensitivity on windows
         let key3 = EnvironmentKey("teSt")
-        XCTAssertEqual(key0, key3)
+            #expect(key0 == key3)
         #endif
     }
 
-    func test_expressibleByStringLiteral() {
+    @Test
+    func expressibleByStringLiteral() {
         let key0 = EnvironmentKey("Test")
-        XCTAssertEqual(key0, "Test")
+        #expect(key0 == "Test")
     }
 
-    func test_decodable() throws {
+    @Test
+    func decodable() throws {
         let jsonString = #""Test""#
         let data = jsonString.data(using: .utf8)!
         let key = try JSONDecoder().decode(EnvironmentKey.self, from: data)
-        XCTAssertEqual(key.rawValue, "Test")
+        #expect(key.rawValue == "Test")
     }
 
-    func test_hashable() {
+    @Test
+    func hashable() {
         var set = Set<EnvironmentKey>()
         let key0 = EnvironmentKey("Test")
-        XCTAssertTrue(set.insert(key0).inserted)
+        #expect(set.insert(key0).inserted)
 
         let key1 = EnvironmentKey("Test")
-        XCTAssertTrue(set.contains(key1))
-        XCTAssertFalse(set.insert(key1).inserted)
+        #expect(set.contains(key1))
+        #expect(!set.insert(key1).inserted)
 
         let key2 = EnvironmentKey("Test2")
-        XCTAssertFalse(set.contains(key2))
-        XCTAssertTrue(set.insert(key2).inserted)
+        #expect(!set.contains(key2))
+        #expect(set.insert(key2).inserted)
 
         #if os(Windows)
         // Test case insensitivity on windows
         let key3 = EnvironmentKey("teSt")
-        XCTAssertTrue(set.contains(key3))
-        XCTAssertFalse(set.insert(key3).inserted)
+            #expect(set.contains(key3))
+            #expect(!set.insert(key3).inserted)
         #endif
 
-        XCTAssertEqual(set, ["Test", "Test2"])
+        #expect(set == ["Test", "Test2"])
     }
 
-    func test_rawRepresentable() {
+    @Test
+    func rawRepresentable() {
         let key = EnvironmentKey(rawValue: "Test")
-        XCTAssertEqual(key?.rawValue, "Test")
+        #expect(key?.rawValue == "Test")
     }
 }

--- a/Tests/BasicsTests/Environment/EnvironmentTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentTests.swift
@@ -2,209 +2,230 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @_spi(SwiftPMInternal)
 @testable
 import Basics
 
-import XCTest
+import Testing
 
-final class EnvironmentTests: XCTestCase {
-    func test_init() {
+struct EnvironmentTests {
+    @Test
+    func initialize() {
         let environment = Environment()
-        XCTAssertTrue(environment.isEmpty)
+        #expect(environment.isEmpty)
     }
 
-    func test_subscript() {
+    @Test
+    func setting_and_accessing_via_subscript() {
         var environment = Environment()
         let key = EnvironmentKey("TestKey")
         environment[key] = "TestValue"
-        XCTAssertEqual(environment[key], "TestValue")
+        #expect(environment[key] == "TestValue")
     }
 
-    func test_initDictionaryFromSelf() {
+    @Test
+    func initDictionaryFromSelf() {
         let dictionary = [
             "TestKey": "TestValue",
             "testKey": "TestValue2",
         ]
         let environment = Environment(dictionary)
+        let expectedValue: String
+        let expectedCount: Int
+
         #if os(Windows)
-        XCTAssertEqual(environment["TestKey"], "TestValue2")
-        XCTAssertEqual(environment.count, 1)
+            expectedValue = "TestValue2"  // uppercase sorts before lowercase, so the second value overwrites the first
+            expectedCount = 1
         #else
-        XCTAssertEqual(environment["TestKey"], "TestValue")
-        XCTAssertEqual(environment.count, 2)
+            expectedValue = "TestValue"
+            expectedCount = 2
         #endif
+        #expect(environment["TestKey"] == expectedValue)
+        #expect(environment.count == expectedCount)
     }
 
-    func test_initSelfFromDictionary() {
+    @Test
+    func initSelfFromDictionary() {
         let dictionary = ["TestKey": "TestValue"]
         let environment = Environment(dictionary)
-        XCTAssertEqual(environment["TestKey"], "TestValue")
-        XCTAssertEqual(environment.count, 1)
+        #expect(environment["TestKey"] == "TestValue")
+        #expect(environment.count == 1)
     }
 
     func path(_ components: String...) -> String {
         components.joined(separator: Environment.pathEntryDelimiter)
     }
 
-    func test_prependPath() {
+    @Test
+    func prependPath() {
         var environment = Environment()
         let key = EnvironmentKey(UUID().uuidString)
-        XCTAssertNil(environment[key])
+        #expect(environment[key] == nil)
 
         environment.prependPath(key: key, value: "/bin")
-        XCTAssertEqual(environment[key], path("/bin"))
+        #expect(environment[key] == path("/bin"))
 
         environment.prependPath(key: key, value: "/usr/bin")
-        XCTAssertEqual(environment[key], path("/usr/bin", "/bin"))
+        #expect(environment[key] == path("/usr/bin", "/bin"))
 
         environment.prependPath(key: key, value: "/usr/local/bin")
-        XCTAssertEqual(environment[key], path("/usr/local/bin", "/usr/bin", "/bin"))
+        #expect(environment[key] == path("/usr/local/bin", "/usr/bin", "/bin"))
 
         environment.prependPath(key: key, value: "")
-        XCTAssertEqual(environment[key], path("/usr/local/bin", "/usr/bin", "/bin"))
+        #expect(environment[key] == path("/usr/local/bin", "/usr/bin", "/bin"))
     }
 
-    func test_appendPath() {
+    @Test
+    func appendPath() {
         var environment = Environment()
         let key = EnvironmentKey(UUID().uuidString)
-        XCTAssertNil(environment[key])
+        #expect(environment[key] == nil)
 
         environment.appendPath(key: key, value: "/bin")
-        XCTAssertEqual(environment[key], path("/bin"))
+        #expect(environment[key] == path("/bin"))
 
         environment.appendPath(key: key, value: "/usr/bin")
-        XCTAssertEqual(environment[key], path("/bin", "/usr/bin"))
+        #expect(environment[key] == path("/bin", "/usr/bin"))
 
         environment.appendPath(key: key, value: "/usr/local/bin")
-        XCTAssertEqual(environment[key], path("/bin", "/usr/bin", "/usr/local/bin"))
+        #expect(environment[key] == path("/bin", "/usr/bin", "/usr/local/bin"))
 
         environment.appendPath(key: key, value: "")
-        XCTAssertEqual(environment[key], path("/bin", "/usr/bin", "/usr/local/bin"))
+        #expect(environment[key] == path("/bin", "/usr/bin", "/usr/local/bin"))
     }
 
-    func test_pathEntryDelimiter() {
+    @Test
+    func pathEntryDelimiter() {
+        let expectedPathDelimiter: String
         #if os(Windows)
-        XCTAssertEqual(Environment.pathEntryDelimiter, ";")
+            expectedPathDelimiter = ";"
         #else
-        XCTAssertEqual(Environment.pathEntryDelimiter, ":")
+            expectedPathDelimiter = ":"
         #endif
+        #expect(Environment.pathEntryDelimiter == expectedPathDelimiter)
     }
 
     /// Important: This test is inherently race-prone, if it is proven to be
     /// flaky, it should run in a singled threaded environment/removed entirely.
-    func test_current() throws {
+    @Test
+    func current() throws {
         #if os(Windows)
         let pathEnvVarName = "Path"
         #else
         let pathEnvVarName = "PATH"
         #endif
 
-
-        XCTAssertEqual(
-            Environment.current["PATH"],
-            ProcessInfo.processInfo.environment[pathEnvVarName]
-        )
+        #expect(Environment.current["PATH"] == ProcessInfo.processInfo.environment[pathEnvVarName])
     }
 
     /// Important: This test is inherently race-prone, if it is proven to be
     /// flaky, it should run in a singled threaded environment/removed entirely.
-    func test_makeCustom() async throws {
+    @Test
+    func makeCustom() async throws {
         let key = EnvironmentKey(UUID().uuidString)
         let value = "TestValue"
 
         var customEnvironment = Environment()
         customEnvironment[key] = value
 
-        XCTAssertNil(Environment.current[key])
+        #expect(Environment.current[key] == nil)
         try Environment.makeCustom(customEnvironment) {
-            XCTAssertEqual(Environment.current[key], value)
+            #expect(Environment.current[key] == value)
         }
-        XCTAssertNil(Environment.current[key])
+        #expect(Environment.current[key] == nil)
     }
 
     /// Important: This test is inherently race-prone, if it is proven to be
     /// flaky, it should run in a singled threaded environment/removed entirely.
-    func testProcess() throws {
+    @Test
+    func process() throws {
         let key = EnvironmentKey(UUID().uuidString)
         let value = "TestValue"
 
         var environment = Environment.current
-        XCTAssertNil(environment[key])
+        #expect(environment[key] == nil)
 
         try Environment.set(key: key, value: value)
         environment = Environment.current // reload
-        XCTAssertEqual(environment[key], value)
+        #expect(environment[key] == value)
 
         try Environment.set(key: key, value: nil)
-        XCTAssertEqual(environment[key], value) // this is a copy!
+        #expect(environment[key] == value)  // this is a copy!
 
         environment = Environment.current // reload
-        XCTAssertNil(environment[key])
+        #expect(environment[key] == nil)
     }
 
-    func test_cachable() {
+    @Test
+    func cachable() {
         let term = EnvironmentKey("TERM")
         var environment = Environment()
         environment[.path] = "/usr/bin"
         environment[term] = "xterm-256color"
 
         let cachableEnvironment = environment.cachable
-        XCTAssertNotNil(cachableEnvironment[.path])
-        XCTAssertNil(cachableEnvironment[term])
+        #expect(cachableEnvironment[.path] != nil)
+        #expect(cachableEnvironment[term] == nil)
     }
 
-    func test_collection() {
+    @Test
+    func collection() {
         let environment: Environment = ["TestKey": "TestValue"]
-        XCTAssertEqual(environment.count, 1)
-        XCTAssertEqual(environment.first?.key, EnvironmentKey("TestKey"))
-        XCTAssertEqual(environment.first?.value, "TestValue")
+        #expect(environment.count == 1)
+        #expect(environment.first?.key == EnvironmentKey("TestKey"))
+        #expect(environment.first?.value == "TestValue")
     }
 
-    func test_description() {
+    @Test
+    func description() {
         var environment = Environment()
         environment[EnvironmentKey("TestKey")] = "TestValue"
-        XCTAssertEqual(environment.description, #"["TestKey=TestValue"]"#)
+        #expect(environment.description == #"["TestKey=TestValue"]"#)
     }
 
-    func test_encodable() throws {
+    @Test
+    func encodable() throws {
         var environment = Environment()
         environment["TestKey"] = "TestValue"
         let data = try JSONEncoder().encode(environment)
         let jsonString = String(data: data, encoding: .utf8)
-        XCTAssertEqual(jsonString, #"{"TestKey":"TestValue"}"#)
+        #expect(jsonString == #"{"TestKey":"TestValue"}"#)
     }
 
-    func test_equatable() {
+    @Test
+    func equatable() {
         let environment0: Environment = ["TestKey": "TestValue"]
         let environment1: Environment = ["TestKey": "TestValue"]
-        XCTAssertEqual(environment0, environment1)
+        #expect(environment0 == environment1)
 
 #if os(Windows)
         // Test case insensitivity on windows
         let environment2: Environment = ["testKey": "TestValue"]
-        XCTAssertEqual(environment0, environment2)
+            #expect(environment0 == environment2)
 #endif
     }
 
-    func test_expressibleByDictionaryLiteral() {
+    @Test
+    func expressibleByDictionaryLiteral() {
         let environment: Environment = ["TestKey": "TestValue"]
-        XCTAssertEqual(environment["TestKey"], "TestValue")
+        #expect(environment["TestKey"] == "TestValue")
     }
 
 
-    func test_decodable() throws {
+    @Test
+    func decodable() throws {
         let jsonString = #"{"TestKey":"TestValue"}"#
         let data = jsonString.data(using: .utf8)!
         let environment = try JSONDecoder().decode(Environment.self, from: data)
-        XCTAssertEqual(environment[EnvironmentKey("TestKey")], "TestValue")
+        #expect(environment[EnvironmentKey("TestKey")] == "TestValue")
     }
 }

--- a/Tests/BasicsTests/Graph/AdjacencyMatrixTests.swift
+++ b/Tests/BasicsTests/Graph/AdjacencyMatrixTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -11,28 +11,30 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Basics
-import XCTest
+import Testing
 
-final class AdjacencyMatrixTests: XCTestCase {
-    func testEmpty() {
+struct AdjacencyMatrixTests {
+    @Test
+    func empty() {
         var matrix = AdjacencyMatrix(rows: 0, columns: 0)
-        XCTAssertEqual(matrix.bitCount, 0)
+        #expect(matrix.bitCount == 0)
 
         matrix = AdjacencyMatrix(rows: 0, columns: 42)
-        XCTAssertEqual(matrix.bitCount, 0)
+        #expect(matrix.bitCount == 0)
 
         matrix = AdjacencyMatrix(rows: 42, columns: 0)
-        XCTAssertEqual(matrix.bitCount, 0)
+        #expect(matrix.bitCount == 0)
     }
 
-    func testBits() {
+    @Test
+    func bits() {
         for count in 1..<10 {
             var matrix = AdjacencyMatrix(rows: count, columns: count)
             for row in 0..<count {
                 for column in 0..<count {
-                    XCTAssertFalse(matrix[row, column])
+                    #expect(!matrix[row, column])
                     matrix[row, column] = true
-                    XCTAssertTrue(matrix[row, column])
+                    #expect(matrix[row, column])
                 }
             }
         }

--- a/Tests/BasicsTests/Graph/DirectedGraphTests.swift
+++ b/Tests/BasicsTests/Graph/DirectedGraphTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -13,21 +13,22 @@
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 import Basics
 
-import XCTest
+import Testing
 
-final class DirectedGraphTests: XCTestCase {
-    func testNodesConnection() {
+struct DirectedGraphTests {
+    @Test
+    func nodesConnection() {
         var graph = DirectedGraph(nodes: ["app1", "lib1", "lib2", "app2", "lib3"])
         graph.addEdge(source: 0, destination: 1)
         graph.addEdge(source: 1, destination: 2)
-        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 2))
-        XCTAssertFalse(graph.areNodesConnected(source: 2, destination: 0))
+        #expect(graph.areNodesConnected(source: 0, destination: 2))
+        #expect(!graph.areNodesConnected(source: 2, destination: 0))
 
         graph.addEdge(source: 0, destination: 4)
         graph.addEdge(source: 3, destination: 4)
-        XCTAssertTrue(graph.areNodesConnected(source: 3, destination: 4))
-        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 4))
-        XCTAssertFalse(graph.areNodesConnected(source: 1, destination: 4))
-        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 4))
+        #expect(graph.areNodesConnected(source: 3, destination: 4))
+        #expect(graph.areNodesConnected(source: 0, destination: 4))
+        #expect(!graph.areNodesConnected(source: 1, destination: 4))
+        #expect(graph.areNodesConnected(source: 0, destination: 4))
     }
 }

--- a/Tests/BasicsTests/Graph/UndirectedGraphTests.swift
+++ b/Tests/BasicsTests/Graph/UndirectedGraphTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -13,28 +13,29 @@
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 import Basics
 
-import XCTest
+import Testing
 
-final class UndirectedGraphTests: XCTestCase {
-    func testNodesConnection() {
+struct UndirectedGraphTests {
+    @Test
+    func nodesConnection() {
         var graph = UndirectedGraph(nodes: ["app1", "lib1", "lib2", "app2", "lib3", "app3"])
         graph.addEdge(source: 0, destination: 1)
         graph.addEdge(source: 1, destination: 2)
-        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 2))
-        XCTAssertTrue(graph.areNodesConnected(source: 2, destination: 0))
+        #expect(graph.areNodesConnected(source: 0, destination: 2))
+        #expect(graph.areNodesConnected(source: 2, destination: 0))
 
         graph.addEdge(source: 0, destination: 4)
         graph.addEdge(source: 3, destination: 4)
-        XCTAssertTrue(graph.areNodesConnected(source: 3, destination: 4))
-        XCTAssertTrue(graph.areNodesConnected(source: 4, destination: 3))
-        XCTAssertTrue(graph.areNodesConnected(source: 0, destination: 4))
-        XCTAssertTrue(graph.areNodesConnected(source: 4, destination: 0))
-        XCTAssertTrue(graph.areNodesConnected(source: 1, destination: 4))
-        XCTAssertTrue(graph.areNodesConnected(source: 4, destination: 1))
+        #expect(graph.areNodesConnected(source: 3, destination: 4))
+        #expect(graph.areNodesConnected(source: 4, destination: 3))
+        #expect(graph.areNodesConnected(source: 0, destination: 4))
+        #expect(graph.areNodesConnected(source: 4, destination: 0))
+        #expect(graph.areNodesConnected(source: 1, destination: 4))
+        #expect(graph.areNodesConnected(source: 4, destination: 1))
 
         for i in 0...4 {
-            XCTAssertFalse(graph.areNodesConnected(source: i, destination: 5))
-            XCTAssertFalse(graph.areNodesConnected(source: 5, destination: i))
+            #expect(!graph.areNodesConnected(source: i, destination: 5))
+            #expect(!graph.areNodesConnected(source: 5, destination: i))
         }
     }
 }

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -2,23 +2,25 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 @testable import Basics
 import _InternalTestSupport
-import XCTest
+import Testing
 
 // TODO: remove when transition to new diagnostics system is complete
 typealias Diagnostic = Basics.Diagnostic
 
-final class ObservabilitySystemTest: XCTestCase {
-    func testScopes() throws {
+struct ObservabilitySystemTest {
+    @Test
+    func scopes() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)
 
@@ -33,16 +35,19 @@ final class ObservabilitySystemTest: XCTestCase {
         let emitter1 = childScope1.makeDiagnosticsEmitter()
         emitter1.emit(error: "error 1.5")
 
-        testDiagnostics(collector.diagnostics) { result in
-            let diagnostic1 = result.check(diagnostic: "error 1", severity: .error)
-            XCTAssertEqual(diagnostic1?.metadata?.testKey1, metadata1.testKey1)
-            XCTAssertEqual(diagnostic1?.metadata?.testKey2, metadata1.testKey2)
-            XCTAssertEqual(diagnostic1?.metadata?.testKey3, metadata1.testKey3)
+        try expectDiagnostics(collector.diagnostics) { result in
+            let diagnostic1 = try #require(result.check(diagnostic: "error 1", severity: .error))
+            let diagnostic1_metadata = try #require(diagnostic1.metadata)
+            #expect(diagnostic1_metadata.testKey1 == metadata1.testKey1)
+            #expect(diagnostic1_metadata.testKey2 == metadata1.testKey2)
+            #expect(diagnostic1_metadata.testKey3 == metadata1.testKey3)
 
-            let diagnostic1_5 = result.check(diagnostic: "error 1.5", severity: .error)
-            XCTAssertEqual(diagnostic1_5?.metadata?.testKey1, metadata1.testKey1)
-            XCTAssertEqual(diagnostic1_5?.metadata?.testKey2, metadata1.testKey2)
-            XCTAssertEqual(diagnostic1_5?.metadata?.testKey3, metadata1.testKey3)
+            let diagnostic1_5 = try #require(result.check(diagnostic: "error 1.5", severity: .error))
+            let diagnostic1_5_metadata = try #require(diagnostic1_5.metadata)
+
+            #expect(diagnostic1_5_metadata.testKey1 == metadata1.testKey1)
+            #expect(diagnostic1_5_metadata.testKey2 == metadata1.testKey2)
+            #expect(diagnostic1_5_metadata.testKey3 == metadata1.testKey3)
         }
 
         collector.clear()
@@ -52,9 +57,9 @@ final class ObservabilitySystemTest: XCTestCase {
         metadata2.testKey2 = Int.random(in: Int.min..<Int.max)
 
         let mergedMetadata2 = metadata1.merging(metadata2)
-        XCTAssertEqual(mergedMetadata2.testKey1, metadata2.testKey1)
-        XCTAssertEqual(mergedMetadata2.testKey2, metadata2.testKey2)
-        XCTAssertEqual(mergedMetadata2.testKey3, metadata1.testKey3)
+        #expect(mergedMetadata2.testKey1 == metadata2.testKey1)
+        #expect(mergedMetadata2.testKey2 == metadata2.testKey2)
+        #expect(mergedMetadata2.testKey3 == metadata1.testKey3)
 
         let childScope2 = childScope1.makeChildScope(description: "child 2", metadata: metadata2)
         childScope2.emit(error: "error 2")
@@ -62,16 +67,18 @@ final class ObservabilitySystemTest: XCTestCase {
         let emitter2 = childScope2.makeDiagnosticsEmitter()
         emitter2.emit(error: "error 2.5")
 
-        testDiagnostics(collector.diagnostics) { result in
-            let diagnostic2 = result.check(diagnostic: "error 2", severity: .error)!
-            XCTAssertEqual(diagnostic2.metadata?.testKey1, mergedMetadata2.testKey1)
-            XCTAssertEqual(diagnostic2.metadata?.testKey2, mergedMetadata2.testKey2)
-            XCTAssertEqual(diagnostic2.metadata?.testKey3, mergedMetadata2.testKey3)
+        try expectDiagnostics(collector.diagnostics) { result in
+            let diagnostic2 = try #require(result.check(diagnostic: "error 2", severity: .error))
+            let diagnostic2_metadata = try #require(diagnostic2.metadata)
+            #expect(diagnostic2_metadata.testKey1 == mergedMetadata2.testKey1)
+            #expect(diagnostic2_metadata.testKey2 == mergedMetadata2.testKey2)
+            #expect(diagnostic2_metadata.testKey3 == mergedMetadata2.testKey3)
 
-            let diagnostic2_5 = result.check(diagnostic: "error 2.5", severity: .error)
-            XCTAssertEqual(diagnostic2_5?.metadata?.testKey1, mergedMetadata2.testKey1)
-            XCTAssertEqual(diagnostic2_5?.metadata?.testKey2, mergedMetadata2.testKey2)
-            XCTAssertEqual(diagnostic2_5?.metadata?.testKey3, mergedMetadata2.testKey3)
+            let diagnostic2_5 = try #require(result.check(diagnostic: "error 2.5", severity: .error))
+            let diagnostic2_5_metadata = try #require(diagnostic2.metadata)
+            #expect(diagnostic2_5_metadata.testKey1 == mergedMetadata2.testKey1)
+            #expect(diagnostic2_5_metadata.testKey2 == mergedMetadata2.testKey2)
+            #expect(diagnostic2_5_metadata.testKey3 == mergedMetadata2.testKey3)
         }
 
         collector.clear()
@@ -80,9 +87,9 @@ final class ObservabilitySystemTest: XCTestCase {
         metadata3.testKey1 = UUID().uuidString
 
         let mergedMetadata3 = metadata1.merging(metadata2).merging(metadata3)
-        XCTAssertEqual(mergedMetadata3.testKey1, metadata3.testKey1)
-        XCTAssertEqual(mergedMetadata3.testKey2, metadata2.testKey2)
-        XCTAssertEqual(mergedMetadata3.testKey3, metadata1.testKey3)
+        #expect(mergedMetadata3.testKey1 == metadata3.testKey1)
+        #expect(mergedMetadata3.testKey2 == metadata2.testKey2)
+        #expect(mergedMetadata3.testKey3 == metadata1.testKey3)
 
         let childScope3 = childScope2.makeChildScope(description: "child 3", metadata: metadata3)
         childScope3.emit(error: "error 3")
@@ -91,27 +98,30 @@ final class ObservabilitySystemTest: XCTestCase {
         metadata3_5.testKey1 = UUID().uuidString
 
         let mergedMetadata3_5 = metadata1.merging(metadata2).merging(metadata3).merging(metadata3_5)
-        XCTAssertEqual(mergedMetadata3_5.testKey1, metadata3_5.testKey1)
-        XCTAssertEqual(mergedMetadata3_5.testKey2, metadata2.testKey2)
-        XCTAssertEqual(mergedMetadata3_5.testKey3, metadata1.testKey3)
+        #expect(mergedMetadata3_5.testKey1 == metadata3_5.testKey1)
+        #expect(mergedMetadata3_5.testKey2 == metadata2.testKey2)
+        #expect(mergedMetadata3_5.testKey3 == metadata1.testKey3)
 
         let emitter3 = childScope3.makeDiagnosticsEmitter(metadata: metadata3_5)
         emitter3.emit(error: "error 3.5")
 
-        testDiagnostics(collector.diagnostics) { result in
-            let diagnostic3 = result.check(diagnostic: "error 3", severity: .error)
-            XCTAssertEqual(diagnostic3?.metadata?.testKey1, mergedMetadata3.testKey1)
-            XCTAssertEqual(diagnostic3?.metadata?.testKey2, mergedMetadata3.testKey2)
-            XCTAssertEqual(diagnostic3?.metadata?.testKey3, mergedMetadata3.testKey3)
+        try expectDiagnostics(collector.diagnostics) { result in
+            let diagnostic3 = try #require(result.check(diagnostic: "error 3", severity: .error))
+            let diagnostic3_metadata = try #require(diagnostic3.metadata)
+            #expect(diagnostic3_metadata.testKey1 == mergedMetadata3.testKey1)
+            #expect(diagnostic3_metadata.testKey2 == mergedMetadata3.testKey2)
+            #expect(diagnostic3_metadata.testKey3 == mergedMetadata3.testKey3)
 
-            let diagnostic3_5 = result.check(diagnostic: "error 3.5", severity: .error)
-            XCTAssertEqual(diagnostic3_5?.metadata?.testKey1, mergedMetadata3_5.testKey1)
-            XCTAssertEqual(diagnostic3_5?.metadata?.testKey2, mergedMetadata3_5.testKey2)
-            XCTAssertEqual(diagnostic3_5?.metadata?.testKey3, mergedMetadata3_5.testKey3)
+            let diagnostic3_5 = try #require(result.check(diagnostic: "error 3.5", severity: .error))
+            let diagnostic3_5_metadata = try #require(diagnostic3_5.metadata)
+            #expect(diagnostic3_5_metadata.testKey1 == mergedMetadata3_5.testKey1)
+            #expect(diagnostic3_5_metadata.testKey2 == mergedMetadata3_5.testKey2)
+            #expect(diagnostic3_5_metadata.testKey3 == mergedMetadata3_5.testKey3)
         }
     }
 
-    func testBasicDiagnostics() throws {
+    @Test
+    func basicDiagnostics() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)
 
@@ -130,48 +140,58 @@ final class ObservabilitySystemTest: XCTestCase {
         emitter.emit(debug: "debug")
         emitter.emit(.debug("debug 2"))
 
-        testDiagnostics(collector.diagnostics, problemsOnly: false) { result in
+        try expectDiagnostics(collector.diagnostics, problemsOnly: false) { result in
             do {
-                let diagnostic = result.check(diagnostic: "error", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "error", severity: .error))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "error 2", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "error 2", severity: .error))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "error 3", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
-                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? StringError, StringError("error 3"))
+                let diagnostic = try #require(result.check(diagnostic: "error 3", severity: .error))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
+                #expect(diagnostic_metadata.underlyingError as? StringError == StringError("error 3"))
             }
             do {
-                let diagnostic = result.check(diagnostic: "warning", severity: .warning)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "warning", severity: .warning))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "warning 2", severity: .warning)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "warning 2", severity: .warning))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "info", severity: .info)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "info", severity: .info))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "info 2", severity: .info)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "info 2", severity: .info))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "debug", severity: .debug)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "debug", severity: .error))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = result.check(diagnostic: "debug 2", severity: .debug)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                let diagnostic = try #require(result.check(diagnostic: "debug 2", severity: .debug))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
         }
     }
 
-    func testDiagnosticsErrorDescription() throws {
+    @Test
+    func diagnosticsErrorDescription() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)
 
@@ -181,26 +201,29 @@ final class ObservabilitySystemTest: XCTestCase {
         observabilitySystem.topScope.emit(MyDescribedError(description: "error 4"))
         observabilitySystem.topScope.emit(MyLocalizedError(errorDescription: "error 5"))
 
-        testDiagnostics(collector.diagnostics, problemsOnly: false) { result in
+        try expectDiagnostics(collector.diagnostics, problemsOnly: false) { result in
             do {
-                let diagnostic = result.check(diagnostic: "error", severity: .error)
-                XCTAssertNil(diagnostic?.metadata?.underlyingError)
+                let diagnostic = try #require(result.check(diagnostic: "error", severity: .error))
+                #expect(diagnostic.metadata?.underlyingError == nil)
             }
             do {
-                let diagnostic = result.check(diagnostic: "error 2", severity: .error)
-                XCTAssertNil(diagnostic?.metadata?.underlyingError)
+                let diagnostic = try #require(result.check(diagnostic: "error 2", severity: .error))
+                #expect(diagnostic.metadata?.underlyingError == nil)
             }
             do {
-                let diagnostic = result.check(diagnostic: "MyError(description: \"error 3\")", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? MyError, MyError(description: "error 3"))
+                let diagnostic = try #require(result.check(diagnostic: "MyError(description: \"error 3\")", severity: .error))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.underlyingError as? MyError == MyError(description: "error 3"))
             }
             do {
-                let diagnostic = result.check(diagnostic: "error 4", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? MyDescribedError, MyDescribedError(description: "error 4"))
+                let diagnostic = try #require(result.check(diagnostic: "error 4", severity: .error))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.underlyingError as? MyDescribedError == MyDescribedError(description: "error 4"))
             }
             do {
-                let diagnostic = result.check(diagnostic: "error 5", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? MyLocalizedError, MyLocalizedError(errorDescription: "error 5"))
+                let diagnostic = try #require(result.check(diagnostic: "error 5", severity: .error))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.underlyingError as? MyLocalizedError == MyLocalizedError(errorDescription: "error 5"))
             }
         }
 
@@ -218,7 +241,8 @@ final class ObservabilitySystemTest: XCTestCase {
         }
     }
 
-    func testDiagnosticsMetadataMerge() throws {
+    @Test
+    func diagnosticsMetadataMerge() throws {
         let collector = Collector()
         let observabilitySystem = ObservabilitySystem(collector)
 
@@ -234,9 +258,9 @@ final class ObservabilitySystemTest: XCTestCase {
         emitterMetadata.testKey2 = Int.random(in: Int.min..<Int.max)
 
         let emitterMergedMetadata = scopeMetadata.merging(emitterMetadata)
-        XCTAssertEqual(emitterMergedMetadata.testKey1, emitterMetadata.testKey1)
-        XCTAssertEqual(emitterMergedMetadata.testKey2, emitterMetadata.testKey2)
-        XCTAssertEqual(emitterMergedMetadata.testKey3, scopeMetadata.testKey3)
+        #expect(emitterMergedMetadata.testKey1 == emitterMetadata.testKey1)
+        #expect(emitterMergedMetadata.testKey2 == emitterMetadata.testKey2)
+        #expect(emitterMergedMetadata.testKey3 == scopeMetadata.testKey3)
 
         let emitter = scope.makeDiagnosticsEmitter(metadata: emitterMetadata)
         emitter.emit(error: "error")
@@ -245,24 +269,26 @@ final class ObservabilitySystemTest: XCTestCase {
         diagnosticMetadata.testKey1 = UUID().uuidString
 
         let diagnosticMergedMetadata = scopeMetadata.merging(emitterMetadata).merging(diagnosticMetadata)
-        XCTAssertEqual(diagnosticMergedMetadata.testKey1, diagnosticMetadata.testKey1)
-        XCTAssertEqual(diagnosticMergedMetadata.testKey2, emitterMetadata.testKey2)
-        XCTAssertEqual(diagnosticMergedMetadata.testKey3, scopeMetadata.testKey3)
+        #expect(diagnosticMergedMetadata.testKey1 == diagnosticMetadata.testKey1)
+        #expect(diagnosticMergedMetadata.testKey2 == emitterMetadata.testKey2)
+        #expect(diagnosticMergedMetadata.testKey3 == scopeMetadata.testKey3)
 
         emitter.emit(warning: "warning", metadata: diagnosticMetadata)
 
-        testDiagnostics(collector.diagnostics) { result in
+        try expectDiagnostics(collector.diagnostics) { result in
             do {
-                let diagnostic = result.check(diagnostic: "error", severity: .error)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, emitterMergedMetadata.testKey1)
-                XCTAssertEqual(diagnostic?.metadata?.testKey2, emitterMergedMetadata.testKey2)
-                XCTAssertEqual(diagnostic?.metadata?.testKey3, emitterMergedMetadata.testKey3)
+                let diagnostic = try #require(result.check(diagnostic: "error", severity: .error))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.testKey1 == emitterMergedMetadata.testKey1)
+                #expect(diagnostic_metadata.testKey2 == emitterMergedMetadata.testKey2)
+                #expect(diagnostic_metadata.testKey3 == emitterMergedMetadata.testKey3)
             }
             do {
-                let diagnostic = result.check(diagnostic: "warning", severity: .warning)
-                XCTAssertEqual(diagnostic?.metadata?.testKey1, diagnosticMergedMetadata.testKey1)
-                XCTAssertEqual(diagnostic?.metadata?.testKey2, diagnosticMergedMetadata.testKey2)
-                XCTAssertEqual(diagnostic?.metadata?.testKey3, diagnosticMergedMetadata.testKey3)
+                let diagnostic = try #require(result.check(diagnostic: "warning", severity: .warning))
+                let diagnostic_metadata = try #require(diagnostic.metadata)
+                #expect(diagnostic_metadata.testKey1 == diagnosticMergedMetadata.testKey1)
+                #expect(diagnostic_metadata.testKey2 == diagnosticMergedMetadata.testKey2)
+                #expect(diagnostic_metadata.testKey3 == diagnosticMergedMetadata.testKey3)
             }
         }
     }

--- a/Tests/BasicsTests/ProgressAnimationTests.swift
+++ b/Tests/BasicsTests/ProgressAnimationTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -11,14 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 import _Concurrency
-import XCTest
+import Testing
 
 @_spi(SwiftPMInternal)
 @testable
 import Basics
 import TSCBasic
 
-final class ProgressAnimationTests: XCTestCase {
+struct ProgressAnimationTests {
     class TrackingProgressAnimation: ProgressAnimationProtocol {
         var steps: [Int] = []
 
@@ -30,7 +30,8 @@ final class ProgressAnimationTests: XCTestCase {
         func clear() {}
     }
 
-    func testThrottledPercentProgressAnimation() {
+    @Test
+    func throttledPercentProgressAnimation1() {
         do {
             let tracking = TrackingProgressAnimation()
             var now = ContinuousClock().now
@@ -46,7 +47,7 @@ final class ProgressAnimationTests: XCTestCase {
                 now += .milliseconds(50)
             }
             animation.complete(success: true)
-            XCTAssertEqual(tracking.steps, [0, 2, 4, 6, 8, 10])
+            #expect(tracking.steps == [0, 2, 4, 6, 8, 10])
         }
 
         do {
@@ -67,10 +68,10 @@ final class ProgressAnimationTests: XCTestCase {
             }
             // The next update is at 1000ms, but we are at 950ms,
             // so "step 9" is not sent yet.
-            XCTAssertEqual(tracking.steps, [0, 2, 4, 6, 8])
+            #expect(tracking.steps == [0, 2, 4, 6, 8])
             // After explicit "completion", the last step is flushed out.
             animation.complete(success: true)
-            XCTAssertEqual(tracking.steps, [0, 2, 4, 6, 8, 9])
+            #expect(tracking.steps == [0, 2, 4, 6, 8, 9])
         }
     }
 }

--- a/Tests/BasicsTests/StringExtensionsTests.swift
+++ b/Tests/BasicsTests/StringExtensionsTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -11,25 +11,27 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-import XCTest
+import Testing
 
-final class StringExtensionsTests: XCTestCase {
-    func testSHA256Checksum() {
+struct StringExtensionsTests {
+    @Test
+    func sHA256Checksum() {
         let string = "abc"
-        XCTAssertEqual(Array(string.utf8), [0x61, 0x62, 0x63])
+        #expect(Array(string.utf8) == [0x61, 0x62, 0x63])
 
         // See https://csrc.nist.gov/csrc/media/projects/cryptographic-standards-and-guidelines/documents/examples/sha_all.pdf
-        XCTAssertEqual(string.sha256Checksum, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+        #expect(string.sha256Checksum == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
     }
 
-    func testDropPrefix() {
+    @Test
+    func dropPrefix() {
         do {
             let string = "prefixSuffix"
-            XCTAssertEqual(string.spm_dropPrefix("prefix"), "Suffix")
+            #expect(string.spm_dropPrefix("prefix") == "Suffix")
         }
         do {
             let string = "prefixSuffix"
-            XCTAssertEqual(string.spm_dropPrefix("notMyPrefix"), string)
+            #expect(string.spm_dropPrefix("notMyPrefix") == string)
         }
     }
 }


### PR DESCRIPTION
Convert `BasicsTests/Environment/*.swift`, `BasicsTests/Graph/*.swift` and a couple other in BasicsTests to Swift Testing

Depends on: https://github.com/swiftlang/swift/pull/81401

Reverts #8647 