### PR TITLE
Provide library paths to plugin tools when run as custom tasks

### DIFF
--- a/Sources/Basics/Environment/EnvironmentKey.swift
+++ b/Sources/Basics/Environment/EnvironmentKey.swift
@@ -24,6 +24,16 @@ public struct EnvironmentKey {
 extension EnvironmentKey {
     package static let path: Self = "PATH"
 
+    package static var libraryPath: Self {
+        #if os(Windows)
+        path
+        #elseif canImport(Darwin)
+        "DYLD_LIBRARY_PATH"
+        #else
+        "LD_LIBRARY_PATH"
+        #endif
+    }
+
     /// A set of known keys which should not be included in cache keys.
     package static let nonCachable: Set<Self> = [
         "TERM",

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -35,6 +35,9 @@ public protocol Toolchain {
     /// An array of paths to search for libraries at link time.
     var librarySearchPaths: [AbsolutePath] { get }
 
+    /// An array of paths to use with binaries produced by this toolchain at run time.
+    var runtimeLibraryPaths: [AbsolutePath] { get }
+
     /// Configuration from the used toolchain.
     var installedSwiftPMConfiguration: InstalledSwiftPMConfiguration { get }
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -212,7 +212,7 @@ public final class UserToolchain: Toolchain {
     private static func computeRuntimeLibraryPaths(targetInfo: JSON) throws -> [AbsolutePath] {
         var libraryPaths: [AbsolutePath] = []
 
-        for runtimeLibPath in try targetInfo.get("paths").getArray("runtimeLibraryPaths") {
+        for runtimeLibPath in (try? (try? targetInfo.get("paths"))?.getArray("runtimeLibraryPaths")) ?? [] {
             guard case .string(let value) = runtimeLibPath else {
                 continue
             }

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -31,6 +31,7 @@ public struct MockToolchain: PackageModel.Toolchain {
     public let swiftCompilerPath = AbsolutePath("/fake/path/to/swiftc")
     public let includeSearchPaths = [AbsolutePath]()
     public let librarySearchPaths = [AbsolutePath]()
+    public let runtimeLibraryPaths: [AbsolutePath] = [AbsolutePath]()
     public let swiftResourcesPath: AbsolutePath?
     public let swiftStaticResourcesPath: AbsolutePath? = nil
     public let sdkRootPath: AbsolutePath? = nil

--- a/Tests/CommandsTests/SwiftSDKCommandTests.swift
+++ b/Tests/CommandsTests/SwiftSDKCommandTests.swift
@@ -66,7 +66,7 @@ final class SwiftSDKCommandTests: CommandsTestCase {
 
                     // We only expect tool's output on the stdout stream.
                     XCTAssertMatch(
-                        stdout,
+                        stdout + "\nstderr:\n" + stderr,
                         .contains("\(bundle)` successfully installed as test-sdk.artifactbundle.")
                     )
 

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -70,11 +70,13 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build of product 'MyTool' complete!"), "stdout:\n\(stdout)")
         }
 
+#if !os(Windows) // https://github.com/swiftlang/swift-package-manager/issues/8774
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MySourceGenClient"), configuration: .Debug, extraArgs: ["--build-system", "swiftbuild", "--product", "MyTool"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
+#endif
     }
 
     func testUseOfPrebuildPluginTargetByExecutableAcrossPackages() async throws {
@@ -90,10 +92,12 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build of product 'MyOtherLocalTool' complete!"), "stdout:\n\(stdout)")
         }
 
+#if !os(Windows) // https://github.com/swiftlang/swift-package-manager/issues/8774
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--build-system", "swiftbuild", "--product", "MyOtherLocalTool"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
+#endif
     }
 
     func testUseOfPluginWithInternalExecutable() async throws {
@@ -111,11 +115,13 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
 
+#if !os(Windows) // https://github.com/swiftlang/swift-package-manager/issues/8774
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("ClientOfPluginWithInternalExecutable"), extraArgs: ["--build-system", "swiftbuild"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
+#endif
     }
 
     func testInternalExecutableAvailableOnlyToPlugin() async throws {
@@ -151,11 +157,13 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
 
+#if !os(Windows) // https://github.com/swiftlang/swift-package-manager/issues/8774
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("LibraryWithLocalBuildToolPluginUsingRemoteTool"), extraArgs: ["--build-system", "swiftbuild"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
+#endif
     }
     
     func testBuildToolPluginDependencies() async throws {
@@ -194,10 +202,12 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
         }
 
+#if !os(Windows) // https://github.com/swiftlang/swift-package-manager/issues/8774
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("ContrivedTestPlugin"), configuration: .Debug, extraArgs: ["--build-system", "swiftbuild", "--product", "MyLocalTool", "--disable-sandbox"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
+#endif
     }
 
     func testPluginScriptSandbox() async throws {
@@ -1146,11 +1156,13 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("type of snippet target: snippet"), "output:\n\(stderr)\n\(stdout)")
         }
 
+#if !os(Windows) // https://github.com/swiftlang/swift-package-manager/issues/8774
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { path in
             let (stdout, stderr) = try await executeSwiftPackage(path.appending("PluginsAndSnippets"), configuration: .Debug, extraArgs: ["--build-system", "swiftbuild", "do-something"])
             XCTAssert(stdout.contains("type of snippet target: snippet"), "output:\n\(stderr)\n\(stdout)")
         }
+#endif
     }
 
     func testIncorrectDependencies() async throws {
@@ -1161,11 +1173,13 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "output:\n\(stderr)\n\(stdout)")
         }
 
+#if !os(Windows) // https://github.com/swiftlang/swift-package-manager/issues/8774
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { path in
             let (stdout, stderr) = try await executeSwiftBuild(path.appending("IncorrectDependencies"), extraArgs: ["--build-system", "swiftbuild", "--build-tests"])
             XCTAssert(stdout.contains("Build complete!"), "output:\n\(stderr)\n\(stdout)")
         }
+#endif
     }
 
     func testSandboxViolatingBuildToolPluginCommands() async throws {
@@ -1203,11 +1217,13 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
 
+#if !os(Windows) // https://github.com/swiftlang/swift-package-manager/issues/8774
         // Try again with Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("TransitivePluginOnlyDependency"), extraArgs: ["--build-system", "swiftbuild"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
+#endif
     }
 
     func testMissingPlugin() async throws {
@@ -1222,6 +1238,7 @@ final class PluginTests: XCTestCase {
             }
         }
 
+#if !os(Windows) // https://github.com/swiftlang/swift-package-manager/issues/8774
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             do {
                 try await executeSwiftBuild(fixturePath.appending("MissingPlugin"), extraArgs: ["--build-system", "swiftbuild"])
@@ -1229,6 +1246,7 @@ final class PluginTests: XCTestCase {
                 XCTAssert(stderr.contains("error: 'missingplugin': no plugin named 'NonExistingPlugin' found"), "stderr:\n\(stderr)")
             }
         }
+#endif
     }
 
     func testPluginCanBeReferencedByProductName() async throws {
@@ -1242,11 +1260,13 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
 
+#if !os(Windows) // https://github.com/swiftlang/swift-package-manager/issues/8774
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("PluginCanBeReferencedByProductName"), extraArgs: ["--build-system", "swiftbuild"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
+#endif
     }
 
     func testPluginCanBeAffectedByXBuildToolsParameters() async throws {
@@ -1310,9 +1330,11 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
 
+#if !os(Windows) // https://github.com/swiftlang/swift-package-manager/issues/8774
         try await fixture(name: "Miscellaneous/Plugins/DependentPlugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath, extraArgs: ["--build-system", "swiftbuild"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
+#endif
     }
 }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -70,13 +70,11 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build of product 'MyTool' complete!"), "stdout:\n\(stdout)")
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MySourceGenClient"), configuration: .Debug, extraArgs: ["--build-system", "swiftbuild", "--product", "MyTool"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
-#endif
     }
 
     func testUseOfPrebuildPluginTargetByExecutableAcrossPackages() async throws {
@@ -92,12 +90,10 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build of product 'MyOtherLocalTool' complete!"), "stdout:\n\(stdout)")
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--build-system", "swiftbuild", "--product", "MyOtherLocalTool"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
-#endif
     }
 
     func testUseOfPluginWithInternalExecutable() async throws {
@@ -115,13 +111,11 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("ClientOfPluginWithInternalExecutable"), extraArgs: ["--build-system", "swiftbuild"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
-#endif
     }
 
     func testInternalExecutableAvailableOnlyToPlugin() async throws {
@@ -136,13 +130,11 @@ final class PluginTests: XCTestCase {
             }
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             await XCTAssertThrowsCommandExecutionError(try await executeSwiftBuild(fixturePath.appending("InvalidUseOfInternalPluginExecutable")), "Illegally used internal executable"
 ) { error in
             }
         }
-#endif
     }
     
     func testLocalBuildToolPluginUsingRemoteExecutable() async throws {
@@ -159,13 +151,11 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("LibraryWithLocalBuildToolPluginUsingRemoteTool"), extraArgs: ["--build-system", "swiftbuild"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
-#endif
     }
     
     func testBuildToolPluginDependencies() async throws {
@@ -182,7 +172,7 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
+#if os(macOS)
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MyBuildToolPluginDependencies"), extraArgs: ["--build-system", "swiftbuild"])
@@ -204,12 +194,10 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("ContrivedTestPlugin"), configuration: .Debug, extraArgs: ["--build-system", "swiftbuild", "--product", "MyLocalTool", "--disable-sandbox"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
-#endif
     }
 
     func testPluginScriptSandbox() async throws {
@@ -1158,13 +1146,11 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("type of snippet target: snippet"), "output:\n\(stderr)\n\(stdout)")
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { path in
             let (stdout, stderr) = try await executeSwiftPackage(path.appending("PluginsAndSnippets"), configuration: .Debug, extraArgs: ["--build-system", "swiftbuild", "do-something"])
             XCTAssert(stdout.contains("type of snippet target: snippet"), "output:\n\(stderr)\n\(stdout)")
         }
-#endif
     }
 
     func testIncorrectDependencies() async throws {
@@ -1175,13 +1161,11 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "output:\n\(stderr)\n\(stdout)")
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { path in
             let (stdout, stderr) = try await executeSwiftBuild(path.appending("IncorrectDependencies"), extraArgs: ["--build-system", "swiftbuild", "--build-tests"])
             XCTAssert(stdout.contains("Build complete!"), "output:\n\(stderr)\n\(stdout)")
         }
-#endif
     }
 
     func testSandboxViolatingBuildToolPluginCommands() async throws {
@@ -1219,13 +1203,11 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
         // Try again with Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("TransitivePluginOnlyDependency"), extraArgs: ["--build-system", "swiftbuild"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
-#endif
     }
 
     func testMissingPlugin() async throws {
@@ -1240,7 +1222,6 @@ final class PluginTests: XCTestCase {
             }
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             do {
                 try await executeSwiftBuild(fixturePath.appending("MissingPlugin"), extraArgs: ["--build-system", "swiftbuild"])
@@ -1248,7 +1229,6 @@ final class PluginTests: XCTestCase {
                 XCTAssert(stderr.contains("error: 'missingplugin': no plugin named 'NonExistingPlugin' found"), "stderr:\n\(stderr)")
             }
         }
-#endif
     }
 
     func testPluginCanBeReferencedByProductName() async throws {
@@ -1262,13 +1242,11 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("PluginCanBeReferencedByProductName"), extraArgs: ["--build-system", "swiftbuild"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
-#endif
     }
 
     func testPluginCanBeAffectedByXBuildToolsParameters() async throws {
@@ -1292,7 +1270,7 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
+#if os(macOS)
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, stderr) = try await executeSwiftBuild(
                 fixturePath.appending(component: "MySourceGenPlugin"),
@@ -1315,8 +1293,7 @@ final class PluginTests: XCTestCase {
             let (stdout, _) = try await executeSwiftBuild(fixturePath, configuration: .Debug)
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
-
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
+#if os(macOS)
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins/MySourceGenPluginUsingURLBasedAPI") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath, configuration: .Debug, extraArgs: ["--build-system", "swiftbuild"])
@@ -1333,11 +1310,9 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
 
-#if os(macOS) // See https://github.com/swiftlang/swift-package-manager/issues/8416 for errors running build tools on Linux
         try await fixture(name: "Miscellaneous/Plugins/DependentPlugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath, extraArgs: ["--build-system", "swiftbuild"])
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
-#endif
     }
 }


### PR DESCRIPTION
Linux build tool plugins won't work because they require a library
path to the Swift standard libraries. Add the toolchain's library path
to the environment for the custom task. Enable the tests that cover
this area for non-macOS platforms.