### PR TITLE
swift-package-migrate: Report a fix-it application summary

### DIFF
--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -94,7 +94,7 @@ extension SwiftPackageCommand {
             // Next, let's build all of the individual targets or the
             // whole project to get diagnostic files.
 
-            print("> Starting the build.")
+            print("> Starting the build")
             if let targets = self.options.targets {
                 for target in targets {
                     try await buildSystem.build(subset: .target(target))
@@ -123,7 +123,7 @@ extension SwiftPackageCommand {
             // If the build suceeded, let's extract all of the diagnostic
             // files from build plan and feed them to the fix-it tool.
 
-            print("> Applying fix-its.")
+            print("> Applying fix-its")
 
             var summary = SwiftFixIt.Summary(numberOfFixItsApplied: 0, numberOfFilesChanged: 0)
             let fixItDuration = try ContinuousClock().measure {
@@ -155,7 +155,7 @@ extension SwiftPackageCommand {
                         fractionalPart: .init(lengthLimits: 0 ... 3, roundingRule: .up)
                     )
                 )
-                message += ")."
+                message += ")"
 
                 print(message)
             }
@@ -163,9 +163,9 @@ extension SwiftPackageCommand {
             // Once the fix-its were applied, it's time to update the
             // manifest with newly adopted feature settings.
 
-            print("> Updating manifest.")
+            print("> Updating manifest")
             for module in modules.map(\.module) {
-                swiftCommandState.observabilityScope.emit(debug: "Adding feature(s) to '\(module.name)'.")
+                swiftCommandState.observabilityScope.emit(debug: "Adding feature(s) to '\(module.name)'")
                 try self.updateManifest(
                     for: module.name,
                     add: features,
@@ -235,7 +235,15 @@ extension SwiftPackageCommand {
                     verbose: !self.globalOptions.logging.quiet
                 )
             } catch {
-                swiftCommandState.observabilityScope.emit(error: "Could not update manifest for '\(target)' (\(error)). Please enable '\(try features.map { try $0.swiftSettingDescription }.joined(separator: ", "))' features manually.")
+                try swiftCommandState.observabilityScope.emit(
+                    error: """
+                    Could not update manifest for '\(target)' (\(error)). \
+                    Please enable '\(
+                        features.map { try $0.swiftSettingDescription }
+                            .joined(separator: ", ")
+                    )' features manually
+                    """
+                )
             }
         }
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2112,7 +2112,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             "skipping because test environment compiler doesn't support `-print-supported-features`"
         )
 
-        func doMigration(featureName: String) async throws {
+      func doMigration(featureName: String, expectedSummary: String) async throws {
             try await fixture(name: "SwiftMigrate/\(featureName)Migration") { fixturePath in
                 let sourcePaths: [AbsolutePath]
                 let fixedSourcePaths: [AbsolutePath]
@@ -2133,7 +2133,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                     }
                 }
 
-                _ = try await self.execute(
+                let (stdout, _) = try await self.execute(
                     ["migrate", "--to-feature", featureName],
                     packagePath: fixturePath
                 )
@@ -2146,12 +2146,14 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                         localFileSystem.readFileContents(fixedSourcePath)
                     )
                 }
+
+                XCTAssertMatch(stdout, .regex("> \(expectedSummary)" + #" \([0-9]\.[0-9]{1,3}s\)"#))
             }
         }
 
-        try await doMigration(featureName: "ExistentialAny")
-        try await doMigration(featureName: "StrictMemorySafety")
-        try await doMigration(featureName: "InferIsolatedConformances")
+        try await doMigration(featureName: "ExistentialAny", expectedSummary: "Applied 3 fix-its in 1 file")
+        try await doMigration(featureName: "StrictMemorySafety", expectedSummary: "Applied 1 fix-it in 1 file")
+        try await doMigration(featureName: "InferIsolatedConformances", expectedSummary: "Applied 1 fix-it in 1 file")
     }
 
     func testBuildToolPlugin() async throws {

--- a/Tests/SwiftFixItTests/BasicTests.swift
+++ b/Tests/SwiftFixItTests/BasicTests.swift
@@ -272,8 +272,8 @@ struct BasicTests {
         try testAPI2Files { (filename1: String, filename2: String) in
             .init(
                 edits: (
-                    .init(input: "var x = 1", result: "let x = 1"),
-                    .init(input: "var x = 1", result: "let x = 1")
+                    .init(input: "var x = 1", result: "let _ = 1"),
+                    .init(input: "var x = 1", result: "let _ = 1")
                 ),
                 diagnostics: [
                     // filename1
@@ -292,12 +292,12 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename1, line: 1, column: 1, offset: 0),
+                        location: .init(filename: filename1, line: 1, column: 5, offset: 0),
                         fixIts: [
                             .init(
-                                start: .init(filename: filename1, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename1, line: 1, column: 4, offset: 0),
-                                text: "let"
+                                start: .init(filename: filename1, line: 1, column: 5, offset: 0),
+                                end: .init(filename: filename1, line: 1, column: 6, offset: 0),
+                                text: "_"
                             ),
                         ]
                     ),
@@ -305,12 +305,12 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .warning,
                         text: "warning2",
-                        location: .init(filename: filename2, line: 1, column: 1, offset: 0),
+                        location: .init(filename: filename2, line: 1, column: 5, offset: 0),
                         fixIts: [
                             .init(
-                                start: .init(filename: filename2, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename2, line: 1, column: 4, offset: 0),
-                                text: "let"
+                                start: .init(filename: filename2, line: 1, column: 5, offset: 0),
+                                end: .init(filename: filename2, line: 1, column: 6, offset: 0),
+                                text: "_"
                             ),
                         ]
                     ),

--- a/Tests/SwiftFixItTests/BasicTests.swift
+++ b/Tests/SwiftFixItTests/BasicTests.swift
@@ -19,6 +19,7 @@ struct BasicTests {
         try testAPI1File { _ in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 1"),
+                summary: .init(numberOfFixItsApplied: 0, numberOfFilesChanged: 0),
                 diagnostics: []
             )
         }
@@ -29,6 +30,7 @@ struct BasicTests {
         try testAPI1File { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "let x = 1"),
+                summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -52,6 +54,7 @@ struct BasicTests {
         try testAPI1File { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "let x = 1"),
+                summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -81,6 +84,7 @@ struct BasicTests {
         try testAPI1File { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "let x = 22"),
+                summary: .init(numberOfFixItsApplied: 2, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -142,6 +146,7 @@ struct BasicTests {
                     w = fooo(1, 233)
                     """
                 ),
+                summary: .init(numberOfFixItsApplied: 2, numberOfFilesChanged: 1),
                 diagnostics: [
                     // Different lines.
                     PrimaryDiagnostic(
@@ -205,6 +210,7 @@ struct BasicTests {
         try testAPI1File { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "_ = 1"),
+                summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -235,6 +241,11 @@ struct BasicTests {
         try testAPI1File { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "_ = 1"),
+                summary: .init(
+                    // 2 because skipped by SwiftIDEUtils.FixItApplier, not SwiftFixIt.
+                    numberOfFixItsApplied: 2 /**/,
+                    numberOfFilesChanged: 1
+                ),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -275,6 +286,7 @@ struct BasicTests {
                     .init(input: "var x = 1", result: "let _ = 1"),
                     .init(input: "var x = 1", result: "let _ = 1")
                 ),
+                summary: .init(numberOfFixItsApplied: 4, numberOfFilesChanged: 2),
                 diagnostics: [
                     // filename1
                     PrimaryDiagnostic(
@@ -339,6 +351,7 @@ struct BasicTests {
                     .init(input: "var x = 1", result: "let x = 1"),
                     .init(input: "var x = 1", result: "var x = 1")
                 ),
+                summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -372,6 +385,7 @@ struct BasicTests {
                         .init(input: "var x = 1", result: "let x = 1"),
                         .init(input: "", result: "")
                     ),
+                    summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
                     diagnostics: [
                         PrimaryDiagnostic(
                             level: .error,

--- a/Tests/SwiftFixItTests/CategoryTests.swift
+++ b/Tests/SwiftFixItTests/CategoryTests.swift
@@ -18,6 +18,7 @@ struct CategoryTests {
         try testAPI1File(categories: ["Other", "Test"]) { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "let _ = 1"),
+                summary: .init(numberOfFixItsApplied: 2, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -57,6 +58,7 @@ struct CategoryTests {
         try testAPI1File(categories: ["Other", "Test"]) { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "let _ = 22"),
+                summary: .init(numberOfFixItsApplied: 3, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -137,6 +139,7 @@ struct CategoryTests {
         try testAPI1File(categories: ["Test"]) { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 22"),
+                summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -175,6 +178,7 @@ struct CategoryTests {
         try testAPI1File(categories: ["Test"]) { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 22"),
+                summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -247,6 +251,7 @@ struct CategoryTests {
         try testAPI1File(categories: ["Test"]) { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 22"),
+                summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -286,6 +291,7 @@ struct CategoryTests {
         try testAPI1File(categories: ["Test"]) { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 22"),
+                summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,

--- a/Tests/SwiftFixItTests/FilteringTests.swift
+++ b/Tests/SwiftFixItTests/FilteringTests.swift
@@ -18,6 +18,7 @@ struct FilteringTests {
         try testAPI1File { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 22"),
+                summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .ignored,
@@ -78,6 +79,7 @@ struct FilteringTests {
         try testAPI1File { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 22"),
+                summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -161,6 +163,7 @@ struct FilteringTests {
         try testAPI1File { filename in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 1"),
+                summary: .init(numberOfFixItsApplied: 0, numberOfFilesChanged: 0),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -239,6 +242,7 @@ struct FilteringTests {
         try testAPI1File { filename in
             .init(
                 edits: .init(input: "var x = (1, 1)", result: "let x = (22, 13)"),
+                summary: .init(numberOfFixItsApplied: 3, numberOfFilesChanged: 1),
                 diagnostics: [
                     PrimaryDiagnostic(
                         level: .error,
@@ -285,7 +289,7 @@ struct FilteringTests {
                                 text: "error1_note1",
                                 location: .init(filename: filename, line: 1, column: 5, offset: 0),
                                 fixIts: [
-                                    // Skipped, duplicate.
+                                    // Skipped, duplicate primary diagnostic.
                                     .init(
                                         start: .init(filename: filename, line: 1, column: 5, offset: 0),
                                         end: .init(filename: filename, line: 1, column: 6, offset: 0),
@@ -300,7 +304,7 @@ struct FilteringTests {
                         text: "warning1",
                         location: .init(filename: filename, line: 1, column: 10, offset: 0),
                         fixIts: [
-                            // Skipped, duplicate.
+                            // Skipped, duplicate primary diagnostic.
                             .init(
                                 start: .init(filename: filename, line: 1, column: 7, offset: 0),
                                 end: .init(filename: filename, line: 1, column: 8, offset: 0),
@@ -331,6 +335,11 @@ struct FilteringTests {
         try testAPI1File { (filename: String) in
             .init(
                 edits: .init(input: "var x = 1", result: "let x = 22"),
+                summary: .init(
+                    // 4 because skipped by SwiftIDEUtils.FixItApplier, not SwiftFixIt.
+                    numberOfFixItsApplied: 4,
+                    numberOfFilesChanged: 1
+                ),
                 diagnostics: [
                     // On primary diagnostics.
                     PrimaryDiagnostic(
@@ -351,7 +360,7 @@ struct FilteringTests {
                         text: "error2",
                         location: .init(filename: filename, line: 1, column: 4, offset: 0),
                         fixIts: [
-                            // Applied.
+                            // Skipped.
                             .init(
                                 start: .init(filename: filename, line: 1, column: 1, offset: 0),
                                 end: .init(filename: filename, line: 1, column: 4, offset: 0),
@@ -388,7 +397,7 @@ struct FilteringTests {
                                 text: "error4_note1",
                                 location: .init(filename: filename, line: 1, column: 9, offset: 0),
                                 fixIts: [
-                                    // Applied.
+                                    // Skipped.
                                     .init(
                                         start: .init(filename: filename, line: 1, column: 9, offset: 0),
                                         end: .init(filename: filename, line: 1, column: 10, offset: 0),


### PR DESCRIPTION
* E.g. `> Applied 3 fix-its in 1 file (0.001s)`.
* Don’t output messages with a period for consistency with other commands.
* Minor optimization for fix-it application. 
  
  `SwiftIDEUtils.FixItApplier.applyFixes` performs some O(n^2) filtering based on `SwiftDiagnostics.FixItMessage` messages, which we don't need. Use the overload that directly takes an array of source edits instead.


Sits on top of https://github.com/swiftlang/swift-package-manager/pull/8683.