### PR TITLE
Fix `swift package describe` for packages with binary artifacts that has a .zip extension.

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1161,18 +1161,25 @@ extension Workspace {
                         if let path = target.path {
                             let artifactPath = try manifest.path.parentDirectory
                                 .appending(RelativePath(validating: path))
-                            guard let (_, artifactKind) = try BinaryArtifactsManager.deriveBinaryArtifact(
+                            if artifactPath.extension?.lowercased() == "zip" {
+                                partial[target.name] = BinaryArtifact(
+                                    kind: .unknown,
+                                    originURL: .none,
+                                    path: artifactPath
+                                )
+                            } else if let (_, artifactKind) = try BinaryArtifactsManager.deriveBinaryArtifact(
                                 fileSystem: self.fileSystem,
                                 path: artifactPath,
                                 observabilityScope: observabilityScope
-                            ) else {
+                            ) {
+                                partial[target.name] = BinaryArtifact(
+                                    kind: artifactKind,
+                                    originURL: .none,
+                                    path: artifactPath
+                                )
+                            } else {
                                 throw StringError("\(artifactPath) does not contain binary artifact")
                             }
-                            partial[target.name] = BinaryArtifact(
-                                kind: artifactKind,
-                                originURL: .none,
-                                path: artifactPath
-                            )
                         } else if let url = target.url.flatMap(URL.init(string:)) {
                             let fakePath = try manifest.path.parentDirectory.appending(components: "remote", "archive")
                                 .appending(RelativePath(validating: url.lastPathComponent))

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -9231,6 +9231,11 @@ final class WorkspaceTests: XCTestCase {
                             url: "https://a.com/a2.zip.zip",
                             checksum: "a3"
                         ),
+                        MockTarget(
+                            name: "A4",
+                            type: .binary,
+                            path: "a4.zip"
+                        ),
                     ],
                     products: []
                 ),


### PR DESCRIPTION
Fix `swift package describe` for packages with binary artifacts that has a .zip extension.

### Motivation:

Fixes #4387

I want to avoid an error when running `swift package describe` on a package that contains a binary artifact target with a `.zip` extension.

### Modifications:

I modified the `Workspace.loadRootPackage(at:observabilityScope:completion)` method. Specifically, I updated the logic for local binary targets to also return a `BinaryArtifact` object when the file extension is `.zip`.
This change is also based on the comment referenced [here](https://github.com/swiftlang/swift-package-manager/pull/5826#issuecomment-1282990236).

### Result:

When running `swift package describe` on a package that contains a binary artifact target with a `.zip` extension, the package description is now output without throwing an error.
