### PR TITLE
[6.2] Fixes a few issues with `swift package {migrate, add-setting}` commands

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -102,7 +102,8 @@ extension BuildPlan {
                     dependencies: testProduct.underlying.modules.map { .module($0, conditions: []) },
                     packageAccess: true, // test target is allowed access to package decls by default
                     testDiscoverySrc: Sources(paths: discoveryPaths, root: discoveryDerivedDir),
-                    buildSettings: discoveryBuildSettings
+                    buildSettings: discoveryBuildSettings,
+                    implicit: true
                 )
                 let discoveryResolvedModule = ResolvedModule(
                     packageIdentity: testProduct.packageIdentity,
@@ -287,7 +288,8 @@ private extension PackageModel.SwiftModule {
             dependencies: dependencies,
             packageAccess: packageAccess,
             buildSettings: buildSettings,
-            usesUnsafeFlags: false
+            usesUnsafeFlags: false,
+            implicit: true
         )
     }
 }

--- a/Sources/Commands/PackageCommands/AddSetting.swift
+++ b/Sources/Commands/PackageCommands/AddSetting.swift
@@ -44,7 +44,7 @@ extension SwiftPackageCommand {
 
         @Option(
             name: .customLong("swift"),
-            parsing: .unconditionalSingleValue,
+            parsing: .upToNextOption,
             help: "The Swift language setting(s) to add. Supported settings: \(SwiftSetting.allCases.map(\.rawValue).joined(separator: ", "))."
         )
         var _swiftSettings: [String]

--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -206,6 +206,9 @@ extension SwiftPackageCommand {
 
             return try await swiftCommandState.createBuildSystem(
                 traitConfiguration: .init(),
+                // Don't attempt to cache manifests with temporary
+                // feature flags added just for migration purposes.
+                cacheBuildManifest: false,
                 productsBuildParameters: destinationBuildParameters,
                 toolsBuildParameters: toolsBuildParameters,
                 // command result output goes on stdout

--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -116,8 +116,12 @@ extension SwiftPackageCommand {
             } else {
                 let graph = try await buildSystem.getPackageGraph()
                 for buildDescription in buildPlan.buildModules
-                    where graph.isRootPackage(buildDescription.package) && buildDescription.module.type != .plugin
+                    where graph.isRootPackage(buildDescription.package)
                 {
+                    let module = buildDescription.module
+                    guard module.type != .plugin, !module.implicit else {
+                        continue
+                    }
                     modules.append(buildDescription)
                 }
             }

--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -19,6 +19,8 @@ import CoreCommands
 
 import Foundation
 
+import OrderedCollections
+
 import PackageGraph
 import PackageModel
 
@@ -29,18 +31,15 @@ import var TSCBasic.stdoutStream
 
 struct MigrateOptions: ParsableArguments {
     @Option(
-        name: .customLong("targets"),
+        name: .customLong("target"),
+        parsing: .upToNextOption,
         help: "The targets to migrate to specified set of features."
     )
-    var _targets: String?
-
-    var targets: Set<String>? {
-        self._targets.flatMap { Set($0.components(separatedBy: ",")) }
-    }
+    var targets: [String] = []
 
     @Option(
         name: .customLong("to-feature"),
-        parsing: .unconditionalSingleValue,
+        parsing: .upToNextOption,
         help: "The Swift language upcoming/experimental feature to migrate to."
     )
     var features: [String]
@@ -85,9 +84,11 @@ extension SwiftPackageCommand {
                 features.append(feature)
             }
 
+            let uniqueTargets = OrderedSet(self.options.targets)
+
             let buildSystem = try await createBuildSystem(
                 swiftCommandState,
-                targets: self.options.targets,
+                targets: uniqueTargets,
                 features: features
             )
 
@@ -95,8 +96,8 @@ extension SwiftPackageCommand {
             // whole project to get diagnostic files.
 
             print("> Starting the build")
-            if let targets = self.options.targets {
-                for target in targets {
+            if !uniqueTargets.isEmpty {
+                for target in uniqueTargets {
                     try await buildSystem.build(subset: .target(target))
                 }
             } else {
@@ -107,8 +108,9 @@ extension SwiftPackageCommand {
             let buildPlan = try buildSystem.buildPlan
 
             var modules: [any ModuleBuildDescription] = []
-            if let targets = self.options.targets {
-                for buildDescription in buildPlan.buildModules where targets.contains(buildDescription.module.name) {
+            if !uniqueTargets.isEmpty {
+                for buildDescription in buildPlan.buildModules
+                    where uniqueTargets.contains(buildDescription.module.name) {
                     modules.append(buildDescription)
                 }
             } else {
@@ -176,7 +178,7 @@ extension SwiftPackageCommand {
 
         private func createBuildSystem(
             _ swiftCommandState: SwiftCommandState,
-            targets: Set<String>? = .none,
+            targets: OrderedSet<String>,
             features: [SwiftCompilerFeature]
         ) async throws -> BuildSystem {
             let toolsBuildParameters = try swiftCommandState.toolsBuildParameters
@@ -190,7 +192,7 @@ extension SwiftPackageCommand {
                 }
             }
 
-            if let targets {
+            if !targets.isEmpty {
                 targets.lazy.compactMap {
                     modulesGraph.module(for: $0)
                 }.forEach(addFeaturesToModule)

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -680,12 +680,7 @@ private func createResolvedPackages(
         // Get all implicit system library dependencies in this package.
         let implicitSystemLibraryDeps = packageBuilder.dependencies
             .flatMap(\.modules)
-            .filter {
-                if case let systemLibrary as SystemLibraryModule = $0.module {
-                    return systemLibrary.isImplicit
-                }
-                return false
-            }
+            .filter(\.module.implicit)
 
         let packageDoesNotSupportProductAliases = packageBuilder.package.doesNotSupportProductAliases
         let lookupByProductIDs = !packageDoesNotSupportProductAliases &&

--- a/Sources/PackageGraph/Resolution/ResolvedModule.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedModule.swift
@@ -180,6 +180,12 @@ public struct ResolvedModule {
         })
     }
 
+    /// Whether this module comes from a declaration in the manifest file
+    /// or was synthesized (i.e. some test modules are synthesized).
+    public var implicit: Bool {
+        self.underlying.implicit
+    }
+
     /// Create a resolved module instance.
     public init(
         packageIdentity: PackageIdentity,

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1079,7 +1079,8 @@ public final class PackageBuilder {
                 declaredSwiftVersions: self.declaredSwiftVersions(),
                 buildSettings: buildSettings,
                 buildSettingsDescription: manifestTarget.settings,
-                usesUnsafeFlags: manifestTarget.usesUnsafeFlags
+                usesUnsafeFlags: manifestTarget.usesUnsafeFlags,
+                implicit: false
             )
         } else {
             // It's not a Swift target, so it's a Clang target (those are the only two types of source target currently
@@ -1124,7 +1125,8 @@ public final class PackageBuilder {
                 dependencies: dependencies,
                 buildSettings: buildSettings,
                 buildSettingsDescription: manifestTarget.settings,
-                usesUnsafeFlags: manifestTarget.usesUnsafeFlags
+                usesUnsafeFlags: manifestTarget.usesUnsafeFlags,
+                implicit: false
             )
         }
     }
@@ -1903,7 +1905,8 @@ extension PackageBuilder {
                     packageAccess: false,
                     buildSettings: buildSettings,
                     buildSettingsDescription: targetDescription.settings,
-                    usesUnsafeFlags: false
+                    usesUnsafeFlags: false,
+                    implicit: true
                 )
             }
     }

--- a/Sources/PackageModel/Module/BinaryModule.swift
+++ b/Sources/PackageModel/Module/BinaryModule.swift
@@ -49,7 +49,8 @@ public final class BinaryModule: Module {
             buildSettings: .init(),
             buildSettingsDescription: [],
             pluginUsages: [],
-            usesUnsafeFlags: false
+            usesUnsafeFlags: false,
+            implicit: false
         )
     }
 

--- a/Sources/PackageModel/Module/ClangModule.swift
+++ b/Sources/PackageModel/Module/ClangModule.swift
@@ -61,7 +61,8 @@ public final class ClangModule: Module {
         dependencies: [Module.Dependency] = [],
         buildSettings: BuildSettings.AssignmentTable = .init(),
         buildSettingsDescription: [TargetBuildSettingDescription.Setting] = [],
-        usesUnsafeFlags: Bool
+        usesUnsafeFlags: Bool,
+        implicit: Bool
     ) throws {
         guard includeDir.isDescendantOfOrEqual(to: sources.root) else {
             throw StringError("\(includeDir) should be contained in the source root \(sources.root)")
@@ -86,7 +87,8 @@ public final class ClangModule: Module {
             buildSettings: buildSettings,
             buildSettingsDescription: buildSettingsDescription,
             pluginUsages: [],
-            usesUnsafeFlags: usesUnsafeFlags
+            usesUnsafeFlags: usesUnsafeFlags,
+            implicit: implicit
         )
     }
 }

--- a/Sources/PackageModel/Module/Module.swift
+++ b/Sources/PackageModel/Module/Module.swift
@@ -242,6 +242,10 @@ public class Module {
     /// Whether or not this target uses any custom unsafe flags.
     public let usesUnsafeFlags: Bool
 
+    /// Whether this module comes from a declaration in the manifest file
+    /// or was synthesized (i.e. some test modules are synthesized).
+    public let implicit: Bool
+
     init(
         name: String,
         potentialBundleName: String? = nil,
@@ -256,7 +260,8 @@ public class Module {
         buildSettings: BuildSettings.AssignmentTable,
         buildSettingsDescription: [TargetBuildSettingDescription.Setting],
         pluginUsages: [PluginUsage],
-        usesUnsafeFlags: Bool
+        usesUnsafeFlags: Bool,
+        implicit: Bool
     ) {
         self.name = name
         self.potentialBundleName = potentialBundleName
@@ -273,6 +278,7 @@ public class Module {
         self.buildSettingsDescription = buildSettingsDescription
         self.pluginUsages = pluginUsages
         self.usesUnsafeFlags = usesUnsafeFlags
+        self.implicit = implicit
     }
 }
 

--- a/Sources/PackageModel/Module/PluginModule.swift
+++ b/Sources/PackageModel/Module/PluginModule.swift
@@ -45,7 +45,8 @@ public final class PluginModule: Module {
             buildSettings: .init(),
             buildSettingsDescription: [],
             pluginUsages: [],
-            usesUnsafeFlags: false
+            usesUnsafeFlags: false,
+            implicit: false
         )
     }
 }

--- a/Sources/PackageModel/Module/SwiftModule.swift
+++ b/Sources/PackageModel/Module/SwiftModule.swift
@@ -33,7 +33,8 @@ public final class SwiftModule: Module {
         dependencies: [Module.Dependency],
         packageAccess: Bool,
         testDiscoverySrc: Sources,
-        buildSettings: BuildSettings.AssignmentTable = .init()) {
+        buildSettings: BuildSettings.AssignmentTable = .init(),
+        implicit: Bool) {
         self.declaredSwiftVersions = []
 
         super.init(
@@ -46,7 +47,8 @@ public final class SwiftModule: Module {
             buildSettings: buildSettings,
             buildSettingsDescription: [],
             pluginUsages: [],
-            usesUnsafeFlags: false
+            usesUnsafeFlags: false,
+            implicit: implicit
         )
     }
 
@@ -68,7 +70,8 @@ public final class SwiftModule: Module {
         buildSettings: BuildSettings.AssignmentTable = .init(),
         buildSettingsDescription: [TargetBuildSettingDescription.Setting] = [],
         pluginUsages: [PluginUsage] = [],
-        usesUnsafeFlags: Bool
+        usesUnsafeFlags: Bool,
+        implicit: Bool
     ) {
         self.declaredSwiftVersions = declaredSwiftVersions
         super.init(
@@ -85,7 +88,8 @@ public final class SwiftModule: Module {
             buildSettings: buildSettings,
             buildSettingsDescription: buildSettingsDescription,
             pluginUsages: pluginUsages,
-            usesUnsafeFlags: usesUnsafeFlags
+            usesUnsafeFlags: usesUnsafeFlags,
+            implicit: implicit
         )
     }
 
@@ -133,7 +137,8 @@ public final class SwiftModule: Module {
             buildSettings: buildSettings,
             buildSettingsDescription: [],
             pluginUsages: [],
-            usesUnsafeFlags: false
+            usesUnsafeFlags: false,
+            implicit: true
         )
     }
 

--- a/Sources/PackageModel/Module/SystemLibraryModule.swift
+++ b/Sources/PackageModel/Module/SystemLibraryModule.swift
@@ -25,9 +25,6 @@ public final class SystemLibraryModule: Module {
     /// List of system package providers, if any.
     public let providers: [SystemPackageProviderDescription]?
 
-    /// True if this system library should become implicit dependency of its dependent packages.
-    public let isImplicit: Bool
-
     public init(
         name: String,
         path: AbsolutePath,
@@ -38,7 +35,6 @@ public final class SystemLibraryModule: Module {
         let sources = Sources(paths: [], root: path)
         self.pkgConfig = pkgConfig
         self.providers = providers
-        self.isImplicit = isImplicit
         super.init(
             name: name,
             type: .systemModule,
@@ -49,7 +45,8 @@ public final class SystemLibraryModule: Module {
             buildSettings: .init(),
             buildSettingsDescription: [],
             pluginUsages: [],
-            usesUnsafeFlags: false
+            usesUnsafeFlags: false,
+            implicit: isImplicit
         )
     }
 }

--- a/Sources/_InternalTestSupport/ResolvedModule+Mock.swift
+++ b/Sources/_InternalTestSupport/ResolvedModule+Mock.swift
@@ -29,7 +29,8 @@ extension ResolvedModule {
                 sources: Sources(paths: [], root: "/"),
                 dependencies: [],
                 packageAccess: false,
-                usesUnsafeFlags: false
+                usesUnsafeFlags: false,
+                implicit: true
             ),
             dependencies: deps.map { .module($0, conditions: conditions) },
             defaultLocalization: nil,

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -7435,6 +7435,94 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             }
         }
     }
+
+    func testImplicitModules() async throws {
+        let fileSystem = InMemoryFileSystem(
+            emptyFiles:
+            "/A/Sources/ATarget/foo.swift",
+            "/A/Sources/AMacro/macro.swift",
+            "/A/Sources/AExecutable/main.swift",
+            "/A/Sources/ASystemLib/module.modulemap",
+            "/A/Plugins/APlugin/main.swift",
+            "/A/Tests/ATargetTests/foo.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fileSystem,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "A",
+                    path: "/A",
+                    dependencies: [
+                    ],
+                    targets: [
+                        TargetDescription(name: "ATarget"),
+                        TargetDescription(
+                            name: "AMacro",
+                            dependencies: [],
+                            type: .`macro`
+                        ),
+                        TargetDescription(
+                            name: "AExecutable",
+                            dependencies: ["ATarget"],
+                            type: .executable
+                        ),
+                        TargetDescription(
+                            name: "APlugin",
+                            type: .plugin,
+                            pluginCapability: .buildTool
+                        ),
+                        TargetDescription(
+                            name: "ASystemLib",
+                            type: .system
+                        ),
+                        TargetDescription(
+                            name: "ATargetTests",
+                            dependencies: ["ATarget"],
+                            type: .test
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
+            graph: graph,
+            fileSystem: fileSystem,
+            observabilityScope: observability.topScope
+        ))
+
+        struct ExpectedTarget: Hashable, Equatable {
+            let name: String
+            let implicit: Bool
+        }
+
+        var expectedTargets: Set<ExpectedTarget> = [
+            .init(name: "ATarget", implicit: false),
+            .init(name: "AMacro", implicit: false),
+            .init(name: "AExecutable", implicit: false),
+            .init(name: "ATargetTests", implicit: false),
+            .init(name: "APackageTests", implicit: true),
+        ]
+        #if !os(macOS)
+        expectedTargets.insert(.init(name: "APackageDiscoveredTests", implicit: true))
+        #endif
+        XCTAssertEqual(
+            Set(result.targetMap.map { ExpectedTarget(name: $0.module.name, implicit: $0.module.implicit) }),
+            expectedTargets
+        )
+        XCTAssertEqual(
+            result.plan.graph.module(for: "APlugin")?.implicit,
+            false
+        )
+        XCTAssertEqual(
+            result.plan.graph.module(for: "ASystemLib")?.implicit,
+            false
+        )
+    }
 }
 
 class BuildPlanNativeTests: BuildPlanTestCase {

--- a/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
@@ -61,7 +61,8 @@ final class ClangTargetBuildDescriptionTests: XCTestCase {
             type: .library,
             path: .root,
             sources: .init(paths: [.root.appending(component: "foo.c")], root: .root),
-            usesUnsafeFlags: false
+            usesUnsafeFlags: false,
+            implicit: true
         )
     }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-package-manager/pull/8800, https://github.com/swiftlang/swift-package-manager/pull/8806

### Motivation:

Fixes for the following problems:

  - Sometimes if the previous build was unsuccessful subsequent `swift package migrate` invocation fails with `error: did not compute a build plan yet`.
  - Implicitly generated targets (currently only test targets) are included in migration which results in extraneous warnings and failures (i.e. to update the manifest).

The inconsistency in argument formatting came up as part of SE-0486 review. This is the first step in a direction to make command formatting more consistent.

- `swift package migrate`:
  - Rename `--targets` to `--target`
  - Change `--target` and `--to-feature` to accept space separated argument lists

- `swift package -add-setting`:
   - Switch to `.upToNextOption` formatting. Instead of `--swift A=B --swift C=D` switch to `--swift A=B C=D`.

### Modifications:

- Update `Migrate` command's `createBuildSystem` API to avoid build manifest caching. That ensures that features in migration mode are never persistent and requires a fresh build plan which avoid issues with previous builds.
- Make it possible to mark a `Module` as `implicit` i.e. when it's a synthesized/discovered test target or a system module.
- Update `Migrate` command to filter `implicit` modules when no targets are specified by the user.
- Update `MigrateOptions` to use `.upToNextOption` for targets and features.
- Update `SwiftPackageCommand`'s `_swiftSettings` option to use `.upToNextOption`

### Result:

`swift package migrate` is made more stable with fewer unactionable warnings and errors and the command line is now shorter and has consistent formatting.

Resolves: rdar://152687586
Resolves: rdar://152689053
Resolves: rdar://152687084