### PR TITLE
build: avoid duplicating all the flags for FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,10 +53,9 @@ find_package(Foundation QUIET)
 find_package(SQLite3 REQUIRED)
 
 # Enable `package` modifier for the whole package.
+add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:-package-name;SwiftPM>")
 if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-  add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:-package-name;SwiftPM>" -L/usr/local/lib)
-else()
-  add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:-package-name;SwiftPM>")
+  link_directories(/usr/local/lib)
 endif()
 
 add_subdirectory(BuildSupport/SwiftSyntax)


### PR DESCRIPTION
This simplifies the build logic and properly adds the linker search path to the build when building for FreeBSD.