### PR TITLE
clean up misformatting for CLI command options

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddDependency.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddDependency.md
@@ -10,287 +10,287 @@ Add a package dependency to the manifest.
 package add-dependency <dependency> [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--exact=<exact>] [--revision=<revision>] [--branch=<branch>] [--from=<from>] [--up-to-next-minor-from=<up-to-next-minor-from>] [--to=<to>] [--type=<type>] [--version] [--help]
 ```
 
-- term **dependency:**
+- term **dependency**:
 
 *The URL or directory of the package to add.*
 
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--exact=\<exact\>:**
+- term **--exact=\<exact\>**:
 
 *The exact package version to depend on.*
 
 
-- term **--revision=\<revision\>:**
+- term **--revision=\<revision\>**:
 
 *The specific package revision to depend on.*
 
 
-- term **--branch=\<branch\>:**
+- term **--branch=\<branch\>**:
 
 *The branch of the package to depend on.*
 
 
-- term **--from=\<from\>:**
+- term **--from=\<from\>**:
 
 *The package version to depend on (up to the next major version).*
 
 
-- term **--up-to-next-minor-from=\<up-to-next-minor-from\>:**
+- term **--up-to-next-minor-from=\<up-to-next-minor-from\>**:
 
 *The package version to depend on (up to the next minor version).*
 
 
-- term **--to=\<to\>:**
+- term **--to=\<to\>**:
 
 *Specify upper bound on the package version range (exclusive).*
 
 
-- term **--type=\<type\>:**
+- term **--type=\<type\>**:
 
 *Specify dependency type.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddProduct.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddProduct.md
@@ -10,261 +10,261 @@ Add a new product to the manifest.
 package add-product [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] <name> [--type=<type>] [--targets=<targets>...] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **name:**
+- term **name**:
 
 *The name of the new product.*
 
 
-- term **--type=\<type\>:**
+- term **--type=\<type\>**:
 
 *The type of target to add.*
 
 
-- term **--targets=\<targets\>:**
+- term **--targets=\<targets\>**:
 
 *A list of targets that are part of this product.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddSetting.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddSetting.md
@@ -10,256 +10,256 @@ Add a new setting to the manifest.
 package add-setting [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] --target=<target> --swift=<swift>... [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--target=\<target\>:**
+- term **--target=\<target\>**:
 
 *The target to add the setting to.*
 
 
-- term **--swift=\<swift\>:**
+- term **--swift=\<swift\>**:
 
 *The Swift language setting(s) to add. Supported settings: experimentalFeature, upcomingFeature, languageMode, strictMemorySafety.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddTarget.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddTarget.md
@@ -10,281 +10,281 @@ Add a new target to the manifest.
 package add-target [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] <name> [--type=<type>] [--dependencies=<dependencies>...] [--url=<url>] [--path=<path>] [--checksum=<checksum>] [--testing-library=<testing-library>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **name:**
+- term **name**:
 
 *The name of the new target.*
 
 
-- term **--type=\<type\>:**
+- term **--type=\<type\>**:
 
 *The type of target to add.*
 
 
-- term **--dependencies=\<dependencies\>:**
+- term **--dependencies=\<dependencies\>**:
 
 *A list of target dependency names.*
 
 
-- term **--url=\<url\>:**
+- term **--url=\<url\>**:
 
 *The URL for a remote binary target.*
 
 
-- term **--path=\<path\>:**
+- term **--path=\<path\>**:
 
 *The path to a local binary target.*
 
 
-- term **--checksum=\<checksum\>:**
+- term **--checksum=\<checksum\>**:
 
 *The checksum for a remote binary target.*
 
 
-- term **--testing-library=\<testing-library\>:**
+- term **--testing-library=\<testing-library\>**:
 
 *The testing library to use when generating test targets, which can be one of 'xctest', 'swift-testing', or 'none'.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddTargetDependency.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAddTargetDependency.md
@@ -10,261 +10,261 @@ Add a new target dependency to the manifest.
 package add-target-dependency [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] <dependency-name> <target-name> [--package=<package>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **dependency-name:**
+- term **dependency-name**:
 
 *The name of the new dependency.*
 
 
-- term **target-name:**
+- term **target-name**:
 
 *The name of the target to update.*
 
 
-- term **--package=\<package\>:**
+- term **--package=\<package\>**:
 
 *The package in which the dependency resides.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageArchiveSource.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageArchiveSource.md
@@ -10,252 +10,252 @@ Create a source archive for the package.
 package archive-source [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--output=<output>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--output=\<output\>:**
+- term **--output=\<output\>**:
 
 *The absolute or relative path for the generated source archive.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageClean.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageClean.md
@@ -10,247 +10,247 @@ Delete build artifacts.
 package clean [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageCompletionTool.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageCompletionTool.md
@@ -11,252 +11,252 @@ Command to generate shell completions.
 package completion-tool [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] <mode> [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **mode:**
+- term **mode**:
 
 *Type of completions to list.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageComputeChecksum.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageComputeChecksum.md
@@ -10,252 +10,252 @@ Compute the checksum for a binary artifact.
 package compute-checksum [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] <path> [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **path:**
+- term **path**:
 
 *The absolute or relative path to the binary artifact.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageConfigGetMirror.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageConfigGetMirror.md
@@ -10,252 +10,252 @@ Print mirror configuration for the given package dependency.
 package config get-mirror [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath]   [--original=<original>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--original=\<original\>:**
+- term **--original=\<original\>**:
 
 *The original url or identity.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageConfigSetMirror.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageConfigSetMirror.md
@@ -10,256 +10,256 @@ Set a mirror for a dependency.
 package config set-mirror [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath]    [--original=<original>] [--mirror=<mirror>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--original=\<original\>:**
+- term **--original=\<original\>**:
 
 *The original url or identity.*
 
 
-- term **--mirror=\<mirror\>:**
+- term **--mirror=\<mirror\>**:
 
 *The mirror url or identity.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageConfigUnsetMirror.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageConfigUnsetMirror.md
@@ -10,257 +10,257 @@ Remove an existing mirror.
 package config unset-mirror [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath]    [--original=<original>] [--mirror=<mirror>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--original=\<original\>:**
+- term **--original=\<original\>**:
 
 *The original url or identity.*
 
 
-- term **--mirror=\<mirror\>:**
+- term **--mirror=\<mirror\>**:
 
 *The mirror url or identity.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDescribe.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDescribe.md
@@ -10,251 +10,251 @@ Describe the current package.
 package describe [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--type=<type>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--type=\<type\>:**
+- term **--type=\<type\>**:
 
 *Set the output format.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDiagnoseAPIBreakingChange.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDiagnoseAPIBreakingChange.md
@@ -13,292 +13,292 @@ package diagnose-api-breaking-changes [--package-path=<package-path>] [--cache-p
 
 The diagnose-api-breaking-changes command can be used to compare the Swift API of a package to a baseline revision, diagnosing any breaking changes which have been introduced. By default, it compares every Swift module from the baseline revision which is part of a library product. For packages with many targets, this behavior may be undesirable as the comparison can be slow. The `--products` and `--targets` options may be used to restrict the scope of the comparison.
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--breakage-allowlist-path=\<breakage-allowlist-path\>:**
+- term **--breakage-allowlist-path=\<breakage-allowlist-path\>**:
 
 *The path to a text file containing breaking changes which should be ignored by the API comparison. Each ignored breaking change in the file should appear on its own line and contain the exact message to be ignored (e.g. 'API breakage: func foo() has been removed').*
 
 
-- term **treeish:**
+- term **treeish**:
 
 *The baseline treeish to compare to (for example, a commit hash, branch name, tag, and so on).*
 
 
-- term **--products=\<products\>:**
+- term **--products=\<products\>**:
 
 *One or more products to include in the API comparison. If present, only the specified products (and any targets specified using `--targets`) will be compared.*
 
 
-- term **--targets=\<targets\>:**
+- term **--targets=\<targets\>**:
 
 *One or more targets to include in the API comparison. If present, only the specified targets (and any products specified using `--products`) will be compared.*
 
 
-- term **--traits=\<traits\>:**
+- term **--traits=\<traits\>**:
 
 *Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command.*
 
 
-- term **--enable-all-traits:**
+- term **--enable-all-traits**:
 
 *Enables all traits of the package.*
 
 
-- term **--disable-default-traits:**
+- term **--disable-default-traits**:
 
 *Disables all default traits of the package.*
 
 
-- term **--baseline-dir=\<baseline-dir\>:**
+- term **--baseline-dir=\<baseline-dir\>**:
 
 *The path to a directory used to store API baseline files. If unspecified, a temporary directory will be used.*
 
 
-- term **--regenerate-baseline:**
+- term **--regenerate-baseline**:
 
 *Regenerate the API baseline, even if an existing one is available.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDumpPackage.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDumpPackage.md
@@ -10,247 +10,247 @@ Print parsed Package.swift as JSON.
 package dump-package [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDumpSymbolGraph.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDumpSymbolGraph.md
@@ -10,277 +10,277 @@ Dump symbol graphs.
 package dump-symbol-graph [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--pretty-print] [--skip-synthesized-members] [--minimum-access-level=<minimum-access-level>] [--skip-inherited-docs] [--include-spi-symbols] [--emit-extension-block-symbols|omit-extension-block-symbols] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--pretty-print:**
+- term **--pretty-print**:
 
 *Pretty-print the output JSON.*
 
 
-- term **--skip-synthesized-members:**
+- term **--skip-synthesized-members**:
 
 *Skip members inherited through classes or default implementations.*
 
 
-- term **--minimum-access-level=\<minimum-access-level\>:**
+- term **--minimum-access-level=\<minimum-access-level\>**:
 
 *Include symbols with this access level or more. Possible values: private | fileprivate | internal | package | public | open.*
 
 
-- term **--skip-inherited-docs:**
+- term **--skip-inherited-docs**:
 
 *Skip emitting doc comments for members inherited through classes or default implementations.*
 
 
-- term **--include-spi-symbols:**
+- term **--include-spi-symbols**:
 
 *Add symbols with SPI information to the symbol graph.*
 
 
-- term **--emit-extension-block-symbols|omit-extension-block-symbols:**
+- term **--emit-extension-block-symbols|omit-extension-block-symbols**:
 
 *Emit extension block symbols for extensions to external types or directly associate members and conformances with the extended nominal.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageEdit.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageEdit.md
@@ -10,267 +10,267 @@ Put a package in editable mode.
 package edit [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--revision=<revision>] [--branch=<branch>] [--path=<path>] <package-identity> [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--revision=\<revision\>:**
+- term **--revision=\<revision\>**:
 
 *The revision to edit.*
 
 
-- term **--branch=\<branch\>:**
+- term **--branch=\<branch\>**:
 
 *The branch to create.*
 
 
-- term **--path=\<path\>:**
+- term **--path=\<path\>**:
 
 *Create or use the checkout at this path.*
 
 
-- term **package-identity:**
+- term **package-identity**:
 
 *The identity of the package to edit.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageExperimentalInstall.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageExperimentalInstall.md
@@ -10,252 +10,252 @@ Offers the ability to install executable products of the current package.
 package experimental-install [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--product=<product>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--product=\<product\>:**
+- term **--product=\<product\>**:
 
 *The name of the executable product to install.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageExperimentalUninstall.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageExperimentalUninstall.md
@@ -10,251 +10,251 @@ Offers the ability to uninstall executable products previously installed by `swi
 package experimental-uninstall [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] <name> [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **name:**
+- term **name**:
 
 *Name of the executable to uninstall.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageInit.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageInit.md
@@ -10,242 +10,242 @@ Initialize a new package.
 package init [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--type=<type>] [--enable-xctest|disable-xctest] [--enable-swift-testing|disable-swift-testing]  [--name=<name>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--type=\<type\>:**
+- term **--type=\<type\>**:
 
 *Package type:*
 
@@ -260,26 +260,26 @@ macro             - A package that vends a macro.
 empty             - An empty package with a Package.swift manifest.
 
 
-- term **--enable-xctest|disable-xctest:**
+- term **--enable-xctest|disable-xctest**:
 
 *Enable support for XCTest.*
 
 
-- term **--enable-swift-testing|disable-swift-testing:**
+- term **--enable-swift-testing|disable-swift-testing**:
 
 *Enable support for Swift Testing.*
 
 
-- term **--name=\<name\>:**
+- term **--name=\<name\>**:
 
 *Provide custom package name.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageMigrate.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageMigrate.md
@@ -11,256 +11,256 @@ Migrate a package or its individual targets to use the given set of features.
 package migrate [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--targets=<targets>] --to-feature=<to-feature>... [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--targets=\<targets\>:**
+- term **--targets=\<targets\>**:
 
 *The targets to migrate to specified set of features.*
 
 
-- term **--to-feature=\<to-feature\>:**
+- term **--to-feature=\<to-feature\>**:
 
 *The Swift language upcoming/experimental feature to migrate to.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackagePlugin.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackagePlugin.md
@@ -11,280 +11,280 @@ Invoke a command plugin or perform other actions on command plugins.
 package plugin [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--list] [--allow-writing-to-package-directory] [--allow-writing-to-directory=<allow-writing-to-directory>...] [--allow-network-connections=<allow-network-connections>] [--package=<package>] [<command>] [<arguments>...] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--list:**
+- term **--list**:
 
 *List the available command plugins.*
 
 
-- term **--allow-writing-to-package-directory:**
+- term **--allow-writing-to-package-directory**:
 
 *Allow the plugin to write to the package directory.*
 
 
-- term **--allow-writing-to-directory=\<allow-writing-to-directory\>:**
+- term **--allow-writing-to-directory=\<allow-writing-to-directory\>**:
 
 *Allow the plugin to write to an additional directory.*
 
 
-- term **--allow-network-connections=\<allow-network-connections\>:**
+- term **--allow-network-connections=\<allow-network-connections\>**:
 
 
-- term **--package=\<package\>:**
+- term **--package=\<package\>**:
 
 *Limit available plugins to a single package with the given identity.*
 
 
-- term **command:**
+- term **command**:
 
 *Verb of the command plugin to invoke.*
 
 
-- term **arguments:**
+- term **arguments**:
 
 *Arguments to pass to the command plugin.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackagePurgeCache.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackagePurgeCache.md
@@ -10,247 +10,247 @@ Purge the global repository cache.
 package purge-cache [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageReset.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageReset.md
@@ -10,246 +10,246 @@ Reset the complete cache/build directory.
 package reset [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageResolve.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageResolve.md
@@ -10,281 +10,281 @@ Resolve package dependencies.
 package resolve [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] --version=<version> [--branch=<branch>] [--revision=<revision>] [<package-name>] [--traits=<traits>] [--enable-all-traits] [--disable-default-traits] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--version=\<version\>:**
+- term **--version=\<version\>**:
 
 *The version to resolve at.*
 
 
-- term **--branch=\<branch\>:**
+- term **--branch=\<branch\>**:
 
 *The branch to resolve at.*
 
 
-- term **--revision=\<revision\>:**
+- term **--revision=\<revision\>**:
 
 *The revision to resolve at.*
 
 
-- term **package-name:**
+- term **package-name**:
 
 *The name of the package to resolve.*
 
 
-- term **--traits=\<traits\>:**
+- term **--traits=\<traits\>**:
 
 *Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command.*
 
 
-- term **--enable-all-traits:**
+- term **--enable-all-traits**:
 
 *Enables all traits of the package.*
 
 
-- term **--disable-default-traits:**
+- term **--disable-default-traits**:
 
 *Disables all default traits of the package.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageShowDependencies.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageShowDependencies.md
@@ -10,257 +10,257 @@ Print the resolved dependency graph.
 package show-dependencies [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--format=<format>] [--output-path=<output-path>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--format=\<format\>:**
+- term **--format=\<format\>**:
 
 *Set the output format.*
 
 
-- term **--output-path=\<output-path\>:**
+- term **--output-path=\<output-path\>**:
 
 *The absolute or relative path to output the resolved dependency graph.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageShowExecutables.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageShowExecutables.md
@@ -10,252 +10,252 @@ List the available executables from this package.
 package show-executables [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--format=<format>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--format=\<format\>:**
+- term **--format=\<format\>**:
 
 *Set the output format.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageToolsVersion.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageToolsVersion.md
@@ -10,257 +10,257 @@ Manipulate tools version of the current package.
 package tools-version [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--set-current] [--set=<set>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--set-current:**
+- term **--set-current**:
 
 *Set tools version of package to the current tools version in use.*
 
 
-- term **--set=\<set\>:**
+- term **--set=\<set\>**:
 
 *Set tools version of package to the given value.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageUnedit.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageUnedit.md
@@ -10,257 +10,257 @@ Remove a package from editable mode.
 package unedit [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--force] <package-identity> [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--force:**
+- term **--force**:
 
 *Unedit the package even if it has uncommitted and unpushed changes.*
 
 
-- term **package-identity:**
+- term **package-identity**:
 
 *The identity of the package to unedit.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageUpdate.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageUpdate.md
@@ -10,257 +10,257 @@ Update package dependencies.
 package update [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--dry-run] [<packages>...] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--dry-run:**
+- term **--dry-run**:
 
 *Display the list of dependencies that can be updated.*
 
 
-- term **packages:**
+- term **packages**:
 
 *The packages to update.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionAdd.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionAdd.md
@@ -10,267 +10,267 @@ Add a new collection.
 package-collection add <collection-url> [--order=<order>] [--trust-unsigned] [--skip-signature-check] [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--version] [--help]
 ```
 
-- term **collection-url:**
+- term **collection-url**:
 
 *URL of the collection to add.*
 
 
-- term **--order=\<order\>:**
+- term **--order=\<order\>**:
 
 *Sort order for the added collection.*
 
 
-- term **--trust-unsigned:**
+- term **--trust-unsigned**:
 
 *Trust the collection even if it is unsigned.*
 
 
-- term **--skip-signature-check:**
+- term **--skip-signature-check**:
 
 *Skip signature check if the collection is signed.*
 
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionDescribe.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionDescribe.md
@@ -10,267 +10,267 @@ Get metadata for a collection or a package included in an imported collection.
 package-collection describe [--json] <package-url> [--version=<version>] [--skip-signature-check] [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--version] [--help]
 ```
 
-- term **--json:**
+- term **--json**:
 
 *Output as JSON*
 
 
-- term **package-url:**
+- term **package-url**:
 
 *URL of the package or collection to get information for.*
 
 
-- term **--version=\<version\>:**
+- term **--version=\<version\>**:
 
 *Version of the package to get information for.*
 
 
-- term **--skip-signature-check:**
+- term **--skip-signature-check**:
 
 *Skip signature check if the collection is signed.*
 
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionList.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionList.md
@@ -10,252 +10,252 @@ List configured collections.
 package-collection list [--json] [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--version] [--help]
 ```
 
-- term **--json:**
+- term **--json**:
 
 *Output as JSON*
 
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionRefresh.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionRefresh.md
@@ -10,247 +10,247 @@ Refresh configured collections.
 package-collection refresh [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionRemove.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionRemove.md
@@ -10,252 +10,252 @@ Remove a configured collection.
 package-collection remove <collection-url> [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--version] [--help]
 ```
 
-- term **collection-url:**
+- term **collection-url**:
 
 *URL of the collection to remove.*
 
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionSearch.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageCollections/PackageCollectionSearch.md
@@ -10,261 +10,261 @@ Search for packages by keywords or module names.
 package-collection search [--json] --keywords|module <search-query> [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--version] [--help]
 ```
 
-- term **--json:**
+- term **--json**:
 
 *Output as JSON*
 
 
-- term **--keywords|module:**
+- term **--keywords|module**:
 
 *Pick the method for searching.*
 
 
-- term **search-query:**
+- term **search-query**:
 
 *The search query.*
 
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryLogin.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryLogin.md
@@ -10,277 +10,277 @@ Log in to a registry.
 package-registry login [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [<url>] [--username=<username>] [--password=<password>] [--token=<token>] [--token-file=<token-file>] [--no-confirm] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **url:**
+- term **url**:
 
 *The registry URL.*
 
 
-- term **--username=\<username\>:**
+- term **--username=\<username\>**:
 
 *The username for the registry.*
 
 
-- term **--password=\<password\>:**
+- term **--password=\<password\>**:
 
 *The password for the registry.*
 
 
-- term **--token=\<token\>:**
+- term **--token=\<token\>**:
 
 *The access token for the registry.*
 
 
-- term **--token-file=\<token-file\>:**
+- term **--token-file=\<token-file\>**:
 
 *Path to the file containing access token.*
 
 
-- term **--no-confirm:**
+- term **--no-confirm**:
 
 *Allow writing to netrc file without confirmation.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryLogout.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryLogout.md
@@ -10,251 +10,251 @@ Log out from a registry
 package-registry logout [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [<url>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **url:**
+- term **url**:
 
 *The registry URL*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryPublish.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryPublish.md
@@ -10,297 +10,297 @@ Publish to a registry.
 package-registry publish [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] <package-id> <package-version> [--url|registry-url=<url>] [--scratch-directory=<scratch-directory>] [--metadata-path=<metadata-path>]  [--signing-identity=<signing-identity>] [--private-key-path=<private-key-path>] [--cert-chain-paths=<cert-chain-paths>...] [--allow-insecure-http] [--dry-run] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **package-id:**
+- term **package-id**:
 
 *The package identifier.*
 
 
-- term **package-version:**
+- term **package-version**:
 
 *The package release version being created.*
 
 
-- term **--url|registry-url=\<url\>:**
+- term **--url|registry-url=\<url\>**:
 
 *The registry URL.*
 
 
-- term **--scratch-directory=\<scratch-directory\>:**
+- term **--scratch-directory=\<scratch-directory\>**:
 
 *The path of the directory where working file(s) will be written.*
 
 
-- term **--metadata-path=\<metadata-path\>:**
+- term **--metadata-path=\<metadata-path\>**:
 
 *The path to the package metadata JSON file if it is not 'package-metadata.json' in the package directory.*
 
 
-- term **--signing-identity=\<signing-identity\>:**
+- term **--signing-identity=\<signing-identity\>**:
 
 *The label of the signing identity to be retrieved from the system's identity store if supported.*
 
 
-- term **--private-key-path=\<private-key-path\>:**
+- term **--private-key-path=\<private-key-path\>**:
 
 *The path to the certificate's PKCS#8 private key (DER-encoded).*
 
 
-- term **--cert-chain-paths=\<cert-chain-paths\>:**
+- term **--cert-chain-paths=\<cert-chain-paths\>**:
 
 *Path(s) to the signing certificate (DER-encoded) and optionally the rest of the certificate chain. Certificates should be ordered with the leaf first and the root last.*
 
 
-- term **--allow-insecure-http:**
+- term **--allow-insecure-http**:
 
 *Allow using a non-HTTPS registry URL.*
 
 
-- term **--dry-run:**
+- term **--dry-run**:
 
 *Dry run only; prepare the archive and sign it but do not publish to the registry.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistrySet.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistrySet.md
@@ -10,266 +10,266 @@ Set a custom registry.
 package-registry set [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--global] [--scope=<scope>] [--allow-insecure-http] <url> [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--global:**
+- term **--global**:
 
 *Apply settings to all projects for this user.*
 
 
-- term **--scope=\<scope\>:**
+- term **--scope=\<scope\>**:
 
 *Associate the registry with a given scope.*
 
 
-- term **--allow-insecure-http:**
+- term **--allow-insecure-http**:
 
 *Allow using a non-HTTPS registry URL.*
 
 
-- term **url:**
+- term **url**:
 
 *The registry URL.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryUnset.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/PackageRegistry/PackageRegistryUnset.md
@@ -10,257 +10,257 @@ Remove a configured registry.
 package-registry unset [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--global] [--scope=<scope>] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--global:**
+- term **--global**:
 
 *Apply settings to all projects for this user.*
 
 
-- term **--scope=\<scope\>:**
+- term **--scope=\<scope\>**:
 
 *Associate the registry with a given scope.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigurationSet.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigurationSet.md
@@ -10,93 +10,93 @@ Sets configuration options for installed Swift SDKs.
 sdk configuration set [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--sdk-root-path=<sdk-root-path>] [--swift-resources-path=<swift-resources-path>] [--swift-static-resources-path=<swift-static-resources-path>] [--include-search-path=<include-search-path>...] [--library-search-path=<library-search-path>...] [--toolset-path=<toolset-path>...] <sdk-id> <target-triple> [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--sdk-root-path=\<sdk-root-path\>:**
+- term **--sdk-root-path=\<sdk-root-path\>**:
 
 *A path to a directory containing the SDK root.*
 
 
-- term **--swift-resources-path=\<swift-resources-path\>:**
+- term **--swift-resources-path=\<swift-resources-path\>**:
 
 *A path to a directory containing Swift resources for dynamic linking.*
 
 
-- term **--swift-static-resources-path=\<swift-static-resources-path\>:**
+- term **--swift-static-resources-path=\<swift-static-resources-path\>**:
 
 *A path to a directory containing Swift resources for static linking.*
 
 
-- term **--include-search-path=\<include-search-path\>:**
+- term **--include-search-path=\<include-search-path\>**:
 
 *A path to a directory containing headers. Multiple paths can be specified by providing this option multiple times to the command.*
 
 
-- term **--library-search-path=\<library-search-path\>:**
+- term **--library-search-path=\<library-search-path\>**:
 
 *"A path to a directory containing libraries. Multiple paths can be specified by providing this option multiple times to the command.*
 
 
-- term **--toolset-path=\<toolset-path\>:**
+- term **--toolset-path=\<toolset-path\>**:
 
 *"A path to a toolset file. Multiple paths can be specified by providing this option multiple times to the command.*
 
 
-- term **sdk-id:**
+- term **sdk-id**:
 
 *An identifier of an already installed Swift SDK. Use the `list` subcommand to see all available identifiers.*
 
 
-- term **target-triple:**
+- term **target-triple**:
 
 *The target triple of the Swift SDK to configure.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigurationShow.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigurationShow.md
@@ -10,63 +10,63 @@ Prints all configuration properties currently applied to a given Swift SDK and t
 sdk configuration show [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   <sdk-id> <target-triple> [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **sdk-id:**
+- term **sdk-id**:
 
 *An identifier of an already installed Swift SDK. Use the `list` subcommand to see all available identifiers.*
 
 
-- term **target-triple:**
+- term **target-triple**:
 
 *The target triple of the Swift SDK to configure.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigure.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigure.md
@@ -10,103 +10,103 @@ Manages configuration options for installed Swift SDKs.
 sdk configure [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--sdk-root-path=<sdk-root-path>] [--swift-resources-path=<swift-resources-path>] [--swift-static-resources-path=<swift-static-resources-path>] [--include-search-path=<include-search-path>...] [--library-search-path=<library-search-path>...] [--toolset-path=<toolset-path>...] [--reset] [--show-configuration] <sdk-id> <target-triple> [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--sdk-root-path=\<sdk-root-path\>:**
+- term **--sdk-root-path=\<sdk-root-path\>**:
 
 *A path to a directory containing the SDK root.*
 
 
-- term **--swift-resources-path=\<swift-resources-path\>:**
+- term **--swift-resources-path=\<swift-resources-path\>**:
 
 *A path to a directory containing Swift resources for dynamic linking.*
 
 
-- term **--swift-static-resources-path=\<swift-static-resources-path\>:**
+- term **--swift-static-resources-path=\<swift-static-resources-path\>**:
 
 *A path to a directory containing Swift resources for static linking.*
 
 
-- term **--include-search-path=\<include-search-path\>:**
+- term **--include-search-path=\<include-search-path\>**:
 
 *A path to a directory containing headers. Multiple paths can be specified by providing this option multiple times to the command.*
 
 
-- term **--library-search-path=\<library-search-path\>:**
+- term **--library-search-path=\<library-search-path\>**:
 
 *"A path to a directory containing libraries. Multiple paths can be specified by providing this option multiple times to the command.*
 
 
-- term **--toolset-path=\<toolset-path\>:**
+- term **--toolset-path=\<toolset-path\>**:
 
 *"A path to a toolset file. Multiple paths can be specified by providing this option multiple times to the command.*
 
 
-- term **--reset:**
+- term **--reset**:
 
 *Resets configuration properties currently applied to a given Swift SDK and target triple. If no specific property is specified, all of them are reset for the Swift SDK.*
 
 
-- term **--show-configuration:**
+- term **--show-configuration**:
 
 *Prints all configuration properties currently applied to a given Swift SDK and target triple.*
 
 
-- term **sdk-id:**
+- term **sdk-id**:
 
 *An identifier of an already installed Swift SDK. Use the `list` subcommand to see all available identifiers.*
 
 
-- term **target-triple:**
+- term **target-triple**:
 
 *The target triple of the Swift SDK to configure.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKInstall.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKInstall.md
@@ -12,69 +12,69 @@ If the artifact bundle is at a remote location, it's downloaded to local filesys
 sdk install [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   <bundle-path-or-url> [--checksum=<checksum>] [--color-diagnostics|no-color-diagnostics] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **bundle-path-or-url:**
+- term **bundle-path-or-url**:
 
 *A local filesystem path or a URL of a Swift SDK bundle to install.*
 
 
-- term **--checksum=\<checksum\>:**
+- term **--checksum=\<checksum\>**:
 
 *The checksum of the bundle generated with `swift package compute-checksum`.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKList.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKList.md
@@ -10,53 +10,53 @@ Print a list of IDs of available Swift SDKs available on the filesystem.
 sdk list [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKRemove.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKRemove.md
@@ -10,58 +10,58 @@ Removes a previously installed Swift SDK bundle from the filesystem.
 sdk remove [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   <sdk-id-or-bundle-name> [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **sdk-id-or-bundle-name:**
+- term **sdk-id-or-bundle-name**:
 
 *Name of the Swift SDK bundle or ID of the Swift SDK to remove from the filesystem.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftBuild.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftBuild.md
@@ -14,312 +14,312 @@ build [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path
 
 SEE ALSO: swift run, swift package, swift test
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--build-tests:**
+- term **--build-tests**:
 
 *Build both source and test targets.*
 
 
-- term **--enable-code-coverage|disable-code-coverage:**
+- term **--enable-code-coverage|disable-code-coverage**:
 
 *Enable code coverage.*
 
 
-- term **--show-bin-path:**
+- term **--show-bin-path**:
 
 *Print the binary output path.*
 
 
-- term **--print-manifest-job-graph:**
+- term **--print-manifest-job-graph**:
 
 *Write the command graph for the build manifest as a Graphviz file.*
 
 
-- term **--print-pif-manifest-graph:**
+- term **--print-pif-manifest-graph**:
 
 *Write the PIF JSON sent to Swift Build as a Graphviz file.*
 
 
-- term **--target=\<target\>:**
+- term **--target=\<target\>**:
 
 *Build the specified target.*
 
 
-- term **--product=\<product\>:**
+- term **--product=\<product\>**:
 
 *Build the specified product.*
 
 
-- term **--enable-xctest|disable-xctest:**
+- term **--enable-xctest|disable-xctest**:
 
 *Enable support for XCTest.*
 
 
-- term **--enable-swift-testing|disable-swift-testing:**
+- term **--enable-swift-testing|disable-swift-testing**:
 
 *Enable support for Swift Testing.*
 
 
-- term **--traits=\<traits\>:**
+- term **--traits=\<traits\>**:
 
 *Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command.*
 
 
-- term **--enable-all-traits:**
+- term **--enable-all-traits**:
 
 *Enables all traits of the package.*
 
 
-- term **--disable-default-traits:**
+- term **--disable-default-traits**:
 
 *Disables all default traits of the package.*
 
 
-- term **--static-swift-stdlib|no-static-swift-stdlib:**
+- term **--static-swift-stdlib|no-static-swift-stdlib**:
 
 *Link Swift stdlib statically.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -331,9 +331,3 @@ Show subcommand help information.
 ```
 build help [<subcommands>...] 
 ```
-
-- term **subcommands:**
-
-
-
-

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageManager.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageManager.md
@@ -17,8 +17,7 @@ The Swift Package Manager leets you share your code as a package, depend on and 
 - <doc:GettingStarted>      <!-- tutorial or article based walk through -->
 - <doc:IntroducingPackages> <!-- content from Documentation/README -->
 
-<!-- ### Guides -->
-<!-- placeholder location for articles (to be written or copy/updated from existing content -->
+### Guides
 
 <!-- ### Command Plugins -->
 <!-- placeholder for content about swift package manager extensions - command plugins -->
@@ -40,3 +39,5 @@ The Swift Package Manager leets you share your code as a package, depend on and 
 - <doc:SwiftPackageRegistryCommands>
 - <doc:SwiftPackageCollectionCommands>
 - <doc:SwiftRun>
+
+### Design

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftRun.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftRun.md
@@ -14,297 +14,297 @@ run [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<
 
 SEE ALSO: swift build, swift package, swift test
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--repl:**
+- term **--repl**:
 
 *Launch Swift REPL for the package.*
 
 
-- term **--debugger:**
+- term **--debugger**:
 
 *Launch the executable in a debugger session.*
 
 
-- term **--run:**
+- term **--run**:
 
 *Launch the executable with the provided arguments.*
 
 
-- term **--skip-build:**
+- term **--skip-build**:
 
 *Skip building the executable product.*
 
 
-- term **--build-tests:**
+- term **--build-tests**:
 
 *Build both source and test targets.*
 
 
-- term **executable:**
+- term **executable**:
 
 *The executable to run.*
 
 
-- term **--traits=\<traits\>:**
+- term **--traits=\<traits\>**:
 
 *Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command.*
 
 
-- term **--enable-all-traits:**
+- term **--enable-all-traits**:
 
 *Enables all traits of the package.*
 
 
-- term **--disable-default-traits:**
+- term **--disable-default-traits**:
 
 *Disables all default traits of the package.*
 
 
-- term **arguments:**
+- term **arguments**:
 
 *The arguments to pass to the executable.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftTest.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftTest.md
@@ -14,330 +14,330 @@ test [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=
 
 SEE ALSO: swift build, swift run, swift package
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--skip-build:**
+- term **--skip-build**:
 
 *Skip building the test target.*
 
 
-- term **--enable-xctest|disable-xctest:**
+- term **--enable-xctest|disable-xctest**:
 
 *Enable support for XCTest.*
 
 
-- term **--enable-swift-testing|disable-swift-testing:**
+- term **--enable-swift-testing|disable-swift-testing**:
 
 *Enable support for Swift Testing.*
 
 
-- term **--attachments-path=\<attachments-path\>:**
+- term **--attachments-path=\<attachments-path\>**:
 
 *Path where attachments should be written (Swift Testing only). This path must be an existing directory the current user can write to. If not specified, any attachments created during testing are discarded.*
 
 
-- term **--parallel|no-parallel:**
+- term **--parallel|no-parallel**:
 
 *Run the tests in parallel.*
 
 
-- term **--num-workers=\<num-workers\>:**
+- term **--num-workers=\<num-workers\>**:
 
 *Number of tests to execute in parallel.*
 
 
-- term **--list-tests:**
+- term **--list-tests**:
 
 *Lists test methods in specifier format.*
 
 
-- term **--show-codecov-path|show-code-coverage-path|show-coverage-path:**
+- term **--show-codecov-path|show-code-coverage-path|show-coverage-path**:
 
 *Print the path of the exported code coverage JSON file.*
 
 
-- term **--specifier=\<specifier\>:**
+- term **--specifier=\<specifier\>**:
 
 
-- term **--filter=\<filter\>:**
+- term **--filter=\<filter\>**:
 
 *Run test cases that match a regular expression, Format: '<test-target>.<test-case>' or '<test-target>.<test-case>/<test>'.*
 
 
-- term **--skip=\<skip\>:**
+- term **--skip=\<skip\>**:
 
 *Skip test cases that match a regular expression, Example: '--skip PerformanceTests'.*
 
 
-- term **--xunit-output=\<xunit-output\>:**
+- term **--xunit-output=\<xunit-output\>**:
 
 *Path where the xUnit xml file should be generated.*
 
 
-- term **--enable-testable-imports|disable-testable-imports:**
+- term **--enable-testable-imports|disable-testable-imports**:
 
 *Enable or disable testable imports. Enabled by default.*
 
 
-- term **--enable-code-coverage|disable-code-coverage:**
+- term **--enable-code-coverage|disable-code-coverage**:
 
 *Enable code coverage.*
 
 
-- term **--traits=\<traits\>:**
+- term **--traits=\<traits\>**:
 
 *Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command.*
 
 
-- term **--enable-all-traits:**
+- term **--enable-all-traits**:
 
 *Enables all traits of the package.*
 
 
-- term **--disable-default-traits:**
+- term **--disable-default-traits**:
 
 *Disables all default traits of the package.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -350,282 +350,282 @@ Lists test methods in specifier format
 test list [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--skip-build]  [--enable-xctest|disable-xctest] [--enable-swift-testing|disable-swift-testing]         [--attachments-path=<attachments-path>] [--traits=<traits>] [--enable-all-traits] [--disable-default-traits]  [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--skip-build:**
+- term **--skip-build**:
 
 *Skip building the test target.*
 
 
-- term **--enable-xctest|disable-xctest:**
+- term **--enable-xctest|disable-xctest**:
 
 *Enable support for XCTest.*
 
 
-- term **--enable-swift-testing|disable-swift-testing:**
+- term **--enable-swift-testing|disable-swift-testing**:
 
 *Enable support for Swift Testing.*
 
 
-- term **--attachments-path=\<attachments-path\>:**
+- term **--attachments-path=\<attachments-path\>**:
 
 *Path where attachments should be written (Swift Testing only). This path must be an existing directory the current user can write to. If not specified, any attachments created during testing are discarded.*
 
 
-- term **--traits=\<traits\>:**
+- term **--traits=\<traits\>**:
 
 *Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command.*
 
 
-- term **--enable-all-traits:**
+- term **--enable-all-traits**:
 
 *Enables all traits of the package.*
 
 
-- term **--disable-default-traits:**
+- term **--disable-default-traits**:
 
 *Disables all default traits of the package.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
 
@@ -638,263 +638,246 @@ By default, color diagnostics are enabled when connected to a TTY and disabled o
 test last [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--enable-dependency-cache|disable-dependency-cache]  [--enable-build-manifest-caching|disable-build-manifest-caching] [--manifest-cache=<manifest-cache>] [--enable-experimental-prebuilts|disable-experimental-prebuilts] [--verbose] [--very-verbose|vv] [--quiet] [--color-diagnostics|no-color-diagnostics] [--disable-sandbox] [--netrc] [--enable-netrc|disable-netrc] [--netrc-file=<netrc-file>] [--enable-keychain|disable-keychain] [--resolver-fingerprint-checking=<resolver-fingerprint-checking>] [--resolver-signing-entity-checking=<resolver-signing-entity-checking>] [--enable-signature-validation|disable-signature-validation] [--enable-prefetching|disable-prefetching] [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file] [--skip-update] [--disable-scm-to-registry-transformation] [--use-registry-identity-for-scm] [--replace-scm-with-registry]  [--default-registry-url=<default-registry-url>] [--configuration=<configuration>] [--=<Xcc>...] [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]    [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]   [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...] [--auto-index-store|enable-index-store|disable-index-store]   [--enable-parseable-module-interfaces] [--jobs=<jobs>] [--use-integrated-swift-driver] [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>] [--experimental-explicit-module-build] [--build-system=<build-system>] [--=<debug-info-format>]      [--enable-dead-strip|disable-dead-strip] [--disable-local-rpath] [--version] [--help]
 ```
 
-- term **--package-path=\<package-path\>:**
+- term **--package-path=\<package-path\>**:
 
 *Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
 
 
-- term **--cache-path=\<cache-path\>:**
+- term **--cache-path=\<cache-path\>**:
 
 *Specify the shared cache directory path.*
 
 
-- term **--config-path=\<config-path\>:**
+- term **--config-path=\<config-path\>**:
 
 *Specify the shared configuration directory path.*
 
 
-- term **--security-path=\<security-path\>:**
+- term **--security-path=\<security-path\>**:
 
 *Specify the shared security directory path.*
 
 
-- term **--scratch-path=\<scratch-path\>:**
+- term **--scratch-path=\<scratch-path\>**:
 
 *Specify a custom scratch directory path. (default .build)*
 
 
-- term **--swift-sdks-path=\<swift-sdks-path\>:**
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
 
 *Path to the directory containing installed Swift SDKs.*
 
 
-- term **--toolset=\<toolset\>:**
+- term **--toolset=\<toolset\>**:
 
 *Specify a toolset JSON file to use when building for the target platform. Use the option multiple times to specify more than one toolset. Toolsets will be merged in the order they're specified into a single final toolset for the current build.*
 
 
-- term **--pkg-config-path=\<pkg-config-path\>:**
+- term **--pkg-config-path=\<pkg-config-path\>**:
 
 *Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
 specify more than one path.*
 
 
-- term **--enable-dependency-cache|disable-dependency-cache:**
+- term **--enable-dependency-cache|disable-dependency-cache**:
 
 *Use a shared cache when fetching dependencies.*
 
 
-- term **--enable-build-manifest-caching|disable-build-manifest-caching:**
+- term **--enable-build-manifest-caching|disable-build-manifest-caching**:
 
 
-- term **--manifest-cache=\<manifest-cache\>:**
+- term **--manifest-cache=\<manifest-cache\>**:
 
 *Caching mode of Package.swift manifests. Valid values are: (shared: shared cache, local: package's build directory, none: disabled)*
 
 
-- term **--enable-experimental-prebuilts|disable-experimental-prebuilts:**
+- term **--enable-experimental-prebuilts|disable-experimental-prebuilts**:
 
 *Whether to use prebuilt swift-syntax libraries for macros.*
 
 
-- term **--verbose:**
+- term **--verbose**:
 
 *Increase verbosity to include informational output.*
 
 
-- term **--very-verbose|vv:**
+- term **--very-verbose|vv**:
 
 *Increase verbosity to include debug output.*
 
 
-- term **--quiet:**
+- term **--quiet**:
 
 *Decrease verbosity to only include error output.*
 
 
-- term **--color-diagnostics|no-color-diagnostics:**
+- term **--color-diagnostics|no-color-diagnostics**:
 
 *Enables or disables color diagnostics when printing to a TTY. 
 By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
 
 
-- term **--disable-sandbox:**
+- term **--disable-sandbox**:
 
 *Disable using the sandbox when executing subprocesses.*
 
 
-- term **--netrc:**
+- term **--netrc**:
 
 *Use netrc file even in cases where other credential stores are preferred.*
 
 
-- term **--enable-netrc|disable-netrc:**
+- term **--enable-netrc|disable-netrc**:
 
 *Load credentials from a netrc file.*
 
 
-- term **--netrc-file=\<netrc-file\>:**
+- term **--netrc-file=\<netrc-file\>**:
 
 *Specify the netrc file path.*
 
 
-- term **--enable-keychain|disable-keychain:**
+- term **--enable-keychain|disable-keychain**:
 
 *Search credentials in macOS keychain.*
 
 
-- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>:**
+- term **--resolver-fingerprint-checking=\<resolver-fingerprint-checking\>**:
 
 
-- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>:**
+- term **--resolver-signing-entity-checking=\<resolver-signing-entity-checking\>**:
 
 
-- term **--enable-signature-validation|disable-signature-validation:**
+- term **--enable-signature-validation|disable-signature-validation**:
 
 *Validate signature of a signed package release downloaded from registry.*
 
 
-- term **--enable-prefetching|disable-prefetching:**
+- term **--enable-prefetching|disable-prefetching**:
 
 
-- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file:**
+- term **--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file**:
 
 *Only use versions from the Package.resolved file and fail resolution if it is out-of-date.*
 
 
-- term **--skip-update:**
+- term **--skip-update**:
 
 *Skip updating dependencies from their remote during a resolution.*
 
 
-- term **--disable-scm-to-registry-transformation:**
+- term **--disable-scm-to-registry-transformation**:
 
 *Disable source control to registry transformation.*
 
 
-- term **--use-registry-identity-for-scm:**
+- term **--use-registry-identity-for-scm**:
 
 *Look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins.*
 
 
-- term **--replace-scm-with-registry:**
+- term **--replace-scm-with-registry**:
 
 *Look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible.*
 
 
-- term **--default-registry-url=\<default-registry-url\>:**
+- term **--default-registry-url=\<default-registry-url\>**:
 
 *Default registry URL to use, instead of the registries.json configuration file.*
 
 
-- term **--configuration=\<configuration\>:**
+- term **--configuration=\<configuration\>**:
 
 *Build with configuration*
 
 
-- term **--=\<Xcc\>:**
+- term **--=\<Xcc\>**:
 
 *Pass flag through to all C compiler invocations.*
 
 
-- term **--=\<Xswiftc\>:**
+- term **--=\<Xswiftc\>**:
 
 *Pass flag through to all Swift compiler invocations.*
 
 
-- term **--=\<Xlinker\>:**
+- term **--=\<Xlinker\>**:
 
 *Pass flag through to all linker invocations.*
 
 
-- term **--=\<Xcxx\>:**
+- term **--=\<Xcxx\>**:
 
 *Pass flag through to all C++ compiler invocations.*
 
 
-- term **--triple=\<triple\>:**
+- term **--triple=\<triple\>**:
 
 
-- term **--sdk=\<sdk\>:**
+- term **--sdk=\<sdk\>**:
 
 
-- term **--toolchain=\<toolchain\>:**
+- term **--toolchain=\<toolchain\>**:
 
 
-- term **--swift-sdk=\<swift-sdk\>:**
+- term **--swift-sdk=\<swift-sdk\>**:
 
 *Filter for selecting a specific Swift SDK to build with.*
 
 
-- term **--sanitize=\<sanitize\>:**
+- term **--sanitize=\<sanitize\>**:
 
 *Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo.*
 
 
-- term **--auto-index-store|enable-index-store|disable-index-store:**
+- term **--auto-index-store|enable-index-store|disable-index-store**:
 
 *Enable or disable indexing-while-building feature.*
 
 
-- term **--enable-parseable-module-interfaces:**
+- term **--enable-parseable-module-interfaces**:
 
 
-- term **--jobs=\<jobs\>:**
+- term **--jobs=\<jobs\>**:
 
 *The number of jobs to spawn in parallel during the build process.*
 
 
-- term **--use-integrated-swift-driver:**
+- term **--use-integrated-swift-driver**:
 
 
-- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>:**
+- term **--explicit-target-dependency-import-check=\<explicit-target-dependency-import-check\>**:
 
 *A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.*
 
 
-- term **--experimental-explicit-module-build:**
+- term **--experimental-explicit-module-build**:
 
 
-- term **--build-system=\<build-system\>:**
+- term **--build-system=\<build-system\>**:
 
 
-- term **--=\<debug-info-format\>:**
+- term **--=\<debug-info-format\>**:
 
 *The Debug Information Format to use.*
 
 
-- term **--enable-dead-strip|disable-dead-strip:**
+- term **--enable-dead-strip|disable-dead-strip**:
 
 *Disable/enable dead code stripping by the linker.*
 
 
-- term **--disable-local-rpath:**
+- term **--disable-local-rpath**:
 
 *Disable adding $ORIGIN/@loader_path to the rpath by default.*
 
 
-- term **--version:**
+- term **--version**:
 
 *Show the version.*
 
 
-- term **--help:**
+- term **--help**:
 
 *Show help information.*
-
-
-
-
-## test.help
-
-Show subcommand help information.
-
-```
-test help [<subcommands>...] 
-```
-
-- term **subcommands:**
-
-
-
-


### PR DESCRIPTION
While previewing other changes, I realized the content generated by swift argument parser for the DocC style was misformatted for the term lists. (https://github.com/apple/swift-argument-parser/issues/772) I've manually gone through and updated this content while I also work on a fix in swift-argument-parser upstream for future needs.
