### PR TITLE
Add support for a `--sanitize=fuzzer` flag

### DIFF
--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -198,6 +198,10 @@ public final class SwiftModuleBuildDescription {
     /// True if this module needs to be parsed as a library based on the target type and the configuration
     /// of the source code
     var needsToBeParsedAsLibrary: Bool {
+        if buildParameters.sanitizers.sanitizers.contains(.fuzzer) {
+            return true
+        }
+
         switch self.target.type {
         case .library, .test:
             return true

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -874,7 +874,7 @@ public final class SwiftCommandState {
                     flags: ["entry-point-function-name"],
                     toolchain: toolchain,
                     fileSystem: self.fileSystem
-                ),
+                ) && !options.build.sanitizers.contains(.fuzzer),
                 enableParseableModuleInterfaces: self.options.build.shouldEnableParseableModuleInterfaces,
                 explicitTargetDependencyImportCheckingMode: self.options.build.explicitTargetDependencyImportCheck
                     .modeParameter,

--- a/Sources/PackageModel/Sanitizers.swift
+++ b/Sources/PackageModel/Sanitizers.swift
@@ -16,6 +16,7 @@ public enum Sanitizer: String, Encodable, CaseIterable {
     case thread
     case undefined
     case scudo
+    case fuzzer
 
     /// Return an established short name for a sanitizer, e.g. "asan".
     public var shortName: String {
@@ -24,6 +25,7 @@ public enum Sanitizer: String, Encodable, CaseIterable {
             case .thread: return "tsan"
             case .undefined: return "ubsan"
             case .scudo: return "scudo"
+            case .fuzzer: return "fuzzer"
         }
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -6656,6 +6656,10 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         try await self.sanitizerTest(.scudo, expectedName: "scudo")
     }
 
+    func testFuzzerSanitizer() async throws {
+        try await self.sanitizerTest(.fuzzer, expectedName: "fuzzer")
+    }
+
     func testSnippets() async throws {
         let fs: FileSystem = InMemoryFileSystem(
             emptyFiles:
@@ -6762,6 +6766,14 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
 
         let clib = try result.moduleBuildDescription(for: "clib").clang().basicArguments(isCXX: false)
         XCTAssertMatch(clib, ["-fsanitize=\(expectedName)"])
+
+        if sanitizer == .fuzzer {
+            XCTAssertMatch(exe, ["-parse-as-library"])
+            XCTAssertNoMatch(exe, ["-Xlinker", "alias", "_main"])
+            XCTAssertMatch(lib, ["-parse-as-library"])
+            XCTAssertNoMatch(lib, ["-Xlinker", "alias", "_main"])
+            XCTAssertNoMatch(clib, ["-parse-as-library"])
+        }
 
         XCTAssertMatch(try result.buildProduct(for: "exe").linkArguments(), ["-sanitize=\(expectedName)"])
     }


### PR DESCRIPTION
### Motivation:

I hope that this should fix https://github.com/swiftlang/swift-package-manager/issues/8731, and make it easier to build with libFuzzer.

### Modifications:

Add support for a `-sanitize=fuzzer` option in `swift-build`, that sets the correct flags (including `-parse-as-library`) to build a binary for fuzzing. Add an additional test to make sure that these flags get set. 