### PR TITLE
Dynamically determine the swift compiler version.

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -198,7 +198,7 @@ public struct CachingOptions: ParsableArguments {
     @Flag(name: .customLong("experimental-prebuilts"),
           inversion: .prefixedEnableDisable,
           help: "Whether to use prebuilt swift-syntax libraries for macros.")
-    public var usePrebuilts: Bool = false
+    public var usePrebuilts: Bool = true
 
     /// Hidden option to override the prebuilts download location for testing
     @Option(

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -47,6 +47,7 @@ import Bionic
 import class Basics.AsyncProcess
 import func TSCBasic.exec
 import class TSCBasic.FileLock
+import enum TSCBasic.JSON
 import protocol TSCBasic.OutputByteStream
 import enum TSCBasic.ProcessEnv
 import enum TSCBasic.ProcessLockError
@@ -287,6 +288,8 @@ public final class SwiftCommandState {
 
     private let hostTriple: Basics.Triple?
 
+    private let targetInfo: JSON?
+
     package var preferredBuildConfiguration = BuildConfiguration.debug
 
     /// Create an instance of this tool.
@@ -323,10 +326,12 @@ public final class SwiftCommandState {
         workspaceLoaderProvider: @escaping WorkspaceLoaderProvider,
         createPackagePath: Bool,
         hostTriple: Basics.Triple? = nil,
+        targetInfo: JSON? = nil,
         fileSystem: any FileSystem = localFileSystem,
         environment: Environment = .current
     ) throws {
         self.hostTriple = hostTriple
+        self.targetInfo = targetInfo
         self.fileSystem = fileSystem
         self.environment = environment
         // first, bootstrap the observability system
@@ -968,7 +973,11 @@ public final class SwiftCommandState {
         }
 
         return Result(catching: {
-            try UserToolchain(swiftSDK: swiftSDK, environment: self.environment, fileSystem: self.fileSystem)
+            try UserToolchain(
+                swiftSDK: swiftSDK,
+                environment: self.environment,
+                customTargetInfo: targetInfo,
+                fileSystem: self.fileSystem)
         })
     }()
 
@@ -983,6 +992,7 @@ public final class SwiftCommandState {
         return try UserToolchain(
             swiftSDK: hostSwiftSDK,
             environment: self.environment,
+            customTargetInfo: targetInfo,
             fileSystem: self.fileSystem
         )
     })

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -13,6 +13,7 @@
 import Basics
 import Foundation
 import TSCUtility
+import enum TSCBasic.JSON
 
 import class Basics.AsyncProcess
 
@@ -73,6 +74,9 @@ public final class UserToolchain: Toolchain {
     public var triple: Basics.Triple { targetTriple }
 
     public let targetTriple: Basics.Triple
+
+    // A version string that can be used to identify the swift compiler version
+    public let swiftCompilerVersion: String?
 
     /// The list of CPU architectures to build for.
     public let architectures: [String]?
@@ -158,6 +162,75 @@ public final class UserToolchain: Toolchain {
         }
 
         return try getTool(name, binDirectories: envSearchPaths, fileSystem: fileSystem)
+    }
+
+    private static func getTargetInfo(swiftCompiler: AbsolutePath) throws -> JSON {
+        // Call the compiler to get the target info JSON.
+        let compilerOutput: String
+        do {
+            let result = try AsyncProcess.popen(args: swiftCompiler.pathString, "-print-target-info")
+            compilerOutput = try result.utf8Output().spm_chomp()
+        } catch {
+            throw InternalError(
+                "Failed to load target info (\(error.interpolationDescription))"
+            )
+        }
+        // Parse the compiler's JSON output.
+        do {
+            return try JSON(string: compilerOutput)
+        } catch {
+            throw InternalError(
+                "Failed to parse target info (\(error.interpolationDescription)).\nRaw compiler output: \(compilerOutput)"
+            )
+        }
+    }
+
+    private static func getHostTriple(targetInfo: JSON) throws -> Basics.Triple {
+        // Get the triple string from the target info.
+        let tripleString: String
+        do {
+            tripleString = try targetInfo.get("target").get("triple")
+        } catch {
+            throw InternalError(
+                "Target info does not contain a triple string (\(error.interpolationDescription)).\nTarget info: \(targetInfo)"
+            )
+        }
+
+        // Parse the triple string.
+        do {
+            return try Triple(tripleString)
+        } catch {
+            throw InternalError(
+                "Failed to parse triple string (\(error.interpolationDescription)).\nTriple string: \(tripleString)"
+            )
+        }
+    }
+
+    private static func computeSwiftCompilerVersion(targetInfo: JSON) -> String? {
+        // Get the compiler version from the target info
+        let compilerVersion: String
+        do {
+            compilerVersion = try targetInfo.get("compilerVersion")
+        } catch {
+            return nil
+        }
+
+        // Extract the swift version using regex from the description if available
+        do {
+            let regex = try Regex(#"\((swift(lang)?-[^ )]*)"#)
+            if let match = try regex.firstMatch(in: compilerVersion), match.count > 1, let substring = match[1].substring {
+                return String(substring)
+            }
+
+            let regex2 = try Regex(#"\(.*Swift (.*)[ )]"#)
+            if let match2 = try regex2.firstMatch(in: compilerVersion), match2.count > 1, let substring = match2[1].substring {
+                return "swift-\(substring)"
+            } else {
+                return nil
+            }
+        } catch {
+            return nil
+        }
     }
 
     // MARK: - public API
@@ -570,6 +643,7 @@ public final class UserToolchain: Toolchain {
         swiftSDK: SwiftSDK,
         environment: Environment = .current,
         searchStrategy: SearchStrategy = .default,
+        customTargetInfo: JSON? = nil,
         customLibrariesLocation: ToolchainConfiguration.SwiftPMLibrariesLocation? = nil,
         customInstalledSwiftPMConfiguration: InstalledSwiftPMConfiguration? = nil,
         fileSystem: any FileSystem = localFileSystem
@@ -612,8 +686,14 @@ public final class UserToolchain: Toolchain {
                 default: InstalledSwiftPMConfiguration.default)
         }
 
-        // Use the triple from Swift SDK or compute the host triple using swiftc.
-        var triple = try swiftSDK.targetTriple ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)
+        // targetInfo from the compiler
+        let targetInfo = try customTargetInfo ?? Self.getTargetInfo(swiftCompiler: swiftCompilers.compile)
+
+        // Get compiler version information from target info
+        self.swiftCompilerVersion = Self.computeSwiftCompilerVersion(targetInfo: targetInfo)
+
+        // Use the triple from Swift SDK or compute the host triple from the target info
+        var triple = try swiftSDK.targetTriple ?? Self.getHostTriple(targetInfo: targetInfo)
 
         // Change the triple to the specified arch if there's exactly one of them.
         // The Triple property is only looked at by the native build system currently.

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -568,7 +568,10 @@ public class Workspace {
         // register the binary artifacts downloader with the cancellation handler
         cancellator?.register(name: "binary artifacts downloads", handler: binaryArtifactsManager)
 
-        if configuration.usePrebuilts, let hostPlatform = customPrebuiltsManager?.hostPlatform ?? PrebuiltsManifest.Platform.hostPlatform {
+        if configuration.usePrebuilts,
+           let hostPlatform = customPrebuiltsManager?.hostPlatform ?? PrebuiltsManifest.Platform.hostPlatform,
+           let swiftCompilerVersion = hostToolchain.swiftCompilerVersion
+        {
             let rootCertPath: AbsolutePath?
             if let path = configuration.prebuiltsRootCertPath {
                 rootCertPath = try AbsolutePath(validating: path)
@@ -579,6 +582,7 @@ public class Workspace {
             let prebuiltsManager = PrebuiltsManager(
                 fileSystem: fileSystem,
                 hostPlatform: hostPlatform,
+                swiftCompilerVersion: customPrebuiltsManager?.swiftVersion ?? swiftCompilerVersion,
                 authorizationProvider: authorizationProvider,
                 scratchPath: location.prebuiltsDirectory,
                 cachePath: customPrebuiltsManager?.useCache == false || !configuration.sharedDependenciesCacheEnabled ? .none : location.sharedPrebuiltsCacheDirectory,

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -21,8 +21,15 @@ import Workspace
 import XCTest
 
 import struct TSCUtility.Version
+import enum TSCBasic.JSON
 
 extension UserToolchain {
+    package static var mockTargetInfo: JSON {
+        JSON.dictionary([
+            "compilerVersion": .string("Apple Swift version 6.2-dev (LLVM 815013bbc318474, Swift 1459ecafa998782)")
+        ])
+    }
+
     package static func mockHostToolchain(
         _ fileSystem: InMemoryFileSystem,
         hostTriple: Triple = hostTriple
@@ -42,6 +49,7 @@ extension UserToolchain {
                 ),
                 useXcrun: true
             ),
+            customTargetInfo: Self.mockTargetInfo,
             fileSystem: fileSystem
         )
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4914,6 +4914,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 ),
                 useXcrun: true
             ),
+            customTargetInfo: UserToolchain.mockTargetInfo,
             fileSystem: fs
         )
         let commonFlags = BuildFlags(
@@ -5040,6 +5041,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 ),
                 useXcrun: true
             ),
+            customTargetInfo: UserToolchain.mockTargetInfo,
             fileSystem: fs
         )
 
@@ -5078,6 +5080,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = try await BuildPlanResult(plan: mockBuildPlan(
+            triple: mockToolchain.targetTriple,
             toolchain: mockToolchain,
             graph: graph,
             commonFlags: .init(),
@@ -5157,6 +5160,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 ),
                 useXcrun: true
             ),
+            customTargetInfo: UserToolchain.mockTargetInfo,
             fileSystem: fs
         )
 
@@ -5193,6 +5197,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = try await BuildPlanResult(plan: mockBuildPlan(
+            triple: mockToolchain.targetTriple,
             toolchain: mockToolchain,
             graph: graph,
             commonFlags: .init(),
@@ -5279,7 +5284,12 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 swiftStaticResourcesPath: "/usr/lib/swift_static/none"
             )
         )
-        let toolchain = try UserToolchain(swiftSDK: swiftSDK, environment: .mockEnvironment, fileSystem: fileSystem)
+        let toolchain = try UserToolchain(
+            swiftSDK: swiftSDK,
+            environment: .mockEnvironment,
+            customTargetInfo: UserToolchain.mockTargetInfo,
+            fileSystem: fileSystem
+        )
         let result = try await BuildPlanResult(plan: mockBuildPlan(
             triple: targetTriple,
             toolchain: toolchain,
@@ -5445,6 +5455,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 ),
                 useXcrun: true
             ),
+            customTargetInfo: UserToolchain.mockTargetInfo,
             fileSystem: fileSystem
         )
         let result = try await BuildPlanResult(plan: mockBuildPlan(

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -566,6 +566,7 @@ extension SwiftCommandState {
             },
             createPackagePath: createPackagePath,
             hostTriple: .arm64Linux,
+            targetInfo: UserToolchain.mockTargetInfo,
             fileSystem: fileSystem,
             environment: environment
         )

--- a/Tests/WorkspaceTests/PrebuiltsTests.swift
+++ b/Tests/WorkspaceTests/PrebuiltsTests.swift
@@ -205,11 +205,12 @@ final class PrebuiltsTests: XCTestCase {
                     swiftSyntax
                 ],
                 prebuiltsManager: .init(
+                    swiftVersion: swiftVersion,
                     httpClient: httpClient,
                     archiver: archiver,
                     hostPlatform: .macos_aarch64,
                     rootCertPath: rootCertPath
-                )
+                ),
             )
 
             try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
@@ -268,6 +269,7 @@ final class PrebuiltsTests: XCTestCase {
                     swiftSyntax
                 ],
                 prebuiltsManager: .init(
+                    swiftVersion: swiftVersion,
                     httpClient: httpClient,
                     archiver: archiver,
                     hostPlatform: .macos_aarch64,
@@ -372,6 +374,7 @@ final class PrebuiltsTests: XCTestCase {
                     swiftSyntax
                 ],
                 prebuiltsManager: .init(
+                    swiftVersion: swiftVersion,
                     httpClient: httpClient,
                     archiver: archiver,
                     hostPlatform: .macos_aarch64,
@@ -434,6 +437,7 @@ final class PrebuiltsTests: XCTestCase {
                     swiftSyntax
                 ],
                 prebuiltsManager: .init(
+                    swiftVersion: swiftVersion,
                     httpClient: httpClient,
                     archiver: archiver,
                     hostPlatform: .macos_aarch64,
@@ -486,6 +490,7 @@ final class PrebuiltsTests: XCTestCase {
                     swiftSyntax
                 ],
                 prebuiltsManager: .init(
+                    swiftVersion: swiftVersion,
                     httpClient: httpClient,
                     archiver: archiver,
                     rootCertPath: rootCertPath
@@ -551,6 +556,7 @@ final class PrebuiltsTests: XCTestCase {
                     swiftSyntax
                 ],
                 prebuiltsManager: .init(
+                    swiftVersion: swiftVersion,
                     httpClient: httpClient,
                     archiver: archiver,
                     hostPlatform: .ubuntu_noble_x86_64,
@@ -600,6 +606,7 @@ final class PrebuiltsTests: XCTestCase {
                     swiftSyntax
                 ],
                 prebuiltsManager: .init(
+                    swiftVersion: swiftVersion,
                     httpClient: httpClient,
                     archiver: archiver,
                     rootCertPath: rootCertPath
@@ -666,6 +673,7 @@ final class PrebuiltsTests: XCTestCase {
                     swiftSyntax
                 ],
                 prebuiltsManager: .init(
+                    swiftVersion: swiftVersion,
                     httpClient: httpClient,
                     archiver: archiver,
                     hostPlatform: .macos_aarch64,
@@ -727,6 +735,7 @@ final class PrebuiltsTests: XCTestCase {
                     swiftSyntax
                 ],
                 prebuiltsManager: .init(
+                    swiftVersion: swiftVersion,
                     httpClient: httpClient,
                     archiver: archiver,
                     hostPlatform: .macos_aarch64,
@@ -790,6 +799,7 @@ final class PrebuiltsTests: XCTestCase {
                     swiftSyntax
                 ],
                 prebuiltsManager: .init(
+                    swiftVersion: swiftVersion,
                     httpClient: httpClient,
                     archiver: archiver,
                     hostPlatform: .macos_aarch64,
@@ -846,6 +856,7 @@ final class PrebuiltsTests: XCTestCase {
                     swiftSyntax
                 ],
                 prebuiltsManager: .init(
+                    swiftVersion: swiftVersion,
                     httpClient: httpClient,
                     archiver: archiver
                 )


### PR DESCRIPTION
Prebuilts for macros and the automated downloading of SwiftSDKs need to know the version of the compiler so we can fetch compatible binaries. The swiftc compiler has a --print-target-info options which dumps out a JSON structure that contains the compilerVersion. We already use info in this structure to determine the hostTriple for the UserToolchain.

This adds the swiftCompilerVersion to UserToolchain that uses a couple of regex's to pull out the Swift compiler version. This is then used by the prebuilts feature instead of our current hardcodeing of the swift toolchain version.

This also turns the prebuilts feature on by default which was supposed to be done in the last update.

Cherry pick of https://github.com/swiftlang/swift-package-manager/pull/8707