### PR TITLE
Unskip tests blocked by requireThreadSafeWorkingDirectory

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -7466,14 +7466,7 @@ class BuildPlanSwiftBuildTests: BuildPlanTestCase {
     }
 
     override func testPackageNameFlag() async throws {
-        try XCTSkipIfWorkingDirectoryUnsupported()
         try XCTSkipOnWindows(because: "Skip until there is a resolution to the partial linking with Windows that results in a 'subsystem must be defined' error.")
-#if os(Linux)
-        // Linking error: "/usr/bin/ld.gold: fatal error: -pie and -static are incompatible".
-        // Tracked by GitHub issue: https://github.com/swiftlang/swift-package-manager/issues/8499
-        throw XCTSkip("Skipping Swift Build testing on Linux because of linking issues.")
-#endif
-
         try await super.testPackageNameFlag()
     }
 

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -856,7 +856,6 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
     }
 
     override func testParseableInterfaces() async throws {
-        try XCTSkipIfWorkingDirectoryUnsupported()
         try XCTSkipOnWindows(because: "possible long filename issue: needs investigation")
 
         try await fixture(name: "Miscellaneous/ParseableInterfaces") { fixturePath in
@@ -939,13 +938,11 @@ class BuildCommandSwiftBuildTests: BuildCommandTestCases {
 
     override func testBuildSystemDefaultSettings() async throws {
         try XCTSkipOnWindows(because: "possible long filename issue: needs investigation")
-        try XCTSkipIfWorkingDirectoryUnsupported()
 
         try await super.testBuildSystemDefaultSettings()
     }
 
     override func testBuildCompleteMessage() async throws {
-        try XCTSkipIfWorkingDirectoryUnsupported()
         try XCTSkipOnWindows(because: "possible long filename issue: needs investigation")
 
         try await super.testBuildCompleteMessage()

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -4084,8 +4084,6 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
 #if !os(macOS)
     override func testCommandPluginTestingCallbacks() async throws {
         try XCTSkipOnWindows(because: "TSCBasic/Path.swift:969: Assertion failed, https://github.com/swiftlang/swift-package-manager/issues/8602")
-        try XCTSkipIfWorkingDirectoryUnsupported()
-
         try await super.testCommandPluginTestingCallbacks()
     }
 #endif


### PR DESCRIPTION
Now that llbuild has fork/exec support, the tests can be enabled on Amazon Linux 2, OpenBSD, etc.

Closes #8499