### PR TITLE
[ModuleGraph] Bring back original check for implicit system libraries

### DIFF
--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -680,7 +680,12 @@ private func createResolvedPackages(
         // Get all implicit system library dependencies in this package.
         let implicitSystemLibraryDeps = packageBuilder.dependencies
             .flatMap(\.modules)
-            .filter(\.module.implicit)
+            .filter {
+                if case let systemLibrary as SystemLibraryModule = $0.module {
+                    return systemLibrary.implicit
+                }
+                return false
+            }
 
         let packageDoesNotSupportProductAliases = packageBuilder.package.doesNotSupportProductAliases
         let lookupByProductIDs = !packageDoesNotSupportProductAliases &&


### PR DESCRIPTION
The original check was about system libraries only, the new one checks all of the implicit modules.