### PR TITLE
Add FreeBSD platform again to SwiftBuild PIF builder

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -968,6 +968,7 @@ extension ProjectModel.BuildSettings.Platform {
         case .windows: .windows
         case .wasi: .wasi
         case .openbsd: .openbsd
+        case .freebsd: .freebsd
         default: preconditionFailure("Unexpected platform: \(platform.name)")
         }
     }


### PR DESCRIPTION
### Motivation:

Fix a silly typo I did in #8539 (i.e., `Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift`), where I removed the`freebsd` platform by mistake 🫠

### Modifications:

Add back `freebsd`to the `SwiftBuild.ProjectModel.BuildSettings.Platform` value we sent over to Swift Build.

Tracked by **rdar://151042619**.