### PR TITLE
Tests: re-enabled swift-testing in bootstrap

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -467,8 +467,6 @@ def test(args):
     cmd = [
         os.path.join(args.bin_dir, "swift-test")
     ]
-    # Disabling in release/6.2 due to crash
-    cmd.append("--disable-swift-testing")
     if args.parallel:
         cmd.append("--parallel")
     for arg in args.filter:


### PR DESCRIPTION
Swift Testing was disabled to due to https://github.com/swiftlang/swift/issues/81144. However, a workaround was applied to the SwiftPM linux smoke test preset to enabled swift-testing by not building Swift Standard library with assertions.  See https://github.com/swiftlang/swift/pull/81513