### PR TITLE
Temporarily skip a Swift Build test to allow staging in changes to the test product type.

### DIFF
--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -4081,14 +4081,13 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
         throw XCTSkip("SWBINTTODO: Build plan is not currently supported")
     }
 
-#if !os(macOS)
     override func testCommandPluginTestingCallbacks() async throws {
+        throw XCTSkip("SWBINTTODO: Requires PIF generation to adopt new test runner product type")
         try XCTSkipOnWindows(because: "TSCBasic/Path.swift:969: Assertion failed, https://github.com/swiftlang/swift-package-manager/issues/8602")
         try XCTSkipIfWorkingDirectoryUnsupported()
 
         try await super.testCommandPluginTestingCallbacks()
     }
-#endif
 
     override func testCommandPluginTargetBuilds() async throws {
         try XCTSkipOnWindows(because: "TSCBasic/Path.swift:969: Assertion failed, https://github.com/swiftlang/swift-package-manager/issues/8602")


### PR DESCRIPTION
We're staging in changes so tests build as dylibs with a separate runner executable on non-Darwin platforms, which more closely matches the native build system. Skip this test temporarily as it will fail after the Swift Build changes land but before the SwiftPM ones do, to avoid the need for coordinated merges