### PR TITLE
build: correct the package name for SPM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ find_package(Foundation QUIET)
 find_package(SQLite3 REQUIRED)
 
 # Enable `package` modifier for the whole package.
-add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:-package-name;SwiftPM>")
+add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-package-name swift_package_manager>")
 if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
   link_directories(/usr/local/lib)
 endif()


### PR DESCRIPTION
This was caught by the attempt to claw back some of the build time by
re-using the artifacts. The package name did not match across SPM and
CMake resulting in the API being unavailable to the tests.