### PR TITLE
[6.2][ModuleGraph] Bring back original check for implicit system libraries

### DIFF
--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -680,7 +680,12 @@ private func createResolvedPackages(
         // Get all implicit system library dependencies in this package.
         let implicitSystemLibraryDeps = packageBuilder.dependencies
             .flatMap(\.modules)
-            .filter(\.module.implicit)
+            .filter {
+                if case let systemLibrary as SystemLibraryModule = $0.module {
+                    return systemLibrary.implicit
+                }
+                return false
+            }
 
         let packageDoesNotSupportProductAliases = packageBuilder.package.doesNotSupportProductAliases
         let lookupByProductIDs = !packageDoesNotSupportProductAliases &&


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-package-manager/pull/8824

---

- Explanation:

  The original check was about system libraries only, the new one filters all of the implicit modules (including snippets) which is incorrect. The is a follow-up to https://github.com/swiftlang/swift-package-manager/pull/8812

- Main Branch PR: https://github.com/swiftlang/swift-package-manager/pull/8824

- Risk: Low

- Reviewed By: @bnbarham 

- Testing: No testing was added, speculative fix.

(cherry picked from commit 68d07f24e363e4e001f1d216ce02e5503df32ec1)