### PR TITLE
Support using a Swift file as a build tool plugin executable

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/SwiftFilePlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/SwiftFilePlugin/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftFilePluginFixture",
+    products: [
+        .library(
+            name: "SwiftFilePluginFixture",
+            targets: ["SwiftFilePluginFixture"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "SwiftFilePluginFixture",
+            plugins: [
+                .plugin(name: "MyCustomBuildTool")
+            ]
+        ),
+        .plugin(
+            name: "MyCustomBuildTool",
+            capability: .buildTool()
+        )
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/SwiftFilePlugin/Plugins/MyCustomBuildTool/SwiftToolsBuildPlugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/SwiftFilePlugin/Plugins/MyCustomBuildTool/SwiftToolsBuildPlugin.swift
@@ -1,0 +1,16 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct SwiftToolsBuildPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        let formatExecutable = context.package.directoryURL.appending(components: "SimpleSwiftScript.swift")
+        return [.buildCommand(
+            displayName: "Run a swift script",
+            executable: formatExecutable,
+            arguments: [],
+            inputFiles: [formatExecutable],
+            outputFiles: []
+        )]
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/SwiftFilePlugin/SimpleSwiftScript.swift
+++ b/Fixtures/Miscellaneous/Plugins/SwiftFilePlugin/SimpleSwiftScript.swift
@@ -1,0 +1,3 @@
+#!/usr/bin/swift
+
+print("Hello, Build Tool Plugin!")

--- a/Fixtures/Miscellaneous/Plugins/SwiftFilePlugin/SimpleSwiftScript.swift
+++ b/Fixtures/Miscellaneous/Plugins/SwiftFilePlugin/SimpleSwiftScript.swift
@@ -1,3 +1,3 @@
-#!/usr/bin/swift
+#!/usr/bin/env swift
 
 print("Hello, Build Tool Plugin!")

--- a/Sources/Basics/Sandbox.swift
+++ b/Sources/Basics/Sandbox.swift
@@ -190,8 +190,8 @@ fileprivate func macOSSandboxProfile(
     else if strictness == .writableTemporaryDirectory {
         var stableCacheDirectories: [AbsolutePath] = []
         // Add `subpath` expressions for the regular, Foundation and clang module cache temporary directories.
-        for tmpDir in threadSafeDarwinCacheDirectories {
-            let resolved = try resolveSymlinks(tmpDir)
+        for tmpDir in (["/tmp"] + threadSafeDarwinCacheDirectories.map(\.pathString)) {
+            let resolved = try resolveSymlinks(AbsolutePath(validating: tmpDir))
             if !stableCacheDirectories.contains(where: { $0.isAncestorOfOrEqual(to: resolved) }) {
                 stableCacheDirectories.append(resolved)
                 writableDirectoriesExpression += [

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -381,7 +381,7 @@ public final class PIFBuilder {
                                         self.parameters.disableSandbox ?
                                             nil :
                                             .init(
-                                                strictness: .default,
+                                                strictness: .writableTemporaryDirectory,
                                                 writableDirectories: writableDirectories,
                                                 readOnlyDirectories: buildCommand.inputFiles
                                             )

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -1206,12 +1206,14 @@ final class PluginTests: XCTestCase {
         }
     }
 
+#if os(macOS)
     func testBuildToolPluginSwiftFileExecutable() async throws {
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("SwiftFilePlugin"), configuration: .Debug)
             XCTAssertTrue(stdout.contains("Hello, Build Tool Plugin!"), "stdout:\n\(stdout)")
         }
     }
+#endif
 
     func testTransitivePluginOnlyDependency() async throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -1206,6 +1206,13 @@ final class PluginTests: XCTestCase {
         }
     }
 
+    func testBuildToolPluginSwiftFileExecutable() async throws {
+        try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("SwiftFilePlugin"), configuration: .Debug)
+            XCTAssertTrue(stdout.contains("Hello, Build Tool Plugin!"), "stdout:\n\(stdout)")
+        }
+    }
+
     func testTransitivePluginOnlyDependency() async throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -1208,9 +1208,15 @@ final class PluginTests: XCTestCase {
 
 #if os(macOS)
     func testBuildToolPluginSwiftFileExecutable() async throws {
-        try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("SwiftFilePlugin"), configuration: .Debug)
-            XCTAssertTrue(stdout.contains("Hello, Build Tool Plugin!"), "stdout:\n\(stdout)")
+        for buildSystem in ["native", "swiftbuild"] {
+            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
+                let (stdout, stderr) = try await executeSwiftBuild(fixturePath.appending("SwiftFilePlugin"), configuration: .Debug, extraArgs: ["--build-system", buildSystem, "--verbose"])
+                if buildSystem == "native" {
+                    XCTAssertTrue(stdout.contains("Hello, Build Tool Plugin!"), "stdout:\n\(stdout)")
+                } else {
+                    XCTAssertTrue(stderr.contains("Hello, Build Tool Plugin!"), "stderr:\n\(stderr)")
+                }
+            }
         }
     }
 #endif


### PR DESCRIPTION
A Swift file can be executed directly in the shell. Typically the file begins with a `#/usr/bin/swift` or an equivalent `xcrun` incantation, and then simply running `swift MyFile.swift` will automatically compile and execute it.

Build tool plugins often leverage Swift, but to do so they add two targets, a `.plugin` and an `.executableTarget`. The executable target builds a binary that the plugin tool then calls during a build.

Often this is more heavyweight than needed. By passing the path to a Swift file to the `executable` argument of the `.buildCommand` returned from your build tool plugin, you could bypass the need to create a separate executable target and just execute the file directly.

However, because SwiftPM executes build tool plugins within a sandbox the sandbox script needs to be ammended with the clang module cache temporary directory so that the swift compiler can write the modules it needs to execute the file.

Ammend the sandbox script to add write permissions to the root tmp directory that LLVM uses to write clang modules. With this addition you can now use a .swift file as a build tool plugin executable.

rdar://152874736