### PR TITLE
Fix several warnings across the codebase

### DIFF
--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -226,7 +226,7 @@ extension Workspace {
 
             let inputNodes: [GraphLoadingNode] = try root.packages.map { identity, package in
                 inputIdentities.append(package.reference)
-                var traits: Set<String>? = rootEnabledTraitsMap[package.reference.identity] ?? []
+                let traits: Set<String>? = rootEnabledTraitsMap[package.reference.identity] ?? []
 
                 let node = try GraphLoadingNode(
                     identity: identity,
@@ -239,7 +239,7 @@ extension Workspace {
                 let package = dependency.packageRef
                 inputIdentities.append(package)
                 return try manifestsMap[dependency.identity].map { manifest in
-                    var traits: Set<String>? = rootDependenciesEnabledTraitsMap[dependency.identity] ?? []
+                    let traits: Set<String>? = rootDependenciesEnabledTraitsMap[dependency.identity] ?? []
 
                     return try GraphLoadingNode(
                         identity: dependency.identity,
@@ -629,7 +629,7 @@ extension Workspace {
         let firstLevelDependencies = try topLevelManifests.values.map { manifest in
             try manifest.dependencies.filter { dep in
                 guard configuration.pruneDependencies else { return true }
-                var enabledTraits: Set<String>? = root.enabledTraits[manifest.packageIdentity]
+                let enabledTraits: Set<String>? = root.enabledTraits[manifest.packageIdentity]
                 let isDepUsed = try manifest.isPackageDependencyUsed(dep, enabledTraits: enabledTraits)
                 return isDepUsed
             }.map(\.packageRef)

--- a/Tests/BasicsTests/FileSystem/InMemoryFilesSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/InMemoryFilesSystemTests.swift
@@ -145,7 +145,7 @@ struct InMemoryFileSystemTests {
 
             // WHEN we write contents to the file
             // THEn we expect an error to occus
-            try withKnownIssue {
+            withKnownIssue {
                 try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
             }
 
@@ -165,7 +165,7 @@ struct InMemoryFileSystemTests {
 
             // WHEN we write contents to the file
             // THEN we expect an error to occur
-            try withKnownIssue {
+            withKnownIssue {
                 try fs.writeFileContents(pathUnderTest, bytes: expectedContents)
             }
 
@@ -201,7 +201,7 @@ struct InMemoryFileSystemTests {
 
             // WHEN we read a non-existing file
             // THEN an error occurs
-            try withKnownIssue {
+            withKnownIssue {
                 let _ = try fs.readFileContents("/file/does/not/exists")
             }
         }

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -49,7 +49,7 @@ struct TripleTests {
         ],
     )
     func isAppleIsDarwin(_ tripleName: String, _ isApple: Bool, _ isDarwin: Bool) throws {
-        let triple = try #require(try Triple(tripleName), "Unknown triple '\(tripleName)'.")
+        let triple = try Triple(tripleName)
         #expect(
             isApple == triple.isApple(),
             """
@@ -160,7 +160,7 @@ struct TripleTests {
     func tripleStringForPlatformVersion(
         tripleName: String, version: String, expectedTriple: String
     ) throws {
-        let triple = try #require(try Triple(tripleName), "Unknown triple '\(tripleName)'.")
+        let triple = try Triple(tripleName)
         let actualTriple = triple.tripleString(forPlatformVersion: version)
         #expect(
             actualTriple == expectedTriple,
@@ -252,8 +252,7 @@ struct TripleTests {
     func knownTripleParsing(
         data: DataKnownTripleParsing,
     ) throws {
-        let triple = try #require(
-            try Triple(data.tripleName), "Unknown triple '\(data.tripleName)'.")
+        let triple = try Triple(data.tripleName)
         #expect(triple.arch == data.expectedArch, "Actual arch not as expected")
         #expect(triple.subArch == data.expectedSubArch, "Actual subarch is not as expected")
         #expect(triple.vendor == data.expectedVendor, "Actual Vendor is not as expected")
@@ -263,31 +262,27 @@ struct TripleTests {
     }
 
     @Test
-    func triple() {
-        let linux = try? Triple("x86_64-unknown-linux-gnu")
-        #expect(linux != nil)
-        #expect(linux!.os == .linux)
-        #expect(linux!.osVersion == Triple.Version.zero)
-        #expect(linux!.environment == .gnu)
+    func triple() throws {
+        let linux = try Triple("x86_64-unknown-linux-gnu")
+        #expect(linux.os == .linux)
+        #expect(linux.osVersion == Triple.Version.zero)
+        #expect(linux.environment == .gnu)
 
-        let macos = try? Triple("x86_64-apple-macosx10.15")
-        #expect(macos! != nil)
-        #expect(macos!.osVersion == .init(parse: "10.15"))
+        let macos = try Triple("x86_64-apple-macosx10.15")
+        #expect(macos.osVersion == .init(parse: "10.15"))
         let newVersion = "10.12"
-        let tripleString = macos!.tripleString(forPlatformVersion: newVersion)
+        let tripleString = macos.tripleString(forPlatformVersion: newVersion)
         #expect(tripleString == "x86_64-apple-macosx10.12")
-        let macosNoX = try? Triple("x86_64-apple-macos12.2")
-        #expect(macosNoX! != nil)
-        #expect(macosNoX!.os == .macosx)
-        #expect(macosNoX!.osVersion == .init(parse: "12.2"))
+        let macosNoX = try Triple("x86_64-apple-macos12.2")
+        #expect(macosNoX.os == .macosx)
+        #expect(macosNoX.osVersion == .init(parse: "12.2"))
 
-        let android = try? Triple("aarch64-unknown-linux-android24")
-        #expect(android != nil)
-        #expect(android!.os == .linux)
-        #expect(android!.environment == .android)
+        let android = try Triple("aarch64-unknown-linux-android24")
+        #expect(android.os == .linux)
+        #expect(android.environment == .android)
 
-        let linuxWithABIVersion = try? Triple("x86_64-unknown-linux-gnu42")
-        #expect(linuxWithABIVersion!.environment == .gnu)
+        let linuxWithABIVersion = try Triple("x86_64-unknown-linux-gnu42")
+        #expect(linuxWithABIVersion.environment == .gnu)
     }
 
     @Test

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3886,8 +3886,6 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolvedFileSchemeToolsVersion() async throws {
-        let fs = InMemoryFileSystem()
-
         for pair in [
             (ToolsVersion.v5_2, ToolsVersion.v5_2),
             (ToolsVersion.v5_6, ToolsVersion.v5_6),


### PR DESCRIPTION
Fix warnings in the repo

### Motivation:

Warnings are lame

### Modifications:

Remove unused code
Removed unneeded try
Use unforced unwraps in tests

### Result:

Fewer warnings
