### PR TITLE
Add PackageIdentity to Workspace prebuilt delegate methods

### DIFF
--- a/Sources/Commands/CommandWorkspaceDelegate.swift
+++ b/Sources/Commands/CommandWorkspaceDelegate.swift
@@ -183,7 +183,7 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
     }
 
     /// The workspace has started downloading a binary artifact.
-    func willDownloadPrebuilt(from url: String, fromCache: Bool) {
+    func willDownloadPrebuilt(package: PackageIdentity, from url: String, fromCache: Bool) {
         if fromCache {
             self.outputHandler("Fetching package prebuilt \(url) from cache", false)
         } else {
@@ -193,6 +193,7 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
 
     /// The workspace has finished downloading a binary artifact.
     func didDownloadPrebuilt(
+        package: PackageIdentity,
         from url: String,
         result: Result<(path: AbsolutePath, fromCache: Bool), Error>,
         duration: DispatchTimeInterval
@@ -209,7 +210,7 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
     }
 
     /// The workspace is downloading a binary artifact.
-    func downloadingPrebuilt(from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
+    func downloadingPrebuilt(package: PackageIdentity, from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
 
     }
 

--- a/Sources/Workspace/Workspace+Delegation.swift
+++ b/Sources/Workspace/Workspace+Delegation.swift
@@ -139,15 +139,25 @@ public protocol WorkspaceDelegate: AnyObject {
     func didDownloadAllBinaryArtifacts()
 
     /// The workspace has started downloading a binary artifact.
-    func willDownloadPrebuilt(from url: String, fromCache: Bool)
+    func willDownloadPrebuilt(
+        package: PackageIdentity,
+        from url: String,
+        fromCache: Bool
+    )
     /// The workspace has finished downloading a binary artifact.
     func didDownloadPrebuilt(
+        package: PackageIdentity,
         from url: String,
         result: Result<(path: AbsolutePath, fromCache: Bool), Error>,
         duration: DispatchTimeInterval
     )
     /// The workspace is downloading a binary artifact.
-    func downloadingPrebuilt(from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?)
+    func downloadingPrebuilt(
+        package: PackageIdentity,
+        from url: String,
+        bytesDownloaded: Int64,
+        totalBytesToDownload: Int64?
+    )
     /// The workspace finished downloading all binary artifacts.
     func didDownloadAllPrebuilts()
 
@@ -444,20 +454,40 @@ struct WorkspacePrebuiltsManagerDelegate: Workspace.PrebuiltsManager.Delegate {
         self.workspaceDelegate = workspaceDelegate
     }
 
-    func willDownloadPrebuilt(from url: String, fromCache: Bool) {
-        self.workspaceDelegate?.willDownloadPrebuilt(from: url, fromCache: fromCache)
+    func willDownloadPrebuilt(
+        for package: PackageIdentity,
+        from url: String,
+        fromCache: Bool
+    ) {
+        self.workspaceDelegate?.willDownloadPrebuilt(
+            package: package,
+            from: url,
+            fromCache: fromCache
+        )
     }
 
     func didDownloadPrebuilt(
+        for package: PackageIdentity,
         from url: String,
         result: Result<(path: AbsolutePath, fromCache: Bool), Error>,
         duration: DispatchTimeInterval
     ) {
-        self.workspaceDelegate?.didDownloadPrebuilt(from: url, result: result, duration: duration)
+        self.workspaceDelegate?.didDownloadPrebuilt(
+            package: package,
+            from: url,
+            result: result,
+            duration: duration
+        )
     }
 
-    func downloadingPrebuilt(from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
+    func downloadingPrebuilt(
+        for package: PackageIdentity,
+        from url: String,
+        bytesDownloaded: Int64,
+        totalBytesToDownload: Int64?
+    ) {
         self.workspaceDelegate?.downloadingPrebuilt(
+            package: package,
             from: url,
             bytesDownloaded: bytesDownloaded,
             totalBytesToDownload: totalBytesToDownload

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -1206,11 +1206,12 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         // noop
     }
 
-    public func willDownloadPrebuilt(from url: String, fromCache: Bool) {
+    public func willDownloadPrebuilt(package: PackageIdentity, from url: String, fromCache: Bool) {
         self.append("downloading package prebuilt: \(url)")
     }
 
     public func didDownloadPrebuilt(
+        package: PackageIdentity,
         from url: String,
         result: Result<(path: AbsolutePath, fromCache: Bool), Error>,
         duration: DispatchTimeInterval
@@ -1218,7 +1219,7 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         self.append("finished downloading package prebuilt: \(url)")
     }
 
-    public func downloadingPrebuilt(from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
+    public func downloadingPrebuilt(package: PackageIdentity, from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
         // noop
     }
 


### PR DESCRIPTION
In order to associate what prebuilt artifact goes with what package, add the `PackageIdentity` as a parameter to the delegate methods for prebuilts on `WorkspaceDelegate`.
