### PR TITLE
Allow staging in new BuildSettings.Declaration cases without introducing failures

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -902,6 +902,9 @@ extension ProjectModel.BuildSettings {
 
             case .ARCHS, .IPHONEOS_DEPLOYMENT_TARGET, .SPECIALIZATION_SDK_OPTIONS:
                 fatalError("Unexpected BuildSettings.Declaration: \(setting)")
+            // Allow staging in new cases
+            default:
+                fatalError("Unhandled enum case in BuildSettings.Declaration. Will generate a warning until we have SE-0487")
             }
         } else {
             switch setting {
@@ -921,6 +924,9 @@ extension ProjectModel.BuildSettings {
 
             case .ARCHS, .IPHONEOS_DEPLOYMENT_TARGET, .SPECIALIZATION_SDK_OPTIONS:
                 fatalError("Unexpected BuildSettings.Declaration: \(setting)")
+            // Allow staging in new cases
+            default:
+                fatalError("Unhandled enum case in BuildSettings.Declaration. Will generate a warning until we have SE-0487")
             }
         }
     }
@@ -949,6 +955,9 @@ extension ProjectModel.BuildSettings.MultipleValueSetting {
             self = .SWIFT_ACTIVE_COMPILATION_CONDITIONS
         case .ARCHS, .IPHONEOS_DEPLOYMENT_TARGET, .SWIFT_VERSION:
             return nil
+        // Allow staging in new cases
+        default:
+            fatalError("Unhandled enum case in BuildSettings.Declaration. Will generate a warning until we have SE-0487")
         }
     }
 }


### PR DESCRIPTION
Until we get https://github.com/swiftlang/swift-evolution/blob/main/proposals/0487-extensible-enums.md or a similar mechanism, add some redundant default clauses so that changes like https://github.com/swiftlang/swift-build/pull/526 can be staged in without revlock.