### PR TITLE
Make SwiftSDKMetadataV4.sdkRootPath optional

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -350,7 +350,9 @@ public struct SwiftSDK: Equatable {
         fileprivate init(_ properties: SwiftSDKMetadataV4.TripleProperties, swiftSDKDirectory: Basics.AbsolutePath? = nil) throws {
             if let swiftSDKDirectory {
                 self.init(
-                    sdkRootPath: try AbsolutePath(validating: properties.sdkRootPath, relativeTo: swiftSDKDirectory),
+                    sdkRootPath: try properties.sdkRootPath.map {
+                        try AbsolutePath(validating: $0, relativeTo: swiftSDKDirectory)
+                    },
                     swiftResourcesPath: try properties.swiftResourcesPath.map {
                         try AbsolutePath(validating: $0, relativeTo: swiftSDKDirectory)
                     },
@@ -369,7 +371,9 @@ public struct SwiftSDK: Equatable {
                 )
             } else {
                 self.init(
-                    sdkRootPath: try AbsolutePath(validating: properties.sdkRootPath),
+                    sdkRootPath: try properties.sdkRootPath.map {
+                        try AbsolutePath(validating: $0)
+                    },
                     swiftResourcesPath: try properties.swiftResourcesPath.map {
                         try AbsolutePath(validating: $0)
                     },
@@ -1167,7 +1171,7 @@ struct SerializedDestinationV3: Decodable {
 struct SwiftSDKMetadataV4: Decodable {
     struct TripleProperties: Codable {
         /// Path relative to `swift-sdk.json` containing SDK root.
-        var sdkRootPath: String
+        var sdkRootPath: String?
 
         /// Path relative to `swift-sdk.json` containing Swift resources for dynamic linking.
         var swiftResourcesPath: String?


### PR DESCRIPTION
Makes the "sdkRootPath" property of `swift-sdk.json` optional.

### Motivation:

The Android SDK bundle (https://github.com/swiftlang/swift/issues/80788) does not include the Android NDK's sysroot in the bundle itself, but instead relies on it being installed locally. The install location will vary, and the user will be able to configure it with a command (modulo https://github.com/swiftlang/swift-package-manager/issues/8584) like:

```
swift sdk configure --sdk-root-path ~/Library/Android/sdk/ndk/27.0.12077973/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/ swift-6.2-RELEASE-android-0.1 aarch64-unknown-linux-android28
```

However, since the `SwiftSDKMetadataV4.sdkRootPath` property is declared as non-optional, *some* value must be included in the `swift-sdk.json` file.

@MaxDesiatov at https://github.com/swiftlang/swift/issues/80788#issuecomment-2841270696 mentions:

> As for making it optional, I don't quite remember the exact issue that caused it to become non-optional. After all, making it optional is technically not a breaking change, so potentially could be considered if necessary.


### Modifications:

Change `SwiftSDKMetadataV4.sdkRootPath` from `String` to `String?`

### Result:

The swift-sdk.json can now contain destinations that do not specify a `sdkRootPath` property.