### PR TITLE
Widen swift-crypto version range

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1065,7 +1065,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // dependency version changes here with those projects.
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.4.0")),
         .package(url: "https://github.com/swiftlang/swift-driver.git", branch: relatedDependenciesBranch),
-        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "3.0.0")),
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0" ..< "3.13.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: relatedDependenciesBranch),
         .package(url: "https://github.com/apple/swift-system.git", from: "1.1.1"),
         .package(url: "https://github.com/apple/swift-collections.git", "1.0.1" ..< "1.2.0"),


### PR DESCRIPTION
`.upToNextMinor(from: "3.0.0")` on swift-crypto prevents updating of dependent packages that need swift-crypto >= 3.1.0.

### Motivation:

We need to depend on SwiftPM ([for reasons laid out here](https://github.com/swiftlang/swift-package-manager/issues/8622)) and the narrow version range on swift-crypto (which is at version 3.12.3) prevents us from updating to a newer version of PostgresNIO, which requires swift-crypto >= 3.9.0.

```
error: Dependencies could not be resolved because root depends on 'swift-crypto' 3.9.0..<4.0.0 and 'swift-package-manager' depends on 'swift-crypto' 3.0.0..<3.1.0.
```

### Modifications:

This opens the range to 3.0.0 ..< 3.13.0, although perhaps simply `upToNextMajor` would also be acceptable? It would certainly prevent future instances of this happening.

### Result:

Dependents are able to update to the latest swift-crypto.