### PR TITLE
Generate the compatibility header for libraries on all platforms

### DIFF
--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -801,7 +801,7 @@ public final class SwiftModuleBuildDescription {
 
     /// Returns true if ObjC compatibility header should be emitted.
     private var shouldEmitObjCCompatibilityHeader: Bool {
-        self.buildParameters.triple.isDarwin() && self.target.type == .library
+        self.target.type == .library
     }
 
     func writeOutputFileMap(to path: AbsolutePath) throws {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -5475,7 +5475,6 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         let buildPath = result.plan.productsBuildPath
 
         let fooTarget = try result.moduleBuildDescription(for: "Foo").swift().compileArguments()
-        #if os(macOS)
         XCTAssertMatch(
             fooTarget,
             [
@@ -5485,30 +5484,12 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 .anySequence,
             ]
         )
-        #else
-        XCTAssertNoMatch(
-            fooTarget,
-            [
-                .anySequence,
-                "-emit-objc-header",
-                "-emit-objc-header-path", "/path/to/build/\(result.plan.destinationBuildParameters.triple)/Foo.build/Foo-Swift.h",
-                .anySequence,
-            ]
-        )
-        #endif
 
         let barTarget = try result.moduleBuildDescription(for: "Bar").clang().basicArguments(isCXX: false)
-        #if os(macOS)
         XCTAssertMatch(
             barTarget,
             [.anySequence, "-fmodule-map-file=/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/Foo.build/module.modulemap", .anySequence]
         )
-        #else
-        XCTAssertNoMatch(
-            barTarget,
-            [.anySequence, "-fmodule-map-file=/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/Foo.build/module.modulemap", .anySequence]
-        )
-        #endif
 
         let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
         try fs.createDirectory(yaml.parentDirectory, recursive: true)
@@ -5574,7 +5555,6 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         let buildPath = result.plan.productsBuildPath
 
         let fooTarget = try result.moduleBuildDescription(for: "Foo").swift().compileArguments()
-        #if os(macOS)
         XCTAssertMatch(
             fooTarget,
             [
@@ -5585,21 +5565,8 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 .anySequence,
             ]
         )
-        #else
-        XCTAssertNoMatch(
-            fooTarget,
-            [
-                .anySequence,
-                "-emit-objc-header",
-                "-emit-objc-header-path",
-                "/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/Foo.build/Foo-Swift.h",
-                .anySequence,
-            ]
-        )
-        #endif
 
         let barTarget = try result.moduleBuildDescription(for: "Bar").clang().basicArguments(isCXX: false)
-        #if os(macOS)
         XCTAssertMatch(
             barTarget,
             [
@@ -5608,16 +5575,6 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 .anySequence,
             ]
         )
-        #else
-        XCTAssertNoMatch(
-            barTarget,
-            [
-                .anySequence,
-                "-fmodule-map-file=/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/Foo.build/module.modulemap",
-                .anySequence,
-            ]
-        )
-        #endif
 
         let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
         try fs.createDirectory(yaml.parentDirectory, recursive: true)
@@ -5687,7 +5644,6 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         let result = try BuildPlanResult(plan: plan)
 
         let fooTarget = try result.moduleBuildDescription(for: "Foo").swift().compileArguments()
-        #if os(macOS)
         XCTAssertMatch(
             fooTarget,
             [
@@ -5698,21 +5654,8 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 .anySequence,
             ]
         )
-        #else
-        XCTAssertNoMatch(
-            fooTarget,
-            [
-                .anySequence,
-                "-emit-objc-header",
-                "-emit-objc-header-path",
-                "/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/Foo.build/Foo-Swift.h",
-                .anySequence,
-            ]
-        )
-        #endif
 
         let barTarget = try result.moduleBuildDescription(for: "Bar").clang().basicArguments(isCXX: false)
-        #if os(macOS)
         XCTAssertMatch(
             barTarget,
             [
@@ -5721,16 +5664,6 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 .anySequence,
             ]
         )
-        #else
-        XCTAssertNoMatch(
-            barTarget,
-            [
-                .anySequence,
-                "-fmodule-map-file=/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/Foo.build/module.modulemap",
-                .anySequence,
-            ]
-        )
-        #endif
 
         let buildPath = result.plan.productsBuildPath
 

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -732,7 +732,6 @@ final class ModuleAliasingBuildTests: XCTestCase {
         let fooLoggingArgs = try result.moduleBuildDescription(for: "FooLogging").swift().compileArguments()
         let barLoggingArgs = try result.moduleBuildDescription(for: "BarLogging").swift().compileArguments()
         let loggingArgs = try result.moduleBuildDescription(for: "Logging").swift().compileArguments()
-        #if os(macOS)
         XCTAssertMatch(
             fooLoggingArgs,
             [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
@@ -748,23 +747,6 @@ final class ModuleAliasingBuildTests: XCTestCase {
             [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
              "/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/Logging.build/Logging-Swift.h", .anySequence]
         )
-        #else
-        XCTAssertNoMatch(
-            fooLoggingArgs,
-            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
-             "/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/FooLogging.build/FooLogging-Swift.h", .anySequence]
-        )
-        XCTAssertNoMatch(
-            barLoggingArgs,
-            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
-             "/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/BarLogging.build/BarLogging-Swift.h", .anySequence]
-        )
-        XCTAssertNoMatch(
-            loggingArgs,
-            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
-             "/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/Logging.build/Logging-Swift.h", .anySequence]
-        )
-        #endif
     }
 
     func testModuleAliasingDuplicateTargetNameInUpstream() async throws {
@@ -852,7 +834,6 @@ final class ModuleAliasingBuildTests: XCTestCase {
         let otherLoggingArgs = try result.moduleBuildDescription(for: "OtherLogging").swift().compileArguments()
         let loggingArgs = try result.moduleBuildDescription(for: "Logging").swift().compileArguments()
 
-        #if os(macOS)
         XCTAssertMatch(
             otherLoggingArgs,
             [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
@@ -863,18 +844,6 @@ final class ModuleAliasingBuildTests: XCTestCase {
             [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
              "/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/Logging.build/Logging-Swift.h", .anySequence]
         )
-        #else
-        XCTAssertNoMatch(
-            otherLoggingArgs,
-            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
-             "/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/OtherLogging.build/OtherLogging-Swift.h", .anySequence]
-        )
-        XCTAssertNoMatch(
-            loggingArgs,
-            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
-             "/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/Logging.build/Logging-Swift.h", .anySequence]
-        )
-        #endif
     }
 
     func testModuleAliasingMultipleAliasesInProduct() async throws {


### PR DESCRIPTION
Enable generating the compatibility header for library targets on all platforms by lifting the restriction on Darwin.

As part of the work to formalize `@cdecl` we've been adding content to the compatibility header that is usable by C compilers without the need for Objective-C or modules. Lifting this restriction will allow Linux and Windows users to generate and import the compatibility header to call `@cdecl` functions in their package.