### PR TITLE
SwiftFixIt: Always rely on the UTF-8 offset of an input source location

### DIFF
--- a/Tests/SwiftFixItTests/BasicTests.swift
+++ b/Tests/SwiftFixItTests/BasicTests.swift
@@ -27,7 +27,7 @@ struct BasicTests {
 
     @Test
     func testPrimaryDiag() throws {
-        try testAPI1File { (filename: String) in
+        try testAPI1File { path in
             .init(
                 edits: .init(input: "var x = 1", result: "let x = 1"),
                 summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
@@ -35,11 +35,11 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         fixIts: [
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -51,7 +51,7 @@ struct BasicTests {
 
     @Test
     func testNote() throws {
-        try testAPI1File { (filename: String) in
+        try testAPI1File { path in
             .init(
                 edits: .init(input: "var x = 1", result: "let x = 1"),
                 summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
@@ -59,15 +59,15 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         notes: [
                             Note(
                                 text: "note",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 fixIts: [
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                        start: .init(path: path, line: 1, column: 1),
+                                        end: .init(path: path, line: 1, column: 4),
                                         text: "let"
                                     ),
                                 ]
@@ -81,7 +81,7 @@ struct BasicTests {
 
     @Test
     func testMultiplePrimaryDiagsWithNotes() throws {
-        try testAPI1File { (filename: String) in
+        try testAPI1File { path in
             .init(
                 edits: .init(input: "var x = 1", result: "let x = 22"),
                 summary: .init(numberOfFixItsApplied: 2, numberOfFilesChanged: 1),
@@ -89,15 +89,15 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         notes: [
                             Note(
                                 text: "error1_note1",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 fixIts: [
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                        start: .init(path: path, line: 1, column: 1),
+                                        end: .init(path: path, line: 1, column: 4),
                                         text: "let"
                                     ),
                                 ]
@@ -107,16 +107,16 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         notes: [
                             Note(
                                 text: "error2_note1",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 fixIts: [
                                     // Make sure we apply this fix-it.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 9, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 10, offset: 0),
+                                        start: .init(path: path, line: 1, column: 9),
+                                        end: .init(path: path, line: 1, column: 10),
                                         text: "22"
                                     ),
                                 ]
@@ -130,7 +130,7 @@ struct BasicTests {
 
     @Test
     func testNonOverlappingCompoundFixIt() throws {
-        try testAPI1File { (filename: String) in
+        try testAPI1File { path in
             .init(
                 edits: .init(
                     input: """
@@ -152,24 +152,24 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         fixIts: [
                             // Replacement.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 4),
                                 text: "let"
                             ),
                             // Addition.
                             .init(
-                                start: .init(filename: filename, line: 2, column: 10, offset: 0),
-                                end: .init(filename: filename, line: 2, column: 10, offset: 0),
+                                start: .init(path: path, line: 2, column: 10),
+                                end: .init(path: path, line: 2, column: 10),
                                 text: "44"
                             ),
                             // Deletion.
                             .init(
-                                start: .init(filename: filename, line: 3, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 3, column: 5, offset: 0),
+                                start: .init(path: path, line: 3, column: 1),
+                                end: .init(path: path, line: 3, column: 5),
                                 text: ""
                             ),
                         ]
@@ -178,24 +178,24 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename, line: 4, column: 1, offset: 0),
+                        location: .init(path: path, line: 4, column: 1),
                         fixIts: [
                             // Replacement.
                             .init(
-                                start: .init(filename: filename, line: 4, column: 9, offset: 0),
-                                end: .init(filename: filename, line: 4, column: 12, offset: 0),
+                                start: .init(path: path, line: 4, column: 9),
+                                end: .init(path: path, line: 4, column: 12),
                                 text: "fooo"
                             ),
                             // Addition.
                             .init(
-                                start: .init(filename: filename, line: 4, column: 17, offset: 0),
-                                end: .init(filename: filename, line: 4, column: 17, offset: 0),
+                                start: .init(path: path, line: 4, column: 17),
+                                end: .init(path: path, line: 4, column: 17),
                                 text: "33"
                             ),
                             // Deletion.
                             .init(
-                                start: .init(filename: filename, line: 4, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 4, column: 5, offset: 0),
+                                start: .init(path: path, line: 4, column: 1),
+                                end: .init(path: path, line: 4, column: 5),
                                 text: ""
                             ),
                         ]
@@ -207,7 +207,7 @@ struct BasicTests {
 
     @Test
     func testOverlappingCompoundFixIt() throws {
-        try testAPI1File { (filename: String) in
+        try testAPI1File { path in
             .init(
                 edits: .init(input: "var x = 1", result: "_ = 1"),
                 summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
@@ -215,18 +215,18 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         fixIts: [
                             // Applied.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 6, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 6),
                                 text: "_"
                             ),
                             // Skipped, overlaps with previous fix-it.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -238,7 +238,7 @@ struct BasicTests {
 
     @Test
     func testOverlappingFixIts() throws {
-        try testAPI1File { (filename: String) in
+        try testAPI1File { path in
             .init(
                 edits: .init(input: "var x = 1", result: "_ = 1"),
                 summary: .init(
@@ -250,12 +250,12 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         fixIts: [
                             // Applied.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 6, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 6),
                                 text: "_"
                             ),
                         ]
@@ -263,12 +263,12 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         fixIts: [
                             // Skipped, overlaps with previous fix-it.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -280,7 +280,7 @@ struct BasicTests {
 
     @Test
     func testFixItsMultipleFiles() throws {
-        try testAPI2Files { (filename1: String, filename2: String) in
+        try testAPI2Files { path1, path2 in
             .init(
                 edits: (
                     .init(input: "var x = 1", result: "let _ = 1"),
@@ -288,15 +288,15 @@ struct BasicTests {
                 ),
                 summary: .init(numberOfFixItsApplied: 4, numberOfFilesChanged: 2),
                 diagnostics: [
-                    // filename1
+                    // path1
                     PrimaryDiagnostic(
                         level: .warning,
                         text: "warning1",
-                        location: .init(filename: filename1, line: 1, column: 1, offset: 0),
+                        location: .init(path: path1, line: 1, column: 1),
                         fixIts: [
                             .init(
-                                start: .init(filename: filename1, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename1, line: 1, column: 4, offset: 0),
+                                start: .init(path: path1, line: 1, column: 1),
+                                end: .init(path: path1, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -304,24 +304,24 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename1, line: 1, column: 5, offset: 0),
+                        location: .init(path: path1, line: 1, column: 5),
                         fixIts: [
                             .init(
-                                start: .init(filename: filename1, line: 1, column: 5, offset: 0),
-                                end: .init(filename: filename1, line: 1, column: 6, offset: 0),
+                                start: .init(path: path1, line: 1, column: 5),
+                                end: .init(path: path1, line: 1, column: 6),
                                 text: "_"
                             ),
                         ]
                     ),
-                    // filename2
+                    // path2
                     PrimaryDiagnostic(
                         level: .warning,
                         text: "warning2",
-                        location: .init(filename: filename2, line: 1, column: 5, offset: 0),
+                        location: .init(path: path2, line: 1, column: 5),
                         fixIts: [
                             .init(
-                                start: .init(filename: filename2, line: 1, column: 5, offset: 0),
-                                end: .init(filename: filename2, line: 1, column: 6, offset: 0),
+                                start: .init(path: path2, line: 1, column: 5),
+                                end: .init(path: path2, line: 1, column: 6),
                                 text: "_"
                             ),
                         ]
@@ -329,11 +329,11 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename2, line: 1, column: 1, offset: 0),
+                        location: .init(path: path2, line: 1, column: 1),
                         fixIts: [
                             .init(
-                                start: .init(filename: filename2, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename2, line: 1, column: 4, offset: 0),
+                                start: .init(path: path2, line: 1, column: 1),
+                                end: .init(path: path2, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -345,7 +345,7 @@ struct BasicTests {
 
     @Test
     func testNoteInDifferentFile() throws {
-        try testAPI2Files { (filename1: String, filename2: String) in
+        try testAPI2Files { path1, path2 in
             .init(
                 edits: (
                     .init(input: "var x = 1", result: "let x = 1"),
@@ -356,15 +356,15 @@ struct BasicTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error",
-                        location: .init(filename: filename2, line: 1, column: 1, offset: 0),
+                        location: .init(path: path2, line: 1, column: 1),
                         notes: [
                             Note(
                                 text: "note",
-                                location: .init(filename: filename1, line: 1, column: 1, offset: 0),
+                                location: .init(path: path1, line: 1, column: 1),
                                 fixIts: [
                                     .init(
-                                        start: .init(filename: filename1, line: 1, column: 1, offset: 0),
-                                        end: .init(filename: filename1, line: 1, column: 4, offset: 0),
+                                        start: .init(path: path1, line: 1, column: 1),
+                                        end: .init(path: path1, line: 1, column: 4),
                                         text: "let"
                                     ),
                                 ]
@@ -379,7 +379,7 @@ struct BasicTests {
     @Test
     func testDiagNotInTheSameFileAsFixIt() {
         #expect(throws: Error.self) {
-            try testAPI2Files { (filename1: String, filename2: String) in
+            try testAPI2Files { path1, path2 in
                 .init(
                     edits: (
                         .init(input: "var x = 1", result: "let x = 1"),
@@ -390,11 +390,11 @@ struct BasicTests {
                         PrimaryDiagnostic(
                             level: .error,
                             text: "error",
-                            location: .init(filename: filename2, line: 1, column: 1, offset: 0),
+                            location: .init(path: path2, line: 1, column: 1),
                             fixIts: [
                                 .init(
-                                    start: .init(filename: filename1, line: 1, column: 1, offset: 0),
-                                    end: .init(filename: filename1, line: 1, column: 4, offset: 0),
+                                    start: .init(path: path1, line: 1, column: 1),
+                                    end: .init(path: path1, line: 1, column: 4),
                                     text: "let"
                                 ),
                             ]

--- a/Tests/SwiftFixItTests/CategoryTests.swift
+++ b/Tests/SwiftFixItTests/CategoryTests.swift
@@ -15,7 +15,7 @@ import Testing
 struct CategoryTests {
     @Test
     func testCorrectCategory() throws {
-        try testAPI1File(categories: ["Other", "Test"]) { (filename: String) in
+        try testAPI1File(categories: ["Other", "Test"]) { path in
             .init(
                 edits: .init(input: "var x = 1", result: "let _ = 1"),
                 summary: .init(numberOfFixItsApplied: 2, numberOfFilesChanged: 1),
@@ -23,13 +23,13 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         category: "Test",
                         fixIts: [
                             // Applied, correct category.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -37,13 +37,13 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename, line: 1, column: 4, offset: 0),
+                        location: .init(path: path, line: 1, column: 4),
                         category: "Other",
                         fixIts: [
                             // Applied, correct category.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 5, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 6, offset: 0),
+                                start: .init(path: path, line: 1, column: 5),
+                                end: .init(path: path, line: 1, column: 6),
                                 text: "_"
                             ),
                         ]
@@ -55,7 +55,7 @@ struct CategoryTests {
 
     @Test
     func testCorrectCategoryWithNotes() throws {
-        try testAPI1File(categories: ["Other", "Test"]) { (filename: String) in
+        try testAPI1File(categories: ["Other", "Test"]) { path in
             .init(
                 edits: .init(input: "var x = 1", result: "let _ = 22"),
                 summary: .init(numberOfFixItsApplied: 3, numberOfFilesChanged: 1),
@@ -63,18 +63,18 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         category: "Test",
                         notes: [
                             Note(
                                 text: "error1_note1",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 fixIts: [
                                     // Applied, primary diagnostic has correct category.
                                     // Category of note does not matter.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                        start: .init(path: path, line: 1, column: 1),
+                                        end: .init(path: path, line: 1, column: 4),
                                         text: "let"
                                     ),
                                 ]
@@ -84,23 +84,23 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename, line: 1, column: 4, offset: 0),
+                        location: .init(path: path, line: 1, column: 4),
                         category: "Other",
                         notes: [
                             // This separator note should not make a difference.
                             Note(
                                 text: "error2_note1",
-                                location: .init(filename: filename, line: 1, column: 3, offset: 0),
+                                location: .init(path: path, line: 1, column: 3),
                             ),
                             Note(
                                 text: "error2_note2",
-                                location: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                location: .init(path: path, line: 1, column: 4),
                                 fixIts: [
                                     // Applied, primary diagnostic has correct category.
                                     // Category of note does not matter.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 5, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 6, offset: 0),
+                                        start: .init(path: path, line: 1, column: 5),
+                                        end: .init(path: path, line: 1, column: 6),
                                         text: "_"
                                     ),
                                 ]
@@ -110,19 +110,19 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error3",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         category: "Test",
                         notes: [
                             Note(
                                 text: "error3_note1",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 category: "Wrong",
                                 fixIts: [
                                     // Applied, primary diagnostic has correct category.
                                     // Category of note does not matter.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 9, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 10, offset: 0),
+                                        start: .init(path: path, line: 1, column: 9),
+                                        end: .init(path: path, line: 1, column: 10),
                                         text: "22",
                                     ),
                                 ]
@@ -136,7 +136,7 @@ struct CategoryTests {
 
     @Test
     func testNoCategory() throws {
-        try testAPI1File(categories: ["Test"]) { (filename: String) in
+        try testAPI1File(categories: ["Test"]) { path in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 22"),
                 summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
@@ -144,12 +144,12 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         fixIts: [
                             // Skipped, no category.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -157,13 +157,13 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         category: "Test",
                         fixIts: [
                             // Applied, correct category.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 9, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 10, offset: 0),
+                                start: .init(path: path, line: 1, column: 9),
+                                end: .init(path: path, line: 1, column: 10),
                                 text: "22",
                             ),
                         ]
@@ -175,7 +175,7 @@ struct CategoryTests {
 
     @Test
     func testNoCategoryWithNotes() throws {
-        try testAPI1File(categories: ["Test"]) { (filename: String) in
+        try testAPI1File(categories: ["Test"]) { path in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 22"),
                 summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
@@ -183,22 +183,22 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 5, offset: 0),
+                        location: .init(path: path, line: 1, column: 5),
                         category: nil,
                         notes: [
                             // This separator note should not make a difference.
                             Note(
                                 text: "error1_note1",
-                                location: .init(filename: filename, line: 1, column: 3, offset: 0),
+                                location: .init(path: path, line: 1, column: 3),
                             ),
                             Note(
                                 text: "error1_note2",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 fixIts: [
                                     // Skipped, primary diagnostic has no category.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                        start: .init(path: path, line: 1, column: 1),
+                                        end: .init(path: path, line: 1, column: 4),
                                         text: "let",
                                     ),
                                 ]
@@ -208,13 +208,13 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         category: "Test",
                         fixIts: [
                             // Applied, correct category.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 9, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 10, offset: 0),
+                                start: .init(path: path, line: 1, column: 9),
+                                end: .init(path: path, line: 1, column: 10),
                                 text: "22",
                             ),
                         ]
@@ -222,19 +222,19 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error3",
-                        location: .init(filename: filename, line: 1, column: 4, offset: 0),
+                        location: .init(path: path, line: 1, column: 4),
                         category: nil,
                         notes: [
                             Note(
                                 text: "error3_note1",
-                                location: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                location: .init(path: path, line: 1, column: 4),
                                 category: "Test",
                                 fixIts: [
                                     // Skipped, primary diagnostic has no category.
                                     // Category of note does not matter.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 5, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 6, offset: 0),
+                                        start: .init(path: path, line: 1, column: 5),
+                                        end: .init(path: path, line: 1, column: 6),
                                         text: "_"
                                     ),
                                 ]
@@ -248,7 +248,7 @@ struct CategoryTests {
 
     @Test
     func testWrongCategory() throws {
-        try testAPI1File(categories: ["Test"]) { (filename: String) in
+        try testAPI1File(categories: ["Test"]) { path in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 22"),
                 summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
@@ -256,13 +256,13 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         category: "Other",
                         fixIts: [
                             // Skipped, wrong category.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -270,13 +270,13 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         category: "Test",
                         fixIts: [
                             // Applied, correct category.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 9, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 10, offset: 0),
+                                start: .init(path: path, line: 1, column: 9),
+                                end: .init(path: path, line: 1, column: 10),
                                 text: "22",
                             ),
                         ]
@@ -288,7 +288,7 @@ struct CategoryTests {
 
     @Test
     func testWrongCategoryWithNotes() throws {
-        try testAPI1File(categories: ["Test"]) { (filename: String) in
+        try testAPI1File(categories: ["Test"]) { path in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 22"),
                 summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
@@ -296,22 +296,22 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 5, offset: 0),
+                        location: .init(path: path, line: 1, column: 5),
                         category: "Other",
                         notes: [
                             // This separator note should not make a difference.
                             Note(
                                 text: "error1_note1",
-                                location: .init(filename: filename, line: 1, column: 3, offset: 0),
+                                location: .init(path: path, line: 1, column: 3),
                             ),
                             Note(
                                 text: "error1_note2",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 fixIts: [
                                     // Skipped, primary diagnostic has wrong category.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                        start: .init(path: path, line: 1, column: 1),
+                                        end: .init(path: path, line: 1, column: 4),
                                         text: "let",
                                     ),
                                 ]
@@ -321,13 +321,13 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         category: "Test",
                         fixIts: [
                             // Applied, correct category.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 9, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 10, offset: 0),
+                                start: .init(path: path, line: 1, column: 9),
+                                end: .init(path: path, line: 1, column: 10),
                                 text: "22",
                             ),
                         ]
@@ -335,19 +335,19 @@ struct CategoryTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error3",
-                        location: .init(filename: filename, line: 1, column: 4, offset: 0),
+                        location: .init(path: path, line: 1, column: 4),
                         category: "Other",
                         notes: [
                             Note(
                                 text: "error3_note1",
-                                location: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                location: .init(path: path, line: 1, column: 4),
                                 category: "Test",
                                 fixIts: [
                                     // Skipped, primary diagnostic has wrong category.
                                     // Category of note does not matter.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 5, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 6, offset: 0),
+                                        start: .init(path: path, line: 1, column: 5),
+                                        end: .init(path: path, line: 1, column: 6),
                                         text: "_"
                                     ),
                                 ]

--- a/Tests/SwiftFixItTests/FilteringTests.swift
+++ b/Tests/SwiftFixItTests/FilteringTests.swift
@@ -15,7 +15,7 @@ import Testing
 struct FilteringTests {
     @Test
     func testIgnoredDiag() throws {
-        try testAPI1File { (filename: String) in
+        try testAPI1File { path in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 22"),
                 summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
@@ -23,12 +23,12 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .ignored,
                         text: "ignored1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         fixIts: [
                             // Skipped, diagnostic is 'ignored'.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -36,12 +36,12 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 9, offset: 0),
+                        location: .init(path: path, line: 1, column: 9),
                         fixIts: [
                             // Applied.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 9, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 10, offset: 0),
+                                start: .init(path: path, line: 1, column: 9),
+                                end: .init(path: path, line: 1, column: 10),
                                 text: "22"
                             ),
                         ]
@@ -49,20 +49,20 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .ignored,
                         text: "ignored2",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         notes: [
                             Note(
                                 text: "ignored2_note1",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0)
+                                location: .init(path: path, line: 1, column: 1)
                             ),
                             Note(
                                 text: "ignored2_note2",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 fixIts: [
                                     // Skipped, primary diagnostic is 'ignored'.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 5, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 6, offset: 0),
+                                        start: .init(path: path, line: 1, column: 5),
+                                        end: .init(path: path, line: 1, column: 6),
                                         text: "_"
                                     ),
                                 ]
@@ -76,7 +76,7 @@ struct FilteringTests {
 
     @Test
     func testDiagWithNoLocation() throws {
-        try testAPI1File { (filename: String) in
+        try testAPI1File { path in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 22"),
                 summary: .init(numberOfFixItsApplied: 1, numberOfFilesChanged: 1),
@@ -88,8 +88,8 @@ struct FilteringTests {
                         fixIts: [
                             // Skipped, no location.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -97,12 +97,12 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         fixIts: [
                             // Applied.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 9, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 10, offset: 0),
+                                start: .init(path: path, line: 1, column: 9),
+                                end: .init(path: path, line: 1, column: 10),
                                 text: "22"
                             ),
                         ]
@@ -110,11 +110,11 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error3",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         notes: [
                             Note(
                                 text: "error3_note1",
-                                location: .init(filename: filename, line: 1, column: 3, offset: 0),
+                                location: .init(path: path, line: 1, column: 3),
                             ),
                             Note(
                                 text: "error3_note2",
@@ -122,8 +122,8 @@ struct FilteringTests {
                                 fixIts: [
                                     // Skipped, no location.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 5, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 6, offset: 0),
+                                        start: .init(path: path, line: 1, column: 5),
+                                        end: .init(path: path, line: 1, column: 6),
                                         text: "_"
                                     ),
                                 ]
@@ -137,16 +137,16 @@ struct FilteringTests {
                         notes: [
                             Note(
                                 text: "error4_note1",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0)
+                                location: .init(path: path, line: 1, column: 1)
                             ),
                             Note(
                                 text: "error4_note2",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 fixIts: [
                                     // Skipped, primary diagnostic has no location.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 7, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 8, offset: 0),
+                                        start: .init(path: path, line: 1, column: 7),
+                                        end: .init(path: path, line: 1, column: 8),
                                         text: ":"
                                     ),
                                 ]
@@ -160,7 +160,7 @@ struct FilteringTests {
 
     @Test
     func testMultipleNotesWithFixIts() throws {
-        try testAPI1File { filename in
+        try testAPI1File { path in
             .init(
                 edits: .init(input: "var x = 1", result: "var x = 1"),
                 summary: .init(numberOfFixItsApplied: 0, numberOfFilesChanged: 0),
@@ -168,28 +168,28 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         notes: [
                             Note(
                                 text: "error1_note1",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 fixIts: [
                                     // Skipped, primary diagnostic has more than 1 note with fix-it.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                        start: .init(path: path, line: 1, column: 1),
+                                        end: .init(path: path, line: 1, column: 4),
                                         text: "let"
                                     ),
                                 ]
                             ),
                             Note(
                                 text: "error1_note2",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 fixIts: [
                                     // Skipped, primary diagnostic has more than 1 note with fix-it.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 9, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 10, offset: 0),
+                                        start: .init(path: path, line: 1, column: 9),
+                                        end: .init(path: path, line: 1, column: 10),
                                         text: "22"
                                     ),
                                 ]
@@ -199,16 +199,16 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .warning,
                         text: "warning1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         notes: [
                             Note(
                                 text: "warning1_note1",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 fixIts: [
                                     // Skipped, primary diagnostic has more than 1 note with fix-it.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 5, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 6, offset: 0),
+                                        start: .init(path: path, line: 1, column: 5),
+                                        end: .init(path: path, line: 1, column: 6),
                                         text: "y"
                                     ),
                                 ]
@@ -216,16 +216,16 @@ struct FilteringTests {
                             // This separator note should not make a difference.
                             Note(
                                 text: "warning1_note2",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0)
+                                location: .init(path: path, line: 1, column: 1)
                             ),
                             Note(
                                 text: "warning1_note3",
-                                location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                                location: .init(path: path, line: 1, column: 1),
                                 fixIts: [
                                     // Skipped, primary diagnostic has more than 1 note with fix-it.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 7, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 8, offset: 0),
+                                        start: .init(path: path, line: 1, column: 7),
+                                        end: .init(path: path, line: 1, column: 8),
                                         text: ":"
                                     ),
                                 ]
@@ -239,7 +239,7 @@ struct FilteringTests {
 
     @Test
     func testDuplicatePrimaryDiag() throws {
-        try testAPI1File { filename in
+        try testAPI1File { path in
             .init(
                 edits: .init(input: "var x = (1, 1)", result: "let x = (22, 13)"),
                 summary: .init(numberOfFixItsApplied: 3, numberOfFilesChanged: 1),
@@ -247,12 +247,12 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         fixIts: [
                             // Applied.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -260,39 +260,39 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .warning,
                         text: "warning1",
-                        location: .init(filename: filename, line: 1, column: 10, offset: 0),
+                        location: .init(path: path, line: 1, column: 10),
                         notes: [
                             Note(
                                 text: "warning1_note1",
-                                location: .init(filename: filename, line: 1, column: 10, offset: 0),
+                                location: .init(path: path, line: 1, column: 10),
                                 fixIts: [
                                     // Applied.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 10, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 11, offset: 0),
+                                        start: .init(path: path, line: 1, column: 10),
+                                        end: .init(path: path, line: 1, column: 11),
                                         text: "22"
                                     ),
                                 ]
                             ),
                             Note(
                                 text: "warning1_note2",
-                                location: .init(filename: filename, line: 1, column: 5, offset: 0),
+                                location: .init(path: path, line: 1, column: 5),
                             ),
                         ]
                     ),
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         notes: [
                             Note(
                                 text: "error1_note1",
-                                location: .init(filename: filename, line: 1, column: 5, offset: 0),
+                                location: .init(path: path, line: 1, column: 5),
                                 fixIts: [
                                     // Skipped, duplicate primary diagnostic.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 5, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 6, offset: 0),
+                                        start: .init(path: path, line: 1, column: 5),
+                                        end: .init(path: path, line: 1, column: 6),
                                         text: "y"
                                     ),
                                 ]
@@ -302,12 +302,12 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .warning,
                         text: "warning1",
-                        location: .init(filename: filename, line: 1, column: 10, offset: 0),
+                        location: .init(path: path, line: 1, column: 10),
                         fixIts: [
                             // Skipped, duplicate primary diagnostic.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 7, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 8, offset: 0),
+                                start: .init(path: path, line: 1, column: 7),
+                                end: .init(path: path, line: 1, column: 8),
                                 text: ":"
                             ),
                         ]
@@ -315,12 +315,12 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename, line: 1, column: 14, offset: 0),
+                        location: .init(path: path, line: 1, column: 14),
                         fixIts: [
                             // Applied.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 14, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 14, offset: 0),
+                                start: .init(path: path, line: 1, column: 14),
+                                end: .init(path: path, line: 1, column: 14),
                                 text: "3"
                             ),
                         ]
@@ -332,7 +332,7 @@ struct FilteringTests {
 
     @Test
     func testDuplicateReplacementFixIts() throws {
-        try testAPI1File { (filename: String) in
+        try testAPI1File { path in
             .init(
                 edits: .init(input: "var x = 1", result: "let x = 22"),
                 summary: .init(
@@ -345,12 +345,12 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error1",
-                        location: .init(filename: filename, line: 1, column: 1, offset: 0),
+                        location: .init(path: path, line: 1, column: 1),
                         fixIts: [
                             // Applied.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -358,12 +358,12 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error2",
-                        location: .init(filename: filename, line: 1, column: 4, offset: 0),
+                        location: .init(path: path, line: 1, column: 4),
                         fixIts: [
                             // Skipped.
                             .init(
-                                start: .init(filename: filename, line: 1, column: 1, offset: 0),
-                                end: .init(filename: filename, line: 1, column: 4, offset: 0),
+                                start: .init(path: path, line: 1, column: 1),
+                                end: .init(path: path, line: 1, column: 4),
                                 text: "let"
                             ),
                         ]
@@ -372,16 +372,16 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error3",
-                        location: .init(filename: filename, line: 1, column: 9, offset: 0),
+                        location: .init(path: path, line: 1, column: 9),
                         notes: [
                             Note(
                                 text: "error3_note1",
-                                location: .init(filename: filename, line: 1, column: 9, offset: 0),
+                                location: .init(path: path, line: 1, column: 9),
                                 fixIts: [
                                     // Applied.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 9, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 10, offset: 0),
+                                        start: .init(path: path, line: 1, column: 9),
+                                        end: .init(path: path, line: 1, column: 10),
                                         text: "22"
                                     ),
                                 ]
@@ -391,16 +391,16 @@ struct FilteringTests {
                     PrimaryDiagnostic(
                         level: .error,
                         text: "error4",
-                        location: .init(filename: filename, line: 1, column: 9, offset: 0),
+                        location: .init(path: path, line: 1, column: 9),
                         notes: [
                             Note(
                                 text: "error4_note1",
-                                location: .init(filename: filename, line: 1, column: 9, offset: 0),
+                                location: .init(path: path, line: 1, column: 9),
                                 fixIts: [
                                     // Skipped.
                                     .init(
-                                        start: .init(filename: filename, line: 1, column: 9, offset: 0),
-                                        end: .init(filename: filename, line: 1, column: 10, offset: 0),
+                                        start: .init(path: path, line: 1, column: 9),
+                                        end: .init(path: path, line: 1, column: 10),
                                         text: "22"
                                     ),
                                 ]


### PR DESCRIPTION
As it turns out, contrary to an old comment in the diagnostic deserializer, the Swift compiler *does* serialize the offset of a source location, so stop assuming that it may have been left blank.

### Motivation:

 This slightly simplifies the diagnostic conversion logic and also enables us to stop hashing the line and column in the diagnostic filter.

