### PR TITLE
Fix comment typo in `SwiftCommandState.swift`

### DIFF
--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -923,7 +923,7 @@ public final class SwiftCommandState {
         )
     })
 
-    /// Lazily compute the target toolchain.z
+    /// Lazily compute the target toolchain.
     private lazy var _targetToolchain: Result<UserToolchain, Swift.Error> = {
         let swiftSDK: SwiftSDK
         let hostSwiftSDK: SwiftSDK


### PR DESCRIPTION
`compute the target toolchain.z` -> `compute the target toolchain.`
