### PR TITLE
exclude README in docs sources to resolve build warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -466,7 +466,8 @@ let package = Package(
         // MARK: Documentation
 
         .target(
-            name: "PackageManagerDocs"
+            name: "PackageManagerDocs",
+            exclude: ["README.md"],
         ),
 
         // MARK: Package Manager Functionality


### PR DESCRIPTION
exclude README in docs sources to resolve build warning

### Motivation:

resolves the build warning when building the package manger

### Modifications:

add the README housed in the PackageManagerDocs to the exclude list

### Result:

Builds without warning:
```bash
swift build --target PackageManagerDocs
```
