### PR TITLE
Remove Swift-numerics dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -828,7 +828,6 @@ let package = Package(
                 "Basics",
                 "_InternalTestSupport",
                 "tsan_utils",
-                .product(name: "Numerics", package: "swift-numerics"),
             ],
             exclude: [
                 "Archiver/Inputs/archive.tar.gz",
@@ -1082,9 +1081,6 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/swiftlang/swift-toolchain-sqlite.git", from: "1.0.0"),
         // For use in previewing documentation
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
-
-        // Test dependency
-        .package(url: "https://github.com/apple/swift-numerics.git", from: "1.0.3"),
     ]
 } else {
     package.dependencies += [
@@ -1097,7 +1093,6 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-collections"),
         .package(path: "../swift-certificates"),
         .package(path: "../swift-toolchain-sqlite"),
-        .package(path: "../swift-numerics"),
     ]
 }
 


### PR DESCRIPTION
A `swift-numerics` package dependency was added to convert an XCTest `XCTAssertEqual(_:_:accuracy:_:file:line:)` API do use the `isApproximatelyEqual()` API in `swift-numerics`, but converting that test resulted in a flaky behaviour.  As such, the test was not converted to Swift Testing, but the swift-numerics dependency remained.

This change removes the swift-numerics dependency as it's no currently required.
