### PR TITLE
build-using-self: Add ability to pass extra build/run/test arguments

### DIFF
--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -68,7 +68,7 @@ def get_arguments() -> argparse.Namespace:
         dest="config",
         default=Configuration.DEBUG,
         choices=[e for e in Configuration],
-        help="The configuraiton to use.",
+        help="The configuration to use.",
     )
     parser.add_argument(
         "-t",
@@ -90,6 +90,36 @@ def get_arguments() -> argparse.Namespace:
         "--enable-xctest",
         action="store_true",
     )
+    parser.add_argument(
+        "--additional-build-args",
+        type=str,
+        dest="additional_build_args",
+        default=""
+    )
+    parser.add_argument(
+        "--additional-run-args",
+        type=str,
+        dest="additional_run_args",
+        default=""
+    )
+    parser.add_argument(
+        "--additional-test-args",
+        type=str,
+        dest="additional_test_args",
+        default=""
+    )
+    parser.add_argument(
+        "--additional-integration-test-args",
+        type=str,
+        dest="additional_integration_test_args",
+        default=""
+    )
+    parser.add_argument(
+        "--skip-bootstrap",
+        dest="skip_bootstrap",
+        action="store_true"
+    )
+    parser.set_defaults(skip_bootstrap=False)
     args = parser.parse_args()
     return args
 
@@ -157,8 +187,8 @@ class GlobalArgs:
     value: t.Optional[GlobalArgsValueType]
 
 
-def filterNone(items: t.Iterable) -> t.Iterable:
-    return list(filter(lambda x: x is not None, items))
+def filterNoneAndEmpty(items: t.Iterable) -> t.Iterable:
+    return list(filter(lambda x: x is not None and x != '', items))
 
 
 def main() -> None:
@@ -181,7 +211,7 @@ def main() -> None:
         set_environment(swiftpm_bin_dir=swiftpm_bin_dir)
 
         call(
-            filterNone(
+            filterNoneAndEmpty(
                 [
                     "swift",
                     "--version",
@@ -190,7 +220,7 @@ def main() -> None:
         )
 
         call(
-            filterNone(
+            filterNoneAndEmpty(
                 [
                     "swift",
                     "package",
@@ -199,7 +229,7 @@ def main() -> None:
             )
         )
         call(
-            filterNone(
+            filterNoneAndEmpty(
                 [
                     "swift",
                     "build",
@@ -207,36 +237,34 @@ def main() -> None:
                     "--configuration",
                     args.config,
                     *ignore_args,
+                    *args.additional_build_args.split(" ")
                 ]
             )
         )
-
-        swift_testing_arg = (
-            "--enable-swift-testing" if args.enable_swift_testing else None
-        )
-        xctest_arg = "--enable-xctest" if args.enable_swift_testing else None
         call(
-            filterNone(
+            filterNoneAndEmpty(
                 [
                     "swift",
                     "run",
+                    *args.additional_run_args.split(" "),
                     "swift-test",
                     *global_args,
                     "--configuration",
                     args.config,
                     "--parallel",
-                    swift_testing_arg,
-                    xctest_arg,
+                    "--enable-swift-testing" if args.enable_swift_testing else None,
+                    "--enable-xctest" if args.enable_swift_testing else None,
                     "--scratch-path",
                     ".test",
                     *ignore_args,
+                    *args.additional_test_args.split(" ")
                 ]
             )
         )
 
         integration_test_dir = (REPO_ROOT_PATH / "IntegrationTests").as_posix()
         call(
-            filterNone(
+            filterNoneAndEmpty(
                 [
                     "swift",
                     "package",
@@ -247,21 +275,23 @@ def main() -> None:
             )
         )
         call(
-            filterNone(
-                [
+            filterNoneAndEmpty(
+               [
                     "swift",
                     "run",
+                    *args.additional_run_args.split(" "),
                     "swift-test",
                     *global_args,
                     "--package-path",
                     integration_test_dir,
                     "--parallel",
                     *ignore_args,
+                    *args.additional_integration_test_args.split(" ")
                 ]
             )
         )
 
-    if is_on_darwin():
+    if is_on_darwin() and not args.skip_bootstrap:
         run_bootstrap(swiftpm_bin_dir=swiftpm_bin_dir)
     logging.info("Done")
 


### PR DESCRIPTION
Add the ability to inject arbitrary arguments to the invocations of swift <build|run|test> from the build-using-self-script.
Add a boolean flag to skip running the bootstrap subscript. Default is to run it.

This allows one to add options like '--jobs' or '--event-stream-output-path' .
Thus allowing for different use cases in pipelines, like collection of test output json to a specific path.

For example:
`build-using-self -v --skip-bootstrap --additional-test-args '--event-stream-output-path spm-test.json'`
