### PR TITLE
Do not include all of the build dir for API digester to avoid conflicting definitions.

### DIFF
--- a/Fixtures/Miscellaneous/APIDiff/WithPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/APIDiff/WithPlugin/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "package-with-plugin",
+    products: [.library(name: "PackageLib", targets: ["TargetLib"])],
+    targets: [
+        .target(name: "TargetLib"),
+        .executableTarget(name: "BuildTool", dependencies: ["TargetLib"]),
+        .plugin(
+            name: "BuildPlugin",
+            capability: .command(intent: .custom(verb: "do-it-now", description: "")),
+            dependencies: ["BuildTool"]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/APIDiff/WithPlugin/Plugins/BuildPlugin/BuildToolPlugin.swift
+++ b/Fixtures/Miscellaneous/APIDiff/WithPlugin/Plugins/BuildPlugin/BuildToolPlugin.swift
@@ -1,0 +1,9 @@
+import Foundation
+import PackagePlugin
+
+@main
+final class BuildToolPlugin: CommandPlugin {
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        _ = try context.tool(named: "BuildTool")
+    }
+}

--- a/Fixtures/Miscellaneous/APIDiff/WithPlugin/Sources/BuildTool/BuildTool.swift
+++ b/Fixtures/Miscellaneous/APIDiff/WithPlugin/Sources/BuildTool/BuildTool.swift
@@ -1,0 +1,8 @@
+import TargetLib
+
+@main
+public struct BuildTool {
+    static func main() {
+        TargetLibStruct.do_it()
+    }
+}

--- a/Fixtures/Miscellaneous/APIDiff/WithPlugin/Sources/TargetLib/TargetLib.swift
+++ b/Fixtures/Miscellaneous/APIDiff/WithPlugin/Sources/TargetLib/TargetLib.swift
@@ -1,0 +1,5 @@
+public enum TargetLibStruct {
+    public static func do_it() {
+        print("Hello!")
+    }
+}

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -328,6 +328,17 @@ class APIDiffTestCase: CommandsBuildProviderTestCase {
         }
     }
 
+
+    func testAPIDiffPackageWithPlugin() async throws {
+        try skipIfApiDigesterUnsupportedOrUnset()
+        try await fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending("WithPlugin")
+            let (output, _) = try await execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)
+            XCTAssertMatch(output, .contains("No breaking changes detected in TargetLib"))
+        }
+    }
+
+
     func testBadTreeish() async throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try await fixture(name: "Miscellaneous/APIDiff/") { fixturePath in


### PR DESCRIPTION
Do not include all of the build dir for API digester to avoid conflicting definitions.

### Motivation:

Issue #8081 : when a package or its dependencies define a tool plugin, then diagnose-api-breaking-changes report false API breakage.

Investigation shown that diagnose-api-breaking-changes passes for analysis (with `-I`) all of the build dir, with all of the dependencies. When a tool plugin is in the dependency tree, then dependencies for the plugin itself are built with `.host` destination. If it happens that these modules are also built for `.target` destination, then `swift-api-digester` fails to analyze them, and public API declared there is printed as removed.

```
/Users/yy/work/pub/tst/.build/arm64-apple-macosx/debug/MyLib-tool.build/module.modulemap:1:8: error: redefinition of module 'MyLib'
module MyLib {
       ^
/Users/yy/work/pub/tst/.build/arm64-apple-macosx/debug/MyLib.build/module.modulemap:1:8: note: previously defined here
module MyLib {
       ^
Failed to load module: MyLib
```

### Modifications:

The goal for this PR is to reduce analyzed surface  from "all of the build directory" down to modules built for target.

### Result:

Before the change, example in Issue #8081 

```
1 breaking change detected in mypackage:
  💔 API breakage: var myPublicString has been removed
```

After the change:

```
No breaking changes detected in mypackage
```