### PR TITLE
[6.2][PackageModel] Toolchain: A few fixes for features supported by Swift compiler

### DIFF
--- a/Sources/PackageModel/Toolchain+SupportedFeatures.swift
+++ b/Sources/PackageModel/Toolchain+SupportedFeatures.swift
@@ -102,7 +102,9 @@ extension Toolchain {
 
             let features: JSON = try parsedSupportedFeatures.get("features")
 
-            let optional: [SwiftCompilerFeature] = try (features.get("optional") as [JSON]?)?.map { (json: JSON) in
+            let optionalFeatures = (try? features.getArray("optional")) ?? []
+
+            let optional: [SwiftCompilerFeature] = try optionalFeatures.map { json in
                 let name: String = try json.get("name")
                 let categories: [String]? = try json.getArrayIfAvailable("categories")
                 let migratable: Bool? = json.get("migratable")
@@ -114,7 +116,7 @@ extension Toolchain {
                     categories: categories ?? [name],
                     flagName: flagName
                 )
-            } ?? []
+            }
 
             let upcoming: [SwiftCompilerFeature] = try features.getArray("upcoming").map {
                 let name: String = try $0.get("name")

--- a/Sources/PackageModel/Toolchain+SupportedFeatures.swift
+++ b/Sources/PackageModel/Toolchain+SupportedFeatures.swift
@@ -120,7 +120,11 @@ extension Toolchain {
                 let name: String = try $0.get("name")
                 let categories: [String]? = try $0.getArrayIfAvailable("categories")
                 let migratable: Bool? = $0.get("migratable")
-                let enabledIn: String = try $0.get("enabled_in")
+                let enabledIn = if let version = try? $0.get(String.self, forKey: "enabled_in") {
+                    version
+                } else {
+                    try String($0.get(Int.self, forKey: "enabled_in"))
+                }
 
                 guard let mode = SwiftLanguageVersion(string: enabledIn) else {
                     throw InternalError("Unknown swift language mode: \(enabledIn)")


### PR DESCRIPTION
- Explanation:
 
   `swift package migrate` is broken when used with older toolchains.

   - Fix "supported features" parsing with older toolchains. `-print-supported-features` flag used to output "enabled_in" version as an integer (major only).
   - Handle absence of optional features section. `JSON.get` would throw if the key couldn't be found, let's handle that gracefully for an optional "optional features" section.

- Main Branch PR: https://github.com/swiftlang/swift-package-manager/pull/8761

- Risk: Low (only `swift package migrate` is affected by this changes).

- Resolves: rdar://152533205

- Reviewed By: @dschaefer2 

- Testing: Updated existing tests in the suite, added new test-cases.
