### PR TITLE
Fix typos in package registry documentation

### DIFF
--- a/Documentation/PackageRegistry/PackageRegistryUsage.md
+++ b/Documentation/PackageRegistry/PackageRegistryUsage.md
@@ -137,7 +137,7 @@ Here is an example of a source control dependency:
 
 ```swift
 dependencies: [
-    .package(id: "https://github.com/mona/LinkedList", .upToNextMajor(from: "1.0.0")),
+    .package(url: "https://github.com/mona/LinkedList", .upToNextMajor(from: "1.0.0")),
 ],
 ```
 

--- a/Documentation/PackageRegistry/Registry.md
+++ b/Documentation/PackageRegistry/Registry.md
@@ -560,7 +560,7 @@ Content-Disposition: attachment; filename="Package.swift"
 Content-Length: 361
 Content-Version: 1
 Link: <http://packages.example.com/mona/LinkedList/1.1.1/Package.swift?swift-version=4>; rel="alternate"; filename="Package@swift-4.swift"; swift-tools-version="4.0",
-      <http://packages.example.com/mona/LinkedList/1.1.1/Package.swift?swift-version=4.2>; rel="alternate"; filename="Package@swift-4.2.swift"; swift-tools-version="4.0"
+      <http://packages.example.com/mona/LinkedList/1.1.1/Package.swift?swift-version=4.2>; rel="alternate"; filename="Package@swift-4.2.swift"; swift-tools-version="4.2"
 
 // swift-tools-version:5.0
 import PackageDescription


### PR DESCRIPTION
### Motivation:

I came across these issues while researching existing package registry implementations.
