### PR TITLE
Include search path for Swift Testing's macro plugin from toolchain if present

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4997,6 +4997,122 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         ])
     }
 
+    func testSwiftTestingFlagsOnMacOSWithoutCustomToolchain() async throws {
+        #if !os(macOS)
+        // This is testing swift-testing in a toolchain which is macOS only feature.
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/fake/path/lib/swift/host/plugins/testing/libTestingMacros.dylib",
+            "/Pkg/Sources/Lib/main.swift",
+            "/Pkg/Tests/LibTest/test.swift"
+        )
+        try fs.createMockToolchain()
+
+        let userSwiftSDK = SwiftSDK(
+            hostTriple: .x86_64MacOS,
+            targetTriple: .x86_64MacOS,
+            toolset: .init(
+                knownTools: [
+                    .cCompiler: .init(extraCLIOptions: []),
+                    .swiftCompiler: .init(extraCLIOptions: []),
+                ],
+                rootPaths: ["/fake/path/to"]
+            ),
+            pathsConfiguration: .init(
+                sdkRootPath: "/fake/sdk",
+                swiftResourcesPath: "/fake/lib/swift",
+                swiftStaticResourcesPath: "/fake/lib/swift_static"
+            )
+        )
+
+        let env = Environment.mockEnvironment
+        let mockToolchain = try UserToolchain(
+            swiftSDK: userSwiftSDK,
+            environment: env,
+            searchStrategy: .custom(
+                searchPaths: getEnvSearchPaths(
+                    pathString: env[.path],
+                    currentWorkingDirectory: fs.currentWorkingDirectory
+                ),
+                useXcrun: true
+            ),
+            fileSystem: fs
+        )
+
+        XCTAssertEqual(
+            mockToolchain.extraFlags.swiftCompilerFlags,
+            [
+                "-plugin-path", "/fake/path/lib/swift/host/plugins/testing",
+                "-sdk", "/fake/sdk",
+            ]
+        )
+        XCTAssertNoMatch(mockToolchain.extraFlags.linkerFlags, ["-rpath"])
+        XCTAssertNoMatch(mockToolchain.extraFlags.swiftCompilerFlags, [
+            "-I", "/fake/path/lib/swift/macosx/testing",
+            "-L", "/fake/path/lib/swift/macosx/testing",
+        ])
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: "/Pkg",
+                    targets: [
+                        TargetDescription(name: "Lib", dependencies: []),
+                        TargetDescription(
+                            name: "LibTest",
+                            dependencies: ["Lib"],
+                            type: .test
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
+            toolchain: mockToolchain,
+            graph: graph,
+            commonFlags: .init(),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(2)
+        result.checkTargetsCount(3)
+
+        let testProductLinkArgs = try result.buildProduct(for: "Lib").linkArguments()
+        XCTAssertNoMatch(testProductLinkArgs, [
+            "-I", "/fake/path/lib/swift/macosx/testing",
+            "-L", "/fake/path/lib/swift/macosx/testing",
+        ])
+
+        let libModuleArgs = try result.moduleBuildDescription(for: "Lib").swift().compileArguments()
+        XCTAssertMatch(libModuleArgs, [
+            "-plugin-path", "/fake/path/lib/swift/host/plugins/testing",
+        ])
+        XCTAssertNoMatch(libModuleArgs, ["-Xlinker"])
+        XCTAssertNoMatch(libModuleArgs, [
+            "-I", "/fake/path/lib/swift/macosx/testing",
+            "-L", "/fake/path/lib/swift/macosx/testing",
+        ])
+
+        let testModuleArgs = try result.moduleBuildDescription(for: "LibTest").swift().compileArguments()
+        XCTAssertMatch(testModuleArgs, [
+            "-plugin-path", "/fake/path/lib/swift/host/plugins/testing",
+        ])
+        XCTAssertNoMatch(testModuleArgs, ["-Xlinker"])
+        XCTAssertNoMatch(testModuleArgs, [
+            "-I", "/fake/path/lib/swift/macosx/testing",
+            "-L", "/fake/path/lib/swift/macosx/testing",
+        ])
+    }
+
     func testSwiftTestingFlagsOnMacOSWithCustomToolchain() async throws {
         #if !os(macOS)
         // This is testing swift-testing in a toolchain which is macOS only feature.
@@ -5006,7 +5122,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/fake/path/lib/swift/macosx/testing/Testing.swiftmodule",
-            "/fake/path/lib/swift/host/plugins/testing/libTesting.dylib",
+            "/fake/path/lib/swift/host/plugins/testing/libTestingMacros.dylib",
             "/Pkg/Sources/Lib/main.swift",
             "/Pkg/Tests/LibTest/test.swift"
         )


### PR DESCRIPTION
This modifies the logic for determining compiler flags for locating Swift Testing content such that it will always include a search path for Swift Testing's macro plugin at its newer, testing-specific location in the toolchain, if that directory exists.

### Motivation:

Swift Testing installs a macro plugin library named `TestingMacros` into the official Swift toolchains for several platforms. By convention, most Swift macro plugins are installed into the toolchain's `usr/lib/swift/host/plugins` directory. However, testing libraries are somewhat special in the sense that they should generally only be available for use in "non-product" targets, i.e. targets which are not intended for distribution and only intended for use in qualifying the main product targets which _will_ be distributed.

For that reason, in Darwin toolchains, Swift Testing's plugin is installed into a different location than for other platforms: `usr/lib/swift/host/plugins/testing` (note the final `testing/` directory) — see the [CMake rules](https://github.com/swiftlang/swift-testing/blob/72afbb418542654781a6b7853479c7e70a862b6f/Sources/TestingMacros/CMakeLists.txt#L67-L75) where that is controlled. Over time, we'd like to move the macro plugin on other platforms to that location for consistency, because the current _inconsistent_ install path has caused friction for users if they attempt to form search paths to the plugin on their own — see https://github.com/swiftlang/swift-testing/issues/1039. So this PR paves the way for Swift Testing to begin to relocate its plugin by ensuring that _if_ this distinct plugin directory exists in a toolchain, it will be preferred.

### Modifications:

- Modify logic in `UserToolchain.swift` to begin passing `-plugin-path` whenever the relevant, testing-specific plugin path exists in a toolchain.
- Add a new test which validates this, by simulating the scenario of _not_ having a custom toolchain and validating the expected flags are passed. (This most closely matches the current scenario today of using the toolchain included in Xcode, and in that toolchain the plugin is already installed into the `testing/`-suffixed path.)

rdar://151319768