### PR TITLE
Add command line flag to enable experimental features

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -130,6 +130,11 @@ struct TestEventStreamOptions: ParsableArguments {
     @Option(name: .customLong("attachments-path"),
             help: "Path where attachments should be written (Swift Testing only). This path must be an existing directory the current user can write to. If not specified, any attachments created during testing are discarded.")
     var attachmentsPath: AbsolutePath?
+
+    /// If experimental features should be enabled..
+    @Option(name: .customLong("enable-experimental-features"),
+            help: .private)
+    var enableExperimentalFeatures: Bool
 }
 
 struct TestCommandOptions: ParsableArguments {


### PR DESCRIPTION
Add command line flag to enable experimental features

### Motivation:

In order to support experimental features in Swift Testing we need a cli flag to enable them.

### Modifications:

Added a command line flag called `enable-experimental-features` which can be used to enable all Swift Testing experimental features.

### Result:

Users will be able to specify the `enable-experimental-features` flag when running tests in the CLI to enable experimental Swift Testing features.
