### PR TITLE
Async git repository opening

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -235,7 +235,8 @@ public final class AsyncOperationQueue: @unchecked Sendable {
                 waitingTasks.remove(at: taskIndex)
             }
 
-            // This could be simplified if `waitingTasks` could be an `OrderedDictionary` from swift-collections.
+            // We cannot remove elements from `waitingTasks` while iterating over it, so we make
+            // a pass to collect operations and then apply them after the loop.
             func createTaskListOperations() -> (CollectionDifference<WorkTask>?, WaitingContinuation?) {
                 var changes: [CollectionDifference<WorkTask>.Change] = []
                 for (index, task) in waitingTasks.enumerated() {

--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -133,7 +133,7 @@ public final class AsyncOperationQueue: @unchecked Sendable {
     /// - Returns: The result of the operation.
     /// - Throws: An error thrown by the operation, or a `CancellationError` if the operation is cancelled.
     public func withOperation<ReturnValue>(
-        _ operation: @Sendable () async throws -> sending ReturnValue
+        _ operation: () async throws -> sending ReturnValue
     ) async throws -> ReturnValue {
         let taskId = try await waitIfNeeded()
         defer { signalCompletion(taskId) }

--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -89,18 +89,18 @@ public final class AsyncOperationQueue: @unchecked Sendable {
     fileprivate typealias WaitingContinuation = CheckedContinuation<Void, any Error>
 
     private let concurrentTasks: Int
-    private var activeTasks: Int = 0
-    private var waitingTasks: [WaitingTask] = []
+    private var waitingTasks: [WorkTask] = []
     private let waitingTasksLock = NSLock()
 
-    fileprivate enum WaitingTask {
+    fileprivate enum WorkTask {
         case creating(ID)
         case waiting(ID, WaitingContinuation)
+        case running(ID)
         case cancelled(ID)
 
         var id: ID {
             switch self {
-            case .creating(let id), .waiting(let id, _), .cancelled(let id):
+            case .creating(let id), .waiting(let id, _), .running(let id), .cancelled(let id):
                 return id
             }
         }
@@ -135,23 +135,22 @@ public final class AsyncOperationQueue: @unchecked Sendable {
     public func withOperation<ReturnValue>(
         _ operation: @Sendable () async throws -> sending ReturnValue
     ) async throws -> ReturnValue {
-        try await waitIfNeeded()
-        defer { signalCompletion() }
+        let taskId = try await waitIfNeeded()
+        defer { signalCompletion(taskId) }
         return try await operation()
     }
 
-    private func waitIfNeeded() async throws {
-        guard let taskId = waitingTasksLock.withLock({ () -> ID? in
-            let shouldWait = activeTasks >= concurrentTasks
-            activeTasks += 1
-            guard shouldWait else {
-                return nil
-            }
-            let taskId = ID()
-            waitingTasks.append(.creating(taskId))
-            return taskId
-        }) else {
-            return // Less tasks are in flight than the limit.
+    private func waitIfNeeded() async throws -> ID {
+        let workTask = waitingTasksLock.withLock({
+            let shouldWait = waitingTasks.count >= concurrentTasks
+            let workTask = shouldWait ? WorkTask.creating(ID()) : .running(ID())
+            waitingTasks.append(workTask)
+            return workTask
+        })
+
+        // If we aren't creating a task that needs to wait, we're under the concurrency limit.
+        guard case .creating(let taskId) = workTask else {
+            return workTask.id
         }
 
         enum TaskAction {
@@ -163,30 +162,27 @@ public final class AsyncOperationQueue: @unchecked Sendable {
             try await withCheckedThrowingContinuation { (continuation: WaitingContinuation) -> Void in
                 let action: TaskAction? = waitingTasksLock.withLock {
                     guard let index = waitingTasks.firstIndex(where: { $0.id == taskId }) else {
-                        // If the task was cancelled in onCancelled it will have been removed from the waiting tasks list.
+                        // The task may have been marked as cancelled already and then removed from
+                        // waitingTasks in `signalCompletion`.
                         return .cancel(continuation)
                     }
 
-                    // If the task was cancelled in between creating the task cancellation handler and aquiring the lock,
-                    // we should resume the continuation with a `CancellationError`.
-                    if case .cancelled = waitingTasks[index] {
-                        waitingTasks.remove(at: index)
-                        return .cancel(continuation)
-                    }
-
-                    // A task may have completed since we iniitally checked if we should wait. Check again in this locked
-                    // section and if we can start it, remove it from the waiting tasks and start it immediately.
-                    let shouldWait = activeTasks >= concurrentTasks
-                    if shouldWait {
-                        waitingTasks[index] = .waiting(taskId, continuation)
-                        return nil
-                    } else {
-                        waitingTasks.remove(at: index)
-
-                        // activeTasks isn't decremented in the `signalCompletion` method
-                        // when the next task to start is .creating, so we decrement it here.
-                        activeTasks -= 1
-                        return .start(continuation)
+                    switch waitingTasks[index] {
+                        case .cancelled:
+                            // If the task was cancelled in between creating the task cancellation handler and acquiring the lock,
+                            // we should resume the continuation with a `CancellationError`.
+                            waitingTasks.remove(at: index)
+                            return .cancel(continuation)
+                        case .creating, .running, .waiting:
+                            // A task may have completed since we initially checked if we should wait. Check again in this locked
+                            // section and if we can start it, remove it from the waiting tasks and start it immediately.
+                            if waitingTasks.count >= concurrentTasks {
+                                waitingTasks[index] = .waiting(taskId, continuation)
+                                return nil
+                            } else {
+                                waitingTasks.remove(at: index)
+                                return .start(continuation)
+                            }
                     }
                 }
 
@@ -198,7 +194,6 @@ public final class AsyncOperationQueue: @unchecked Sendable {
                     case .none:
                         return
                 }
-
             }
         } onCancel: {
             let continuation: WaitingContinuation? = self.waitingTasksLock.withLock {
@@ -214,11 +209,10 @@ public final class AsyncOperationQueue: @unchecked Sendable {
                         // continuation for the waiting task with a `CancellationError`. Return the continuation
                         // here so it can be resumed once the `waitingTasksLock` is released.
                         return continuation
-                    case .creating:
-                        // If the task was still being created, mark it as cancelled in the queue so that
-                        // withCheckedThrowingContinuation can immediately cancel it.
+                    case .creating, .running:
+                        // If the task was still being created, mark it as cancelled in `waitingTasks` so that
+                        // the handler for `withCheckedThrowingContinuation` can immediately cancel it.
                         self.waitingTasks[taskIndex] = .cancelled(taskId)
-                        activeTasks -= 1
                         return nil
                     case .cancelled:
                         preconditionFailure("Attempting to cancel a task that was already cancelled")
@@ -227,32 +221,56 @@ public final class AsyncOperationQueue: @unchecked Sendable {
 
             continuation?.resume(throwing: _Concurrency.CancellationError())
         }
+        return workTask.id
     }
 
-    private func signalCompletion() {
+    private func signalCompletion(_ taskId: ID) {
         let continuationToResume = waitingTasksLock.withLock { () -> WaitingContinuation? in
             guard !waitingTasks.isEmpty else {
-                activeTasks -= 1
                 return nil
             }
 
-            while let lastTask = waitingTasks.first {
-                switch lastTask {
-                case .creating:
-                    // If the next task is in the process of being created, let the
-                    return Optional<WaitingContinuation>.none
-                case .waiting:
-                    activeTasks -= 1
-                    // Begin the next waiting task
-                    return waitingTasks.remove(at: 0).continuation
-                case .cancelled:
-                    // If the next task is cancelled, continue removing cancelled
-                    // tasks until we find one that hasn't run yet or we run out.
-                    _ = waitingTasks.remove(at: 0)
-                    continue
-                }
+            // Remove the completed task from the list to decrement the active task count.
+            if let taskIndex = self.waitingTasks.firstIndex(where: { $0.id == taskId }) {
+                waitingTasks.remove(at: taskIndex)
             }
-            return nil
+
+            // This could be simplified if `waitingTasks` could be an `OrderedDictionary` from swift-collections.
+            func createTaskListOperations() -> (CollectionDifference<WorkTask>?, WaitingContinuation?) {
+                var changes: [CollectionDifference<WorkTask>.Change] = []
+                for (index, task) in waitingTasks.enumerated() {
+                    switch task {
+                    case .running:
+                        // Skip tasks that are already running, looking for the first one that is waiting or creating.
+                        continue
+                    case .creating:
+                        // If the next task is in the process of being created, let the
+                        // creation code in the `withCheckedThrowingContinuation` in `waitIfNeeded`
+                        // handle starting the task.
+                        break
+                    case .waiting:
+                        // Begin the next waiting task
+                        changes.append(.remove(offset: index, element: task, associatedWith: nil))
+                        return (CollectionDifference<WorkTask>(changes), task.continuation)
+                    case .cancelled:
+                        // If the next task is cancelled, continue removing cancelled
+                        // tasks until we find one that hasn't run yet, or we exaust the list of waiting tasks.
+                        changes.append(.remove(offset: index, element: task, associatedWith: nil))
+                        continue
+                    }
+                }
+                return (CollectionDifference<WorkTask>(changes), nil)
+            }
+
+            let (collectionOperations, continuation) = createTaskListOperations()
+            if let operations = collectionOperations {
+                guard let appliedDiff = waitingTasks.applying(operations) else {
+                    preconditionFailure("Failed to apply changes to waiting tasks")
+                }
+                waitingTasks = appliedDiff
+            }
+
+            return continuation
         }
 
         continuationToResume?.resume()

--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -121,7 +121,7 @@ public final class AsyncOperationQueue: @unchecked Sendable {
 
     deinit {
         waitingTasksLock.withLock {
-            if !waitingTasks.filter({ $0.continuation != nil }).isEmpty {
+            if !waitingTasks.isEmpty {
                 preconditionFailure("Deallocated with waiting tasks")
             }
         }
@@ -170,6 +170,7 @@ public final class AsyncOperationQueue: @unchecked Sendable {
                     // If the task was cancelled in between creating the task cancellation handler and aquiring the lock,
                     // we should resume the continuation with a `CancellationError`.
                     if case .cancelled = waitingTasks[index] {
+                        waitingTasks.remove(at: index)
                         return .cancel(continuation)
                     }
 

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -197,7 +197,14 @@ extension PackageContainerConstraint: CustomStringConvertible {
 /// An interface for resolving package containers.
 public protocol PackageContainerProvider {
     /// Get the container for a particular identifier asynchronously.
+    func getContainer(
+        for package: PackageReference,
+        updateStrategy: ContainerUpdateStrategy,
+        observabilityScope: ObservabilityScope
+    ) async throws -> PackageContainer
+}
 
+public extension PackageContainerProvider {
     @available(*, noasync, message: "Use the async alternative")
     func getContainer(
         for package: PackageReference,
@@ -205,25 +212,12 @@ public protocol PackageContainerProvider {
         observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping @Sendable (Result<PackageContainer, Error>) -> Void
-    )
-}
-
-public extension PackageContainerProvider {
-    func getContainer(
-        for package: PackageReference,
-        updateStrategy: ContainerUpdateStrategy,
-        observabilityScope: ObservabilityScope,
-        on queue: DispatchQueue
-    ) async throws -> PackageContainer {
-        try await withCheckedThrowingContinuation { continuation in
-            self.getContainer(
+    ) {
+        queue.asyncResult(completion) {
+            try await self.getContainer(
                 for: package,
                 updateStrategy: updateStrategy,
-                observabilityScope: observabilityScope,
-                on: queue,
-                completion: {
-                    continuation.resume(with: $0)
-                }
+                observabilityScope: observabilityScope
             )
         }
     }

--- a/Sources/PackageMetadata/PackageMetadata.swift
+++ b/Sources/PackageMetadata/PackageMetadata.swift
@@ -232,7 +232,7 @@ public struct PackageSearchClient {
         let fetchStandalonePackageByURL = { (error: Error?) async throws -> [Package] in
             let url = SourceControlURL(query)
             do {
-                return try withTemporaryDirectory(removeTreeOnDeinit: true) { (tempDir: AbsolutePath) in
+                return try await withTemporaryDirectory(removeTreeOnDeinit: true) { (tempDir: AbsolutePath) in
                     let tempPath = tempDir.appending(component: url.lastPathComponent)
                     let repositorySpecifier = RepositorySpecifier(url: url)
                     try self.repositoryProvider.fetch(
@@ -240,7 +240,7 @@ public struct PackageSearchClient {
                         to: tempPath,
                         progressHandler: nil
                     )
-                    guard try self.repositoryProvider.isValidDirectory(tempPath), let repository = try self.repositoryProvider.open(
+                    guard try self.repositoryProvider.isValidDirectory(tempPath), let repository = try await self.repositoryProvider.open(
                         repository: repositorySpecifier,
                         at: tempPath
                     ) as? GitRepository else {

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -27,7 +27,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
     private let path: Basics.AbsolutePath
     private let cachePath: Basics.AbsolutePath?
     private let registryClient: RegistryClient
-    private let delegate: Delegate?
+    private let delegate: RegistryDownloadManagerDelegateProxy?
 
     struct PackageLookup: Hashable {
         let package: PackageIdentity
@@ -48,14 +48,13 @@ public class RegistryDownloadsManager: AsyncCancellable {
         self.path = path
         self.cachePath = cachePath
         self.registryClient = registryClient
-        self.delegate = delegate
+        self.delegate = RegistryDownloadManagerDelegateProxy(delegate)
     }
 
     public func lookup(
         package: PackageIdentity,
         version: Version,
-        observabilityScope: ObservabilityScope,
-        delegateQueue: DispatchQueue
+        observabilityScope: ObservabilityScope
     ) async throws -> Basics.AbsolutePath {
         let packageRelativePath: Basics.RelativePath
         let packagePath: Basics.AbsolutePath
@@ -82,9 +81,9 @@ public class RegistryDownloadsManager: AsyncCancellable {
                     // inform delegate that we are starting to fetch
                     // calculate if cached (for delegate call) outside queue as it may change while queue is processing
                     let isCached = self.cachePath.map { self.fileSystem.exists($0.appending(packageRelativePath)) } ?? false
-                    delegateQueue.async { [delegate = self.delegate] in
+                    Task {
                         let details = FetchDetails(fromCache: isCached, updatedCache: false)
-                        delegate?.willFetch(package: package, version: version, fetchDetails: details)
+                        await delegate?.willFetch(package: package, version: version, fetchDetails: details)
                     }
 
                     // make sure destination is free.
@@ -96,18 +95,17 @@ public class RegistryDownloadsManager: AsyncCancellable {
                             package: package,
                             version: version,
                             packagePath: packagePath,
-                            observabilityScope: observabilityScope,
-                            delegateQueue: delegateQueue
+                            observabilityScope: observabilityScope
                         )
                         // inform delegate that we finished to fetch
                         let duration = start.distance(to: .now())
-                        delegateQueue.async { [delegate = self.delegate] in
-                            delegate?.didFetch(package: package, version: version, result: .success(result), duration: duration)
+                        Task {
+                            await delegate?.didFetch(package: package, version: version, result: .success(result), duration: duration)
                         }
                     } catch {
                         let duration = start.distance(to: .now())
-                        delegateQueue.async { [delegate = self.delegate] in
-                            delegate?.didFetch(package: package, version: version, result: .failure(error), duration: duration)
+                        Task {
+                            await delegate?.didFetch(package: package, version: version, result: .failure(error), duration: duration)
                         }
                         throw error
                     }
@@ -126,7 +124,6 @@ public class RegistryDownloadsManager: AsyncCancellable {
         package: PackageIdentity,
         version: Version,
         observabilityScope: ObservabilityScope,
-        delegateQueue: DispatchQueue,
         callbackQueue: DispatchQueue,
         completion: @escaping @Sendable (Result<Basics.AbsolutePath, Error>) -> Void
     ) {
@@ -134,8 +131,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
             try await self.lookup(
                 package: package,
                 version: version,
-                observabilityScope: observabilityScope,
-                delegateQueue: delegateQueue
+                observabilityScope: observabilityScope
             )
         }
     }
@@ -149,8 +145,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
         package: PackageIdentity,
         version: Version,
         packagePath: Basics.AbsolutePath,
-        observabilityScope: ObservabilityScope,
-        delegateQueue: DispatchQueue
+        observabilityScope: ObservabilityScope
     ) async throws -> FetchDetails {
         if let cachePath {
             do {
@@ -238,8 +233,8 @@ public class RegistryDownloadsManager: AsyncCancellable {
         // utility to update progress
 
         @Sendable func updateDownloadProgress(downloaded: Int64, total: Int64?) {
-            delegateQueue.async { [delegate = self.delegate] in
-                delegate?.fetching(
+            Task {
+                await delegate?.fetching(
                     package: package,
                     version: version,
                     bytesDownloaded: downloaded,
@@ -325,6 +320,34 @@ public protocol RegistryDownloadsManagerDelegate: Sendable {
 
     /// Called every time the progress of a repository fetch operation updates.
     func fetching(package: PackageIdentity, version: Version, bytesDownloaded: Int64, totalBytesToDownload: Int64?)
+}
+
+actor RegistryDownloadManagerDelegateProxy {
+    private let delegate: RegistryDownloadsManagerDelegate
+
+    init?(_ delegate: RegistryDownloadsManagerDelegate?) {
+        guard let delegate else {
+            return nil
+        }
+        self.delegate = delegate
+    }
+
+    func willFetch(package: PackageIdentity, version: Version, fetchDetails: RegistryDownloadsManager.FetchDetails) {
+        self.delegate.willFetch(package: package, version: version, fetchDetails: fetchDetails)
+    }
+
+    func didFetch(
+        package: PackageIdentity,
+        version: Version,
+        result: Result<RegistryDownloadsManager.FetchDetails, Error>,
+        duration: DispatchTimeInterval
+    ) {
+        self.delegate.didFetch(package: package, version: version, result: result, duration: duration)
+    }
+
+    func fetching(package: PackageIdentity, version: Version, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
+        self.delegate.fetching(package: package, version: version, bytesDownloaded: bytesDownloaded, totalBytesToDownload: totalBytesToDownload)
+    }
 }
 
 extension Dictionary where Key == RegistryDownloadsManager.PackageLookup {

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -79,7 +79,7 @@ extension RepositorySpecifier: CustomStringConvertible {
 /// This protocol defines the lower level interface used to to access
 /// repositories. High-level clients should access repositories via a
 /// `RepositoryManager`.
-public protocol RepositoryProvider: Cancellable {
+public protocol RepositoryProvider: Cancellable, Sendable {
     /// Fetch the complete repository at the given location to `path`.
     ///
     /// - Parameters:
@@ -98,7 +98,7 @@ public protocol RepositoryProvider: Cancellable {
     ///     repository has previously been created via `fetch`.
     ///
     /// - Throws: If the repository is unable to be opened.
-    func open(repository: RepositorySpecifier, at path: AbsolutePath) throws -> Repository
+    func open(repository: RepositorySpecifier, at path: AbsolutePath) async throws -> Repository
 
     /// Create a working copy from a managed repository.
     ///
@@ -276,7 +276,7 @@ public protocol WorkingCheckout {
 }
 
 /// A single repository revision.
-public struct Revision: Hashable {
+public struct Revision: Hashable, Sendable {
     /// A precise identifier for a single repository revision, in a repository-specified manner.
     ///
     /// This string is intended to be opaque to the client, but understandable
@@ -289,7 +289,7 @@ public struct Revision: Hashable {
     }
 }
 
-public protocol FetchProgress {
+public protocol FetchProgress: Sendable {
     typealias Handler = (FetchProgress) -> Void
 
     var message: String { get }

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -34,22 +34,17 @@ public class RepositoryManager: Cancellable {
     private let provider: RepositoryProvider
 
     /// The delegate interface.
-    private let delegate: Delegate?
-
-    /// DispatchSemaphore to restrict concurrent operations on manager.
-    private let concurrencySemaphore: DispatchSemaphore
-    /// OperationQueue to park pending lookups
-    private let lookupQueue: OperationQueue
+    private let delegate: RepositoryManagerDelegateProxy?
 
     /// The filesystem to operate on.
     private let fileSystem: FileSystem
 
     // tracks outstanding lookups for de-duping requests
-    private var pendingLookups = [RepositorySpecifier: DispatchGroup]()
+    private var pendingLookups = [RepositorySpecifier: Task<RepositoryManager.RepositoryHandle, Error>]()
     private var pendingLookupsLock = NSLock()
 
-    // tracks outstanding lookups for cancellation
-    private var outstandingLookups = ThreadSafeKeyValueStore<UUID, (repository: RepositorySpecifier, completion: (Result<RepositoryHandle, Error>) -> Void, queue: DispatchQueue)>()
+    // Limits how many concurrent operations can be performed at once.
+    private let concurrencyLimiter: ConcurrencyLimiter
 
     private var emitNoConnectivityWarning = ThreadSafeBox<Bool>(true)
 
@@ -82,35 +77,11 @@ public class RepositoryManager: Cancellable {
         self.cacheLocalPackages = cacheLocalPackages
 
         self.provider = provider
-        self.delegate = delegate
+        self.delegate = RepositoryManagerDelegateProxy(delegate)
 
         // this queue and semaphore is used to limit the amount of concurrent git operations taking place
-        let maxConcurrentOperations = max(1, maxConcurrentOperations ?? 3*Concurrency.maxOperations/4)
-        self.lookupQueue = OperationQueue()
-        self.lookupQueue.name = "org.swift.swiftpm.repository-manager"
-        self.lookupQueue.maxConcurrentOperationCount = maxConcurrentOperations
-        self.concurrencySemaphore = DispatchSemaphore(value: maxConcurrentOperations)
-    }
-
-    public func lookup(
-        package: PackageIdentity,
-        repository: RepositorySpecifier,
-        updateStrategy: RepositoryUpdateStrategy,
-        observabilityScope: ObservabilityScope,
-        delegateQueue: DispatchQueue,
-        callbackQueue: DispatchQueue
-    ) async throws -> RepositoryHandle {
-        try await withCheckedThrowingContinuation { continuation in
-            self.lookup(
-                package: package,
-                repository: repository,
-                updateStrategy: updateStrategy,
-                observabilityScope: observabilityScope,
-                delegateQueue: delegateQueue,
-                callbackQueue: callbackQueue,
-                completion: { continuation.resume(with: $0) }
-            )
-        }
+        let maxConcurrentOperations = max(1, maxConcurrentOperations ?? (3 * Concurrency.maxOperations / 4))
+        self.concurrencyLimiter = ConcurrencyLimiter(limit: maxConcurrentOperations)
     }
 
     /// Get a handle to a repository.
@@ -134,96 +105,107 @@ public class RepositoryManager: Cancellable {
         repository: RepositorySpecifier,
         updateStrategy: RepositoryUpdateStrategy,
         observabilityScope: ObservabilityScope,
-        delegateQueue: DispatchQueue,
         callbackQueue: DispatchQueue,
-        completion: @escaping (Result<RepositoryHandle, Error>) -> Void
+        completion: @escaping @Sendable (Result<RepositoryHandle, Error>) -> Void
     ) {
-        // records outstanding lookups for cancellation purposes
-        let lookupKey = UUID()
-        self.outstandingLookups[lookupKey] = (repository: repository, completion: completion, queue: callbackQueue)
-
-        // wrap the callback in the requested queue and cleanup operations
-        let completion: (Result<RepositoryHandle, Error>) -> Void = { result in
-            // free concurrency control semaphore
-            self.concurrencySemaphore.signal()
-            // remove any pending lookup
-            self.pendingLookupsLock.lock()
-            self.pendingLookups[repository]?.leave()
-            self.pendingLookups[repository] = nil
-            self.pendingLookupsLock.unlock()
-            // cancellation support
-            // if the callback is no longer on the pending lists it has been canceled already
-            // read + remove from outstanding requests atomically
-            if let (_, callback, queue) = self.outstandingLookups.removeValue(forKey: lookupKey) {
-                // call back on the request queue
-                queue.async { callback(result) }
-            }
-        }
-
-        // we must not block the calling thread (for concurrency control) so nesting this in a queue
-        self.lookupQueue.addOperation {
-            // park the lookup thread based on the max concurrency allowed
-            self.concurrencySemaphore.wait()
-
-            // check if there is a pending lookup
-            self.pendingLookupsLock.lock()
-            if let pendingLookup = self.pendingLookups[repository] {
-                self.pendingLookupsLock.unlock()
-                // chain onto the pending lookup
-                return pendingLookup.notify(queue: .sharedConcurrent) {
-                    // at this point the previous lookup should be complete and we can re-lookup
-                    completion(.init(catching: {
-                        try self.lookup(
-                            package: package,
-                            repository: repository,
-                            updateStrategy: updateStrategy,
-                            observabilityScope: observabilityScope,
-                            delegateQueue: delegateQueue
-                        )
-                    }))
-                }
-            } else {
-                // record the pending lookup
-                assert(self.pendingLookups[repository] == nil)
-                let group = DispatchGroup()
-                group.enter()
-                self.pendingLookups[repository] = group
-                self.pendingLookupsLock.unlock()
-            }
-
-            completion(.init(catching: {
-                try self.lookup(
-                    package: package,
-                    repository: repository,
-                    updateStrategy: updateStrategy,
-                    observabilityScope: observabilityScope,
-                    delegateQueue: delegateQueue
-                )
-            }))
+        callbackQueue.asyncResult(completion) {
+            // check if the repository is already being looked up
+            // if so, wait for it to finish and return the result
+            try await self.lookup(
+                package: package,
+                repository: repository,
+                updateStrategy: updateStrategy,
+                observabilityScope: observabilityScope
+            )
         }
     }
 
-    // sync version of the lookup,
-    // this is here because it simplifies reading & maintaining the logical flow
-    // while the underlying git client is sync
-    // once we move to an async  git client we would need to get rid of this
-    // sync func and roll the logic into the async version above
-    private func lookup(
+    public func lookup(
         package: PackageIdentity,
         repository repositorySpecifier: RepositorySpecifier,
         updateStrategy: RepositoryUpdateStrategy,
-        observabilityScope: ObservabilityScope,
-        delegateQueue: DispatchQueue
-    ) throws -> RepositoryHandle {
+        observabilityScope: ObservabilityScope
+    ) async throws -> RepositoryHandle {
+        await self.concurrencyLimiter.acquire()
+
+        let task = await withCheckedContinuation { continuation in
+            self.pendingLookupsLock.lock()
+            defer { self.pendingLookupsLock.unlock() }
+
+            let lookupTask: Task<RepositoryManager.RepositoryHandle, any Error>
+            if let inFlight = self.pendingLookups[repositorySpecifier] {
+                lookupTask = Task {
+                    // Let the existing in-flight task finish before queuing up the new one
+                    let _ = try await inFlight.value
+
+                    if Task.isCancelled {
+                        throw CancellationError()
+                    }
+
+                    let result = try await self.performLookup(
+                        package: package,
+                        repository: repositorySpecifier,
+                        updateStrategy: updateStrategy,
+                        observabilityScope: observabilityScope
+                    )
+
+                    if Task.isCancelled {
+                        throw CancellationError()
+                    }
+
+                    return result
+                }
+            } else {
+                lookupTask = Task {
+                    if Task.isCancelled {
+                        throw CancellationError()
+                    }
+
+                    let result = try await self.performLookup(
+                        package: package,
+                        repository: repositorySpecifier,
+                        updateStrategy: updateStrategy,
+                        observabilityScope: observabilityScope
+                    )
+
+                    if Task.isCancelled {
+                        throw CancellationError()
+                    }
+
+                    return result
+                }
+            }
+
+            self.pendingLookups[repositorySpecifier] = lookupTask
+            continuation.resume(returning: lookupTask)
+        }
+
+        do {
+            let result = try await task.value
+            await self.concurrencyLimiter.release()
+            return result
+        } catch {
+            await self.concurrencyLimiter.release()
+            throw error
+        }
+    }
+
+    private func performLookup(
+        package: PackageIdentity,
+        repository repositorySpecifier: RepositorySpecifier,
+        updateStrategy: RepositoryUpdateStrategy,
+        observabilityScope: ObservabilityScope
+    ) async throws -> RepositoryHandle {
         let relativePath = try repositorySpecifier.storagePath()
         let repositoryPath = self.path.appending(relativePath)
         let handle = RepositoryHandle(manager: self, repository: repositorySpecifier, subpath: relativePath)
+        let delegate = self.delegate
 
         // check if a repository already exists
         // errors when trying to check if a repository already exists are legitimate
         // and recoverable, and as such can be ignored
         quick: if (try? self.provider.isValidDirectory(repositoryPath)) ?? false {
-            let repository = try handle.open()
+            let repository = try await handle.open()
 
             guard ((try? self.provider.isValidDirectory(repositoryPath, for: repositorySpecifier)) ?? false) else {
                 observabilityScope.emit(warning: "\(repositoryPath) is not valid git repository for '\(repositorySpecifier.location)', will fetch again.")
@@ -234,14 +216,14 @@ public class RepositoryManager: Cancellable {
             if self.fetchRequired(repository: repository, updateStrategy: updateStrategy) {
                 let start = DispatchTime.now()
 
-                delegateQueue.async {
-                    self.delegate?.willUpdate(package: package, repository: handle.repository)
+                Task {
+                    await delegate?.willUpdate(package: package, repository: handle.repository)
                 }
 
                 try repository.fetch()
                 let duration = start.distance(to: .now())
-                delegateQueue.async {
-                    self.delegate?.didUpdate(package: package, repository: handle.repository, duration: duration)
+                Task {
+                    await delegate?.didUpdate(package: package, repository: handle.repository, duration: duration)
                 }
             }
 
@@ -250,50 +232,51 @@ public class RepositoryManager: Cancellable {
 
         // inform delegate that we are starting to fetch
         // calculate if cached (for delegate call) outside queue as it may change while queue is processing
-        let isCached = self.cachePath.map{ self.fileSystem.exists($0.appending(handle.subpath)) } ?? false
-        delegateQueue.async {
+        let isCached = self.cachePath.map { self.fileSystem.exists($0.appending(handle.subpath)) } ?? false
+        Task {
             let details = FetchDetails(fromCache: isCached, updatedCache: false)
-            self.delegate?.willFetch(package: package, repository: handle.repository, details: details)
+            await delegate?.willFetch(package: package, repository: handle.repository, details: details)
         }
 
         // perform the fetch
         let start = DispatchTime.now()
-        let fetchResult = Result<FetchDetails, Error>(catching: {
+        do {
             // make sure destination is free.
             try? self.fileSystem.removeFileTree(repositoryPath)
             // fetch the repo and cache the results
-            return try self.fetchAndPopulateCache(
+            let result = try await self.fetchAndPopulateCache(
                 package: package,
                 handle: handle,
                 repositoryPath: repositoryPath,
                 updateStrategy: updateStrategy,
-                observabilityScope: observabilityScope,
-                delegateQueue: delegateQueue
+                observabilityScope: observabilityScope
             )
-        })
-
-        // inform delegate fetch is done
-        let duration = start.distance(to: .now())
-        delegateQueue.async {
-            self.delegate?.didFetch(package: package, repository: handle.repository, result: fetchResult, duration: duration)
+            // inform delegate fetch is done
+            let duration = start.distance(to: .now())
+            Task {
+                await delegate?.didFetch(package: package, repository: handle.repository, result: .success(result), duration: duration)
+            }
+            return handle
+        } catch {
+            // inform delegate fetch is done
+            let duration = start.distance(to: .now())
+            Task {
+                await delegate?.didFetch(package: package, repository: handle.repository, result: .failure(error), duration: duration)
+            }
+            throw error
         }
-
-        // at this point we can throw, as we already notified the delegate above
-        _ = try fetchResult.get()
-
-        return handle
     }
 
     public func cancel(deadline: DispatchTime) throws {
         // ask the provider to cancel
         try self.provider.cancel(deadline: deadline)
-        // cancel any outstanding lookups
-        let outstanding = self.outstandingLookups.clear()
-        for (_, callback, queue) in outstanding.values {
-            queue.async {
-                callback(.failure(CancellationError()))
-            }
+
+        self.pendingLookupsLock.lock()
+        defer { self.pendingLookupsLock.unlock() }
+        for task in self.pendingLookups.values {
+            task.cancel()
         }
+        self.pendingLookups = [:]
     }
 
     /// Fetches the repository into the cache. If no `cachePath` is set or an error occurred fall back to fetching the repository without populating the cache.
@@ -309,18 +292,17 @@ public class RepositoryManager: Cancellable {
         handle: RepositoryHandle,
         repositoryPath: Basics.AbsolutePath,
         updateStrategy: RepositoryUpdateStrategy,
-        observabilityScope: ObservabilityScope,
-        delegateQueue: DispatchQueue
-    ) throws -> FetchDetails {
+        observabilityScope: ObservabilityScope
+    ) async throws -> FetchDetails {
         var cacheUsed = false
         var cacheUpdated = false
 
         // utility to update progress
-
         func updateFetchProgress(progress: FetchProgress) -> Void {
             if let total = progress.totalSteps {
-                delegateQueue.async {
-                    self.delegate?.fetching(
+                let delegate = self.delegate
+                Task {
+                    await delegate?.fetching(
                         package: package,
                         repository: handle.repository,
                         objectsFetched: progress.step,
@@ -337,11 +319,11 @@ public class RepositoryManager: Cancellable {
             let cachedRepositoryPath = try cachePath.appending(handle.repository.storagePath())
             do {
                 try self.initializeCacheIfNeeded(cachePath: cachePath)
-                try self.fileSystem.withLock(on: cachePath, type: .shared) {
-                    try self.fileSystem.withLock(on: cachedRepositoryPath, type: .exclusive) {
+                try await self.fileSystem.withLock(on: cachePath, type: .shared) {
+                    try await self.fileSystem.withLock(on: cachedRepositoryPath, type: .exclusive) {
                         // Fetch the repository into the cache.
                         if (self.fileSystem.exists(cachedRepositoryPath)) {
-                            let repo = try self.provider.open(repository: handle.repository, at: cachedRepositoryPath)
+                            let repo = try await self.provider.open(repository: handle.repository, at: cachedRepositoryPath)
                             if self.fetchRequired(repository: repo, updateStrategy: updateStrategy) {
                                 try repo.fetch(progress: updateFetchProgress(progress:))
                             }
@@ -421,8 +403,8 @@ public class RepositoryManager: Cancellable {
     }
 
     /// Open a repository from a handle.
-    private func open(_ handle: RepositoryHandle) throws -> Repository {
-        try self.provider.open(
+    private func open(_ handle: RepositoryHandle) async throws -> Repository {
+        try await self.provider.open(
             repository: handle.repository,
             at: self.path.appending(handle.subpath)
         )
@@ -516,7 +498,7 @@ public class RepositoryManager: Cancellable {
 
 extension RepositoryManager {
     /// Handle to a managed repository.
-    public struct RepositoryHandle {
+    public struct RepositoryHandle: Sendable {
         /// The manager this repository is owned by.
         private unowned let manager: RepositoryManager
 
@@ -537,8 +519,8 @@ extension RepositoryManager {
         }
 
         /// Open the given repository.
-        public func open() throws -> Repository {
-            return try self.manager.open(self)
+        public func open() async throws -> Repository {
+            return try await self.manager.open(self)
         }
 
         /// Create a working copy at on the local file system.
@@ -556,7 +538,7 @@ extension RepositoryManager {
 
 extension RepositoryManager {
     /// Additional information about a fetch
-    public struct FetchDetails: Equatable {
+    public struct FetchDetails: Equatable, Sendable {
         /// Indicates if the repository was fetched from the cache or from the remote.
         public let fromCache: Bool
         /// Indicates whether the repository was already present in the cache and updated or if a clean fetch was performed.
@@ -564,14 +546,14 @@ extension RepositoryManager {
     }
 }
 
-public enum RepositoryUpdateStrategy {
+public enum RepositoryUpdateStrategy: Sendable {
     case never
     case always
     case ifNeeded(revision: Revision)
 }
 
 /// Delegate to notify clients about actions being performed by RepositoryManager.
-public protocol RepositoryManagerDelegate {
+public protocol RepositoryManagerDelegate: Sendable {
     /// Called when a repository is about to be fetched.
     func willFetch(package: PackageIdentity, repository: RepositorySpecifier, details: RepositoryManager.FetchDetails)
 
@@ -586,6 +568,38 @@ public protocol RepositoryManagerDelegate {
 
     /// Called when a repository has finished updating from its remote.
     func didUpdate(package: PackageIdentity, repository: RepositorySpecifier, duration: DispatchTimeInterval)
+}
+
+/// Actor to proxy the delegate methods to the actual delegate, ensuring serialized delegate calls.
+fileprivate actor RepositoryManagerDelegateProxy {
+    private let delegate: RepositoryManagerDelegate
+
+    init?(_ delegate: RepositoryManagerDelegate?) {
+        guard let delegate else {
+            return nil
+        }
+        self.delegate = delegate
+    }
+
+    func willFetch(package: PackageIdentity, repository: RepositorySpecifier, details: RepositoryManager.FetchDetails) {
+        delegate.willFetch(package: package, repository: repository, details: details)
+    }
+
+    func fetching(package: PackageIdentity, repository: RepositorySpecifier, objectsFetched: Int, totalObjectsToFetch: Int) {
+        delegate.fetching(package: package, repository: repository, objectsFetched: objectsFetched, totalObjectsToFetch: totalObjectsToFetch)
+    }
+
+    func didFetch(package: PackageIdentity, repository: RepositorySpecifier, result: Result<RepositoryManager.FetchDetails, Error>, duration: DispatchTimeInterval) {
+        delegate.didFetch(package: package, repository: repository, result: result, duration: duration)
+    }
+
+    func willUpdate(package: PackageIdentity, repository: RepositorySpecifier) {
+        delegate.willUpdate(package: package, repository: repository)
+    }
+
+    func didUpdate(package: PackageIdentity, repository: RepositorySpecifier, duration: DispatchTimeInterval) {
+        delegate.didUpdate(package: package, repository: repository, duration: duration)
+    }
 }
 
 

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -72,7 +72,6 @@ extension Workspace {
         // Create cache directories.
         self.createCacheDirectories(observabilityScope: observabilityScope)
 
-        // FIXME: this should not block
         // Load the root manifests and currently checked out manifests.
         let rootManifests = try await self.loadRootManifests(
             packages: root.packages,
@@ -345,7 +344,6 @@ extension Workspace {
         // Ensure the cache path exists.
         self.createCacheDirectories(observabilityScope: observabilityScope)
 
-        // FIXME: this should not block
         let rootManifests = try await self.loadRootManifests(
             packages: root.packages,
             observabilityScope: observabilityScope
@@ -403,8 +401,7 @@ extension Workspace {
                     _ = try await self.packageContainerProvider.getContainer(
                         for: resolvedPackage.packageRef,
                         updateStrategy: updateStrategy,
-                        observabilityScope: observabilityScope,
-                        on: .sharedConcurrent
+                        observabilityScope: observabilityScope
                     )
                 }
             }
@@ -747,12 +744,10 @@ extension Workspace {
     ) async throws -> AbsolutePath {
         switch requirement {
         case .version(let version):
-            // FIXME: this should not block
             let container = try await packageContainerProvider.getContainer(
                 for: package,
                 updateStrategy: ContainerUpdateStrategy.never,
-                observabilityScope: observabilityScope,
-                on: .sharedConcurrent
+                observabilityScope: observabilityScope
             )
 
             if let container = container as? SourceControlPackageContainer {
@@ -1066,8 +1061,7 @@ extension Workspace {
                     packageContainerProvider.getContainer(
                         for: binding.package,
                         updateStrategy: .never,
-                        observabilityScope: observabilityScope,
-                        on: .sharedConcurrent
+                        observabilityScope: observabilityScope
                     )
                  as? SourceControlPackageContainer else {
                     throw InternalError(

--- a/Sources/Workspace/Workspace+Editing.swift
+++ b/Sources/Workspace/Workspace+Editing.swift
@@ -98,17 +98,14 @@ extension Workspace {
             // Otherwise, create a checkout at the destination from our repository store.
             //
             // Get handle to the repository.
-            // TODO: replace with async/await when available
             let repository = try dependency.packageRef.makeRepositorySpecifier()
             let handle = try await repositoryManager.lookup(
                 package: dependency.packageRef.identity,
                 repository: repository,
                 updateStrategy: .never,
-                observabilityScope: observabilityScope,
-                delegateQueue: .sharedConcurrent,
-                callbackQueue: .sharedConcurrent
+                observabilityScope: observabilityScope
             )
-            let repo = try handle.open()
+            let repo = try await handle.open()
 
             // Do preliminary checks on branch and revision, if provided.
             if let branch = checkoutBranch, repo.exists(revision: Revision(identifier: branch)) {

--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -990,8 +990,7 @@ extension Workspace {
                     let container = try await self.packageContainerProvider.getContainer(
                         for: dependency.packageRef,
                         updateStrategy: .never,
-                        observabilityScope: observabilityScope,
-                        on: .sharedConcurrent
+                        observabilityScope: observabilityScope
                     )
                     if let customContainer = container as? CustomPackageContainer {
                         let newPath = try customContainer.retrieve(at: version, observabilityScope: observabilityScope)

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -398,8 +398,7 @@ extension Workspace {
         let downloadPath = try await self.registryDownloadsManager.lookup(
             package: package.identity,
             version: version,
-            observabilityScope: observabilityScope,
-            delegateQueue: .sharedConcurrent
+            observabilityScope: observabilityScope
         )
 
         // Record the new state.

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -395,7 +395,6 @@ extension Workspace {
         at version: Version,
         observabilityScope: ObservabilityScope
     ) async throws -> AbsolutePath {
-        // FIXME: this should not block
         let downloadPath = try await self.registryDownloadsManager.lookup(
             package: package.identity,
             version: version,

--- a/Sources/Workspace/Workspace+SourceControl.swift
+++ b/Sources/Workspace/Workspace+SourceControl.swift
@@ -172,14 +172,11 @@ extension Workspace {
         }
 
         // If not, we need to get the repository from the checkouts.
-        // FIXME: this should not block
         let handle = try await self.repositoryManager.lookup(
             package: package.identity,
             repository: repository,
             updateStrategy: .never,
-            observabilityScope: observabilityScope,
-            delegateQueue: .sharedConcurrent,
-            callbackQueue: .sharedConcurrent
+            observabilityScope: observabilityScope
         )
 
         // Clone the repository into the checkouts.

--- a/Sources/_InternalTestSupport/MockPackageContainer.swift
+++ b/Sources/_InternalTestSupport/MockPackageContainer.swift
@@ -171,14 +171,11 @@ public struct MockPackageContainerProvider: PackageContainerProvider {
     public func getContainer(
         for package: PackageReference,
         updateStrategy: ContainerUpdateStrategy,
-        observabilityScope: ObservabilityScope,
-        on queue: DispatchQueue,
-        completion: @escaping (Result<PackageContainer, Swift.Error>
-        ) -> Void
-    ) {
-        queue.async {
-            completion(self.containersByIdentifier[package].map { .success($0) } ??
-                .failure(StringError("unknown module \(package)")))
+        observabilityScope: ObservabilityScope
+    ) async throws -> PackageContainer {
+        guard let container = self.containersByIdentifier[package] else {
+            throw StringError("unknown module \(package)")
         }
+        return container
     }
 }

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -216,17 +216,11 @@ public final class MockWorkspace {
                         identity: PackageIdentity(url: url),
                         kind: .remoteSourceControl(url)
                     )
-                    let container = try await withCheckedThrowingContinuation { continuation in
-                        containerProvider.getContainer(
-                            for: packageRef,
-                            updateStrategy: .never,
-                            observabilityScope: observability.topScope,
-                            on: .sharedConcurrent,
-                            completion: {
-                                continuation.resume(with: $0)
-                            }
-                        )
-                    }
+                    let container = try await containerProvider.getContainer(
+                        for: packageRef,
+                        updateStrategy: .never,
+                        observabilityScope: observability.topScope
+                    )
                     guard let customContainer = container as? CustomPackageContainer else {
                         throw StringError("invalid custom container: \(container)")
                     }

--- a/Tests/BasicsTests/ConcurrencyHelpersTests.swift
+++ b/Tests/BasicsTests/ConcurrencyHelpersTests.swift
@@ -16,69 +16,73 @@ import TSCTestSupport
 import Testing
 
 struct ConcurrencyHelpersTest {
-    let queue = DispatchQueue(label: "ConcurrencyHelpersTest", attributes: .concurrent)
+    @Suite
+    struct ThreadSafeKeyValueStoreTests {
+        let queue = DispatchQueue(label: "ConcurrencyHelpersTest", attributes: .concurrent)
 
-    @Test
-    func threadSafeKeyValueStore() throws {
-        for _ in 0 ..< 100 {
-            let sync = DispatchGroup()
+        @Test
+        func threadSafeKeyValueStore() throws {
+            for _ in 0 ..< 100 {
+                let sync = DispatchGroup()
 
-            var expected = [Int: Int]()
-            let lock = NSLock()
+                var expected = [Int: Int]()
+                let lock = NSLock()
 
-            let cache = ThreadSafeKeyValueStore<Int, Int>()
-            for index in 0 ..< 1000 {
-                self.queue.async(group: sync) {
-                    Thread.sleep(forTimeInterval: Double.random(in: 100 ... 300) * 1.0e-6)
-                    let value = Int.random(in: Int.min ..< Int.max)
-                    lock.withLock {
-                        expected[index] = value
-                    }
-                    cache.memoize(index) {
-                        value
-                    }
-                    cache.memoize(index) {
-                        Int.random(in: Int.min ..< Int.max)
+                let cache = ThreadSafeKeyValueStore<Int, Int>()
+                for index in 0 ..< 1000 {
+                    self.queue.async(group: sync) {
+                        Thread.sleep(forTimeInterval: Double.random(in: 100 ... 300) * 1.0e-6)
+                        let value = Int.random(in: Int.min ..< Int.max)
+                        lock.withLock {
+                            expected[index] = value
+                        }
+                        cache.memoize(index) {
+                            value
+                        }
+                        cache.memoize(index) {
+                            Int.random(in: Int.min ..< Int.max)
+                        }
                     }
                 }
-            }
 
-            try #require(sync.wait(timeout: .now() + .seconds(2)) == .success)
-            expected.forEach { key, value in
-                #expect(cache[key] == value)
+                try #require(sync.wait(timeout: .now() + .seconds(2)) == .success)
+                expected.forEach { key, value in
+                    #expect(cache[key] == value)
+                }
             }
         }
-    }
 
-    @Test
-    func threadSafeArrayStore() throws {
-        for _ in 0 ..< 100 {
-            let sync = DispatchGroup()
+        @Test
+        func threadSafeArrayStore() throws {
+            for _ in 0 ..< 100 {
+                let sync = DispatchGroup()
 
-            var expected = [Int]()
-            let lock = NSLock()
+                var expected = [Int]()
+                let lock = NSLock()
 
-            let cache = ThreadSafeArrayStore<Int>()
-            for _ in 0 ..< 1000 {
-                self.queue.async(group: sync) {
-                    Thread.sleep(forTimeInterval: Double.random(in: 100 ... 300) * 1.0e-6)
-                    let value = Int.random(in: Int.min ..< Int.max)
-                    lock.withLock {
-                        expected.append(value)
+                let cache = ThreadSafeArrayStore<Int>()
+                for _ in 0 ..< 1000 {
+                    self.queue.async(group: sync) {
+                        Thread.sleep(forTimeInterval: Double.random(in: 100 ... 300) * 1.0e-6)
+                        let value = Int.random(in: Int.min ..< Int.max)
+                        lock.withLock {
+                            expected.append(value)
+                        }
+                        cache.append(value)
                     }
-                    cache.append(value)
                 }
-            }
 
-            try #require(sync.wait(timeout: .now() + .seconds(2)) == .success)
-            let expectedSorted = expected.sorted()
-            let resultsSorted = cache.get().sorted()
-            #expect(expectedSorted == resultsSorted)
+                try #require(sync.wait(timeout: .now() + .seconds(2)) == .success)
+                let expectedSorted = expected.sorted()
+                let resultsSorted = cache.get().sorted()
+                #expect(expectedSorted == resultsSorted)
+            }
         }
     }
 
     @Test
     func threadSafeBox() throws {
+        let queue = DispatchQueue(label: "ConcurrencyHelpersTest", attributes: .concurrent)
         for _ in 0 ..< 100 {
             let sync = DispatchGroup()
 
@@ -89,7 +93,7 @@ struct ConcurrencyHelpersTest {
 
             let cache = ThreadSafeBox<Int>()
             for index in 0 ..< 1000 {
-                self.queue.async(group: sync) {
+                queue.async(group: sync) {
                     Thread.sleep(forTimeInterval: Double.random(in: 100 ... 300) * 1.0e-6)
                     serial.async(group: sync) {
                         lock.withLock {
@@ -106,6 +110,124 @@ struct ConcurrencyHelpersTest {
 
             try #require(sync.wait(timeout: .now() + .seconds(2)) == .success)
             #expect(cache.get() == winner)
+        }
+    }
+
+    @Suite
+    struct AsyncOperationQueueTests {
+        fileprivate actor ResultsTracker {
+            var results = [Int]()
+            var maxConcurrent = 0
+            var currentConcurrent = 0
+
+            func incrementConcurrent() {
+                currentConcurrent += 1
+                maxConcurrent = max(maxConcurrent, currentConcurrent)
+            }
+
+            func decrementConcurrent() {
+                currentConcurrent -= 1
+            }
+
+            func appendResult(_ value: Int) {
+                results.append(value)
+            }
+        }
+
+        @Test
+        func limitsConcurrentOperations() async throws {
+            let queue = AsyncOperationQueue(concurrentTasks: 5)
+
+            let totalTasks = 20
+            let tracker = ResultsTracker()
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for index in 0..<totalTasks {
+                    group.addTask {
+                        try await queue.withOperation {
+                            await tracker.incrementConcurrent()
+                            try? await Task.sleep(nanoseconds: 5_000_000)
+                            await tracker.decrementConcurrent()
+                            await tracker.appendResult(index)
+                        }
+                    }
+                }
+                try await group.waitForAll()
+            }
+
+            let maxConcurrent = await tracker.maxConcurrent
+            let results = await tracker.results
+
+            // Check that at no point did we exceed 5 concurrent operations
+            #expect(maxConcurrent == 5)
+            #expect(results.count == totalTasks)
+        }
+
+        @Test
+        func handlesImmediateCancellation() async throws {
+            let queue = AsyncOperationQueue(concurrentTasks: 5)
+            let totalTasks = 20
+            let tracker = ResultsTracker()
+
+            await #expect(throws: CancellationError.self) {
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    for index in 0..<totalTasks {
+                        group.addTask {
+                            try await queue.withOperation {
+                                await tracker.incrementConcurrent()
+                                // sleep for a long time to ensure cancellation can occur.
+                                // If this is too short the cancellation may be triggered after
+                                // all tasks have completed.
+                                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                                await tracker.decrementConcurrent()
+                                await tracker.appendResult(index)
+                            }
+                        }
+                    }
+                    // Cancel the task group before it finishes
+                    group.cancelAll()
+                    try await group.waitForAll()
+                }
+            }
+
+            let maxConcurrent = await tracker.maxConcurrent
+            let results = await tracker.results
+
+            #expect(maxConcurrent <= 5)
+            #expect(results.count < totalTasks)
+        }
+
+        @Test
+        func handlesCancellationDuringWait() async throws {
+            let queue = AsyncOperationQueue(concurrentTasks: 5)
+            let totalTasks = 20
+            let tracker = ResultsTracker()
+
+            await #expect(throws: CancellationError.self) {
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    for index in 0..<totalTasks {
+                        group.addTask {
+                            try await queue.withOperation {
+                                await tracker.incrementConcurrent()
+                                try? await Task.sleep(nanoseconds: 5_000_000)
+                                await tracker.decrementConcurrent()
+                                await tracker.appendResult(index)
+                            }
+                        }
+                    }
+
+                    group.addTask { [group] in
+                        group.cancelAll()
+                    }
+                    try await group.waitForAll()
+                }
+            }
+
+            let maxConcurrent = await tracker.maxConcurrent
+            let results = await tracker.results
+
+            #expect(maxConcurrent <= 5)
+            #expect(results.count < totalTasks)
         }
     }
 }

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -3275,14 +3275,12 @@ public struct MockProvider: PackageContainerProvider {
     public func getContainer(
         for package: PackageReference,
         updateStrategy: ContainerUpdateStrategy,
-        observabilityScope: ObservabilityScope,
-        on queue: DispatchQueue,
-        completion: @escaping (Result<PackageContainer, Error>
-    ) -> Void) {
-        queue.async {
-            completion(self.containersByIdentifier[package].map{ .success($0) } ??
-                .failure(_MockLoadingError.unknownModule))
+        observabilityScope: ObservabilityScope
+    ) async throws -> PackageContainer {
+        guard let container = self.containersByIdentifier[package] else {
+            throw _MockLoadingError.unknownModule
         }
+        return container
     }
 }
 

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -409,17 +409,6 @@ private final class MockRegistryDownloadsManagerDelegate: RegistryDownloadsManag
     }
 }
 
-extension RegistryDownloadsManager {
-    fileprivate func lookup(package: PackageIdentity, version: Version, observabilityScope: ObservabilityScope) async throws -> AbsolutePath {
-        try await self.lookup(
-            package: package,
-            version: version,
-            observabilityScope: observabilityScope,
-            delegateQueue: .sharedConcurrent
-        )
-    }
-}
-
 fileprivate struct PackageVersion: Hashable, Equatable, Sendable {
     let package: PackageIdentity
     let version: Version

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -48,7 +48,7 @@ final class RepositoryManagerTests: XCTestCase {
                 XCTAssertEqual(provider.numFetches, 0)
 
                 // Open the repository.
-                let repository = try! handle.open()
+                let repository = try! await handle.open()
                 XCTAssertEqual(try! repository.getTags(), ["1.0.0"])
 
                 // Create a checkout of the repository.
@@ -64,7 +64,6 @@ final class RepositoryManagerTests: XCTestCase {
             }
 
             // Get a bad repository.
-
             do {
                 delegate.prepare(fetchExpected: true, updateExpected: false)
                 await XCTAssertAsyncThrowsError(try await manager.lookup(repository: badDummyRepo, observabilityScope: observability.topScope)) { error in
@@ -359,9 +358,7 @@ final class RepositoryManagerTests: XCTestCase {
                             package: PackageIdentity(path: dummyRepoPath),
                             repository: dummyRepo,
                             updateStrategy: .always,
-                            observabilityScope: observability.topScope,
-                            delegateQueue: .sharedConcurrent,
-                            callbackQueue: .sharedConcurrent
+                            observabilityScope: observability.topScope
                         )
                     }
                 }
@@ -449,7 +446,6 @@ final class RepositoryManagerTests: XCTestCase {
 
         cancellator.register(name: "repository manager", handler: manager)
 
-        //let startGroup = DispatchGroup()
         let finishGroup = DispatchGroup()
         let results = ThreadSafeKeyValueStore<RepositorySpecifier, Result<RepositoryManager.RepositoryHandle, Error>>()
         for index in 0 ..< total {
@@ -462,7 +458,6 @@ final class RepositoryManagerTests: XCTestCase {
                 repository: repository,
                 updateStrategy: .never,
                 observabilityScope: observability.topScope,
-                delegateQueue: .sharedConcurrent,
                 callbackQueue: .sharedConcurrent
             ) { result in
                 defer { finishGroup.leave() }
@@ -499,7 +494,7 @@ final class RepositoryManagerTests: XCTestCase {
 
         // the provider called in a thread managed by the RepositoryManager
         // the use of blocking semaphore is intentional
-        class MockRepositoryProvider: RepositoryProvider {
+        class MockRepositoryProvider: RepositoryProvider, @unchecked Sendable {
             let total: Int
             // this DispatchGroup is used to wait for the requests to start before calling cancel
             let startGroup = DispatchGroup()
@@ -524,7 +519,6 @@ final class RepositoryManagerTests: XCTestCase {
                     defer { self.outstandingGroup.leave() }
                     print("\(repository) waiting to be cancelled")
                     XCTAssertEqual(.success, self.terminatedGroup.wait(timeout: .now() + 5), "timeout waiting on terminated signal")
-                    throw StringError("\(repository) should be cancelled")
                 }
                 print("\(repository) okay")
             }
@@ -590,7 +584,7 @@ final class RepositoryManagerTests: XCTestCase {
             }
         }
 
-        class MockRepositoryProvider: RepositoryProvider {
+        class MockRepositoryProvider: RepositoryProvider, @unchecked Sendable {
             let repository: RepositorySpecifier
             var fetch: Int = 0
 
@@ -698,19 +692,12 @@ extension RepositoryManager {
         updateStrategy: RepositoryUpdateStrategy = .always,
         observabilityScope: ObservabilityScope
     ) async throws -> RepositoryHandle {
-        return try await withCheckedThrowingContinuation { continuation in
-            self.lookup(
-                package: .init(url: SourceControlURL(repository.url)),
-                repository: repository,
-                updateStrategy: updateStrategy,
-                observabilityScope: observabilityScope,
-                delegateQueue: .sharedConcurrent,
-                callbackQueue: .sharedConcurrent,
-                completion: {
-                  continuation.resume(with: $0)
-                }
-            )
-        }
+        try await self.lookup(
+            package: .init(url: SourceControlURL(repository.url)),
+            repository: repository,
+            updateStrategy: updateStrategy,
+            observabilityScope: observabilityScope
+        )
     }
 }
 
@@ -718,7 +705,7 @@ private enum DummyError: Swift.Error {
     case invalidRepository
 }
 
-private class DummyRepositoryProvider: RepositoryProvider {
+private class DummyRepositoryProvider: RepositoryProvider, @unchecked Sendable {
     private let fileSystem: FileSystem
 
     private let lock = NSLock()
@@ -730,7 +717,7 @@ private class DummyRepositoryProvider: RepositoryProvider {
     }
 
     func fetch(repository: RepositorySpecifier, to path: AbsolutePath, progressHandler: FetchProgress.Handler? = nil) throws {
-        assert(!self.fileSystem.exists(path))
+        assert(!self.fileSystem.exists(path), "\(path) should not exist")
         try self.fileSystem.createDirectory(path, recursive: true)
         try self.fileSystem.writeFileContents(path.appending("readme.md"), string: repository.location.description)
 
@@ -860,7 +847,7 @@ private class DummyRepositoryProvider: RepositoryProvider {
     }
 }
 
-fileprivate class DummyRepositoryManagerDelegate: RepositoryManager.Delegate {
+fileprivate class DummyRepositoryManagerDelegate: RepositoryManager.Delegate, @unchecked Sendable {
     private var _willFetch = ThreadSafeArrayStore<(repository: RepositorySpecifier, details: RepositoryManager.FetchDetails)>()
     private var _didFetch = ThreadSafeArrayStore<(repository: RepositorySpecifier, result: Result<RepositoryManager.FetchDetails, Error>)>()
     private var _willUpdate = ThreadSafeArrayStore<RepositorySpecifier>()

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -330,7 +330,7 @@ final class RegistryPackageContainerTests: XCTestCase {
             let manifest = try await container.loadManifest(version: packageVersion)
             XCTAssertEqual(manifest.toolsVersion, .v5_5)
         }
-        
+
         do {
             let provider = try createProvider(.v5) // the version of the alternate
             let ref = PackageReference.registry(identity: packageIdentity)
@@ -504,8 +504,7 @@ extension PackageContainerProvider {
         try await self.getContainer(
             for: package,
             updateStrategy: updateStrategy,
-            observabilityScope: ObservabilitySystem.NOOP,
-            on: .global()
+            observabilityScope: ObservabilitySystem.NOOP
         )
     }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3886,8 +3886,6 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolvedFileSchemeToolsVersion() async throws {
-        let fs = InMemoryFileSystem()
-
         for pair in [
             (ToolsVersion.v5_2, ToolsVersion.v5_2),
             (ToolsVersion.v5_6, ToolsVersion.v5_6),


### PR DESCRIPTION
The `RepositoryProvider` protocol's `open` method is defined as synchronous. Convert this to `async` to avoid concurrency workarounds in clients that might be prone to deadlocks.

This involved porting `RepositoryManager.lookup` to structured concurrency. The method has some concurrency constraints that are preserved:

- There is a limit (`maxConcurrentOperations`) on how many simultaneous lookups can be performed concurrently.
- If a lookup is requested and one is in flight for the same `RepositorySpecifier`, the in flight request completes before the new one is started.