### PR TITLE
Add SwiftBuildSupport to the primary libSwiftPM product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,7 @@ let swiftPMProduct = (
         "LLBuildManifest",
         "SourceKitLSPAPI",
         "SPMLLBuild",
+        "SwiftBuildSupport",
     ]
 )
 


### PR DESCRIPTION
This will make it accessible to clients like sourcekit-lsp