### PR TITLE
Support String Catalog symbol generation by always treating String Catalogs as Sources

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -334,6 +334,13 @@ struct PackagePIFProjectBuilder {
                 self.log(.debug, indent: 2, "Added asset catalog as source file '\(resourcePath)'")
             }
 
+            // String Catalogs can also generate symbols.
+            if SwiftBuild.SwiftBuildFileType.xcstrings.fileTypes.contains(resourcePath.pathExtension) {
+                self.project[keyPath: sourceModuleTargetKeyPath].addSourceFile { id in
+                    BuildFile(id: id, fileRef: ref)
+                }
+            }
+
             self.log(.debug, indent: 2, "Added resource file '\(resourcePath)'")
         }
 

--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -1124,6 +1124,11 @@ public struct XCBuildFileType: CaseIterable {
         fileTypeIdentifier: "folder.abstractassetcatalog"
     )
 
+    public static let xcstrings: XCBuildFileType = XCBuildFileType(
+        fileType: "xcstrings",
+        fileTypeIdentifier: "text.json.xcstrings"
+    )
+
     public static let xcdatamodeld: XCBuildFileType = XCBuildFileType(
         fileType: "xcdatamodeld",
         fileTypeIdentifier: "wrapper.xcdatamodeld"
@@ -1140,6 +1145,8 @@ public struct XCBuildFileType: CaseIterable {
     )
 
     public static let allCases: [XCBuildFileType] = [
+        .xcassets,
+        .xcstrings,
         .xcdatamodeld,
         .xcdatamodel,
         .xcmappingmodel,

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -946,6 +946,11 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
                 pifTarget.addSourceFile(resourceFile)
             }
 
+            // String Catalogs can also generate symbols.
+            if XCBuildFileType.xcstrings.fileTypes.contains(resource.path.extension ?? "") {
+                pifTarget.addSourceFile(resourceFile)
+            }
+
             resourcesTarget.addResourceFile(resourceFile)
         }
 


### PR DESCRIPTION
This change adds support for String Catalog symbol generation by ensuring that String Catalogs get added to the Sources build phase in the same way that Asset Catalogs do.