### PR TITLE
[Swift migrate] Handle migration for optional features

### DIFF
--- a/Fixtures/SwiftMigrate/InferIsolatedConformancesMigration/Package.swift
+++ b/Fixtures/SwiftMigrate/InferIsolatedConformancesMigration/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version:6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "InferIsolatedConformancesMigration",
+    targets: [
+        .target(name: "Diagnostics", path: "Sources", exclude: ["Fixed"]),
+    ]
+)

--- a/Fixtures/SwiftMigrate/InferIsolatedConformancesMigration/Sources/Fixed/Test.swift
+++ b/Fixtures/SwiftMigrate/InferIsolatedConformancesMigration/Sources/Fixed/Test.swift
@@ -1,0 +1,8 @@
+@MainActor
+class C: nonisolated Equatable {
+  let name = "Hello"
+
+  nonisolated static func ==(lhs: C, rhs: C) -> Bool {
+    lhs.name == rhs.name
+  }
+}

--- a/Fixtures/SwiftMigrate/InferIsolatedConformancesMigration/Sources/Test.swift
+++ b/Fixtures/SwiftMigrate/InferIsolatedConformancesMigration/Sources/Test.swift
@@ -1,0 +1,8 @@
+@MainActor
+class C: Equatable {
+  let name = "Hello"
+
+  nonisolated static func ==(lhs: C, rhs: C) -> Bool {
+    lhs.name == rhs.name
+  }
+}

--- a/Fixtures/SwiftMigrate/StrictMemorySafetyMigration/Package.swift
+++ b/Fixtures/SwiftMigrate/StrictMemorySafetyMigration/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version:6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "StrictMemorySafetyMigration",
+    targets: [
+        .target(name: "Diagnostics", path: "Sources", exclude: ["Fixed"]),
+    ]
+)

--- a/Fixtures/SwiftMigrate/StrictMemorySafetyMigration/Sources/Fixed/Test.swift
+++ b/Fixtures/SwiftMigrate/StrictMemorySafetyMigration/Sources/Fixed/Test.swift
@@ -1,0 +1,5 @@
+@unsafe func f() { }
+
+func g() {
+  unsafe f()
+}

--- a/Fixtures/SwiftMigrate/StrictMemorySafetyMigration/Sources/Test.swift
+++ b/Fixtures/SwiftMigrate/StrictMemorySafetyMigration/Sources/Test.swift
@@ -1,0 +1,5 @@
+@unsafe func f() { }
+
+func g() {
+  f()
+}

