### PR TITLE
adds documentation to define the default value for target isolation

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -472,6 +472,9 @@ public struct SwiftSetting: Sendable {
     ///     inference. The only valid arguments are `MainActor.self` and `nil`.
     ///   - condition: A condition that restricts the application of the build
     ///     setting.
+    ///
+    /// The compiler defaults to inferring unannotated code as `nonisolated` if unspecified,
+    /// or if the `isolation` parameter is set to `nil`.
     @available(_PackageDescription, introduced: 6.2)
     public static func defaultIsolation(
         _ isolation: MainActor.Type?,


### PR DESCRIPTION
adds documentation to define the default value for target isolation

### Motivation:

Following up from [my question in the Swift Forums about the default value for "isolation mode"](https://forums.swift.org/t/what-is-the-default-isolation-mode-for-swift-packages-6-2/80453) for Swift packages.
The default is defined in the [proposal SE-0466](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0466-control-default-actor-isolation.md), but wasn't reflected in PackageDescription documentation.

### Modifications:

Updated the documentation for `defaultIsolation` to describe the default.

### Result:

PackageDescription documentation reflects the default choice if unspecified or set to `nil`
