### PR TITLE
[6.2] Tests: Add "XCTSkipExhibits" call

### DIFF
--- a/Sources/_InternalTestSupport/XCTAssertHelpers.swift
+++ b/Sources/_InternalTestSupport/XCTAssertHelpers.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import class Foundation.ProcessInfo
 import Basics
 #if os(macOS)
 import class Foundation.Bundle
@@ -318,6 +319,15 @@ public struct CommandExecutionError: Error {
     public let stderr: String
 }
 
+
+public func XCTExhibitsGitHubIssue(_ number: Int) throws {
+    let envVar = "SWIFTCI_EXHIBITS_GH_\(number)"
+
+    try XCTSkipIf(
+        ProcessInfo.processInfo.environment[envVar] != nil,
+        "https://github.com/swiftlang/swift-package-manager/issues/\(number): \(envVar)environment variable is set"
+    )
+}
 /// Skips the test if running on a platform which lacks the ability for build tasks to set a working directory due to lack of requisite system API.
 ///
 /// Presently, relevant platforms include Amazon Linux 2 and OpenBSD.

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -4094,4 +4094,9 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
         try XCTSkipOnWindows(because: "TSCBasic/Path.swift:969: Assertion failed, https://github.com/swiftlang/swift-package-manager/issues/8602")
         try await super.testCommandPluginTargetBuilds()
     }
+
+    override func testCommandPluginPermissions() async throws {
+        try XCTExhibitsGitHubIssue(8782)
+        try await super.testCommandPluginPermissions()
+    }
 }


### PR DESCRIPTION
A test fails in certain CI environmnents.  Introduce an `XCTExhibit...` call that would skip a test if an environment variable is set.

(cherry picked from commit ae31314d46777451398ba56933baed5727fe3498 - #8783) 
