### PR TITLE
Detect embedded swift in flags

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -35,6 +35,12 @@ extension BuildPlan {
         // Compute the product's dependency.
         let dependencies = try computeDependencies(of: buildProduct)
 
+        var isEmbeddedSwift = false
+        for module in dependencies.staticTargets {
+            guard case .swift(let module) = module else { continue }
+            isEmbeddedSwift = isEmbeddedSwift || module.isEmbeddedSwift
+        }
+
         // Add flags for system targets.
         for systemModule in dependencies.systemModules {
             guard case let target as SystemLibraryModule = systemModule.underlying else {
@@ -58,7 +64,7 @@ extension BuildPlan {
         // Don't link libc++ or libstd++ when building for Embedded Swift.
         // Users can still link it manually for embedded platforms when needed,
         // by providing `-Xlinker -lc++` options via CLI or `Package.swift`.
-        if !buildProduct.product.modules.contains(where: \.underlying.isEmbeddedSwiftTarget) {
+        if !isEmbeddedSwift {
             // Link C++ if needed.
             // Note: This will come from build settings in future.
             for description in dependencies.staticTargets {

--- a/Sources/PackageModel/Module/Module.swift
+++ b/Sources/PackageModel/Module/Module.swift
@@ -274,15 +274,6 @@ public class Module {
         self.pluginUsages = pluginUsages
         self.usesUnsafeFlags = usesUnsafeFlags
     }
-
-    @_spi(SwiftPMInternal)
-    public var isEmbeddedSwiftTarget: Bool {
-        for case .enableExperimentalFeature("Embedded") in self.buildSettingsDescription.swiftSettings.map(\.kind) {
-            return true
-        }
-
-        return false
-    }
 }
 
 extension Module: Hashable {


### PR DESCRIPTION
SwiftPM currently only detects Embedded Swift set via a swift settings and uses this to enable/disable a couple features. This is nice, but doesn't handle the case where Embedded is enabled via a user flag, typically set in a toolset.json. This commit updates the logic to also search for "-enable-experimental-feature Embedded" in the various place user flags can be placed.
