### PR TITLE
PackageGraph: remove `@testable` imports

### DIFF
--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -19,7 +19,7 @@ import protocol Basics.FileSystem
 import class Basics.ObservabilityScope
 import struct Basics.IdentifiableSet
 
-enum PackageGraphError: Swift.Error {
+package enum PackageGraphError: Swift.Error {
     /// Indicates a non-root package with no modules.
     case noModules(Package)
 
@@ -379,7 +379,7 @@ extension PackageGraphError: CustomStringConvertible {
     }
 }
 
-enum GraphError: Error {
+package enum GraphError: Error {
     /// A cycle was detected in the input.
     case unexpectedCycle
 }
@@ -401,7 +401,7 @@ enum GraphError: Error {
 ///
 /// - Complexity: O(v + e) where (v, e) are the number of vertices and edges
 /// reachable from the input nodes via the relation.
-func topologicalSortIdentifiable<T: Identifiable>(
+package func topologicalSortIdentifiable<T: Identifiable>(
     _ nodes: [T], successors: (T) throws -> [T]
 ) throws -> [T] {
     // Implements a topological sort via recursion and reverse postorder DFS.

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -26,7 +26,7 @@ public struct PubGrubDependencyResolver {
     public typealias Constraint = PackageContainerConstraint
 
     /// the mutable state that get computed
-    internal final class State {
+    package final class State {
         /// The root package reference.
         let root: DependencyResolutionNode
 
@@ -44,7 +44,7 @@ public struct PubGrubDependencyResolver {
 
         private let lock = NSLock()
 
-        init(root: DependencyResolutionNode,
+        package init(root: DependencyResolutionNode,
              overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)] = [:],
              solution: PartialSolution = PartialSolution())
         {
@@ -53,7 +53,7 @@ public struct PubGrubDependencyResolver {
             self.solution = solution
         }
 
-        func addIncompatibility(_ incompatibility: Incompatibility, at location: LogLocation) {
+        package func addIncompatibility(_ incompatibility: Incompatibility, at location: LogLocation) {
             self.lock.withLock {
                 // log("incompat: \(incompatibility) \(location)")
                 for package in incompatibility.terms.map(\.node) {
@@ -69,7 +69,7 @@ public struct PubGrubDependencyResolver {
         }
 
         /// Find all incompatibilities containing a positive term for a given package.
-        func positiveIncompatibilities(for node: DependencyResolutionNode) -> [Incompatibility]? {
+        package func positiveIncompatibilities(for node: DependencyResolutionNode) -> [Incompatibility]? {
             self.lock.withLock {
                 guard let all = self.incompatibilities[node] else {
                     return nil
@@ -80,7 +80,7 @@ public struct PubGrubDependencyResolver {
             }
         }
 
-        func decide(_ node: DependencyResolutionNode, at version: Version) {
+        package func decide(_ node: DependencyResolutionNode, at version: Version) {
             let term = Term(node, .exact(version))
             self.lock.withLock {
                 assert(term.isValidDecision(for: self.solution))
@@ -88,7 +88,7 @@ public struct PubGrubDependencyResolver {
             }
         }
 
-        func derive(_ term: Term, cause: Incompatibility) {
+        package func derive(_ term: Term, cause: Incompatibility) {
             self.lock.withLock {
                 self.solution.derive(term, cause: cause)
             }
@@ -209,7 +209,7 @@ public struct PubGrubDependencyResolver {
     /// Find a set of dependencies that fit the given constraints. If dependency
     /// resolution is unable to provide a result, an error is thrown.
     /// - Warning: It is expected that the root package reference has been set  before this is called.
-    internal func solve(root: DependencyResolutionNode, constraints: [Constraint]) async throws -> (bindings: [DependencyResolverBinding], state: State) {
+    package func solve(root: DependencyResolutionNode, constraints: [Constraint]) async throws -> (bindings: [DependencyResolverBinding], state: State) {
         // first process inputs
         let inputs = try await self.processInputs(root: root, with: constraints)
 
@@ -511,7 +511,7 @@ public struct PubGrubDependencyResolver {
     /// partial solution.
     /// If a conflict is found, the conflicting incompatibility is returned to
     /// resolve the conflict on.
-    internal func propagate(state: State, node: DependencyResolutionNode) throws {
+    package func propagate(state: State, node: DependencyResolutionNode) throws {
         var changed: OrderedCollections.OrderedSet<DependencyResolutionNode> = [node]
 
         while !changed.isEmpty {
@@ -575,7 +575,7 @@ public struct PubGrubDependencyResolver {
     // Based on:
     // https://github.com/dart-lang/pub/tree/master/doc/solver.md#conflict-resolution
     // https://github.com/dart-lang/pub/blob/master/lib/src/solver/version_solver.dart#L201
-    internal func resolve(state: State, conflict: Incompatibility) throws -> Incompatibility {
+    package func resolve(state: State, conflict: Incompatibility) throws -> Incompatibility {
         self.delegate?.conflict(conflict: conflict)
 
         var incompatibility = conflict
@@ -703,7 +703,7 @@ public struct PubGrubDependencyResolver {
         }
     }
 
-    internal func makeDecision(
+    package func makeDecision(
         state: State
     ) async throws -> DependencyResolutionNode? {
         // If there are no more undecided terms, version solving is complete.
@@ -771,7 +771,7 @@ public struct PubGrubDependencyResolver {
     }
 }
 
-internal enum LogLocation: String {
+package enum LogLocation: String {
     case topLevel = "top level"
     case unitPropagation = "unit propagation"
     case decisionMaking = "decision making"

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
@@ -19,14 +19,14 @@ import struct TSCUtility.Version
 
 /// A container for an individual package. This enhances PackageContainer to add PubGrub specific
 /// logic which is mostly related to computing incompatibilities at a particular version.
-final class PubGrubPackageContainer {
+package final class PubGrubPackageContainer {
     /// The underlying package container.
     let underlying: PackageContainer
 
     /// `Package.resolved` in-memory representation.
     private let resolvedPackages: ResolvedPackagesStore.ResolvedPackages
 
-    init(underlying: PackageContainer, resolvedPackages: ResolvedPackagesStore.ResolvedPackages) {
+    package init(underlying: PackageContainer, resolvedPackages: ResolvedPackagesStore.ResolvedPackages) {
         self.underlying = underlying
         self.resolvedPackages = resolvedPackages
     }
@@ -150,7 +150,7 @@ final class PubGrubPackageContainer {
     }
 
     /// Returns the incompatibilities of a package at the given version.
-    func incompatibilites(
+    package func incompatibilites(
         at version: Version,
         node: DependencyResolutionNode,
         overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)],

--- a/Sources/PackageGraph/Resolution/ResolvedModule.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedModule.swift
@@ -289,6 +289,11 @@ extension ResolvedModule: Identifiable {
 
         public let moduleName: String
         let packageIdentity: PackageIdentity
+
+        package init(moduleName: String, packageIdentity: PackageIdentity) {
+            self.moduleName = moduleName
+            self.packageIdentity = packageIdentity
+        }
     }
 
     public var id: ID {

--- a/Sources/PackageGraph/Resolution/ResolvedProduct.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedProduct.swift
@@ -196,6 +196,11 @@ extension ResolvedProduct: Identifiable {
     public struct ID: Hashable {
         public let productName: String
         let packageIdentity: PackageIdentity
+
+        package init(productName: String, packageIdentity: PackageIdentity) {
+            self.productName = productName
+            self.packageIdentity = packageIdentity
+        }
     }
 
     public var id: ID {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -18,7 +18,7 @@
 import DriverSupport
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
-@testable import PackageGraph
+import PackageGraph
 
 import PackageLoading
 

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -14,7 +14,7 @@ import Basics
 @testable import Build
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
-@testable import PackageGraph
+import PackageGraph
 
 import PackageLoading
 @testable import PackageModel

--- a/Tests/BuildTests/PluginInvocationTests.swift
+++ b/Tests/BuildTests/PluginInvocationTests.swift
@@ -14,7 +14,7 @@
 import Basics
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
-@testable import PackageGraph
+import PackageGraph
 
 import PackageLoading
 

--- a/Tests/BuildTests/ProductBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ProductBuildDescriptionTests.swift
@@ -19,7 +19,6 @@ import class Basics.ObservabilitySystem
 import class PackageModel.Manifest
 import struct PackageModel.TargetDescription
 
-@testable
 import struct PackageGraph.ResolvedProduct
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -14,7 +14,7 @@ import Basics
 import _Concurrency
 
 @_spi(SwiftPMInternal)
-@testable import PackageGraph
+import PackageGraph
 import PackageLoading
 import PackageModel
 @testable import SPMBuildCore

--- a/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
+++ b/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
@@ -14,7 +14,6 @@
 @_spi(SwiftPMInternal)
 import _InternalTestSupport
 
-@testable
 import PackageGraph
 
 import PackageModel

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -15,7 +15,7 @@ import PackageLoading
 import TSCUtility
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
-@testable import PackageGraph
+import PackageGraph
 
 import _InternalTestSupport
 import PackageModel

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -13,7 +13,7 @@
 import Basics
 import _Concurrency
 import OrderedCollections
-@testable import PackageGraph
+import PackageGraph
 import PackageLoading
 @testable import PackageModel
 import SourceControl

--- a/Tests/PackageGraphTests/TopologicalSortTests.swift
+++ b/Tests/PackageGraphTests/TopologicalSortTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 
-@testable import PackageGraph
+import PackageGraph
 import XCTest
 
 private func XCTAssertThrows<T: Swift.Error>(

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -13,7 +13,7 @@
 import _InternalTestSupport
 import Basics
 import PackageFingerprint
-@testable import PackageGraph
+import PackageGraph
 import PackageLoading
 import PackageModel
 import PackageRegistry


### PR DESCRIPTION
Adjust the build to open up some of the private APIs to the package and remove the use of @testable for the PackageGraph module in the tests.