### PR TITLE
Unify argument formatting for add setting and migrate

### DIFF
--- a/Sources/Commands/PackageCommands/AddSetting.swift
+++ b/Sources/Commands/PackageCommands/AddSetting.swift
@@ -44,7 +44,7 @@ extension SwiftPackageCommand {
 
         @Option(
             name: .customLong("swift"),
-            parsing: .unconditionalSingleValue,
+            parsing: .upToNextOption,
             help: "The Swift language setting(s) to add. Supported settings: \(SwiftSetting.allCases.map(\.rawValue).joined(separator: ", "))."
         )
         var _swiftSettings: [String]

--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -19,6 +19,8 @@ import CoreCommands
 
 import Foundation
 
+import OrderedCollections
+
 import PackageGraph
 import PackageModel
 
@@ -29,18 +31,15 @@ import var TSCBasic.stdoutStream
 
 struct MigrateOptions: ParsableArguments {
     @Option(
-        name: .customLong("targets"),
+        name: .customLong("target"),
+        parsing: .upToNextOption,
         help: "The targets to migrate to specified set of features."
     )
-    var _targets: String?
-
-    var targets: Set<String>? {
-        self._targets.flatMap { Set($0.components(separatedBy: ",")) }
-    }
+    var targets: [String] = []
 
     @Option(
         name: .customLong("to-feature"),
-        parsing: .unconditionalSingleValue,
+        parsing: .upToNextOption,
         help: "The Swift language upcoming/experimental feature to migrate to."
     )
     var features: [String]
@@ -85,9 +84,11 @@ extension SwiftPackageCommand {
                 features.append(feature)
             }
 
+            let uniqueTargets = OrderedSet(self.options.targets)
+
             let buildSystem = try await createBuildSystem(
                 swiftCommandState,
-                targets: self.options.targets,
+                targets: uniqueTargets,
                 features: features
             )
 
@@ -95,8 +96,8 @@ extension SwiftPackageCommand {
             // whole project to get diagnostic files.
 
             print("> Starting the build")
-            if let targets = self.options.targets {
-                for target in targets {
+            if !uniqueTargets.isEmpty {
+                for target in uniqueTargets {
                     try await buildSystem.build(subset: .target(target))
                 }
             } else {
@@ -107,8 +108,9 @@ extension SwiftPackageCommand {
             let buildPlan = try buildSystem.buildPlan
 
             var modules: [any ModuleBuildDescription] = []
-            if let targets = self.options.targets {
-                for buildDescription in buildPlan.buildModules where targets.contains(buildDescription.module.name) {
+            if !uniqueTargets.isEmpty {
+                for buildDescription in buildPlan.buildModules
+                    where uniqueTargets.contains(buildDescription.module.name) {
                     modules.append(buildDescription)
                 }
             } else {
@@ -176,7 +178,7 @@ extension SwiftPackageCommand {
 
         private func createBuildSystem(
             _ swiftCommandState: SwiftCommandState,
-            targets: Set<String>? = .none,
+            targets: OrderedSet<String>,
             features: [SwiftCompilerFeature]
         ) async throws -> BuildSystem {
             let toolsBuildParameters = try swiftCommandState.toolsBuildParameters
@@ -190,7 +192,7 @@ extension SwiftPackageCommand {
                 }
             }
 
-            if let targets {
+            if !targets.isEmpty {
                 targets.lazy.compactMap {
                     modulesGraph.module(for: $0)
                 }.forEach(addFeaturesToModule)


### PR DESCRIPTION
### Motivation:

The inconsistency in argument formatting came up as part of SE-0486 review. This is the first step in a direction to make command formatting more consistent.

- `swift package migrate`:
  - Rename `--targets` to `--target`
  - Change `--target` and `--to-feature` to accept space separated argument lists

- `swift package -add-setting`:
   - Switch to `.upToNextOption` formatting. Instead of `--swift A=B --swift C=D` switch to `--swift A=B C=D`.

### Modifications:

- Update `MigrateOptions` to use `.upToNextOption` for targets and features.
- Update `SwiftPackageCommand`'s `_swiftSettings` option to use `.upToNextOption`

### Result:

The `swift package migrate` and `swift package add-setting` command line is now shorter and has consistent formatting.

Resolves: rdar://152687586