### PR TITLE
Pass the correct toolchain path to SwiftBuild

### DIFF
--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -88,6 +88,15 @@ extension Toolchain {
         }
     }
 
+    public var toolchainDir: AbsolutePath {
+        get throws {
+            try resolveSymlinks(swiftCompilerPath)
+                .parentDirectory // bin
+                .parentDirectory // usr
+                .parentDirectory // <toolchain>
+        }
+    }
+
     public var toolchainLibDir: AbsolutePath {
         get throws {
             // FIXME: Not sure if it's better to base this off of Swift compiler or our own binary.


### PR DESCRIPTION
SwiftBuild can be initialized with either an Xcode-based developer directory for a Swift toolchain based developer directory, pass the right flags to initialize properly based on what kind of toolchain is in use.