### PR TITLE
[Commands] Migrate: Avoid injecting feature settings into every Swift…

### DIFF
--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -87,6 +87,7 @@ extension SwiftPackageCommand {
 
             let buildSystem = try await createBuildSystem(
                 swiftCommandState,
+                targets: self.options.targets,
                 features: features
             )
 
@@ -150,21 +151,35 @@ extension SwiftPackageCommand {
 
         private func createBuildSystem(
             _ swiftCommandState: SwiftCommandState,
+            targets: Set<String>? = .none,
             features: [SwiftCompilerFeature]
         ) async throws -> BuildSystem {
             let toolsBuildParameters = try swiftCommandState.toolsBuildParameters
-            var destinationBuildParameters = try swiftCommandState.productsBuildParameters
+            let destinationBuildParameters = try swiftCommandState.productsBuildParameters
 
-            // Inject feature settings as flags. This is safe and not as invasive
-            // as trying to update manifest because in adoption mode the features
-            // can only produce warnings.
-            for feature in features {
-                destinationBuildParameters.flags.swiftCompilerFlags.append(contentsOf: [
-                    "-Xfrontend",
-                    "-enable-\(feature.upcoming ? "upcoming" : "experimental")-feature",
-                    "-Xfrontend",
-                    "\(feature.name):migrate",
-                ])
+            let modulesGraph = try await swiftCommandState.loadPackageGraph()
+
+            let addFeaturesToModule = { (module: ResolvedModule) in
+                for feature in features {
+                    module.underlying.buildSettings.add(.init(values: [
+                        "-Xfrontend",
+                        "-enable-\(feature.upcoming ? "upcoming" : "experimental")-feature",
+                        "-Xfrontend",
+                        "\(feature.name):migrate",
+                    ]), for: .OTHER_SWIFT_FLAGS)
+                }
+            }
+
+            if let targets {
+                targets.lazy.compactMap {
+                    modulesGraph.module(for: $0)
+                }.forEach(addFeaturesToModule)
+            } else {
+                for package in modulesGraph.rootPackages {
+                    package.modules.filter {
+                        $0.type != .plugin
+                    }.forEach(addFeaturesToModule)
+                }
             }
 
             return try await swiftCommandState.createBuildSystem(
@@ -173,7 +188,11 @@ extension SwiftPackageCommand {
                 toolsBuildParameters: toolsBuildParameters,
                 // command result output goes on stdout
                 // ie "swift build" should output to stdout
-                outputStream: TSCBasic.stdoutStream
+                packageGraphLoader: {
+                    modulesGraph
+                },
+                outputStream: TSCBasic.stdoutStream,
+                observabilityScope: swiftCommandState.observabilityScope
             )
         }
 

--- a/Sources/PackageModel/Module/Module.swift
+++ b/Sources/PackageModel/Module/Module.swift
@@ -231,7 +231,7 @@ public class Module {
     public let others: [AbsolutePath]
 
     /// The build settings assignments of this module.
-    public let buildSettings: BuildSettings.AssignmentTable
+    public package(set) var buildSettings: BuildSettings.AssignmentTable
 
     @_spi(SwiftPMInternal)
     public let buildSettingsDescription: [TargetBuildSettingDescription.Setting]


### PR DESCRIPTION
… module

### Motivation:

Previously the feature flags in `:migrate` mode were injected globally into "destination" parameter and affected every module in the graph, this is technically harmless but creates a lot of noise and precludes some of the future optimizations i.e. avoid injecting `@concurrent` into some closure literals when context is already `@concurrent`.

Instead of using build parameters, let's make the `Module.buildSettings` mutable in SwiftPM package and inject feature settings directly into `buildSettings` of the user-requested or all root package modules instead.

### Modifications:

- Make `Module.buildSettings` to be a `package(set) var` instead of a `let` to allow for mutation my migration command.
- Update `Migrate` command to inject the requested upcoming/experimental features in `:migrate` mode only into request targets or all non-plugin modules of root packages.

### Result:

No more global build flags and extraneous warnings from dependency modules that shouldn't have migration enabled.