### PR TITLE
Tests: Convert StaticBinaryLibrary Test to Swift Testing

### DIFF
--- a/Sources/_InternalTestSupport/SwiftPMProduct.swift
+++ b/Sources/_InternalTestSupport/SwiftPMProduct.swift
@@ -57,15 +57,11 @@ extension SwiftPM {
     }
 
     public static func xctestBinaryPath(for executableName: RelativePath) -> AbsolutePath {
-        #if canImport(Darwin)
-        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-            return try! AbsolutePath(AbsolutePath(validating: bundle.bundlePath).parentDirectory, executableName)
+        do {
+            return try resolveBinDir().appending(executableName)
+        } catch {
+            fatalError("Unable to determine xctestBinaryPath")
         }
-        fatalError()
-        #else
-        return try! AbsolutePath(validating: CommandLine.arguments.first!, relativeTo: localFileSystem.currentWorkingDirectory!)
-            .parentDirectory.appending(executableName)
-        #endif
     }
 }
 

--- a/Sources/_InternalTestSupport/Toolchain.swift
+++ b/Sources/_InternalTestSupport/Toolchain.swift
@@ -21,15 +21,29 @@ import struct TSCBasic.StringError
 import struct TSCUtility.SerializedDiagnostics
 
 #if os(macOS)
-private func macOSBundleRoot() throws -> AbsolutePath {
+func nextItem<T: Equatable>(in array: [T], after item: T) -> T? {
+    for (index, element) in array.enumerated() {
+        if element == item {
+            let nextIndex = index + 1
+            return nextIndex < array.count ? array[nextIndex] : nil
+        }
+    }
+    return nil // Item not found or it's the last item
+}
+
+package func macOSBundleRoot() throws -> AbsolutePath {
     for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
         return try AbsolutePath(validating: bundle.bundlePath).parentDirectory
     }
-    fatalError()
+    if let testBundlePath = nextItem(in: ProcessInfo.processInfo.arguments, after: "--test-bundle-path") {
+        let binDir = AbsolutePath(testBundlePath).parentDirectory.parentDirectory.parentDirectory.parentDirectory
+        return binDir
+    }
+    fatalError("Unable to find macOS bundle root")
 }
 #endif
 
-private func resolveBinDir() throws -> AbsolutePath {
+package func resolveBinDir() throws -> AbsolutePath {
 #if os(macOS)
     return try macOSBundleRoot()
 #else

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -75,7 +75,7 @@ struct ObservabilitySystemTest {
             #expect(diagnostic2_metadata.testKey3 == mergedMetadata2.testKey3)
 
             let diagnostic2_5 = try #require(result.check(diagnostic: "error 2.5", severity: .error))
-            let diagnostic2_5_metadata = try #require(diagnostic2.metadata)
+            let diagnostic2_5_metadata = try #require(diagnostic2_5.metadata)
             #expect(diagnostic2_5_metadata.testKey1 == mergedMetadata2.testKey1)
             #expect(diagnostic2_5_metadata.testKey2 == mergedMetadata2.testKey2)
             #expect(diagnostic2_5_metadata.testKey3 == mergedMetadata2.testKey3)

--- a/Tests/FunctionalTests/StaticBinaryLibrary.swift
+++ b/Tests/FunctionalTests/StaticBinaryLibrary.swift
@@ -9,27 +9,34 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 import DriverSupport
 import PackageModel
 import TSCBasic
-import XCTest
+import Testing
 import _InternalTestSupport
 
-final class StaticBinaryLibraryTests: XCTestCase {
-    func testStaticLibrary() async throws {
-        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8657")
+struct StaticBinaryLibraryTests {
+    @Test(
+        .bug("https://github.com/swiftlang/swift-package-manager/issues/8657")
+    )
+    func staticLibrary() async throws {
 
-        try await fixture(name: "BinaryLibraries") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftRun(
-                fixturePath.appending("Static").appending("Package1"),
-                "Example",
-                extraArgs: ["--experimental-prune-unused-dependencies"]
-            )
-            XCTAssertEqual(stdout,  """
-            42
-            42
+        try await withKnownIssue {
+            try await fixture(name: "BinaryLibraries") { fixturePath in
+                let (stdout, stderr) = try await executeSwiftRun(
+                    fixturePath.appending("Static").appending("Package1"),
+                    "Example",
+                    extraArgs: ["--experimental-prune-unused-dependencies"]
+                )
+                #expect(stdout == """
+                42
+                42
 
-            """)
+                """)
+            }
+        } when: {
+            ProcessInfo.hostOperatingSystem == .windows
         }
     }
 }


### PR DESCRIPTION
When SwiftPM exeuctes tests using the native build system, the bundle path was failing on MacOS as the `Bundle.allBundles` did not contain the `.xctest` bundle.

If we fail to find the .xctest bundle, we inspect the command line argument for the `--test-bundle-path` argument and contruct the macOS bundle root based on the argument value.

In addition, convert the StaticBinaryLibraryTests to Swift Testing to validate the logic works.
