### PR TITLE
Add sandboxing to build tool plugins in swiftbuild build system

### DIFF
--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -125,7 +125,6 @@ private struct SwiftBuildSystemFactory: BuildSystemFactory {
             },
             packageManagerResourcesDirectory: swiftCommandState.packageManagerResourcesDirectory,
             additionalFileRules: FileRuleDescription.swiftpmFileTypes + FileRuleDescription.xcbuildFileTypes,
-            pkgConfigDirectories: self.swiftCommandState.options.locations.pkgConfigDirectories,
             outputStream: outputStream ?? self.swiftCommandState.outputStream,
             logLevel: logLevel ?? self.swiftCommandState.logLevel,
             fileSystem: self.swiftCommandState.fileSystem,

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -372,7 +372,6 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
                     packageGraphLoader: asyncUnsafePackageGraphLoader,
                     packageManagerResourcesDirectory: nil,
                     additionalFileRules: [],
-                    pkgConfigDirectories: [],
                     outputStream: TSCBasic.stdoutStream,
                     logLevel: logLevel,
                     fileSystem: self.fileSystem,


### PR DESCRIPTION
* Add disable-able sandboxing to the custom tasks in the PIF with the
declared input and output files.
* Add more test coverage of plugin scenarios
* Capture child diagnostics from Swift Build and emit those through
equivalent observability scope in SwiftPM