### PR TITLE
[Commands] Migrate: Group manifest update errors per target

### DIFF
--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -138,13 +138,11 @@ extension SwiftPackageCommand {
             print("> Updating manifest.")
             for module in modules.map(\.module) {
                 print("> Adding feature(s) to '\(module.name)'.")
-                for feature in features {
-                    self.updateManifest(
-                        for: module.name,
-                        add: feature,
-                        using: swiftCommandState
-                    )
-                }
+                self.updateManifest(
+                    for: module.name,
+                    add: features,
+                    using: swiftCommandState
+                )
             }
         }
 
@@ -179,27 +177,29 @@ extension SwiftPackageCommand {
 
         private func updateManifest(
             for target: String,
-            add feature: SwiftCompilerFeature,
+            add features: [SwiftCompilerFeature],
             using swiftCommandState: SwiftCommandState
         ) {
             typealias SwiftSetting = SwiftPackageCommand.AddSetting.SwiftSetting
 
-            let setting: (SwiftSetting, String) = switch feature {
-            case .upcoming(name: let name, migratable: _, enabledIn: _):
-                (.upcomingFeature, "\(name)")
-            case .experimental(name: let name, migratable: _):
-                (.experimentalFeature, "\(name)")
+            let settings: [(SwiftSetting, String)] = features.map {
+                switch $0 {
+                case .upcoming(name: let name, migratable: _, enabledIn: _):
+                    (.upcomingFeature, "\(name)")
+                case .experimental(name: let name, migratable: _):
+                    (.experimentalFeature, "\(name)")
+                }
             }
 
             do {
                 try SwiftPackageCommand.AddSetting.editSwiftSettings(
                     of: target,
                     using: swiftCommandState,
-                    [setting]
+                    settings
                 )
             } catch {
                 print(
-                    "! Couldn't update manifest due to - \(error); Please add '.enable\(feature.upcoming ? "Upcoming" : "Experimental")Feature(\"\(feature.name)\")' to target '\(target)' settings manually."
+                    "error: Couldn't update manifest for '\(target)' (\(error)). Please enable '\(features.map(\.name).joined(separator: ", "))' features manually."
                 )
             }
         }

--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -137,7 +137,7 @@ extension SwiftPackageCommand {
 
             print("> Updating manifest.")
             for module in modules.map(\.module) {
-                print("> Adding feature(s) to '\(module.name)'.")
+                swiftCommandState.observabilityScope.emit(debug: "Adding feature(s) to '\(module.name)'.")
                 self.updateManifest(
                     for: module.name,
                     add: features,
@@ -198,9 +198,7 @@ extension SwiftPackageCommand {
                     settings
                 )
             } catch {
-                print(
-                    "error: Couldn't update manifest for '\(target)' (\(error)). Please enable '\(features.map(\.name).joined(separator: ", "))' features manually."
-                )
+                swiftCommandState.observabilityScope.emit(error: "Could not update manifest for '\(target)' (\(error)). Please enable '\(features.map(\.name).joined(separator: ", "))' features manually.")
             }
         }
 


### PR DESCRIPTION
### Motivation:

If migrate fails to insert one or more features into the manifest for a target, let's produce a single error that lists all of the features, this makes the logging less noisy.

### Modifications:

- Update `SwiftPackageCommand` to request manifest to all of the features related to a target and produce a single error if that fails.

### Result:

If manifest has some non-standard ways of defining targets or settings that cannot be updated by `AddSettting`, migration logging is going to be more organized and less noisy.
