### PR TITLE
Use WasmKit by default for Wasm triples in toolsets

### DIFF
--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -925,12 +925,6 @@ public final class SwiftCommandState {
     private lazy var _targetToolchain: Result<UserToolchain, Swift.Error> = {
         let swiftSDK: SwiftSDK
         let hostSwiftSDK: SwiftSDK
-        let store = SwiftSDKBundleStore(
-            swiftSDKsDirectory: self.sharedSwiftSDKsDirectory,
-            fileSystem: self.fileSystem,
-            observabilityScope: self.observabilityScope,
-            outputHandler: { print($0.description) }
-        )
         do {
             let hostToolchain = try _hostToolchain.get()
             hostSwiftSDK = hostToolchain.swiftSDK
@@ -940,6 +934,15 @@ public final class SwiftCommandState {
                     warning: "`--experimental-swift-sdk` is deprecated and will be removed in a future version of SwiftPM. Use `--swift-sdk` instead."
                 )
             }
+
+            let store = SwiftSDKBundleStore(
+                swiftSDKsDirectory: self.sharedSwiftSDKsDirectory,
+                hostToolchainBinDir: hostToolchain.swiftCompilerPath.parentDirectory,
+                fileSystem: self.fileSystem,
+                observabilityScope: self.observabilityScope,
+                outputHandler: { print($0.description) }
+            )
+
             swiftSDK = try SwiftSDK.deriveTargetSwiftSDK(
                 hostSwiftSDK: hostSwiftSDK,
                 hostTriple: hostToolchain.targetTriple,

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -934,9 +934,7 @@ extension SwiftSDK {
                     [:]
                 }
                 let pathStrings = properties.toolsetPaths ?? []
-                let toolset = try pathStrings.reduce(
-                    into: Toolset(knownTools: defaultTools, rootPaths: [hostToolchainBinDir])
-                ) {
+                let toolset = try pathStrings.reduce(into: Toolset(knownTools: defaultTools, rootPaths: [])) {
                     try $0.merge(
                         with: Toolset(
                             from: .init(validating: $1, relativeTo: swiftSDKDirectory),

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -730,6 +730,7 @@ public struct SwiftSDK: Equatable {
         if let customDestination = customCompileDestination {
             let swiftSDKs = try SwiftSDK.decode(
                 fromFile: customDestination,
+                hostToolchainBinDir: store.hostToolchainBinDir,
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope
             )
@@ -853,6 +854,7 @@ extension SwiftSDK {
     /// Load a ``SwiftSDK`` description from a JSON representation from disk.
     public static func decode(
         fromFile path: Basics.AbsolutePath,
+        hostToolchainBinDir: Basics.AbsolutePath,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
     ) throws -> [SwiftSDK] {
@@ -862,6 +864,7 @@ extension SwiftSDK {
             return try Self.decode(
                 semanticVersion: version,
                 fromFile: path,
+                hostToolchainBinDir: hostToolchainBinDir,
                 fileSystem: fileSystem,
                 decoder: decoder,
                 observabilityScope: observabilityScope
@@ -876,6 +879,7 @@ extension SwiftSDK {
     private static func decode(
         semanticVersion: SemanticVersionInfo,
         fromFile path: Basics.AbsolutePath,
+        hostToolchainBinDir: Basics.AbsolutePath,
         fileSystem: FileSystem,
         decoder: JSONDecoder,
         observabilityScope: ObservabilityScope
@@ -915,7 +919,7 @@ extension SwiftSDK {
                 let triple = try Triple(triple)
 
                 let pathStrings = properties.toolsetPaths ?? []
-                let toolset = try pathStrings.reduce(into: Toolset(knownTools: [:], rootPaths: [])) {
+                let toolset = try pathStrings.reduce(into: Toolset(knownTools: [:], rootPaths: [hostToolchainBinDir])) {
                     try $0.merge(
                         with: Toolset(
                             from: .init(validating: $1, relativeTo: swiftSDKDirectory),

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
@@ -63,6 +63,9 @@ public final class SwiftSDKBundleStore {
     /// Directory in which Swift SDKs bundles are stored.
     let swiftSDKsDirectory: AbsolutePath
 
+    /// `usr/bin` directory of the "root" toolchain that includes this currently running SwiftPM instance.
+    let hostToolchainBinDir: AbsolutePath
+
     /// File system instance used for reading from and writing to SDK bundles stored on it.
     let fileSystem: any FileSystem
 
@@ -77,12 +80,14 @@ public final class SwiftSDKBundleStore {
 
     public init(
         swiftSDKsDirectory: AbsolutePath,
+        hostToolchainBinDir: AbsolutePath,
         fileSystem: any FileSystem,
         observabilityScope: ObservabilityScope,
         outputHandler: @escaping (Output) -> Void,
         downloadProgressAnimation: ProgressAnimationProtocol? = nil
     ) {
         self.swiftSDKsDirectory = swiftSDKsDirectory
+        self.hostToolchainBinDir = hostToolchainBinDir
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
         self.outputHandler = outputHandler
@@ -390,7 +395,9 @@ public final class SwiftSDKBundleStore {
 
                 do {
                     let swiftSDKs = try SwiftSDK.decode(
-                        fromFile: variantConfigurationPath, fileSystem: fileSystem,
+                        fromFile: variantConfigurationPath,
+                        hostToolchainBinDir: self.hostToolchainBinDir,
+                        fileSystem: fileSystem,
                         observabilityScope: observabilityScope
                     )
 

--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -34,7 +34,7 @@ public struct Toolset: Equatable {
     /// Properties of a known tool in a ``Toolset``.
     public struct ToolProperties: Equatable {
         /// Absolute path to the tool on the filesystem. If absent, implies a default tool is used.
-        public fileprivate(set) var path: AbsolutePath?
+        public internal(set) var path: AbsolutePath?
 
         /// Command-line options to be passed to the tool when it's invoked.
         public internal(set) var extraCLIOptions: [String]

--- a/Sources/SwiftSDKCommand/Configuration/ConfigurationSubcommand.swift
+++ b/Sources/SwiftSDKCommand/Configuration/ConfigurationSubcommand.swift
@@ -45,6 +45,7 @@ protocol ConfigurationSubcommand: SwiftSDKSubcommand {
 extension ConfigurationSubcommand {
     func run(
         hostTriple: Triple,
+        hostToolchain: UserToolchain,
         _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {
@@ -52,6 +53,7 @@ extension ConfigurationSubcommand {
 
         let bundleStore = SwiftSDKBundleStore(
             swiftSDKsDirectory: swiftSDKsDirectory,
+            hostToolchainBinDir: hostToolchain.swiftCompilerPath.parentDirectory,
             fileSystem: self.fileSystem,
             observabilityScope: observabilityScope,
             outputHandler: { print($0) }

--- a/Sources/SwiftSDKCommand/ConfigureSwiftSDK.swift
+++ b/Sources/SwiftSDKCommand/ConfigureSwiftSDK.swift
@@ -123,6 +123,7 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
         do {
             let bundleStore = SwiftSDKBundleStore(
                 swiftSDKsDirectory: swiftSDKsDirectory,
+                hostToolchainBinDir: hostToolchain.swiftCompilerPath.parentDirectory,
                 fileSystem: self.fileSystem,
                 observabilityScope: observabilityScope,
                 outputHandler: { print($0) }

--- a/Sources/SwiftSDKCommand/InstallSwiftSDK.swift
+++ b/Sources/SwiftSDKCommand/InstallSwiftSDK.swift
@@ -50,6 +50,7 @@ struct InstallSwiftSDK: SwiftSDKSubcommand {
 
     func run(
         hostTriple: Triple,
+        hostToolchain: UserToolchain,
         _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) async throws {
@@ -58,6 +59,7 @@ struct InstallSwiftSDK: SwiftSDKSubcommand {
 
         let store = SwiftSDKBundleStore(
             swiftSDKsDirectory: swiftSDKsDirectory,
+            hostToolchainBinDir: hostToolchain.swiftCompilerPath.parentDirectory,
             fileSystem: self.fileSystem,
             observabilityScope: observabilityScope,
             outputHandler: { print($0.description) },

--- a/Sources/SwiftSDKCommand/ListSwiftSDKs.swift
+++ b/Sources/SwiftSDKCommand/ListSwiftSDKs.swift
@@ -32,11 +32,13 @@ package struct ListSwiftSDKs: SwiftSDKSubcommand {
 
     func run(
         hostTriple: Triple,
+        hostToolchain: UserToolchain,
         _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {
         let store = SwiftSDKBundleStore(
             swiftSDKsDirectory: swiftSDKsDirectory,
+            hostToolchainBinDir: hostToolchain.swiftCompilerPath.parentDirectory,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope,
             outputHandler: { print($0.description) }

--- a/Sources/SwiftSDKCommand/RemoveSwiftSDK.swift
+++ b/Sources/SwiftSDKCommand/RemoveSwiftSDK.swift
@@ -34,6 +34,7 @@ package struct RemoveSwiftSDK: SwiftSDKSubcommand {
 
     func run(
         hostTriple: Triple,
+        hostToolchain: UserToolchain,
         _ swiftSDKsDirectory: Basics.AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) async throws {
@@ -47,6 +48,7 @@ package struct RemoveSwiftSDK: SwiftSDKSubcommand {
         } else {
             let bundleStore = SwiftSDKBundleStore(
                 swiftSDKsDirectory: swiftSDKsDirectory,
+                hostToolchainBinDir: hostToolchain.swiftCompilerPath.parentDirectory,
                 fileSystem: self.fileSystem,
                 observabilityScope: observabilityScope,
                 outputHandler: { print($0) }

--- a/Sources/SwiftSDKCommand/SwiftSDKSubcommand.swift
+++ b/Sources/SwiftSDKCommand/SwiftSDKSubcommand.swift
@@ -30,6 +30,7 @@ protocol SwiftSDKSubcommand: AsyncParsableCommand {
     ///   - observabilityScope: observability scope used for logging.
     func run(
         hostTriple: Triple,
+        hostToolchain: UserToolchain,
         _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) async throws
@@ -71,7 +72,7 @@ extension SwiftSDKSubcommand {
 
         var commandError: Error? = nil
         do {
-            try await self.run(hostTriple: triple, swiftSDKsDirectory, observabilityScope)
+            try await self.run(hostTriple: triple, hostToolchain: hostToolchain, swiftSDKsDirectory, observabilityScope)
             if observabilityScope.errorsReported {
                 throw ExitCode.failure
             }

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -167,6 +167,7 @@ final class SwiftSDKBundleTests: XCTestCase {
                 var output = [SwiftSDKBundleStore.Output]()
                 let store = SwiftSDKBundleStore(
                     swiftSDKsDirectory: tmpDir,
+                    hostToolchainBinDir: tmpDir,
                     fileSystem: localFileSystem,
                     observabilityScope: observabilityScope,
                     outputHandler: {
@@ -208,6 +209,7 @@ final class SwiftSDKBundleTests: XCTestCase {
         var output = [SwiftSDKBundleStore.Output]()
         let store = SwiftSDKBundleStore(
             swiftSDKsDirectory: swiftSDKsDirectory,
+            hostToolchainBinDir: "/tmp",
             fileSystem: fileSystem,
             observabilityScope: system.topScope,
             outputHandler: {
@@ -300,6 +302,7 @@ final class SwiftSDKBundleTests: XCTestCase {
         var output = [SwiftSDKBundleStore.Output]()
         let store = SwiftSDKBundleStore(
             swiftSDKsDirectory: swiftSDKsDirectory,
+            hostToolchainBinDir: "/tmp",
             fileSystem: fileSystem,
             observabilityScope: system.topScope,
             outputHandler: {
@@ -340,6 +343,7 @@ final class SwiftSDKBundleTests: XCTestCase {
         var output = [SwiftSDKBundleStore.Output]()
         let store = SwiftSDKBundleStore(
             swiftSDKsDirectory: swiftSDKsDirectory,
+            hostToolchainBinDir: "/tmp",
             fileSystem: fileSystem,
             observabilityScope: system.topScope,
             outputHandler: {
@@ -381,9 +385,11 @@ final class SwiftSDKBundleTests: XCTestCase {
         let system = ObservabilitySystem.makeForTesting()
         let hostSwiftSDK = try SwiftSDK.hostSwiftSDK(environment: [:])
         let hostTriple = try! Triple("arm64-apple-macosx14.0")
+        let hostToolchainBinDir = AbsolutePath("/tmp")
         let archiver = MockArchiver()
         let store = SwiftSDKBundleStore(
             swiftSDKsDirectory: swiftSDKsDirectory,
+            hostToolchainBinDir: hostToolchainBinDir,
             fileSystem: fileSystem,
             observabilityScope: system.topScope,
             outputHandler: { _ in }
@@ -434,7 +440,7 @@ final class SwiftSDKBundleTests: XCTestCase {
             // With a target SDK selector, SDK should be chosen from the store.
             XCTAssertEqual(targetSwiftSDK.targetTriple, targetTriple)
             // No toolset in the SDK, so it should be the same as the host SDK.
-            XCTAssertEqual(targetSwiftSDK.toolset.rootPaths, hostSwiftSDK.toolset.rootPaths)
+            XCTAssertEqual(targetSwiftSDK.toolset.rootPaths, [hostToolchainBinDir] + hostSwiftSDK.toolset.rootPaths)
         }
 
         do {
@@ -447,7 +453,10 @@ final class SwiftSDKBundleTests: XCTestCase {
                 fileSystem: fileSystem
             )
             // With toolset in the target SDK, it should contain the host toolset roots at the end.
-            XCTAssertEqual(targetSwiftSDK.toolset.rootPaths, [toolsetRootPath] + hostSwiftSDK.toolset.rootPaths)
+            XCTAssertEqual(
+                targetSwiftSDK.toolset.rootPaths,
+                [toolsetRootPath, hostToolchainBinDir] + hostSwiftSDK.toolset.rootPaths
+            )
         }
 
         do {

--- a/Tests/PackageModelTests/ToolsetTests.swift
+++ b/Tests/PackageModelTests/ToolsetTests.swift
@@ -222,6 +222,7 @@ final class ToolsetTests: XCTestCase {
 
         let store = SwiftSDKBundleStore(
             swiftSDKsDirectory: "/",
+            hostToolchainBinDir: usrBinTools[.swiftCompiler]!.parentDirectory,
             fileSystem: fileSystem,
             observabilityScope: observability.topScope,
             outputHandler: { _ in }


### PR DESCRIPTION
As WasmKit is included in recent development snapshots of the swift.org toolchain, we should select it as a default debugger and test runner when a Wasm triple is selected. User toolsets can still override it if needed through toolset merging algorithm described in SE-0387.

rdar://150382758