### PR TITLE
_AsyncFileSystem: add missing file in the CMake build

### DIFF
--- a/Sources/_AsyncFileSystem/CMakeLists.txt
+++ b/Sources/_AsyncFileSystem/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(_AsyncFileSystem
   MockFileSystem.swift
   OpenReadableFile.swift
   OpenWritableFile.swift
+  OSFileSystem.swift
   ReadableFileStream.swift
   WritableStream.swift
 )


### PR DESCRIPTION
This adds a missing file to the target. This was detected by attempting to claw back some of the time in CI and re-use the existing build artifacts.