--- a/Sources/Commands/PackageCommands/AddSetting.swift
+++ b/Sources/Commands/PackageCommands/AddSetting.swift
@@ -29,7 +29,7 @@ extension SwiftPackageCommand {
             case experimentalFeature
             case upcomingFeature
             case languageMode
-            case strictMemorySafety
+            case strictMemorySafety = "StrictMemorySafety"
         }
 
         package static let configuration = CommandConfiguration(

--- a/Sources/Commands/PackageCommands/AddSetting.swift
+++ b/Sources/Commands/PackageCommands/AddSetting.swift
@@ -150,7 +150,7 @@ extension SwiftPackageCommand {
                         manifest: manifestSyntax
                     )
                 case .strictMemorySafety:
-                    guard value.isEmpty || value == "StrictMemorySafety" else {
+                    guard value.isEmpty || value == SwiftSetting.strictMemorySafety.rawValue else {
                         throw ValidationError("'strictMemorySafety' does not support argument '\(value)'")
                     }
 

--- a/Sources/Commands/PackageCommands/AddSetting.swift
+++ b/Sources/Commands/PackageCommands/AddSetting.swift
@@ -150,8 +150,8 @@ extension SwiftPackageCommand {
                         manifest: manifestSyntax
                     )
                 case .strictMemorySafety:
-                    guard value.isEmpty else {
-                        throw ValidationError("'strictMemorySafety' doesn't have an argument")
+                    guard value.isEmpty || value == "StrictMemorySafety" else {
+                        throw ValidationError("'strictMemorySafety' does not support argument '\(value)'")
                     }
 
                     editResult = try AddSwiftSetting.strictMemorySafety(

--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -227,7 +227,18 @@ fileprivate extension SwiftCompilerFeature {
         case .experimental(name: let name, migratable: _, categories: _):
             return ["-Xfrontend", "-enable-experimental-feature", "-Xfrontend", "\(name):migrate"]
         case .optional(name: _, migratable: _, categories: _, flagName: let flagName):
-            return ["\(flagName):migrate"]
+            let flags = flagName.split(separator: " ")
+            var resultFlags: [String] = []
+            for (index, flag) in flags.enumerated() {
+                resultFlags.append("-Xfrontend")
+                if index == flags.endIndex - 1 {
+                    resultFlags.append(String(flag) + ":migrate")
+                } else {
+                    resultFlags.append(String(flag))
+                }
+            }
+
+            return resultFlags
         }
     }
 

--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -159,12 +159,7 @@ extension SwiftPackageCommand {
 
             let addFeaturesToModule = { (module: ResolvedModule) in
                 for feature in features {
-                    module.underlying.buildSettings.add(.init(values: [
-                        "-Xfrontend",
-                        "-enable-\(feature.upcoming ? "upcoming" : "experimental")-feature",
-                        "-Xfrontend",
-                        "\(feature.name):migrate",
-                    ]), for: .OTHER_SWIFT_FLAGS)
+                    module.underlying.buildSettings.add(.init(values: feature.migrationFlags), for: .OTHER_SWIFT_FLAGS)
                 }
             }
 

--- a/Sources/PackageModel/Toolchain+SupportedFeatures.swift
+++ b/Sources/PackageModel/Toolchain+SupportedFeatures.swift
@@ -13,41 +13,58 @@
 import Basics
 
 import enum TSCBasic.JSON
+import protocol TSCBasic.JSONMappable
 import TSCUtility
 
 public enum SwiftCompilerFeature {
-    case upcoming(name: String, migratable: Bool, enabledIn: SwiftLanguageVersion)
-    case experimental(name: String, migratable: Bool)
+    case optional(name: String, migratable: Bool, categories: [String], flagName: String)
+    case upcoming(name: String, migratable: Bool, categories: [String], enabledIn: SwiftLanguageVersion)
+    case experimental(name: String, migratable: Bool, categories: [String])
 
+    public var optional: Bool {
+        switch self {
+        case .optional: true
+        case .upcoming, .experimental: false
+        }
+    }
     public var upcoming: Bool {
         switch self {
         case .upcoming: true
-        case .experimental: false
+        case .optional, .experimental: false
         }
     }
 
     public var experimental: Bool {
         switch self {
-        case .upcoming: false
+        case .optional, .upcoming: false
         case .experimental: true
         }
     }
 
     public var name: String {
         switch self {
-        case .upcoming(name: let name, migratable: _, enabledIn: _):
-            name
-        case .experimental(name: let name, migratable: _):
+        case .optional(name: let name, migratable: _, categories: _, flagName: _),
+                .upcoming(name: let name, migratable: _, categories: _, enabledIn: _),
+                .experimental(name: let name, migratable: _, categories: _):
             name
         }
     }
 
     public var migratable: Bool {
         switch self {
-        case .upcoming(name: _, migratable: let migratable, enabledIn: _):
+        case .optional(name: _, migratable: let migratable, categories: _, flagName: _),
+             .upcoming(name: _, migratable: let migratable, categories: _, enabledIn: _),
+             .experimental(name: _, migratable: let migratable, categories: _):
             migratable
-        case .experimental(name: _, migratable: let migratable):
-            migratable
+        }
+    }
+
+    public var categories: [String] {
+        switch self {
+        case .optional(name: _, migratable: _, categories: let categories, flagName: _),
+             .upcoming(name: _, migratable: _, categories: let categories, enabledIn: _),
+             .experimental(name: _, migratable: _, categories: let categories):
+            categories
         }
     }
 }
@@ -85,8 +102,23 @@ extension Toolchain {
 
             let features: JSON = try parsedSupportedFeatures.get("features")
 
+            let optional: [SwiftCompilerFeature] = try (features.get("optional") as [JSON]?)?.map { (json: JSON) in
+                let name: String = try json.get("name")
+                let categories: [String]? = try json.getArrayIfAvailable("categories")
+                let migratable: Bool? = json.get("migratable")
+                let flagName: String = try json.get("flag_name")
+
+                return .optional(
+                    name: name,
+                    migratable: migratable ?? false,
+                    categories: categories ?? [name],
+                    flagName: flagName
+                )
+            } ?? []
+
             let upcoming: [SwiftCompilerFeature] = try features.getArray("upcoming").map {
                 let name: String = try $0.get("name")
+                let categories: [String]? = try $0.getArrayIfAvailable("categories")
                 let migratable: Bool? = $0.get("migratable")
                 let enabledIn: String = try $0.get("enabled_in")
 
@@ -97,21 +129,34 @@ extension Toolchain {
                 return .upcoming(
                     name: name,
                     migratable: migratable ?? false,
+                    categories: categories ?? [name],
                     enabledIn: mode
                 )
             }
 
             let experimental: [SwiftCompilerFeature] = try features.getArray("experimental").map {
                 let name: String = try $0.get("name")
+                let categories: [String]? = try $0.getArrayIfAvailable("categories")
                 let migratable: Bool? = $0.get("migratable")
 
                 return .experimental(
                     name: name,
-                    migratable: migratable ?? false
+                    migratable: migratable ?? false,
+                    categories: categories ?? [name]
                 )
             }
 
-            return upcoming + experimental
+            return optional + upcoming + experimental
+        }
+    }
+}
+
+fileprivate extension JSON {
+    func getArrayIfAvailable<T: JSONMappable>(_ key: String) throws -> [T]? {
+        do {
+            return try get(key)
+        } catch MapError.missingKey(key) {
+            return nil
         }
     }
 }

--- a/Sources/PackageModelSyntax/AddSwiftSetting.swift
+++ b/Sources/PackageModelSyntax/AddSwiftSetting.swift
@@ -73,7 +73,7 @@ public enum AddSwiftSetting {
         manifest: SourceFileSyntax
     ) throws -> PackageEditResult {
         try self.addToTarget(
-            target, name: "strictMemorySafety",
+            target, name: "strictMemorySafety()",
             value: String?.none,
             firstIntroduced: .v6_2,
             manifest: manifest

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2112,110 +2112,46 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             "skipping because test environment compiler doesn't support `-print-supported-features`"
         )
 
-        try await fixture(name: "SwiftMigrate/ExistentialAnyMigration") { fixturePath in
-            let sourcePaths: [AbsolutePath]
-            let fixedSourcePaths: [AbsolutePath]
+        func doMigration(featureName: String) async throws {
+            try await fixture(name: "SwiftMigrate/\(featureName)Migration") { fixturePath in
+                let sourcePaths: [AbsolutePath]
+                let fixedSourcePaths: [AbsolutePath]
 
-            do {
-                let sourcesPath = fixturePath.appending(components: "Sources")
-                let fixedSourcesPath = sourcesPath.appending("Fixed")
+                do {
+                    let sourcesPath = fixturePath.appending(components: "Sources")
+                    let fixedSourcesPath = sourcesPath.appending("Fixed")
 
-                sourcePaths = try localFileSystem.getDirectoryContents(sourcesPath).filter { filename in
-                    filename.hasSuffix(".swift")
-                }.sorted().map { filename in
-                    sourcesPath.appending(filename)
+                    sourcePaths = try localFileSystem.getDirectoryContents(sourcesPath).filter { filename in
+                        filename.hasSuffix(".swift")
+                    }.sorted().map { filename in
+                        sourcesPath.appending(filename)
+                    }
+                    fixedSourcePaths = try localFileSystem.getDirectoryContents(fixedSourcesPath).filter { filename in
+                        filename.hasSuffix(".swift")
+                    }.sorted().map { filename in
+                        fixedSourcesPath.appending(filename)
+                    }
                 }
-                fixedSourcePaths = try localFileSystem.getDirectoryContents(fixedSourcesPath).filter { filename in
-                    filename.hasSuffix(".swift")
-                }.sorted().map { filename in
-                    fixedSourcesPath.appending(filename)
-                }
-            }
 
-            _ = try await self.execute(
-                ["migrate", "--to-feature", "ExistentialAny"],
-                packagePath: fixturePath
-            )
-
-            XCTAssertEqual(sourcePaths.count, fixedSourcePaths.count)
-
-            for (sourcePath, fixedSourcePath) in zip(sourcePaths, fixedSourcePaths) {
-                try XCTAssertEqual(
-                    localFileSystem.readFileContents(sourcePath),
-                    localFileSystem.readFileContents(fixedSourcePath)
+                _ = try await self.execute(
+                    ["migrate", "--to-feature", featureName],
+                    packagePath: fixturePath
                 )
+
+                XCTAssertEqual(sourcePaths.count, fixedSourcePaths.count)
+
+                for (sourcePath, fixedSourcePath) in zip(sourcePaths, fixedSourcePaths) {
+                    try XCTAssertEqual(
+                        localFileSystem.readFileContents(sourcePath),
+                        localFileSystem.readFileContents(fixedSourcePath)
+                    )
+                }
             }
         }
 
-        try await fixture(name: "SwiftMigrate/StrictMemorySafetyMigration") { fixturePath in
-            let sourcePaths: [AbsolutePath]
-            let fixedSourcePaths: [AbsolutePath]
-
-            do {
-                let sourcesPath = fixturePath.appending(components: "Sources")
-                let fixedSourcesPath = sourcesPath.appending("Fixed")
-
-                sourcePaths = try localFileSystem.getDirectoryContents(sourcesPath).filter { filename in
-                    filename.hasSuffix(".swift")
-                }.sorted().map { filename in
-                    sourcesPath.appending(filename)
-                }
-                fixedSourcePaths = try localFileSystem.getDirectoryContents(fixedSourcesPath).filter { filename in
-                    filename.hasSuffix(".swift")
-                }.sorted().map { filename in
-                    fixedSourcesPath.appending(filename)
-                }
-            }
-
-            _ = try await self.execute(
-                ["migrate", "--to-feature", "StrictMemorySafety"],
-                packagePath: fixturePath
-            )
-
-            XCTAssertEqual(sourcePaths.count, fixedSourcePaths.count)
-
-            for (sourcePath, fixedSourcePath) in zip(sourcePaths, fixedSourcePaths) {
-                try XCTAssertEqual(
-                    localFileSystem.readFileContents(sourcePath),
-                    localFileSystem.readFileContents(fixedSourcePath)
-                )
-            }
-        }
-
-        try await fixture(name: "SwiftMigrate/InferIsolatedConformancesMigration") { fixturePath in
-            let sourcePaths: [AbsolutePath]
-            let fixedSourcePaths: [AbsolutePath]
-
-            do {
-                let sourcesPath = fixturePath.appending(components: "Sources")
-                let fixedSourcesPath = sourcesPath.appending("Fixed")
-
-                sourcePaths = try localFileSystem.getDirectoryContents(sourcesPath).filter { filename in
-                    filename.hasSuffix(".swift")
-                }.sorted().map { filename in
-                    sourcesPath.appending(filename)
-                }
-                fixedSourcePaths = try localFileSystem.getDirectoryContents(fixedSourcesPath).filter { filename in
-                    filename.hasSuffix(".swift")
-                }.sorted().map { filename in
-                    fixedSourcesPath.appending(filename)
-                }
-            }
-
-            _ = try await self.execute(
-                ["migrate", "--to-feature", "InferIsolatedConformances"],
-                packagePath: fixturePath
-            )
-
-            XCTAssertEqual(sourcePaths.count, fixedSourcePaths.count)
-
-            for (sourcePath, fixedSourcePath) in zip(sourcePaths, fixedSourcePaths) {
-                try XCTAssertEqual(
-                    localFileSystem.readFileContents(sourcePath),
-                    localFileSystem.readFileContents(fixedSourcePath)
-                )
-            }
-        }
+        try await doMigration(featureName: "ExistentialAny")
+        try await doMigration(featureName: "StrictMemorySafety")
+        try await doMigration(featureName: "InferIsolatedConformances")
     }
 
     func testBuildToolPlugin() async throws {

--- a/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
+++ b/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
@@ -789,7 +789,7 @@ class ManifestEditTests: XCTestCase {
                         dependencies: [
                         ],
                         swiftSettings: [
-                            .strictMemorySafety,
+                            .strictMemorySafety(),
                         ]
                     ),
                 ]


### PR DESCRIPTION
In addition to upcoming and experimental features, handle migration for "optional" features (the only one now being StrictMemorySafety). Read optional features from the supported-features JSON coming from the compiler and use their provided flags.

While here, use the newly-introduced "categories" field from the JSON to filter the list of categories rather than assuming it's the same as the feature name.
