### PR TITLE
Command plugins should respect --build-system selection

### DIFF
--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -210,6 +210,7 @@ struct PluginCommand: AsyncSwiftCommand {
             plugin: matchingPlugins[0],
             package: packageGraph.rootPackages[packageGraph.rootPackages.startIndex],
             packageGraph: packageGraph,
+            buildSystem: pluginArguments.globalOptions.build.buildSystem,
             options: pluginOptions,
             arguments: unparsedArguments,
             swiftCommandState: swiftCommandState
@@ -220,6 +221,7 @@ struct PluginCommand: AsyncSwiftCommand {
         plugin: ResolvedModule,
         package: ResolvedPackage,
         packageGraph: ModulesGraph,
+        buildSystem buildSystemKind: BuildSystemProvider.Kind,
         options: PluginOptions,
         arguments: [String],
         swiftCommandState: SwiftCommandState
@@ -328,7 +330,7 @@ struct PluginCommand: AsyncSwiftCommand {
         let buildParameters = try swiftCommandState.toolsBuildParameters
         // Build or bring up-to-date any executable host-side tools on which this plugin depends. Add them and any binary dependencies to the tool-names-to-path map.
         let buildSystem = try await swiftCommandState.createBuildSystem(
-            explicitBuildSystem: .native,
+            explicitBuildSystem: buildSystemKind,
             traitConfiguration: .init(),
             cacheBuildManifest: false,
             productsBuildParameters: swiftCommandState.productsBuildParameters,
@@ -353,7 +355,7 @@ struct PluginCommand: AsyncSwiftCommand {
         }
 
         // Set up a delegate to handle callbacks from the command plugin.
-        let pluginDelegate = PluginDelegate(swiftCommandState: swiftCommandState, plugin: pluginTarget)
+        let pluginDelegate = PluginDelegate(swiftCommandState: swiftCommandState, buildSystem: buildSystemKind, plugin: pluginTarget)
         let delegateQueue = DispatchQueue(label: "plugin-invocation")
 
         // Run the command plugin.

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -25,11 +25,13 @@ import struct Basics.AsyncProcessResult
 
 final class PluginDelegate: PluginInvocationDelegate {
     let swiftCommandState: SwiftCommandState
+    let buildSystem: BuildSystemProvider.Kind
     let plugin: PluginModule
     var lineBufferedOutput: Data
 
-    init(swiftCommandState: SwiftCommandState, plugin: PluginModule) {
+    init(swiftCommandState: SwiftCommandState, buildSystem: BuildSystemProvider.Kind, plugin: PluginModule) {
         self.swiftCommandState = swiftCommandState
+        self.buildSystem = buildSystem
         self.plugin = plugin
         self.lineBufferedOutput = Data()
     }
@@ -167,7 +169,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         }
 
         let buildSystem = try await swiftCommandState.createBuildSystem(
-            explicitBuildSystem: .native,
+            explicitBuildSystem: buildSystem,
             explicitProduct: explicitProduct,
             traitConfiguration: .init(),
             cacheBuildManifest: false,
@@ -398,7 +400,7 @@ final class PluginDelegate: PluginInvocationDelegate {
 
         // Create a build system for building the target., skipping the the cache because we need the build plan.
         let buildSystem = try await swiftCommandState.createBuildSystem(
-            explicitBuildSystem: .native,
+            explicitBuildSystem: buildSystem,
             traitConfiguration: TraitConfiguration(enableAllTraits: true),
             cacheBuildManifest: false
         )

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -3466,7 +3466,14 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                 XCTAssertMatch(stdout, .contains("-DEXTRA_SWIFT_FLAG"))
                 XCTAssertMatch(stdout, .contains("Build of product 'MyExecutable' complete!"))
                 XCTAssertMatch(stdout, .contains("succeeded: true"))
-                XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains(RelativePath("debug/MyExecutable").pathString)))
+                switch buildSystemProvider {
+                case .native:
+                    XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains(RelativePath("debug/MyExecutable").pathString)))
+                case .swiftbuild:
+                    XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains(RelativePath("MyExecutable").pathString)))
+                case .xcode:
+                    XCTFail("unimplemented assertion for --build-system xcode")
+                }
                 XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("executable")))
             }
 
@@ -3478,7 +3485,14 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                 XCTAssertNoMatch(stdout, .contains("-module-name MyExecutable"))
                 XCTAssertMatch(stdout, .contains("Build of product 'MyExecutable' complete!"))
                 XCTAssertMatch(stdout, .contains("succeeded: true"))
-                XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains(RelativePath("release/MyExecutable").pathString)))
+                switch buildSystemProvider {
+                case .native:
+                    XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains(RelativePath("release/MyExecutable").pathString)))
+                case .swiftbuild:
+                    XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains(RelativePath("MyExecutable").pathString)))
+                case .xcode:
+                    XCTFail("unimplemented assertion for --build-system xcode")
+                }
                 XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("executable")))
             }
 
@@ -3490,7 +3504,14 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                 XCTAssertNoMatch(stdout, .contains("-module-name MyLibrary"))
                 XCTAssertMatch(stdout, .contains("Build of product 'MyStaticLibrary' complete!"))
                 XCTAssertMatch(stdout, .contains("succeeded: true"))
-                XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains(RelativePath("release/libMyStaticLibrary").pathString)))
+                switch buildSystemProvider {
+                case .native:
+                    XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains(RelativePath("release/libMyStaticLibrary").pathString)))
+                case .swiftbuild:
+                    XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains(RelativePath("MyStaticLibrary").pathString)))
+                case .xcode:
+                    XCTFail("unimplemented assertion for --build-system xcode")
+                }
                 XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("staticLibrary")))
             }
 
@@ -3502,11 +3523,18 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                 XCTAssertNoMatch(stdout, .contains("-module-name MyLibrary"))
                 XCTAssertMatch(stdout, .contains("Build of product 'MyDynamicLibrary' complete!"))
                 XCTAssertMatch(stdout, .contains("succeeded: true"))
-#if os(Windows)                
-                XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains("release\\MyDynamicLibrary")))
-#else
-                XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains("release/libMyDynamicLibrary")))
-#endif
+                switch buildSystemProvider {
+                case .native:
+                    #if os(Windows)
+                    XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains(RelativePath("release/MyDynamicLibrary.dll").pathString)))
+                    #else
+                    XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains(RelativePath("release/libMyDynamicLibrary").pathString)))
+                    #endif
+                case .swiftbuild:
+                    XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains(RelativePath("MyDynamicLibrary").pathString)))
+                case .xcode:
+                    XCTFail("unimplemented assertion for --build-system xcode")
+                }
                 XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("dynamicLibrary")))
             }
         }
@@ -4069,10 +4097,7 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
     override func testNoParameters() async throws {
         try await super.testNoParameters()
     }
-
-    override func testCommandPluginBuildingCallbacks() async throws {
-        throw XCTSkip("SWBINTTODO: Test fails because plugin is not producing expected output to stdout.")
-    }
+    
     override func testCommandPluginBuildTestability() async throws {
         throw XCTSkip("SWBINTTODO: Test fails as plugins are not currenty supported")
     }


### PR DESCRIPTION
Command plugins should use the user specified build system when building any dependencies, and if the command plugin requests a build of its own. Supporting the full range of command plugin functionality with the Swift Build backend will take a little more work, but this patch gets the fundamentals wired up