### PR TITLE
Basics: remove `@testable` imports

### DIFF
--- a/Sources/Basics/Archiver/TarArchiver.swift
+++ b/Sources/Basics/Archiver/TarArchiver.swift
@@ -25,7 +25,7 @@ public struct TarArchiver: Archiver {
     private let cancellator: Cancellator
 
     /// The underlying command
-    internal let tarCommand: String
+    package let tarCommand: String
 
     /// Creates a `TarArchiver`.
     ///

--- a/Sources/Basics/Archiver/ZipArchiver.swift
+++ b/Sources/Basics/Archiver/ZipArchiver.swift
@@ -29,10 +29,10 @@ public struct ZipArchiver: Archiver, Cancellable {
 
     /// Absolute path to the Windows tar in the system folder
     #if os(Windows)
-        internal let windowsTar: String
+        package let windowsTar: String
     #else
-        internal let unzip = "unzip"
-        internal let zip = "zip"
+        package let unzip = "unzip"
+        package let zip = "zip"
     #endif
 
     #if os(FreeBSD)

--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -55,7 +55,7 @@ extension AuthorizationProvider {
 
 public final class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWriter {
     // marked internal for testing
-    internal let path: AbsolutePath
+    package let path: AbsolutePath
     private let fileSystem: FileSystem
 
     private let cache = ThreadSafeKeyValueStore<String, (user: String, password: String)>()
@@ -140,7 +140,7 @@ public final class NetrcAuthorizationProvider: AuthorizationProvider, Authorizat
     }
 
     // marked internal for testing
-    internal var machines: [Basics.Netrc.Machine] {
+    package var machines: [Basics.Netrc.Machine] {
         // this ignores any errors reading the file
         // initial validation is done at the time of initializing the provider
         // and if the file becomes corrupt at runtime it will handle it gracefully
@@ -408,16 +408,16 @@ public final class KeychainAuthorizationProvider: AuthorizationProvider, Authori
         return item
     }
 
-    struct ProtocolHostPort: Hashable, CustomStringConvertible {
-        let `protocol`: String?
-        let host: String
-        let port: Int?
+    package struct ProtocolHostPort: Hashable, CustomStringConvertible {
+        package let `protocol`: String?
+        package let host: String
+        package let port: Int?
 
         var server: String {
             self.host
         }
 
-        var protocolCFString: CFString {
+        package var protocolCFString: CFString {
             // See
             // https://developer.apple.com/documentation/security/keychain_services/keychain_items/item_attribute_keys_and_values?language=swift
             // for a list of possible values for the `kSecAttrProtocol` attribute.
@@ -431,7 +431,7 @@ public final class KeychainAuthorizationProvider: AuthorizationProvider, Authori
             }
         }
 
-        init?(from url: URL) {
+        package init?(from url: URL) {
             guard let host = url.host?.lowercased(), !host.isEmpty else {
                 return nil
             }
@@ -441,7 +441,7 @@ public final class KeychainAuthorizationProvider: AuthorizationProvider, Authori
             self.port = url.port
         }
 
-        var description: String {
+        package var description: String {
             "\(self.protocol.map { "\($0)://" } ?? "")\(self.host)\(self.port.map { ":\($0)" } ?? "")"
         }
     }
@@ -452,7 +452,7 @@ public final class KeychainAuthorizationProvider: AuthorizationProvider, Authori
 
 public struct CompositeAuthorizationProvider: AuthorizationProvider {
     // marked internal for testing
-    internal let providers: [AuthorizationProvider]
+    package let providers: [AuthorizationProvider]
     private let observabilityScope: ObservabilityScope
 
     public init(_ providers: AuthorizationProvider..., observabilityScope: ObservabilityScope) {

--- a/Sources/Basics/Cancellator.swift
+++ b/Sources/Basics/Cancellator.swift
@@ -144,7 +144,7 @@ public final class Cancellator: Cancellable, Sendable {
 
     // marked internal for testing
     @discardableResult
-    internal func _cancel(deadline: DispatchTime? = .none) -> Int {
+    package func _cancel(deadline: DispatchTime? = .none) -> Int {
         self.cancelling.put(true)
 
         self.observabilityScope?

--- a/Sources/Basics/Concurrency/SendableBox.swift
+++ b/Sources/Basics/Concurrency/SendableBox.swift
@@ -28,17 +28,17 @@ public actor SendableBox<Value: Sendable> {
 }
 
 extension SendableBox where Value == Int {
-    func increment() {
+    package func increment() {
         self.value = value + 1
     }
 
-    func decrement() {
+    package func decrement() {
         self.value = value - 1
     }
 }
 
 extension SendableBox where Value == Date {
-    func resetDate() {
+    package func resetDate() {
         value = Date()
     }
 }

--- a/Sources/Basics/Graph/AdjacencyMatrix.swift
+++ b/Sources/Basics/Graph/AdjacencyMatrix.swift
@@ -18,7 +18,7 @@
 /// edge exists.
 ///
 /// See https://en.wikipedia.org/wiki/Adjacency_matrix for more details.
-struct AdjacencyMatrix {
+package struct AdjacencyMatrix {
     let columns: Int
     let rows: Int
     private var bytes: [UInt8]
@@ -27,7 +27,7 @@ struct AdjacencyMatrix {
     /// - Parameters:
     ///   - rows: Number of rows in the matrix.
     ///   - columns: Number of columns in the matrix.
-    init(rows: Int, columns: Int) {
+    package init(rows: Int, columns: Int) {
         self.columns = columns
         self.rows = rows
         
@@ -35,7 +35,7 @@ struct AdjacencyMatrix {
         self.bytes = .init(repeating: 0, count: quotient + (remainder > 0 ? 1 : 0))
     }
 
-    var bitCount: Int {
+    package var bitCount: Int {
         bytes.count * 8
     }
 
@@ -44,7 +44,7 @@ struct AdjacencyMatrix {
         return (byteOffset: totalBitOffset / 8, bitOffsetInByte: totalBitOffset % 8)
     }
 
-    subscript(row: Int, column: Int) -> Bool {
+    package subscript(row: Int, column: Int) -> Bool {
         get {
             let (byteOffset, bitOffsetInByte) = calculateOffsets(row: row, column: column)
 

--- a/Sources/Basics/HTTPClient/HTTPClientHeaders.swift
+++ b/Sources/Basics/HTTPClient/HTTPClientHeaders.swift
@@ -64,8 +64,8 @@ public struct HTTPClientHeaders: Sendable {
     }
 
     public struct Item: Equatable, Sendable {
-        let name: String
-        let value: String
+        package let name: String
+        package let value: String
 
         public init(name: String, value: String) {
             self.name = name

--- a/Sources/Basics/HTTPClient/HTTPMethod.swift
+++ b/Sources/Basics/HTTPClient/HTTPMethod.swift
@@ -17,7 +17,7 @@ public enum HTTPMethod: Sendable {
     case put
     case delete
 
-    var string: String {
+    package var string: String {
         switch self {
         case .head:
             return "HEAD"

--- a/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
@@ -18,13 +18,13 @@ import struct TSCUtility.Versioning
 import FoundationNetworking
 #endif
 
-final class URLSessionHTTPClient: Sendable {
+package final class URLSessionHTTPClient: Sendable {
     private let dataSession: URLSession
     private let downloadSession: URLSession
     private let dataTaskManager: DataTaskManager
     private let downloadTaskManager: DownloadTaskManager
 
-    init(configuration: URLSessionConfiguration = .default) {
+    package init(configuration: URLSessionConfiguration = .default) {
         let dataDelegateQueue = OperationQueue()
         dataDelegateQueue.name = "org.swift.swiftpm.urlsession-http-client-data-delegate"
         dataDelegateQueue.maxConcurrentOperationCount = 1
@@ -52,7 +52,7 @@ final class URLSessionHTTPClient: Sendable {
     }
 
     @Sendable
-    func execute(
+    package func execute(
         _ request: HTTPClient.Request,
         progress: HTTPClient.ProgressHandler? = nil
     ) async throws -> LegacyHTTPClient.Response {
@@ -364,7 +364,7 @@ private final class DownloadTaskManager: NSObject, URLSessionDownloadDelegate {
 }
 
 extension URLRequest {
-    init(_ request: LegacyHTTPClient.Request) {
+    package init(_ request: LegacyHTTPClient.Request) {
         self.init(url: request.url)
         self.httpMethod = request.method.string
         request.headers.forEach { header in

--- a/Sources/Basics/ProgressAnimation/ThrottledProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/ThrottledProgressAnimation.swift
@@ -14,12 +14,12 @@ import _Concurrency
 import TSCUtility
 
 /// A progress animation wrapper that throttles updates to a given interval.
-final class ThrottledProgressAnimation: ProgressAnimationProtocol {
+package final class ThrottledProgressAnimation: ProgressAnimationProtocol {
     private let animation: ProgressAnimationProtocol
     private let shouldUpdate: () -> Bool
     private var pendingUpdate: (Int, Int, String)?
 
-    init<C: Clock>(
+    package init<C: Clock>(
       _ animation: ProgressAnimationProtocol,
       now: @escaping () -> C.Instant, interval: C.Duration, clock: C.Type = C.self
     ) {
@@ -36,7 +36,7 @@ final class ThrottledProgressAnimation: ProgressAnimationProtocol {
         }
     }
 
-    func update(step: Int, total: Int, text: String) {
+    package func update(step: Int, total: Int, text: String) {
         guard shouldUpdate() else {
             pendingUpdate = (step, total, text)
             return
@@ -45,14 +45,14 @@ final class ThrottledProgressAnimation: ProgressAnimationProtocol {
         animation.update(step: step, total: total, text: text)
     }
 
-    func complete(success: Bool) {
+    package func complete(success: Bool) {
         if let (step, total, text) = pendingUpdate {
             animation.update(step: step, total: total, text: text)
         }
         animation.complete(success: success)
     }
 
-    func clear() {
+    package func clear() {
         animation.clear()
     }
 }

--- a/Sources/Basics/Serialization/SerializedJSON.swift
+++ b/Sources/Basics/Serialization/SerializedJSON.swift
@@ -13,7 +13,7 @@
 /// Wrapper type representing serialized escaped JSON strings providing helpers
 /// for escaped string interpolations for common types such as `AbsolutePath`.
 public struct SerializedJSON {
-    let underlying: String
+    package let underlying: String
 }
 
 extension SerializedJSON: ExpressibleByStringLiteral {

--- a/Tests/BasicsTests/Archiver/TarArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/TarArchiverTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import struct Basics.TarArchiver
+import struct Basics.TarArchiver
 import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported
 import _InternalTestSupport
 import XCTest

--- a/Tests/BasicsTests/Archiver/UniversalArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/UniversalArchiverTests.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import struct Basics.TarArchiver
-@testable import struct Basics.ZipArchiver
+import struct Basics.TarArchiver
+import struct Basics.ZipArchiver
 import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported
 import _InternalTestSupport
 import XCTest

--- a/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import struct Basics.ZipArchiver
+import struct Basics.ZipArchiver
 import _InternalTestSupport
 import XCTest
 import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/BasicsTests/CancellatorTests.swift
+++ b/Tests/BasicsTests/CancellatorTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/BasicsTests/ConcurrencyHelpersTests.swift
+++ b/Tests/BasicsTests/ConcurrencyHelpersTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-@testable import Basics
+import Basics
 import TSCTestSupport
 import Testing
 

--- a/Tests/BasicsTests/DictionaryTest.swift
+++ b/Tests/BasicsTests/DictionaryTest.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import Testing
 
 struct DictionaryTests {

--- a/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-@testable import Basics
+import Basics
 import Testing
 
 struct EnvironmentKeyTests {

--- a/Tests/BasicsTests/Environment/EnvironmentTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentTests.swift
@@ -12,7 +12,6 @@
 import Foundation
 
 @_spi(SwiftPMInternal)
-@testable
 import Basics
 
 import Testing

--- a/Tests/BasicsTests/FileSystem/FileSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/FileSystemTests.swift
@@ -13,7 +13,7 @@ import Foundation
 import TSCTestSupport
 import Testing
 
-@testable import Basics
+import Basics
 
 struct FileSystemTests {
     @Test

--- a/Tests/BasicsTests/Graph/AdjacencyMatrixTests.swift
+++ b/Tests/BasicsTests/Graph/AdjacencyMatrixTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import Testing
 
 struct AdjacencyMatrixTests {

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-@testable import Basics
+import Basics
 import _Concurrency
 import _InternalTestSupport
 import Testing

--- a/Tests/BasicsTests/LegacyHTTPClientTests.swift
+++ b/Tests/BasicsTests/LegacyHTTPClientTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import Testing
 

--- a/Tests/BasicsTests/ProgressAnimationTests.swift
+++ b/Tests/BasicsTests/ProgressAnimationTests.swift
@@ -14,7 +14,6 @@ import _Concurrency
 import Testing
 
 @_spi(SwiftPMInternal)
-@testable
 import Basics
 import TSCBasic
 

--- a/Tests/BasicsTests/SQLiteBackedCacheTests.swift
+++ b/Tests/BasicsTests/SQLiteBackedCacheTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import tsan_utils
 import Testing

--- a/Tests/BasicsTests/SandboxTests.swift
+++ b/Tests/BasicsTests/SandboxTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/BasicsTests/Serialization/SerializedJSONTests.swift
+++ b/Tests/BasicsTests/Serialization/SerializedJSONTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import XCTest
 import _InternalTestSupport // for XCTSkipOnWindows
 

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import Foundation
 #if canImport(FoundationNetworking)
 // TODO: this brings OpenSSL dependency` on Linux

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 @testable import Build
 
 @testable

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 @testable import Build
 @testable import Commands
 @testable import CoreCommands

--- a/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 @testable import PackageLoading
 import PackageModel
 import _InternalTestSupport

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 
 @_spi(SwiftPMInternal)
 @testable import PackageModel

--- a/Tests/PackageModelTests/ToolsetTests.swift
+++ b/Tests/PackageModelTests/ToolsetTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 @testable import PackageModel
 import _InternalTestSupport
 import XCTest

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import _Concurrency
 import PackageModel
 import _InternalTestSupport

--- a/Tests/WorkspaceTests/AuthorizationProviderTests.swift
+++ b/Tests/WorkspaceTests/AuthorizationProviderTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import Workspace
 import Testing


### PR DESCRIPTION
Adjust the build to open up some of the private APIs to the package and remove the use of `@testable` for the Basics module in the tests.