### PR TITLE
@testable cleanup

### DIFF
--- a/Sources/Basics/Archiver/TarArchiver.swift
+++ b/Sources/Basics/Archiver/TarArchiver.swift
@@ -25,7 +25,7 @@ public struct TarArchiver: Archiver {
     private let cancellator: Cancellator
 
     /// The underlying command
-    internal let tarCommand: String
+    package let tarCommand: String
 
     /// Creates a `TarArchiver`.
     ///

--- a/Sources/Basics/Archiver/ZipArchiver.swift
+++ b/Sources/Basics/Archiver/ZipArchiver.swift
@@ -29,10 +29,10 @@ public struct ZipArchiver: Archiver, Cancellable {
 
     /// Absolute path to the Windows tar in the system folder
     #if os(Windows)
-        internal let windowsTar: String
+        package let windowsTar: String
     #else
-        internal let unzip = "unzip"
-        internal let zip = "zip"
+        package let unzip = "unzip"
+        package let zip = "zip"
     #endif
 
     #if os(FreeBSD)

--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -55,7 +55,7 @@ extension AuthorizationProvider {
 
 public final class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWriter {
     // marked internal for testing
-    internal let path: AbsolutePath
+    package let path: AbsolutePath
     private let fileSystem: FileSystem
 
     private let cache = ThreadSafeKeyValueStore<String, (user: String, password: String)>()
@@ -140,7 +140,7 @@ public final class NetrcAuthorizationProvider: AuthorizationProvider, Authorizat
     }
 
     // marked internal for testing
-    internal var machines: [Basics.Netrc.Machine] {
+    package var machines: [Basics.Netrc.Machine] {
         // this ignores any errors reading the file
         // initial validation is done at the time of initializing the provider
         // and if the file becomes corrupt at runtime it will handle it gracefully
@@ -408,16 +408,16 @@ public final class KeychainAuthorizationProvider: AuthorizationProvider, Authori
         return item
     }
 
-    struct ProtocolHostPort: Hashable, CustomStringConvertible {
-        let `protocol`: String?
-        let host: String
-        let port: Int?
+    package struct ProtocolHostPort: Hashable, CustomStringConvertible {
+        package let `protocol`: String?
+        package let host: String
+        package let port: Int?
 
         var server: String {
             self.host
         }
 
-        var protocolCFString: CFString {
+        package var protocolCFString: CFString {
             // See
             // https://developer.apple.com/documentation/security/keychain_services/keychain_items/item_attribute_keys_and_values?language=swift
             // for a list of possible values for the `kSecAttrProtocol` attribute.
@@ -431,7 +431,7 @@ public final class KeychainAuthorizationProvider: AuthorizationProvider, Authori
             }
         }
 
-        init?(from url: URL) {
+        package init?(from url: URL) {
             guard let host = url.host?.lowercased(), !host.isEmpty else {
                 return nil
             }
@@ -441,7 +441,7 @@ public final class KeychainAuthorizationProvider: AuthorizationProvider, Authori
             self.port = url.port
         }
 
-        var description: String {
+        package var description: String {
             "\(self.protocol.map { "\($0)://" } ?? "")\(self.host)\(self.port.map { ":\($0)" } ?? "")"
         }
     }
@@ -452,7 +452,7 @@ public final class KeychainAuthorizationProvider: AuthorizationProvider, Authori
 
 public struct CompositeAuthorizationProvider: AuthorizationProvider {
     // marked internal for testing
-    internal let providers: [AuthorizationProvider]
+    package let providers: [AuthorizationProvider]
     private let observabilityScope: ObservabilityScope
 
     public init(_ providers: AuthorizationProvider..., observabilityScope: ObservabilityScope) {

--- a/Sources/Basics/Cancellator.swift
+++ b/Sources/Basics/Cancellator.swift
@@ -144,7 +144,7 @@ public final class Cancellator: Cancellable, Sendable {
 
     // marked internal for testing
     @discardableResult
-    internal func _cancel(deadline: DispatchTime? = .none) -> Int {
+    package func _cancel(deadline: DispatchTime? = .none) -> Int {
         self.cancelling.put(true)
 
         self.observabilityScope?

--- a/Sources/Basics/Concurrency/SendableBox.swift
+++ b/Sources/Basics/Concurrency/SendableBox.swift
@@ -28,17 +28,17 @@ public actor SendableBox<Value: Sendable> {
 }
 
 extension SendableBox where Value == Int {
-    func increment() {
+    package func increment() {
         self.value = value + 1
     }
 
-    func decrement() {
+    package func decrement() {
         self.value = value - 1
     }
 }
 
 extension SendableBox where Value == Date {
-    func resetDate() {
+    package func resetDate() {
         value = Date()
     }
 }

--- a/Sources/Basics/Graph/AdjacencyMatrix.swift
+++ b/Sources/Basics/Graph/AdjacencyMatrix.swift
@@ -18,7 +18,7 @@
 /// edge exists.
 ///
 /// See https://en.wikipedia.org/wiki/Adjacency_matrix for more details.
-struct AdjacencyMatrix {
+package struct AdjacencyMatrix {
     let columns: Int
     let rows: Int
     private var bytes: [UInt8]
@@ -27,7 +27,7 @@ struct AdjacencyMatrix {
     /// - Parameters:
     ///   - rows: Number of rows in the matrix.
     ///   - columns: Number of columns in the matrix.
-    init(rows: Int, columns: Int) {
+    package init(rows: Int, columns: Int) {
         self.columns = columns
         self.rows = rows
         
@@ -35,7 +35,7 @@ struct AdjacencyMatrix {
         self.bytes = .init(repeating: 0, count: quotient + (remainder > 0 ? 1 : 0))
     }
 
-    var bitCount: Int {
+    package var bitCount: Int {
         bytes.count * 8
     }
 
@@ -44,7 +44,7 @@ struct AdjacencyMatrix {
         return (byteOffset: totalBitOffset / 8, bitOffsetInByte: totalBitOffset % 8)
     }
 
-    subscript(row: Int, column: Int) -> Bool {
+    package subscript(row: Int, column: Int) -> Bool {
         get {
             let (byteOffset, bitOffsetInByte) = calculateOffsets(row: row, column: column)
 

--- a/Sources/Basics/HTTPClient/HTTPClientHeaders.swift
+++ b/Sources/Basics/HTTPClient/HTTPClientHeaders.swift
@@ -64,8 +64,8 @@ public struct HTTPClientHeaders: Sendable {
     }
 
     public struct Item: Equatable, Sendable {
-        let name: String
-        let value: String
+        package let name: String
+        package let value: String
 
         public init(name: String, value: String) {
             self.name = name

--- a/Sources/Basics/HTTPClient/HTTPMethod.swift
+++ b/Sources/Basics/HTTPClient/HTTPMethod.swift
@@ -17,7 +17,7 @@ public enum HTTPMethod: Sendable {
     case put
     case delete
 
-    var string: String {
+    package var string: String {
         switch self {
         case .head:
             return "HEAD"

--- a/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
@@ -18,13 +18,13 @@ import struct TSCUtility.Versioning
 import FoundationNetworking
 #endif
 
-final class URLSessionHTTPClient: Sendable {
+package final class URLSessionHTTPClient: Sendable {
     private let dataSession: URLSession
     private let downloadSession: URLSession
     private let dataTaskManager: DataTaskManager
     private let downloadTaskManager: DownloadTaskManager
 
-    init(configuration: URLSessionConfiguration = .default) {
+    package init(configuration: URLSessionConfiguration = .default) {
         let dataDelegateQueue = OperationQueue()
         dataDelegateQueue.name = "org.swift.swiftpm.urlsession-http-client-data-delegate"
         dataDelegateQueue.maxConcurrentOperationCount = 1
@@ -52,7 +52,7 @@ final class URLSessionHTTPClient: Sendable {
     }
 
     @Sendable
-    func execute(
+    package func execute(
         _ request: HTTPClient.Request,
         progress: HTTPClient.ProgressHandler? = nil
     ) async throws -> LegacyHTTPClient.Response {
@@ -393,7 +393,7 @@ private final class DownloadTaskManager: NSObject, URLSessionDownloadDelegate {
 }
 
 extension URLRequest {
-    init(_ request: LegacyHTTPClient.Request) {
+    package init(_ request: LegacyHTTPClient.Request) {
         self.init(url: request.url)
         self.httpMethod = request.method.string
         request.headers.forEach { header in

--- a/Sources/Basics/ProgressAnimation/ThrottledProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/ThrottledProgressAnimation.swift
@@ -14,12 +14,12 @@ import _Concurrency
 import TSCUtility
 
 /// A progress animation wrapper that throttles updates to a given interval.
-final class ThrottledProgressAnimation: ProgressAnimationProtocol {
+package final class ThrottledProgressAnimation: ProgressAnimationProtocol {
     private let animation: ProgressAnimationProtocol
     private let shouldUpdate: () -> Bool
     private var pendingUpdate: (Int, Int, String)?
 
-    init<C: Clock>(
+    package init<C: Clock>(
       _ animation: ProgressAnimationProtocol,
       now: @escaping () -> C.Instant, interval: C.Duration, clock: C.Type = C.self
     ) {
@@ -36,7 +36,7 @@ final class ThrottledProgressAnimation: ProgressAnimationProtocol {
         }
     }
 
-    func update(step: Int, total: Int, text: String) {
+    package func update(step: Int, total: Int, text: String) {
         guard shouldUpdate() else {
             pendingUpdate = (step, total, text)
             return
@@ -45,14 +45,14 @@ final class ThrottledProgressAnimation: ProgressAnimationProtocol {
         animation.update(step: step, total: total, text: text)
     }
 
-    func complete(success: Bool) {
+    package func complete(success: Bool) {
         if let (step, total, text) = pendingUpdate {
             animation.update(step: step, total: total, text: text)
         }
         animation.complete(success: success)
     }
 
-    func clear() {
+    package func clear() {
         animation.clear()
     }
 }

--- a/Sources/Basics/Serialization/SerializedJSON.swift
+++ b/Sources/Basics/Serialization/SerializedJSON.swift
@@ -13,7 +13,7 @@
 /// Wrapper type representing serialized escaped JSON strings providing helpers
 /// for escaped string interpolations for common types such as `AbsolutePath`.
 public struct SerializedJSON {
-    let underlying: String
+    package let underlying: String
 }
 
 extension SerializedJSON: ExpressibleByStringLiteral {

--- a/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
@@ -128,7 +128,7 @@ public final class ClangModuleBuildDescription {
     public let buildToolPluginInvocationResults: [BuildToolPluginInvocationResult]
 
     /// Create a new target description with target and build parameters.
-    init(
+    package init(
         package: ResolvedPackage,
         target: ResolvedModule,
         toolsVersion: ToolsVersion,

--- a/Sources/Build/BuildDescription/ModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ModuleBuildDescription.swift
@@ -122,7 +122,7 @@ public enum ModuleBuildDescription: SPMBuildCore.ModuleBuildDescription {
         }
     }
 
-    var destination: BuildParameters.Destination {
+    package var destination: BuildParameters.Destination {
         switch self {
         case .swift(let buildDescription):
             buildDescription.destination
@@ -162,6 +162,11 @@ extension ModuleBuildDescription: Identifiable {
     public struct ID: Hashable {
         let moduleID: ResolvedModule.ID
         let destination: BuildParameters.Destination
+
+        package init(moduleID: ResolvedModule.ID, destination: BuildParameters.Destination) {
+            self.moduleID = moduleID
+            self.destination = destination
+        }
     }
 
     public var id: ID {

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -50,7 +50,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
     /// The dynamic libraries this product needs to link with.
     // Computed during build planning.
-    var dylibs: [ProductBuildDescription] = []
+    package var dylibs: [ProductBuildDescription] = []
 
     /// Any additional flags to be added. These flags are expected to be computed during build planning.
     var additionalFlags: [String] = []
@@ -65,7 +65,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
     var libraryBinaryPaths: Set<AbsolutePath> = []
 
     /// Paths to tools shipped in binary dependencies
-    var availableTools: [String: AbsolutePath] = [:]
+    package var availableTools: [String: AbsolutePath] = [:]
 
     /// Path to the temporary directory for this product.
     var tempsPath: AbsolutePath {
@@ -85,7 +85,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
     private let observabilityScope: ObservabilityScope
 
     /// Create a build description for a product.
-    init(
+    package init(
         package: ResolvedPackage,
         product: ResolvedProduct,
         toolsVersion: ToolsVersion,
@@ -422,6 +422,11 @@ extension ProductBuildDescription: Identifiable {
     public struct ID: Hashable {
         let productID: ResolvedProduct.ID
         let destination: BuildParameters.Destination
+
+        package init(productID: ResolvedProduct.ID, destination: BuildParameters.Destination) {
+            self.productID = productID
+            self.destination = destination
+        }
     }
 
     public var id: ID {

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -169,7 +169,7 @@ public final class SwiftModuleBuildDescription {
     var libraryBinaryPaths: Set<AbsolutePath> = []
 
     /// Any addition flags to be added. These flags are expected to be computed during build planning.
-    var additionalFlags: [String] = []
+    package var additionalFlags: [String] = []
 
     /// Describes the purpose of a test target, including any special roles such as containing a list of discovered
     /// tests or serving as the manifest target which contains the main entry point.
@@ -824,7 +824,7 @@ public final class SwiftModuleBuildDescription {
         self.target.type == .library
     }
 
-    func writeOutputFileMap(to path: AbsolutePath) throws {
+    package func writeOutputFileMap(to path: AbsolutePath) throws {
         let masterDepsPath = self.tempsPath.appending("master.swiftdeps")
 
         var content =

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
@@ -20,7 +20,7 @@ import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedProduct
 
 extension LLBuildManifestBuilder {
-    func createProductCommand(_ buildProduct: ProductBuildDescription) throws {
+    package func createProductCommand(_ buildProduct: ProductBuildDescription) throws {
         let cmdName = try buildProduct.commandName
 
         // Add dependency on Info.plist generation on Darwin platforms.

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -65,7 +65,7 @@ public class LLBuildManifestBuilder {
     public internal(set) var manifest: LLBuildManifest = .init()
 
     /// Mapping from Swift compiler path to Swift get version files.
-    var swiftGetVersionFiles = [AbsolutePath: AbsolutePath]()
+    package var swiftGetVersionFiles = [AbsolutePath: AbsolutePath]()
 
     /// Create a new builder with a build plan.
     public init(

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -610,7 +610,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     }
 
     /// Compute the llbuild target name using the given subset.
-    func computeLLBuildTargetName(for subset: BuildSubset) async throws -> String {
+    package func computeLLBuildTargetName(for subset: BuildSubset) async throws -> String {
         func inferTestDestination(
             testModule: ResolvedModule,
             graph: ModulesGraph
@@ -1056,7 +1056,7 @@ extension BuildDescription {
 }
 
 extension BuildSubset {
-    func recursiveDependencies(for graph: ModulesGraph, observabilityScope: ObservabilityScope) throws -> [ResolvedModule]? {
+    package func recursiveDependencies(for graph: ModulesGraph, observabilityScope: ObservabilityScope) throws -> [ResolvedModule]? {
         switch self {
         case .allIncludingTests:
             return Array(graph.reachableModules)

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -731,7 +731,7 @@ extension BuildPlan {
     ///
     /// Note that warnings emitted by the the plugin itself will be returned in the `BuildToolPluginInvocationResult`
     /// structures for later showing to the user, and not added directly to the diagnostics engine.
-    static func invokeBuildToolPlugins(
+    package static func invokeBuildToolPlugins(
         for module: ResolvedModule,
         destination: BuildParameters.Destination,
         configuration: PluginConfiguration,

--- a/Sources/Commands/CommandWorkspaceDelegate.swift
+++ b/Sources/Commands/CommandWorkspaceDelegate.swift
@@ -24,7 +24,7 @@ import Workspace
 import protocol TSCBasic.OutputByteStream
 import struct TSCUtility.Version
 
-final class CommandWorkspaceDelegate: WorkspaceDelegate {
+package final class CommandWorkspaceDelegate: WorkspaceDelegate {
     private struct DownloadProgress {
         let bytesDownloaded: Int64
         let totalBytesToDownload: Int64
@@ -49,7 +49,7 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
     private let progressHandler: (Int64, Int64, String?) -> Void
     private let inputHandler: (String, (String?) -> Void) -> Void
 
-    init(
+    package init(
         observabilityScope: ObservabilityScope,
         outputHandler: @escaping (String, Bool) -> Void,
         progressHandler: @escaping (Int64, Int64, String?) -> Void,
@@ -61,11 +61,11 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
         self.inputHandler = inputHandler
     }
 
-    func willFetchPackage(package: PackageIdentity, packageLocation: String?, fetchDetails: PackageFetchDetails) {
+    package func willFetchPackage(package: PackageIdentity, packageLocation: String?, fetchDetails: PackageFetchDetails) {
         self.outputHandler("Fetching \(packageLocation ?? package.description)\(fetchDetails.fromCache ? " from cache" : "")", false)
     }
 
-    func didFetchPackage(package: PackageIdentity, packageLocation: String?, result: Result<PackageFetchDetails, Error>, duration: DispatchTimeInterval) {
+    package func didFetchPackage(package: PackageIdentity, packageLocation: String?, result: Result<PackageFetchDetails, Error>, duration: DispatchTimeInterval) {
         guard case .success = result, !self.observabilityScope.errorsReported else {
             return
         }
@@ -84,7 +84,7 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
         self.outputHandler("Fetched \(packageLocation ?? package.description) from cache (\(duration.descriptionInSeconds))", false)
     }
 
-    func fetchingPackage(package: PackageIdentity, packageLocation: String?, progress: Int64, total: Int64?) {
+    package func fetchingPackage(package: PackageIdentity, packageLocation: String?, progress: Int64, total: Int64?) {
         let (step, total, packages) = self.fetchProgressLock.withLock { () -> (Int64, Int64, String) in
             self.fetchProgress[package] = FetchProgress(
                 progress: progress,
@@ -99,43 +99,43 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
         self.progressHandler(step, total, "Fetching \(packages)")
     }
 
-    func willUpdateRepository(package: PackageIdentity, repository url: String) {
+    package func willUpdateRepository(package: PackageIdentity, repository url: String) {
         self.outputHandler("Updating \(url)", false)
     }
 
-    func didUpdateRepository(package: PackageIdentity, repository url: String, duration: DispatchTimeInterval) {
+    package func didUpdateRepository(package: PackageIdentity, repository url: String, duration: DispatchTimeInterval) {
         self.outputHandler("Updated \(url) (\(duration.descriptionInSeconds))", false)
     }
 
-    func dependenciesUpToDate() {
+    package func dependenciesUpToDate() {
         self.outputHandler("Everything is already up-to-date", false)
     }
 
-    func willCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath) {
+    package func willCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath) {
         self.outputHandler("Creating working copy for \(url)", false)
     }
 
-    func didCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath, duration: DispatchTimeInterval) {
+    package func didCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath, duration: DispatchTimeInterval) {
         self.outputHandler("Working copy of \(url) resolved at \(revision)", false)
     }
 
-    func removing(package: PackageIdentity, packageLocation: String?) {
+    package func removing(package: PackageIdentity, packageLocation: String?) {
         self.outputHandler("Removing \(packageLocation ?? package.description)", false)
     }
 
-    func willResolveDependencies(reason: WorkspaceResolveReason) {
+    package func willResolveDependencies(reason: WorkspaceResolveReason) {
         self.outputHandler(Workspace.format(workspaceResolveReason: reason), true)
     }
 
-    func willComputeVersion(package: PackageIdentity, location: String) {
+    package func willComputeVersion(package: PackageIdentity, location: String) {
         self.outputHandler("Computing version for \(location)", false)
     }
 
-    func didComputeVersion(package: PackageIdentity, location: String, version: String, duration: DispatchTimeInterval) {
+    package func didComputeVersion(package: PackageIdentity, location: String, version: String, duration: DispatchTimeInterval) {
         self.outputHandler("Computed \(location) at \(version) (\(duration.descriptionInSeconds))", false)
     }
 
-    func willDownloadBinaryArtifact(from url: String, fromCache: Bool) {
+    package func willDownloadBinaryArtifact(from url: String, fromCache: Bool) {
         if fromCache {
             self.outputHandler("Fetching binary artifact \(url) from cache", false)
         } else {
@@ -143,7 +143,7 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
         }
     }
 
-    func didDownloadBinaryArtifact(from url: String, result: Result<(path: AbsolutePath, fromCache: Bool), Error>, duration: DispatchTimeInterval) {
+    package func didDownloadBinaryArtifact(from url: String, result: Result<(path: AbsolutePath, fromCache: Bool), Error>, duration: DispatchTimeInterval) {
         guard case .success(let fetchDetails) = result, !self.observabilityScope.errorsReported else {
             return
         }
@@ -166,7 +166,7 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
         }
     }
 
-    func downloadingBinaryArtifact(from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
+    package func downloadingBinaryArtifact(from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
         let (step, total, artifacts) = self.binaryDownloadProgressLock.withLock { () -> (Int64, Int64, String) in
             self.binaryDownloadProgress[url] = DownloadProgress(
                 bytesDownloaded: bytesDownloaded,
@@ -183,7 +183,7 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
     }
 
     /// The workspace has started downloading a binary artifact.
-    func willDownloadPrebuilt(package: PackageIdentity, from url: String, fromCache: Bool) {
+    package func willDownloadPrebuilt(package: PackageIdentity, from url: String, fromCache: Bool) {
         if fromCache {
             self.outputHandler("Fetching package prebuilt \(url) from cache", false)
         } else {
@@ -192,7 +192,7 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
     }
 
     /// The workspace has finished downloading a binary artifact.
-    func didDownloadPrebuilt(
+    package func didDownloadPrebuilt(
         package: PackageIdentity,
         from url: String,
         result: Result<(path: AbsolutePath, fromCache: Bool), Error>,
@@ -210,18 +210,18 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
     }
 
     /// The workspace is downloading a binary artifact.
-    func downloadingPrebuilt(package: PackageIdentity, from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
+    package func downloadingPrebuilt(package: PackageIdentity, from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
 
     }
 
     /// The workspace finished downloading all binary artifacts.
-    func didDownloadAllPrebuilts() {
+    package func didDownloadAllPrebuilts() {
 
     }
 
     // registry signature handlers
 
-    func onUnsignedRegistryPackage(registryURL: URL, package: PackageModel.PackageIdentity, version: TSCUtility.Version, completion: (Bool) -> Void) {
+    package func onUnsignedRegistryPackage(registryURL: URL, package: PackageModel.PackageIdentity, version: TSCUtility.Version, completion: (Bool) -> Void) {
         self.inputHandler("\(package) \(version) from \(registryURL) is unsigned. okay to proceed? (yes/no) ") { response in
             switch response?.lowercased() {
             case "yes":
@@ -235,7 +235,7 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
         }
     }
 
-    func onUntrustedRegistryPackage(registryURL: URL, package: PackageModel.PackageIdentity, version: TSCUtility.Version, completion: (Bool) -> Void) {
+    package func onUntrustedRegistryPackage(registryURL: URL, package: PackageModel.PackageIdentity, version: TSCUtility.Version, completion: (Bool) -> Void) {
         self.inputHandler("\(package) \(version) from \(registryURL) is signed with an untrusted certificate. okay to proceed? (yes/no) ") { response in
             switch response?.lowercased() {
             case "yes":
@@ -269,36 +269,36 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
         os_signpost(.end, name: SignpostName.resolvingDependencies)
     }
 
-    func willLoadGraph() {
+    package func willLoadGraph() {
         self.observabilityScope.emit(debug: "Loading and validating graph")
         os_signpost(.begin, name: SignpostName.loadingGraph)
     }
 
-    func didLoadGraph(duration: DispatchTimeInterval) {
+    package func didLoadGraph(duration: DispatchTimeInterval) {
         self.observabilityScope.emit(debug: "Graph loaded in (\(duration.descriptionInSeconds))")
         os_signpost(.end, name: SignpostName.loadingGraph)
     }
 
-    func didCompileManifest(packageIdentity: PackageIdentity, packageLocation: String, duration: DispatchTimeInterval) {
+    package func didCompileManifest(packageIdentity: PackageIdentity, packageLocation: String, duration: DispatchTimeInterval) {
         self.observabilityScope.emit(debug: "Compiled manifest for '\(packageIdentity)' (from '\(packageLocation)') in \(duration.descriptionInSeconds)")
     }
 
-    func didEvaluateManifest(packageIdentity: PackageIdentity, packageLocation: String, duration: DispatchTimeInterval) {
+    package func didEvaluateManifest(packageIdentity: PackageIdentity, packageLocation: String, duration: DispatchTimeInterval) {
         self.observabilityScope.emit(debug: "Evaluated manifest for '\(packageIdentity)' (from '\(packageLocation)') in \(duration.descriptionInSeconds)")
     }
 
-    func didLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic], duration: DispatchTimeInterval) {
+    package func didLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic], duration: DispatchTimeInterval) {
         self.observabilityScope.emit(debug: "Loaded manifest for '\(packageIdentity)' (from '\(url)') in \(duration.descriptionInSeconds)")
     }
 
     // noop
-    func willCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath) {}
-    func didCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath, duration: DispatchTimeInterval) {}
-    func resolvedFileChanged() {}
-    func didDownloadAllBinaryArtifacts() {}
-    func willCompileManifest(packageIdentity: PackageIdentity, packageLocation: String) {}
-    func willEvaluateManifest(packageIdentity: PackageIdentity, packageLocation: String) {}
-    func willLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {}
+    package func willCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath) {}
+    package func didCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath, duration: DispatchTimeInterval) {}
+    package func resolvedFileChanged() {}
+    package func didDownloadAllBinaryArtifacts() {}
+    package func willCompileManifest(packageIdentity: PackageIdentity, packageLocation: String) {}
+    package func willEvaluateManifest(packageIdentity: PackageIdentity, packageLocation: String) {}
+    package func willLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {}
 }
 
 public extension _SwiftCommand {

--- a/Sources/Commands/PackageCommands/ShowDependencies.swift
+++ b/Sources/Commands/PackageCommands/ShowDependencies.swift
@@ -21,12 +21,12 @@ import protocol TSCBasic.OutputByteStream
 import var TSCBasic.stdoutStream
 
 extension SwiftPackageCommand {
-    struct ShowDependencies: AsyncSwiftCommand {
-        static let configuration = CommandConfiguration(
+    package struct ShowDependencies: AsyncSwiftCommand {
+        package static let configuration = CommandConfiguration(
             abstract: "Print the resolved dependency graph.")
 
         @OptionGroup(visibility: .hidden)
-        var globalOptions: GlobalOptions
+        package var globalOptions: GlobalOptions
 
         @Option(help: "Set the output format.")
         var format: ShowDependenciesMode = .text
@@ -35,7 +35,9 @@ extension SwiftPackageCommand {
                 help: "The absolute or relative path to output the resolved dependency graph.")
         var outputPath: AbsolutePath?
 
-        func run(_ swiftCommandState: SwiftCommandState) async throws {
+        package init() {}
+
+        package func run(_ swiftCommandState: SwiftCommandState) async throws {
             let graph = try await swiftCommandState.loadPackageGraph()
             // command's result output goes on stdout
             // ie "swift package show-dependencies" should output to stdout
@@ -48,7 +50,7 @@ extension SwiftPackageCommand {
             )
         }
 
-        static func dumpDependenciesOf(
+        package static func dumpDependenciesOf(
             graph: ModulesGraph,
             rootPackage: ResolvedPackage,
             mode: ShowDependenciesMode,
@@ -69,7 +71,7 @@ extension SwiftPackageCommand {
             stream.flush()
         }
 
-        enum ShowDependenciesMode: String, RawRepresentable, CustomStringConvertible, ExpressibleByArgument, CaseIterable {
+        package enum ShowDependenciesMode: String, RawRepresentable, CustomStringConvertible, ExpressibleByArgument, CaseIterable {
             case text, dot, json, flatlist
 
             public init?(rawValue: String) {

--- a/Sources/Commands/Utilities/MermaidPackageSerializer.swift
+++ b/Sources/Commands/Utilities/MermaidPackageSerializer.swift
@@ -15,11 +15,15 @@ import class PackageModel.Package
 import class PackageModel.Product
 import class PackageModel.Module
 
-struct MermaidPackageSerializer {
+package struct MermaidPackageSerializer {
     let package: Package
     var shouldIncludeLegend = false
 
-    var renderedMarkdown: String {
+    package init(package: Package) {
+        self.package = package
+    }
+
+    package var renderedMarkdown: String {
         var subgraphs = OrderedDictionary<String, [Edge]>()
         subgraphs[package.identity.description] = package.products.productTargetEdges
         

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -320,7 +320,7 @@ public final class SwiftCommandState {
     }
 
     // marked internal for testing
-    init(
+    package init(
         outputStream: OutputByteStream,
         options: GlobalOptions,
         toolWorkspaceConfiguration: ToolWorkspaceConfiguration,
@@ -457,7 +457,7 @@ public final class SwiftCommandState {
         }
     }
 
-    func waitForObservabilityEvents(timeout: DispatchTime) {
+    package func waitForObservabilityEvents(timeout: DispatchTime) {
         self.observabilityHandler.wait(timeout: timeout)
     }
 
@@ -824,7 +824,7 @@ public final class SwiftCommandState {
         return buildSystem
     }
 
-    static let entitlementsMacOSWarning = """
+    package static let entitlementsMacOSWarning = """
     `--disable-get-task-allow-entitlement` and `--disable-get-task-allow-entitlement` only have an effect \
     when building on macOS.
     """

--- a/Sources/DriverSupport/DriverSupportUtils.swift
+++ b/Sources/DriverSupport/DriverSupportUtils.swift
@@ -56,7 +56,7 @@ public enum DriverSupport {
     // This checks if given flags are supported in the built-in toolchain driver. Currently
     // there's no good way to get the supported flags from it, so run `swiftc -h` directly
     // to get the flags and cache the result.
-    static func checkToolchainDriverFlags(
+    package static func checkToolchainDriverFlags(
         flags: Set<String>,
         toolchain: PackageModel.Toolchain,
         fileSystem: FileSystem

--- a/Sources/PackageCollections/Model/Collection.swift
+++ b/Sources/PackageCollections/Model/Collection.swift
@@ -19,7 +19,7 @@ import SourceControl
 public enum PackageCollectionsModel {}
 
 // make things less verbose internally
-internal typealias Model = PackageCollectionsModel
+package typealias Model = PackageCollectionsModel
 
 extension PackageCollectionsModel {
     /// A `Collection` is a collection of packages.
@@ -63,7 +63,7 @@ extension PackageCollectionsModel {
         }
 
         /// Initializes a `Collection`
-        init(
+        package init(
             source: Source,
             name: String,
             overview: String?,
@@ -142,7 +142,7 @@ extension PackageCollectionsModel {
         case json(URL)
 
         /// Creates an `Identifier` from `Source`
-        init(from source: CollectionSource) {
+        package init(from source: CollectionSource) {
             switch source.type {
             case .json:
                 self = .json(source.url)
@@ -192,6 +192,10 @@ extension PackageCollectionsModel.Collection {
     public struct Author: Equatable, Codable {
         /// The name of the author
         public let name: String
+
+        package init(name: String) {
+            self.name = name
+        }
     }
 }
 

--- a/Sources/PackageCollections/Model/License.swift
+++ b/Sources/PackageCollections/Model/License.swift
@@ -20,6 +20,11 @@ extension PackageCollectionsModel {
 
         /// URL of the license file
         public let url: URL
+
+        package init(type: LicenseType, url: URL) {
+            self.type = type
+            self.url = url
+        }
     }
 
     /// An enum of license types

--- a/Sources/PackageCollections/Model/PackageList.swift
+++ b/Sources/PackageCollections/Model/PackageList.swift
@@ -24,5 +24,17 @@ extension PackageCollectionsModel {
         
         /// Total number of packages
         public let total: Int
+
+        package init(
+            items: [PackageCollectionsModel.Package],
+            offset: Int,
+            limit: Int,
+            total: Int
+        ) {
+            self.items = items
+            self.offset = offset
+            self.limit = limit
+            self.total = total
+        }
     }
 }

--- a/Sources/PackageCollections/Model/PackageTypes.swift
+++ b/Sources/PackageCollections/Model/PackageTypes.swift
@@ -88,7 +88,7 @@ extension PackageCollectionsModel {
         public let languages: Set<String>?
 
         /// Initializes a `Package`
-        init(
+        package init(
             identity: PackageIdentity,
             location: String,
             summary: String?,
@@ -150,6 +150,30 @@ extension PackageCollectionsModel.Package {
         /// When the package version was created
         public let createdAt: Date?
 
+        package init(
+            version: TSCUtility.Version,
+            title: String?,
+            summary: String?,
+            manifests: [ToolsVersion: Manifest],
+            defaultToolsVersion: ToolsVersion,
+            verifiedCompatibility: [PackageCollectionsModel.Compatibility]?,
+            license: PackageCollectionsModel.License?,
+            author: PackageCollectionsModel.Package.Author?,
+            signer: PackageCollectionsModel.Signer?,
+            createdAt: Date?
+        ) {
+            self.version = version
+            self.title = title
+            self.summary = summary
+            self.manifests = manifests
+            self.defaultToolsVersion = defaultToolsVersion
+            self.verifiedCompatibility = verifiedCompatibility
+            self.license = license
+            self.author = author
+            self.signer = signer
+            self.createdAt = createdAt
+        }
+
         public struct Manifest: Equatable, Codable {
             /// The Swift tools version specified in `Package.swift`.
             public let toolsVersion: ToolsVersion
@@ -167,6 +191,20 @@ extension PackageCollectionsModel.Package {
 
             /// The package version's supported platforms
             public let minimumPlatformVersions: [SupportedPlatform]?
+
+            package init(
+                toolsVersion: ToolsVersion,
+                packageName: String,
+                targets: [Target],
+                products: [Product],
+                minimumPlatformVersions: [SupportedPlatform]?
+            ) {
+                self.toolsVersion = toolsVersion
+                self.packageName = packageName
+                self.targets = targets
+                self.products = products
+                self.minimumPlatformVersions = minimumPlatformVersions
+            }
         }
     }
 }
@@ -179,6 +217,11 @@ extension PackageCollectionsModel {
 
         /// Target module name
         public let moduleName: String?
+
+        package init(name: String, moduleName: String?) {
+            self.name = name
+            self.moduleName = moduleName
+        }
     }
 }
 
@@ -193,6 +236,12 @@ extension PackageCollectionsModel {
 
         /// The product's targets
         public let targets: [Target]
+
+        package init(name: String, type: ProductType, targets: [Target]) {
+            self.name = name
+            self.type = type
+            self.targets = targets
+        }
     }
 }
 
@@ -204,6 +253,11 @@ extension PackageCollectionsModel {
 
         /// The Swift version
         public let swiftVersion: SwiftLanguageVersion
+
+        package init(platform: PackageModel.Platform, swiftVersion: SwiftLanguageVersion) {
+            self.platform = platform
+            self.swiftVersion = swiftVersion
+        }
     }
 }
 
@@ -219,10 +273,20 @@ extension PackageCollectionsModel.Package {
         /// Service that provides the user information
         public let service: Service?
 
+        package init(username: String, url: URL?, service: Service?) {
+            self.username = username
+            self.url = url
+            self.service = service
+        }
+
         /// A representation of user service
         public struct Service: Equatable, Codable {
             /// The service name
             public let name: String
+
+            package init(name: String) {
+                self.name = name
+            }
         }
     }
 }
@@ -272,13 +336,13 @@ extension PackageCollectionsModel.Package.Version: Comparable {
 }
 
 extension Array where Element == PackageCollectionsModel.Package.Version {
-    var latestRelease: PackageCollectionsModel.Package.Version? {
+    package var latestRelease: PackageCollectionsModel.Package.Version? {
         self.filter { $0.version.prereleaseIdentifiers.isEmpty }
             .sorted(by: >)
             .first
     }
 
-    var latestPrerelease: PackageCollectionsModel.Package.Version? {
+    package var latestPrerelease: PackageCollectionsModel.Package.Version? {
         self.filter { !$0.version.prereleaseIdentifiers.isEmpty }
             .sorted(by: >)
             .first

--- a/Sources/PackageCollections/Model/Search.swift
+++ b/Sources/PackageCollections/Model/Search.swift
@@ -18,6 +18,10 @@ extension PackageCollectionsModel {
         /// Result items of the search
         public let items: [Item]
 
+        package init(items: [Item]) {
+            self.items = items
+        }
+
         /// Represents a search result item
         public struct Item: Encodable {
             // Merged package metadata from across collections
@@ -30,7 +34,7 @@ extension PackageCollectionsModel {
             /// Package indexes that contain the package
             public internal(set) var indexes: [URL]
             
-            init(
+            package init(
                 package: PackageCollectionsModel.Package,
                 collections: [PackageCollectionsModel.CollectionIdentifier] = [],
                 indexes: [URL] = []

--- a/Sources/PackageCollections/PackageCollections+CertificatePolicy.swift
+++ b/Sources/PackageCollections/PackageCollections+CertificatePolicy.swift
@@ -17,7 +17,7 @@ import PackageCollectionsSigning
 /// Configuration in this file is intended for package collection sources to define certificate policies
 /// that are more restrictive. For example, a source may want to require that all their package
 /// collections be signed using certificate that belongs to certain subject user ID.
-internal struct PackageCollectionSourceCertificatePolicy {
+package struct PackageCollectionSourceCertificatePolicy {
     private static let defaultSourceCertPolicies: [String: [CertificatePolicyConfig]] = [
         "developer.apple.com": [
             CertificatePolicyConfig(
@@ -38,35 +38,40 @@ internal struct PackageCollectionSourceCertificatePolicy {
 
     private let sourceCertPolicies: [String: [CertificatePolicyConfig]]
 
-    var allRootCerts: Set<String>? {
+    package var allRootCerts: Set<String>? {
         let allRootCerts = self.sourceCertPolicies.values
             .flatMap { configs in configs.compactMap(\.base64EncodedRootCerts) }
             .flatMap { $0 }
         return allRootCerts.isEmpty ? nil : Set(allRootCerts)
     }
 
-    init(sourceCertPolicies: [String: [CertificatePolicyConfig]]? = nil) {
+    package init(sourceCertPolicies: [String: [CertificatePolicyConfig]]? = nil) {
         guard sourceCertPolicies?.values.first(where: { $0.isEmpty }) == nil else {
             preconditionFailure("CertificatePolicyConfig array must not be empty")
         }
         self.sourceCertPolicies = sourceCertPolicies ?? Self.defaultSourceCertPolicies
     }
 
-    func mustBeSigned(source: Model.CollectionSource) -> Bool {
+    package func mustBeSigned(source: Model.CollectionSource) -> Bool {
         source.certPolicyConfigKey.map { self.sourceCertPolicies[$0] != nil } ?? false
     }
 
-    func certificatePolicyKeys(for source: Model.CollectionSource) -> [CertificatePolicyKey]? {
+    package func certificatePolicyKeys(for source: Model.CollectionSource) -> [CertificatePolicyKey]? {
         // Certificate policy is associated to a collection host
         source.certPolicyConfigKey.flatMap { self.sourceCertPolicies[$0]?.map(\.certPolicyKey) }
     }
 
-    struct CertificatePolicyConfig {
+    package struct CertificatePolicyConfig {
         let certPolicyKey: CertificatePolicyKey
 
         /// Root CAs of the signing certificates. Each item is the base64-encoded string
         /// of the DER representation of a root CA.
         let base64EncodedRootCerts: [String]?
+
+        package init(certPolicyKey: CertificatePolicyKey, base64EncodedRootCerts: [String]?) {
+            self.certPolicyKey = certPolicyKey
+            self.base64EncodedRootCerts = base64EncodedRootCerts
+        }
     }
 }
 

--- a/Sources/PackageCollections/PackageCollections+Storage.swift
+++ b/Sources/PackageCollections/PackageCollections+Storage.swift
@@ -13,11 +13,11 @@
 import protocol TSCBasic.Closable
 
 extension PackageCollections {
-    struct Storage: Closable {
-        let sources: PackageCollectionsSourcesStorage
-        let collections: PackageCollectionsStorage
+    package struct Storage: Closable {
+        package let sources: PackageCollectionsSourcesStorage
+        package let collections: PackageCollectionsStorage
 
-        init(sources: PackageCollectionsSourcesStorage, collections: PackageCollectionsStorage) {
+        package init(sources: PackageCollectionsSourcesStorage, collections: PackageCollectionsStorage) {
             self.sources = sources
             self.collections = collections
         }
@@ -25,7 +25,7 @@ extension PackageCollections {
 }
 
 extension PackageCollections.Storage {
-    func close() throws {
+    package func close() throws {
         var errors = [Error]()
 
         let tryClose = { (item: Any) in

--- a/Sources/PackageCollections/PackageCollections+Validation.swift
+++ b/Sources/PackageCollections/PackageCollections+Validation.swift
@@ -20,7 +20,7 @@ import struct TSCUtility.Version
 // MARK: - Model validations
 
 extension Model.CollectionSource {
-    func validate(fileSystem: FileSystem) -> [ValidationMessage]? {
+    package func validate(fileSystem: FileSystem) -> [ValidationMessage]? {
         var messages: [ValidationMessage]?
         let appendMessage = { (message: ValidationMessage) in
             if messages == nil {
@@ -197,11 +197,11 @@ public struct ValidationMessage: Equatable, CustomStringConvertible {
         self.property = property
     }
 
-    static func error(_ message: String, property: String? = nil) -> ValidationMessage {
+    package static func error(_ message: String, property: String? = nil) -> ValidationMessage {
         .init(message, level: .error, property: property)
     }
 
-    static func warning(_ message: String, property: String? = nil) -> ValidationMessage {
+    package static func warning(_ message: String, property: String? = nil) -> ValidationMessage {
         .init(message, level: .warning, property: property)
     }
 
@@ -216,7 +216,7 @@ public struct ValidationMessage: Equatable, CustomStringConvertible {
 }
 
 extension Array where Element == ValidationMessage {
-    func errors(include levels: Set<ValidationMessage.Level> = [.error]) -> [ValidationError]? {
+    package func errors(include levels: Set<ValidationMessage.Level> = [.error]) -> [ValidationError]? {
         let errors = self.filter { levels.contains($0.level) }
 
         guard !errors.isEmpty else { return nil }

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -21,17 +21,17 @@ import protocol TSCBasic.Closable
 public struct PackageCollections: PackageCollectionsProtocol, Closable {
     // Check JSONPackageCollectionProvider.isSignatureCheckSupported before updating or removing this
     #if os(macOS) || os(Linux) || os(Windows) || os(Android)
-    static let isSupportedPlatform = true
+    package static let isSupportedPlatform = true
     #else
-    static let isSupportedPlatform = false
+    package static let isSupportedPlatform = false
     #endif
 
-    let configuration: Configuration
+    package let configuration: Configuration
     private let fileSystem: FileSystem
     private let observabilityScope: ObservabilityScope
     private let storageContainer: (storage: Storage, owned: Bool)
     private let collectionProviders: [Model.CollectionSourceType: PackageCollectionProvider]
-    let metadataProvider: PackageMetadataProvider
+    package let metadataProvider: PackageMetadataProvider
 
     private var storage: Storage {
         self.storageContainer.storage
@@ -92,7 +92,7 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
     }
 
     // internal initializer for testing
-    init(configuration: Configuration = .init(),
+    package init(configuration: Configuration = .init(),
          fileSystem: FileSystem,
          observabilityScope: ObservabilityScope,
          storage: Storage,
@@ -545,8 +545,8 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
         }
     }
 
-    internal static func mergedPackageMetadata(package: Model.Package,
-                                               basicMetadata: Model.PackageBasicMetadata?) -> Model.Package {
+    package static func mergedPackageMetadata(package: Model.Package,
+                                              basicMetadata: Model.PackageBasicMetadata?) -> Model.Package {
         // This dictionary contains recent releases and might not contain everything that's in package.versions.
         let basicVersionMetadata = basicMetadata.map { Dictionary($0.versions.map { ($0.version, $0) }, uniquingKeysWith: { first, _ in first }) } ?? [:]
         var versions = package.versions.map { packageVersion -> Model.Package.Version in

--- a/Sources/PackageCollections/PackageIndex+Configuration.swift
+++ b/Sources/PackageCollections/PackageIndex+Configuration.swift
@@ -21,7 +21,7 @@ public struct PackageIndexConfiguration: Equatable {
     public var cacheMaxSizeInMegabytes: Int
     
     // TODO: rdar://87575573 remove feature flag
-    public internal(set) var enabled = ProcessInfo.processInfo.environment["SWIFTPM_ENABLE_PACKAGE_INDEX"] == "1"
+    public package(set) var enabled = ProcessInfo.processInfo.environment["SWIFTPM_ENABLE_PACKAGE_INDEX"] == "1"
     
     public init(
         url: URL? = nil,

--- a/Sources/PackageCollections/PackageIndex.swift
+++ b/Sources/PackageCollections/PackageIndex.swift
@@ -17,7 +17,7 @@ import PackageModel
 
 import protocol TSCBasic.Closable
 
-struct PackageIndex: PackageIndexProtocol, Closable {
+package struct PackageIndex: PackageIndexProtocol, Closable {
     private let configuration: PackageIndexConfiguration
     private let httpClient: LegacyHTTPClient
     private let callbackQueue: DispatchQueue
@@ -27,11 +27,11 @@ struct PackageIndex: PackageIndexProtocol, Closable {
 
     private let cache: SQLiteBackedCache<CacheValue>?
     
-    var isEnabled: Bool {
+    package var isEnabled: Bool {
         self.configuration.enabled && self.configuration.url != .none
     }
 
-    init(
+    package init(
         configuration: PackageIndexConfiguration,
         customHTTPClient: LegacyHTTPClient? = nil,
         callbackQueue: DispatchQueue,
@@ -57,11 +57,11 @@ struct PackageIndex: PackageIndexProtocol, Closable {
         }
     }
     
-    func close() throws {
+    package func close() throws {
         try self.cache?.close()
     }
 
-    func getPackageMetadata(
+    package func getPackageMetadata(
         identity: PackageIdentity,
         location: String?
     ) async throws -> PackageCollectionsModel.PackageMetadata {
@@ -100,7 +100,7 @@ struct PackageIndex: PackageIndexProtocol, Closable {
         }
     }
     
-    func findPackages(
+    package func findPackages(
         _ query: String
     ) async throws -> PackageCollectionsModel.PackageSearchResult {
         let url = try await self.urlIfConfigured()
@@ -132,7 +132,7 @@ struct PackageIndex: PackageIndexProtocol, Closable {
         }
     }
 
-    func listPackages(
+    package func listPackages(
         offset: Int,
         limit: Int
     ) async throws -> PackageCollectionsModel.PaginatedPackageList {
@@ -213,16 +213,24 @@ struct PackageIndex: PackageIndexProtocol, Closable {
 }
 
 extension PackageIndex {
-    struct ListResponse: Codable {
+    package struct ListResponse: Codable {
         let items: [PackageCollectionsModel.Package]
         let total: Int
+
+        package init(
+            items: [PackageCollectionsModel.Package],
+            total: Int
+        ) {
+            self.items = items
+            self.total = total
+        }
     }
 }
 
 // MARK: - PackageMetadataProvider conformance
 
 extension PackageIndex: PackageMetadataProvider {
-    func get(
+    package func get(
         identity: PackageIdentity,
         location: String
     ) async -> (Result<PackageCollectionsModel.PackageBasicMetadata, Error>, PackageMetadataProviderContext?) {

--- a/Sources/PackageCollections/PackageIndexAndCollections.swift
+++ b/Sources/PackageCollections/PackageIndexAndCollections.swift
@@ -54,7 +54,7 @@ public struct PackageIndexAndCollections: Closable {
         self.observabilityScope = observabilityScope
     }
     
-    init(index: PackageIndexProtocol, collections: PackageCollectionsProtocol, observabilityScope: ObservabilityScope) {
+    package init(index: PackageIndexProtocol, collections: PackageCollectionsProtocol, observabilityScope: ObservabilityScope) {
         self.index = index
         self.collections = collections
         self.observabilityScope = observabilityScope

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -23,18 +23,18 @@ import protocol TSCBasic.Closable
 
 import struct TSCUtility.Version
 
-struct GitHubPackageMetadataProvider: PackageMetadataProvider, Closable {
+package struct GitHubPackageMetadataProvider: PackageMetadataProvider, Closable {
     private static let apiHostPrefix = "api."
     private static let service = Model.Package.Author.Service(name: "GitHub")
 
-    let configuration: Configuration
+    package let configuration: Configuration
     private let observabilityScope: ObservabilityScope
     private let httpClient: LegacyHTTPClient
     private let decoder: JSONDecoder
 
     private let cache: SQLiteBackedCache<CacheValue>?
 
-    init(configuration: Configuration = .init(), observabilityScope: ObservabilityScope, httpClient: LegacyHTTPClient? = nil) {
+    package init(configuration: Configuration = .init(), observabilityScope: ObservabilityScope, httpClient: LegacyHTTPClient? = nil) {
         self.configuration = configuration
         self.observabilityScope = observabilityScope
         self.httpClient = httpClient ?? Self.makeDefaultHTTPClient()
@@ -52,11 +52,11 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider, Closable {
         }
     }
 
-    func close() throws {
+    package func close() throws {
         try self.cache?.close()
     }
 
-    func get(
+    package func get(
         identity: PackageModel.PackageIdentity,
         location: String
     ) async -> (Result<PackageCollectionsModel.PackageBasicMetadata, any Error>, PackageMetadataProviderContext?) {
@@ -233,7 +233,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider, Closable {
     }
 
     // FIXME: use URL instead of string
-    internal static func apiURL(_ url: String) -> URL? {
+    package static func apiURL(_ url: String) -> URL? {
         do {
             let regex = try NSRegularExpression(pattern: #"([^/@]+)[:/]([^:/]+)/([^/.]+)(\.git)?$"#, options: .caseInsensitive)
             if let match = regex.firstMatch(in: url, options: [], range: NSRange(location: 0, length: url.count)) {
@@ -315,7 +315,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider, Closable {
     }
 }
 
-enum GitHubPackageMetadataProviderError: Error, Equatable {
+package enum GitHubPackageMetadataProviderError: Error, Equatable {
     case invalidSourceControlURL(String)
     case invalidResponse(URL, String)
     case permissionDenied(URL)

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -30,13 +30,13 @@ import struct TSCUtility.Version
 
 private typealias JSONModel = PackageCollectionModel.V1
 
-struct JSONPackageCollectionProvider: PackageCollectionProvider {
+package struct JSONPackageCollectionProvider: PackageCollectionProvider {
     // TODO: This can be removed when the `Security` framework APIs that the `PackageCollectionsSigning`
     // module depends on are available on all Apple platforms.
     #if os(macOS) || os(Linux) || os(Windows) || os(Android) || os(FreeBSD)
-    static let isSignatureCheckSupported = true
+    package static let isSignatureCheckSupported = true
     #else
-    static let isSignatureCheckSupported = false
+    package static let isSignatureCheckSupported = false
     #endif
 
     static let defaultCertPolicyKeys: [CertificatePolicyKey] = [.default]
@@ -50,7 +50,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
     private let signatureValidator: PackageCollectionSignatureValidator
     private let sourceCertPolicy: PackageCollectionSourceCertificatePolicy
 
-    init(
+    package init(
         configuration: Configuration = .init(),
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
@@ -73,7 +73,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         self.decoder = JSONDecoder.makeWithDefaults()
     }
 
-    func get(_ source: Model.CollectionSource) async throws -> Model.Collection {
+    package func get(_ source: Model.CollectionSource) async throws -> Model.Collection {
         guard case .json = source.type else {
             throw InternalError(
                 "JSONPackageCollectionProvider can only be used for fetching 'json' package collections"

--- a/Sources/PackageCollections/Providers/PackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageCollectionProvider.swift
@@ -13,7 +13,7 @@
 import Basics
 
 /// `PackageCollection` provider. For example, package feeds, (future) Package Index.
-protocol PackageCollectionProvider {
+package protocol PackageCollectionProvider {
     /// Retrieves `PackageCollection` from the specified source.
     ///
     /// - Parameters:

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -18,7 +18,7 @@ import PackageModel
 import struct TSCUtility.Version
 
 /// `PackageBasicMetadata` provider
-protocol PackageMetadataProvider {
+package protocol PackageMetadataProvider {
 
     // TODO: Review if this API is correct
     // This API is awkward because it unconditionally provides a context
@@ -41,23 +41,57 @@ protocol PackageMetadataProvider {
 }
 
 extension Model {
-    struct PackageBasicMetadata: Equatable, Codable {
-        let summary: String?
-        let keywords: [String]?
-        let versions: [PackageBasicVersionMetadata]
-        let watchersCount: Int?
-        let readmeURL: URL?
-        let license: PackageCollectionsModel.License?
-        let authors: [PackageCollectionsModel.Package.Author]?
-        let languages: Set<String>?
+    package struct PackageBasicMetadata: Equatable, Codable {
+        package let summary: String?
+        package let keywords: [String]?
+        package let versions: [PackageBasicVersionMetadata]
+        package let watchersCount: Int?
+        package let readmeURL: URL?
+        package let license: PackageCollectionsModel.License?
+        package let authors: [PackageCollectionsModel.Package.Author]?
+        package let languages: Set<String>?
+
+        package init(
+            summary: String?,
+            keywords: [String]?,
+            versions: [PackageBasicVersionMetadata],
+            watchersCount: Int?,
+            readmeURL: URL?,
+            license: PackageCollectionsModel.License?,
+            authors: [PackageCollectionsModel.Package.Author]?,
+            languages: Set<String>?
+        ) {
+            self.summary = summary
+            self.keywords = keywords
+            self.versions = versions
+            self.watchersCount = watchersCount
+            self.readmeURL = readmeURL
+            self.license = license
+            self.authors = authors
+            self.languages = languages
+        }
     }
 
-    struct PackageBasicVersionMetadata: Equatable, Codable {
-        let version: TSCUtility.Version
-        let title: String?
-        let summary: String?
-        let author: PackageCollectionsModel.Package.Author?
-        let createdAt: Date?
+    package struct PackageBasicVersionMetadata: Equatable, Codable {
+        package let version: TSCUtility.Version
+        package let title: String?
+        package let summary: String?
+        package let author: PackageCollectionsModel.Package.Author?
+        package let createdAt: Date?
+
+        package init(
+            version: TSCUtility.Version,
+            title: String?,
+            summary: String?,
+            author: PackageCollectionsModel.Package.Author?,
+            createdAt: Date?
+        ) {
+            self.version = version
+            self.title = title
+            self.summary = summary
+            self.author = author
+            self.createdAt = createdAt
+        }
     }
 }
 
@@ -67,7 +101,7 @@ public struct PackageMetadataProviderContext: Equatable {
     public let isAuthTokenConfigured: Bool
     public let error: PackageMetadataProviderError?
 
-    init(
+    package init(
         name: String,
         authTokenType: AuthTokenType?,
         isAuthTokenConfigured: Bool,

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -19,14 +19,14 @@ import class Foundation.JSONDecoder
 import class Foundation.JSONEncoder
 import struct Foundation.URL
 
-struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
+package struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     let fileSystem: FileSystem
-    let path: Basics.AbsolutePath
+    package let path: Basics.AbsolutePath
 
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
-    init(fileSystem: FileSystem, path: Basics.AbsolutePath? = nil) {
+    package init(fileSystem: FileSystem, path: Basics.AbsolutePath? = nil) {
         self.fileSystem = fileSystem
 
         self.path = path ?? (try? fileSystem.swiftPMConfigurationDirectory.appending("collections.json")) ?? .root
@@ -34,13 +34,13 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
         self.decoder = JSONDecoder.makeWithDefaults()
     }
 
-    func list() async throws -> [PackageCollectionsModel.CollectionSource] {
+    package func list() async throws -> [PackageCollectionsModel.CollectionSource] {
         try self.withLock {
             try self.loadFromDisk()
         }
     }
 
-    func add(source: PackageCollectionsModel.CollectionSource, order: Int? = nil) async throws {
+    package func add(source: PackageCollectionsModel.CollectionSource, order: Int? = nil) async throws {
         try self.withLock {
             var sources = try self.loadFromDisk()
             sources = sources.filter { $0 != source }
@@ -50,7 +50,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
         }
     }
 
-    func remove(source: PackageCollectionsModel.CollectionSource) async throws {
+    package func remove(source: PackageCollectionsModel.CollectionSource) async throws {
         try self.withLock {
             var sources = try self.loadFromDisk()
             sources = sources.filter { $0 != source }
@@ -58,7 +58,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
         }
     }
 
-    func move(source: PackageCollectionsModel.CollectionSource, to order: Int) async throws {
+    package func move(source: PackageCollectionsModel.CollectionSource, to order: Int) async throws {
         try self.withLock {
             var sources = try self.loadFromDisk()
             sources = sources.filter { $0 != source }
@@ -68,13 +68,13 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
         }
     }
 
-    func exists(source: PackageCollectionsModel.CollectionSource) async throws -> Bool {
+    package func exists(source: PackageCollectionsModel.CollectionSource) async throws -> Bool {
         try self.withLock {
             try self.loadFromDisk()
         }.contains(source)
     }
 
-    func update(source: PackageCollectionsModel.CollectionSource) async throws {
+    package func update(source: PackageCollectionsModel.CollectionSource) async throws {
         try self.withLock {
             var sources = try self.loadFromDisk()
             if let index = sources.firstIndex(where: { $0 == source }) {

--- a/Sources/PackageCollections/Storage/Trie.swift
+++ b/Sources/PackageCollections/Storage/Trie.swift
@@ -13,18 +13,18 @@
 import class Foundation.NSLock
 import PackageModel
 
-struct Trie<Document: Hashable> {
+package struct Trie<Document: Hashable> {
     private typealias Node = TrieNode<Character, Document>
 
     private let root: Node
     private let lock = NSLock()
 
-    init() {
+    package init() {
         self.root = Node()
     }
 
     /// Inserts a word and its document to the trie.
-    func insert(word: String, foundIn document: Document) {
+    package func insert(word: String, foundIn document: Document) {
         guard !word.isEmpty else { return }
 
         self.lock.withLock {
@@ -43,7 +43,7 @@ struct Trie<Document: Hashable> {
     }
 
     /// Removes word occurrences found in the given document.
-    func remove(document: Document) {
+    package func remove(document: Document) {
         func removeInSubTrie(root: Node, document: Document) {
             if root.isTerminating {
                 root.remove(document: document)
@@ -69,7 +69,7 @@ struct Trie<Document: Hashable> {
     }
 
     /// Removes word occurrences found in matching document(s).
-    func remove(where predicate: @escaping (Document) -> Bool) {
+    package func remove(where predicate: @escaping (Document) -> Bool) {
         func removeInSubTrie(root: Node, where predicate: @escaping (Document) -> Bool) {
             if root.isTerminating {
                 root.remove(where: predicate)
@@ -95,7 +95,7 @@ struct Trie<Document: Hashable> {
     }
 
     /// Checks if the trie contains the exact word or words with matching prefix.
-    func contains(word: String, prefixMatch: Bool = false) -> Bool {
+    package func contains(word: String, prefixMatch: Bool = false) -> Bool {
         guard let node = self.findLastNodeOf(word: word) else {
             return false
         }
@@ -103,7 +103,7 @@ struct Trie<Document: Hashable> {
     }
 
     /// Finds the word in this trie and returns its documents.
-    func find(word: String) throws -> Set<Document> {
+    package func find(word: String) throws -> Set<Document> {
         guard let node = self.findLastNodeOf(word: word), node.isTerminating else {
             throw NotFoundError(word)
         }
@@ -111,7 +111,7 @@ struct Trie<Document: Hashable> {
     }
 
     /// Finds words with matching prefix in this trie and returns their documents.
-    func findWithPrefix(_ prefix: String) throws -> [String: Set<Document>] {
+    package func findWithPrefix(_ prefix: String) throws -> [String: Set<Document>] {
         guard let node = self.findLastNodeOf(word: prefix) else {
             throw NotFoundError(prefix)
         }

--- a/Sources/PackageCollections/Utility.swift
+++ b/Sources/PackageCollections/Utility.swift
@@ -13,22 +13,22 @@
 import PackageModel
 import SourceControl
 
-struct MultipleErrors: Error, CustomStringConvertible {
-    let errors: [Error]
+package struct MultipleErrors: Error, CustomStringConvertible {
+    package let errors: [Error]
     
     init(_ errors: [Error]) {
         self.errors = errors
     }
 
-    var description: String {
+    package var description: String {
         "\(self.errors)"
     }
 }
 
-struct NotFoundError: Error {
+package struct NotFoundError: Error {
     let item: String
 
-    init(_ item: String) {
+    package init(_ item: String) {
         self.item = item
     }
 }

--- a/Sources/PackageCollectionsSigning/CertificatePolicy.swift
+++ b/Sources/PackageCollectionsSigning/CertificatePolicy.swift
@@ -54,7 +54,7 @@ public enum CertificatePolicyKey: Hashable, CustomStringConvertible {
 
 // MARK: - Certificate policies
 
-protocol CertificatePolicy {
+package protocol CertificatePolicy {
     /// Validates the given certificate chain.
     ///
     /// - Parameters:
@@ -71,11 +71,11 @@ extension CertificatePolicy {
     /// - Parameters:
     ///   - certChain: The certificate being verified must be the first element of the array, with its issuer the next
     ///                element and so on, and the root CA certificate is last.
-    func validate(certChain: [Certificate]) async throws {
+    package func validate(certChain: [Certificate]) async throws {
         try await self.validate(certChain: certChain, validationTime: Date())
     }
 
-    func verify(
+    package func verify(
         certChain: [Certificate],
         trustedRoots: [Certificate]?,
         @PolicyBuilder policies: () -> some VerifierPolicy,
@@ -114,7 +114,7 @@ extension CertificatePolicy {
     }
 }
 
-enum CertificatePolicyError: Error, Equatable {
+package enum CertificatePolicyError: Error, Equatable {
     case noTrustedRootCertsConfigured
     case emptyCertChain
     case invalidCertChain
@@ -128,7 +128,7 @@ enum CertificatePolicyError: Error, Equatable {
 ///   - The certificate must use either 256-bit EC (recommended) or 2048-bit RSA key.
 ///   - The certificate must not be revoked. The certificate authority must support OCSP.
 ///   - The certificate chain is valid and root certificate must be trusted.
-struct DefaultCertificatePolicy: CertificatePolicy {
+package struct DefaultCertificatePolicy: CertificatePolicy {
     let trustedRoots: [Certificate]
     let expectedSubjectUserID: String?
     let expectedSubjectOrganizationalUnit: String?
@@ -146,7 +146,7 @@ struct DefaultCertificatePolicy: CertificatePolicy {
     ///                                 user configured and dynamic, while this is configured by SwiftPM and static.
     ///   - expectedSubjectUserID: The subject user ID that must match if specified.
     ///   - expectedSubjectOrganizationalUnit: The subject organizational unit name that must match if specified.
-    init(
+    package init(
         trustedRootCertsDir: URL?,
         additionalTrustedRootCerts: [Certificate]?,
         expectedSubjectUserID: String? = nil,
@@ -168,7 +168,7 @@ struct DefaultCertificatePolicy: CertificatePolicy {
         self.observabilityScope = observabilityScope
     }
 
-    func validate(certChain: [Certificate], validationTime: Date) async throws {
+    package func validate(certChain: [Certificate], validationTime: Date) async throws {
         guard !certChain.isEmpty else {
             throw CertificatePolicyError.emptyCertChain
         }
@@ -202,7 +202,7 @@ struct DefaultCertificatePolicy: CertificatePolicy {
 ///
 /// This has the same requirements as `DefaultCertificatePolicy` plus additional
 /// marker extensions for Swift Package Collection certifiicates.
-struct ADPSwiftPackageCollectionCertificatePolicy: CertificatePolicy {
+package struct ADPSwiftPackageCollectionCertificatePolicy: CertificatePolicy {
     let trustedRoots: [Certificate]
     let expectedSubjectUserID: String?
     let expectedSubjectOrganizationalUnit: String?
@@ -220,7 +220,7 @@ struct ADPSwiftPackageCollectionCertificatePolicy: CertificatePolicy {
     ///                                 user configured and dynamic, while this is configured by SwiftPM and static.
     ///   - expectedSubjectUserID: The subject user ID that must match if specified.
     ///   - expectedSubjectOrganizationalUnit: The subject organizational unit name that must match if specified.
-    init(
+    package init(
         trustedRootCertsDir: URL?,
         additionalTrustedRootCerts: [Certificate]?,
         expectedSubjectUserID: String? = nil,
@@ -242,7 +242,7 @@ struct ADPSwiftPackageCollectionCertificatePolicy: CertificatePolicy {
         self.observabilityScope = observabilityScope
     }
 
-    func validate(certChain: [Certificate], validationTime: Date) async throws {
+    package func validate(certChain: [Certificate], validationTime: Date) async throws {
         guard !certChain.isEmpty else {
             throw CertificatePolicyError.emptyCertChain
         }
@@ -353,13 +353,13 @@ struct ADPAppleDistributionCertificatePolicy: CertificatePolicy {
 // MARK: - Verifier policies
 
 /// Policy for code signing certificates.
-struct _CodeSigningPolicy: VerifierPolicy {
-    let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = [
+package struct _CodeSigningPolicy: VerifierPolicy {
+    package let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = [
         ASN1ObjectIdentifier.X509ExtensionID.keyUsage,
         ASN1ObjectIdentifier.X509ExtensionID.extendedKeyUsage,
     ]
 
-    func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) async -> PolicyEvaluationResult {
+    package func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) async -> PolicyEvaluationResult {
         let isCodeSigning = (
             try? chain.leaf.extensions.extendedKeyUsage?.contains(ExtendedKeyUsage.Usage.codeSigning)
         ) ?? false
@@ -368,6 +368,8 @@ struct _CodeSigningPolicy: VerifierPolicy {
         }
         return .meetsPolicy
     }
+
+    package init() {}
 }
 
 /// Policy for revocation check via OCSP.

--- a/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
+++ b/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
@@ -129,7 +129,7 @@ public actor PackageCollectionSigning: PackageCollectionSigner, PackageCollectio
         self.observabilityScope = observabilityScope
     }
 
-    init(certPolicy: CertificatePolicy, observabilityScope: ObservabilityScope) {
+    package init(certPolicy: CertificatePolicy, observabilityScope: ObservabilityScope) {
         // These should be set through the given CertificatePolicy
         self.trustedRootCertsDir = nil
         self.additionalTrustedRootCerts = nil

--- a/Sources/PackageCollectionsSigning/Signature.swift
+++ b/Sources/PackageCollectionsSigning/Signature.swift
@@ -38,24 +38,24 @@ import X509
 // The logic in this source file loosely follows https://www.rfc-editor.org/rfc/rfc7515.html
 // for JSON Web Signature (JWS).
 
-struct Signature {
-    let header: Header
-    let payload: Data
+package struct Signature {
+    package let header: Header
+    package let payload: Data
     let signature: Data
 }
 
 extension Signature {
-    enum Algorithm: String, Codable {
+    package enum Algorithm: String, Codable {
         case RS256 // RSASSA-PKCS1-v1_5 using SHA-256
         case ES256 // ECDSA using P-256 and SHA-256
     }
 
-    struct Header: Equatable, Codable {
+    package struct Header: Equatable, Codable {
         // https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.1
-        let algorithm: Algorithm
+        package let algorithm: Algorithm
 
         /// Base64 encoded certificate chain
-        let certChain: [String]
+        package let certChain: [String]
 
         enum CodingKeys: String, CodingKey {
             case algorithm = "alg"
@@ -66,9 +66,9 @@ extension Signature {
 
 // Reference: https://github.com/vapor/jwt-kit/blob/master/Sources/JWTKit/JWTSerializer.swift
 extension Signature {
-    static let rsaSigningPadding = _RSA.Signing.Padding.insecurePKCS1v1_5
+    package static let rsaSigningPadding = _RSA.Signing.Padding.insecurePKCS1v1_5
 
-    static func generate(
+    package static func generate(
         payload: some Encodable,
         certChainData: [Data],
         jsonEncoder: JSONEncoder,
@@ -102,9 +102,9 @@ extension Signature {
 
 // Reference: https://github.com/vapor/jwt-kit/blob/master/Sources/JWTKit/JWTParser.swift
 extension Signature {
-    typealias CertChainValidate = ([Data]) async throws -> [Certificate]
+    package typealias CertChainValidate = ([Data]) async throws -> [Certificate]
 
-    static func parse(
+    package static func parse(
         _ signature: String,
         certChainValidate: CertChainValidate,
         jsonDecoder: JSONDecoder
@@ -113,7 +113,7 @@ extension Signature {
         return try await Self.parse(bytes, certChainValidate: certChainValidate, jsonDecoder: jsonDecoder)
     }
 
-    static func parse(
+    package static func parse(
         _ signature: some DataProtocol,
         certChainValidate: CertChainValidate,
         jsonDecoder: JSONDecoder
@@ -180,7 +180,7 @@ extension Signature {
     }
 }
 
-enum SignatureError: Error {
+package enum SignatureError: Error {
     case malformedSignature
     case invalidSignature
     case invalidPublicKey

--- a/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
@@ -20,7 +20,7 @@ import struct TSCUtility.Version
 
 public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
     let fileSystem: FileSystem
-    let directoryPath: Basics.AbsolutePath
+    package let directoryPath: Basics.AbsolutePath
 
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
@@ -350,13 +350,13 @@ protocol FingerprintReference {
 }
 
 extension PackageIdentity: FingerprintReference {
-    var fingerprintsFilename: String {
+    package var fingerprintsFilename: String {
         "\(self.description).json"
     }
 }
 
 extension PackageReference: FingerprintReference {
-    var fingerprintsFilename: String {
+    package var fingerprintsFilename: String {
         get throws {
             guard case .remoteSourceControl(let sourceControlURL) = self.kind else {
                 throw StringError("Package kind [\(self.kind)] does not support fingerprints")

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -19,7 +19,7 @@ import protocol Basics.FileSystem
 import class Basics.ObservabilityScope
 import struct Basics.IdentifiableSet
 
-enum PackageGraphError: Swift.Error {
+package enum PackageGraphError: Swift.Error {
     /// Indicates a non-root package with no modules.
     case noModules(Package)
 
@@ -387,7 +387,7 @@ extension PackageGraphError: CustomStringConvertible {
     }
 }
 
-enum GraphError: Error {
+package enum GraphError: Error {
     /// A cycle was detected in the input.
     case unexpectedCycle
 }
@@ -409,7 +409,7 @@ enum GraphError: Error {
 ///
 /// - Complexity: O(v + e) where (v, e) are the number of vertices and edges
 /// reachable from the input nodes via the relation.
-func topologicalSortIdentifiable<T: Identifiable>(
+package func topologicalSortIdentifiable<T: Identifiable>(
     _ nodes: [T], successors: (T) throws -> [T]
 ) throws -> [T] {
     // Implements a topological sort via recursion and reverse postorder DFS.

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -26,7 +26,7 @@ public struct PubGrubDependencyResolver {
     public typealias Constraint = PackageContainerConstraint
 
     /// the mutable state that get computed
-    internal final class State {
+    package final class State {
         /// The root package reference.
         let root: DependencyResolutionNode
 
@@ -44,7 +44,7 @@ public struct PubGrubDependencyResolver {
 
         private let lock = NSLock()
 
-        init(root: DependencyResolutionNode,
+        package init(root: DependencyResolutionNode,
              overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)] = [:],
              solution: PartialSolution = PartialSolution())
         {
@@ -53,7 +53,7 @@ public struct PubGrubDependencyResolver {
             self.solution = solution
         }
 
-        func addIncompatibility(_ incompatibility: Incompatibility, at location: LogLocation) {
+        package func addIncompatibility(_ incompatibility: Incompatibility, at location: LogLocation) {
             self.lock.withLock {
                 // log("incompat: \(incompatibility) \(location)")
                 for package in incompatibility.terms.map(\.node) {
@@ -69,7 +69,7 @@ public struct PubGrubDependencyResolver {
         }
 
         /// Find all incompatibilities containing a positive term for a given package.
-        func positiveIncompatibilities(for node: DependencyResolutionNode) -> [Incompatibility]? {
+        package func positiveIncompatibilities(for node: DependencyResolutionNode) -> [Incompatibility]? {
             self.lock.withLock {
                 guard let all = self.incompatibilities[node] else {
                     return nil
@@ -80,7 +80,7 @@ public struct PubGrubDependencyResolver {
             }
         }
 
-        func decide(_ node: DependencyResolutionNode, at version: Version) {
+        package func decide(_ node: DependencyResolutionNode, at version: Version) {
             let term = Term(node, .exact(version))
             self.lock.withLock {
                 assert(term.isValidDecision(for: self.solution))
@@ -88,7 +88,7 @@ public struct PubGrubDependencyResolver {
             }
         }
 
-        func derive(_ term: Term, cause: Incompatibility) {
+        package func derive(_ term: Term, cause: Incompatibility) {
             self.lock.withLock {
                 self.solution.derive(term, cause: cause)
             }
@@ -209,7 +209,7 @@ public struct PubGrubDependencyResolver {
     /// Find a set of dependencies that fit the given constraints. If dependency
     /// resolution is unable to provide a result, an error is thrown.
     /// - Warning: It is expected that the root package reference has been set  before this is called.
-    internal func solve(root: DependencyResolutionNode, constraints: [Constraint]) async throws -> (bindings: [DependencyResolverBinding], state: State) {
+    package func solve(root: DependencyResolutionNode, constraints: [Constraint]) async throws -> (bindings: [DependencyResolverBinding], state: State) {
         // first process inputs
         let inputs = try await self.processInputs(root: root, with: constraints)
 
@@ -511,7 +511,7 @@ public struct PubGrubDependencyResolver {
     /// partial solution.
     /// If a conflict is found, the conflicting incompatibility is returned to
     /// resolve the conflict on.
-    internal func propagate(state: State, node: DependencyResolutionNode) throws {
+    package func propagate(state: State, node: DependencyResolutionNode) throws {
         var changed: OrderedCollections.OrderedSet<DependencyResolutionNode> = [node]
 
         while !changed.isEmpty {
@@ -575,7 +575,7 @@ public struct PubGrubDependencyResolver {
     // Based on:
     // https://github.com/dart-lang/pub/tree/master/doc/solver.md#conflict-resolution
     // https://github.com/dart-lang/pub/blob/master/lib/src/solver/version_solver.dart#L201
-    internal func resolve(state: State, conflict: Incompatibility) throws -> Incompatibility {
+    package func resolve(state: State, conflict: Incompatibility) throws -> Incompatibility {
         self.delegate?.conflict(conflict: conflict)
 
         var incompatibility = conflict
@@ -703,7 +703,7 @@ public struct PubGrubDependencyResolver {
         }
     }
 
-    internal func makeDecision(
+    package func makeDecision(
         state: State
     ) async throws -> DependencyResolutionNode? {
         // If there are no more undecided terms, version solving is complete.
@@ -771,7 +771,7 @@ public struct PubGrubDependencyResolver {
     }
 }
 
-internal enum LogLocation: String {
+package enum LogLocation: String {
     case topLevel = "top level"
     case unitPropagation = "unit propagation"
     case decisionMaking = "decision making"

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
@@ -19,14 +19,14 @@ import struct TSCUtility.Version
 
 /// A container for an individual package. This enhances PackageContainer to add PubGrub specific
 /// logic which is mostly related to computing incompatibilities at a particular version.
-final class PubGrubPackageContainer {
+package final class PubGrubPackageContainer {
     /// The underlying package container.
     let underlying: PackageContainer
 
     /// `Package.resolved` in-memory representation.
     private let resolvedPackages: ResolvedPackagesStore.ResolvedPackages
 
-    init(underlying: PackageContainer, resolvedPackages: ResolvedPackagesStore.ResolvedPackages) {
+    package init(underlying: PackageContainer, resolvedPackages: ResolvedPackagesStore.ResolvedPackages) {
         self.underlying = underlying
         self.resolvedPackages = resolvedPackages
     }
@@ -150,7 +150,7 @@ final class PubGrubPackageContainer {
     }
 
     /// Returns the incompatibilities of a package at the given version.
-    func incompatibilites(
+    package func incompatibilites(
         at version: Version,
         node: DependencyResolutionNode,
         overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)],

--- a/Sources/PackageGraph/Resolution/ResolvedModule.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedModule.swift
@@ -289,6 +289,11 @@ extension ResolvedModule: Identifiable {
 
         public let moduleName: String
         let packageIdentity: PackageIdentity
+
+        package init(moduleName: String, packageIdentity: PackageIdentity) {
+            self.moduleName = moduleName
+            self.packageIdentity = packageIdentity
+        }
     }
 
     public var id: ID {

--- a/Sources/PackageGraph/Resolution/ResolvedProduct.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedProduct.swift
@@ -196,6 +196,11 @@ extension ResolvedProduct: Identifiable {
     public struct ID: Hashable {
         public let productName: String
         let packageIdentity: PackageIdentity
+
+        package init(productName: String, packageIdentity: PackageIdentity) {
+            self.productName = productName
+            self.packageIdentity = packageIdentity
+        }
     }
 
     public var id: ID {

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -1013,16 +1013,16 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 }
 
 extension ManifestLoader {
-    struct CacheKey: Hashable {
+    package struct CacheKey: Hashable {
         let packageIdentity: PackageIdentity
         let manifestPath: AbsolutePath
         let manifestContents: [UInt8]
         let toolsVersion: ToolsVersion
         let env: Environment
         let swiftpmVersion: String
-        let sha256Checksum: String
+        package let sha256Checksum: String
 
-        init (packageIdentity: PackageIdentity,
+        package init (packageIdentity: PackageIdentity,
               packageLocation: String,
               manifestPath: AbsolutePath,
               toolsVersion: ToolsVersion,
@@ -1051,7 +1051,7 @@ extension ManifestLoader {
             self.sha256Checksum = sha256Checksum
         }
 
-        func hash(into hasher: inout Hasher) {
+        package func hash(into hasher: inout Hasher) {
             hasher.combine(self.sha256Checksum)
         }
 
@@ -1082,7 +1082,7 @@ extension ManifestLoader {
 }
 
 extension ManifestLoader {
-    struct EvaluationResult: Codable {
+    package struct EvaluationResult: Codable {
         /// The path to the diagnostics file (.dia).
         ///
         /// This is only present if serialized diagnostics are enabled.
@@ -1094,10 +1094,17 @@ extension ManifestLoader {
         var compilerOutput: String?
 
         /// The manifest in JSON format.
-        var manifestJSON: String?
+        package var manifestJSON: String?
 
         /// The command line used to compile the manifest
         var compilerCommandLine: [String]?
+
+        package init(diagnosticFile: AbsolutePath? = nil, compilerOutput: String? = nil, manifestJSON: String? = nil, compilerCommandLine: [String]? = nil) {
+            self.diagnosticFile = diagnosticFile
+            self.compilerOutput = compilerOutput
+            self.manifestJSON = manifestJSON
+            self.compilerCommandLine = compilerCommandLine
+        }
 
         /// Any non-compiler error that might have occurred during manifest loading.
         ///

--- a/Sources/PackageLoading/PkgConfig.swift
+++ b/Sources/PackageLoading/PkgConfig.swift
@@ -159,7 +159,7 @@ extension PkgConfig {
 ///
 /// See: https://www.freedesktop.org/wiki/Software/pkg-config/
 // This is only internal so it can be unit tested.
-internal struct PkgConfigParser {
+package struct PkgConfigParser {
     public let pcFile: Basics.AbsolutePath
     private let fileSystem: FileSystem
     public private(set) var variables = [String: String]()
@@ -458,7 +458,7 @@ internal struct PkgConfigParser {
 }
 
 // This is only internal so it can be unit tested.
-internal struct PCFileFinder {
+package struct PCFileFinder {
     /// Cached results of locations `pkg-config` will search for `.pc` files
     /// FIXME: This shouldn't use a static variable, since the first lookup
     /// will cache the result of whatever `brewPrefix` was passed in.  It is
@@ -512,7 +512,7 @@ internal struct PCFileFinder {
     /// again when instantiating a `PCFileFinder()`.  This is intended only for
     /// use by testing.  This is a temporary workaround for the use of a static
     /// variable by this class.
-    internal static func resetCachedPkgConfigPaths() {
+    package static func resetCachedPkgConfigPaths() {
         PCFileFinder.pkgConfigPaths = nil
     }
 
@@ -539,7 +539,7 @@ internal struct PCFileFinder {
     }
 }
 
-internal enum PkgConfigError: Swift.Error, CustomStringConvertible {
+package enum PkgConfigError: Swift.Error, CustomStringConvertible {
     case couldNotFindConfigFile(name: String)
     case parsingError(String)
     case prohibitedFlags(String)

--- a/Sources/PackageModel/MinimumDeploymentTarget.swift
+++ b/Sources/PackageModel/MinimumDeploymentTarget.swift
@@ -58,14 +58,14 @@ public struct MinimumDeploymentTarget {
         return nil
     }
 
-    static func computeXCTestMinimumDeploymentTarget(with runResult: AsyncProcessResult, platform: PackageModel.Platform) throws -> PlatformVersion? {
+    package static func computeXCTestMinimumDeploymentTarget(with runResult: AsyncProcessResult, platform: PackageModel.Platform) throws -> PlatformVersion? {
         guard let output = try runResult.utf8Output().spm_chuzzle() else { return nil }
         let sdkPath = try Basics.AbsolutePath(validating: output)
         let xcTestPath = try Basics.AbsolutePath(validating: "Developer/Library/Frameworks/XCTest.framework/XCTest", relativeTo: sdkPath)
         return try computeMinimumDeploymentTarget(of: xcTestPath, platform: platform)
     }
 
-    static func computeXCTestMinimumDeploymentTarget(for platform: PackageModel.Platform) -> PlatformVersion {
+    package static func computeXCTestMinimumDeploymentTarget(for platform: PackageModel.Platform) -> PlatformVersion {
         guard let (sdkName, _) = platform.sdkNameAndPlatform else {
             return platform.oldestSupportedVersion
         }

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -21,7 +21,7 @@ public struct PackageIdentity: CustomStringConvertible, Sendable {
 
     /// Creates a package identity from a string.
     /// - Parameter value: A string used to identify a package.
-    init(_ value: String) {
+    package init(_ value: String) {
         self.description = value
     }
 
@@ -296,7 +296,7 @@ extension PackageIdentity {
 
 // MARK: -
 
-struct PackageIdentityParser {
+package struct PackageIdentityParser {
     /// A textual representation of this instance.
     public let description: String
 

--- a/Sources/PackageModel/Snippets/Model/Snippet.swift
+++ b/Sources/PackageModel/Snippets/Model/Snippet.swift
@@ -23,7 +23,7 @@ public struct Snippet {
         path.basenameWithoutExt
     }
 
-    init(parsing source: String, path: AbsolutePath) {
+    package init(parsing source: String, path: AbsolutePath) {
         let extractor = PlainTextSnippetExtractor(source: source)
         self.path = path
         self.explanation = extractor.explanation

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -972,7 +972,7 @@ extension SwiftSDK {
     ///   - properties: properties of the Swift SDK for the given triple.
     ///   - toolset: combined toolset used by this Swift SDK.
     ///   - swiftSDKDirectory: directory used for converting relative paths in `properties` to absolute paths.
-    init(
+    package init(
         targetTriple: Triple,
         properties: SwiftSDKMetadataV4.TripleProperties,
         toolset: Toolset = .init(),
@@ -1174,8 +1174,8 @@ struct SerializedDestinationV3: Decodable {
 }
 
 /// Represents v4 schema of `swift-sdk.json` (previously `destination.json`) files used for cross-compilation.
-struct SwiftSDKMetadataV4: Decodable {
-    struct TripleProperties: Codable {
+package struct SwiftSDKMetadataV4: Decodable {
+    package struct TripleProperties: Codable {
         /// Path relative to `swift-sdk.json` containing SDK root.
         var sdkRootPath: String?
 
@@ -1193,6 +1193,15 @@ struct SwiftSDKMetadataV4: Decodable {
 
         /// Array of paths relative to `swift-sdk.json` containing toolset files.
         var toolsetPaths: [String]?
+
+        package init(sdkRootPath: String, swiftResourcesPath: String? = nil, swiftStaticResourcesPath: String? = nil, includeSearchPaths: [String]? = nil, librarySearchPaths: [String]? = nil, toolsetPaths: [String]? = nil) {
+            self.sdkRootPath = sdkRootPath
+            self.swiftResourcesPath = swiftResourcesPath
+            self.swiftStaticResourcesPath = swiftStaticResourcesPath
+            self.includeSearchPaths = includeSearchPaths
+            self.librarySearchPaths = librarySearchPaths
+            self.toolsetPaths = toolsetPaths
+        }
     }
 
     /// Mapping of triple strings to corresponding properties of such target triple.

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundle.swift
@@ -21,6 +21,11 @@ public struct SwiftSDKBundle {
     public struct Variant: Equatable {
         let metadata: ArtifactsArchiveMetadata.Variant
         let swiftSDKs: [SwiftSDK]
+
+        package init(metadata: ArtifactsArchiveMetadata.Variant, swiftSDKs: [SwiftSDK]) {
+            self.metadata = metadata
+            self.swiftSDKs = swiftSDKs
+        }
     }
 
     // Path to the bundle root directory.
@@ -31,6 +36,11 @@ public struct SwiftSDKBundle {
 
     /// Name of the Swift SDK bundle that can be used to distinguish it from other bundles.
     public var name: String { path.basename }
+
+    package init(path: AbsolutePath, artifacts: [String:[SwiftSDKBundle.Variant]] = [:]) {
+        self.path = path
+        self.artifacts = artifacts
+    }
 }
 
 extension SwiftSDKBundle.Variant {
@@ -81,7 +91,7 @@ extension [SwiftSDKBundle] {
     ///   - hostTriple: triple of the host building with these Swift SDKs.
     ///   - observabilityScope: observability scope to log warnings about multiple matches.
     /// - Returns: ``SwiftSDK`` value matching `query` either by artifact ID or target triple, `nil` if none found.
-    func selectSwiftSDK(
+    package func selectSwiftSDK(
         matching selector: String,
         hostTriple: Triple,
         observabilityScope: ObservabilityScope

--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -38,6 +38,11 @@ public struct Toolset: Equatable {
 
         /// Command-line options to be passed to the tool when it's invoked.
         public internal(set) var extraCLIOptions: [String]
+
+        package init(path: AbsolutePath? = nil, extraCLIOptions: [String] = []) {
+            self.path = path
+            self.extraCLIOptions = extraCLIOptions
+        }
     }
 
     /// A dictionary of known tools in this toolset.
@@ -46,10 +51,18 @@ public struct Toolset: Equatable {
     /// An array of paths specified as `rootPath` in toolset files from which this toolset was formed. May be used
     /// for locating tools that aren't currently listed in ``Toolset/KnownTool``.
     public internal(set) var rootPaths: [AbsolutePath] = []
+
+    package init(
+        knownTools: [KnownTool: ToolProperties] = [:],
+        rootPaths: [AbsolutePath] = []
+    ) {
+        self.knownTools = knownTools
+        self.rootPaths = rootPaths
+    }
 }
 
 extension Toolset.ToolProperties {
-    init(path: AbsolutePath) {
+    package init(path: AbsolutePath) {
         self.init(path: path, extraCLIOptions: [])
     }
 }

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -525,7 +525,7 @@ public final class UserToolchain: Toolchain {
     }
 #endif
 
-    internal static func deriveSwiftCFlags(
+    package static func deriveSwiftCFlags(
         triple: Basics.Triple,
         swiftSDK: SwiftSDK,
         environment: Environment,

--- a/Sources/PackageRegistry/ChecksumTOFU.swift
+++ b/Sources/PackageRegistry/ChecksumTOFU.swift
@@ -20,13 +20,13 @@ import Foundation
 
 import struct TSCUtility.Version
 
-struct PackageVersionChecksumTOFU {
+package struct PackageVersionChecksumTOFU {
     private let fingerprintStorage: PackageFingerprintStorage?
     private let fingerprintCheckingMode: FingerprintCheckingMode
     private let versionMetadataProvider: (PackageIdentity.RegistryIdentity, Version) async throws -> RegistryClient
         .PackageVersionMetadata
 
-    init(
+    package init(
         fingerprintStorage: PackageFingerprintStorage?,
         fingerprintCheckingMode: FingerprintCheckingMode,
         versionMetadataProvider: @escaping (PackageIdentity.RegistryIdentity, Version) async throws -> RegistryClient
@@ -38,7 +38,7 @@ struct PackageVersionChecksumTOFU {
     }
 
     // MARK: - source archive
-    func validateSourceArchive(
+    package func validateSourceArchive(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,
         version: Version,
@@ -139,7 +139,7 @@ struct PackageVersionChecksumTOFU {
         return checksum
     }
 
-    func validateManifest(
+    package func validateManifest(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,
         version: Version,

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -1337,7 +1337,7 @@ public final class RegistryClient: AsyncCancellable {
     }
 
     @available(*, deprecated, message: "Use the async alternative")
-    func checkAvailability(
+    package func checkAvailability(
         registry: Registry,
         timeout: DispatchTimeInterval? = .none,
         observabilityScope: ObservabilityScope,
@@ -1354,7 +1354,7 @@ public final class RegistryClient: AsyncCancellable {
     }
 
     // marked internal for testing
-    func checkAvailability(
+    package func checkAvailability(
         registry: Registry,
         timeout: DispatchTimeInterval? = .none,
         observabilityScope: ObservabilityScope
@@ -1818,7 +1818,7 @@ extension RegistryClient {
         case error(String)
 
         // marked internal for testing
-        static var unavailableStatusCodes = [404, 501]
+        package static var unavailableStatusCodes = [404, 501]
     }
 }
 

--- a/Sources/PackageRegistry/RegistryConfiguration.swift
+++ b/Sources/PackageRegistry/RegistryConfiguration.swift
@@ -145,7 +145,7 @@ extension RegistryConfiguration {
         }
 
         // for testing
-        init(
+        package init(
             default: Global,
             registryOverrides: [String: RegistryOverride] = [:],
             scopeOverrides: [PackageIdentity.Scope: ScopePackageOverride] = [:],
@@ -165,7 +165,7 @@ extension RegistryConfiguration {
             }
 
             // for testing
-            init(signing: Signing) {
+            package init(signing: Signing) {
                 self.signing = signing
             }
         }

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -365,6 +365,11 @@ extension RegistryDownloadsManager {
         public let fromCache: Bool
         /// Indicates whether the repository was already present in the cache and updated or if a clean fetch was performed.
         public let updatedCache: Bool
+
+        package init(fromCache: Bool, updatedCache: Bool) {
+            self.fromCache = fromCache
+            self.updatedCache = updatedCache
+        }
     }
 }
 
@@ -385,7 +390,7 @@ extension PackageIdentity {
         return try RelativePath(validating: registryIdentity.scope.description).appending(component: registryIdentity.name.description)
     }
 
-    internal func downloadPath(version: Version) throws -> Basics.RelativePath {
+    package func downloadPath(version: Version) throws -> Basics.RelativePath {
         try self.downloadPath().appending(component: version.description)
     }
 }

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -22,13 +22,13 @@ import TSCBasic
 
 import struct TSCUtility.Version
 
-protocol SignatureValidationDelegate {
+package protocol SignatureValidationDelegate {
     func onUnsigned(registry: Registry, package: PackageIdentity, version: Version, completion: (Bool) -> Void)
     func onUntrusted(registry: Registry, package: PackageIdentity, version: Version, completion: (Bool) -> Void)
 }
 
-struct SignatureValidation {
-    typealias Delegate = SignatureValidationDelegate
+package struct SignatureValidation {
+    package typealias Delegate = SignatureValidationDelegate
 
     private let skipSignatureValidation: Bool
     private let signingEntityTOFU: PackageSigningEntityTOFU
@@ -40,7 +40,7 @@ struct SignatureValidation {
         case passthrough(Error)
     }
 
-    init(
+    package init(
         skipSignatureValidation: Bool,
         signingEntityStorage: PackageSigningEntityStorage?,
         signingEntityCheckingMode: SigningEntityCheckingMode,
@@ -58,7 +58,7 @@ struct SignatureValidation {
     }
 
     // MARK: - source archive
-    func validate(
+    package func validate(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,
         version: Version,
@@ -313,7 +313,7 @@ struct SignatureValidation {
     }
 
     // MARK: - manifests
-    func validate(
+    package func validate(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,
         version: Version,

--- a/Sources/PackageRegistry/SigningEntityTOFU.swift
+++ b/Sources/PackageRegistry/SigningEntityTOFU.swift
@@ -19,11 +19,11 @@ import PackageSigning
 
 import struct TSCUtility.Version
 
-struct PackageSigningEntityTOFU {
+package struct PackageSigningEntityTOFU {
     private let signingEntityStorage: PackageSigningEntityStorage?
     private let signingEntityCheckingMode: SigningEntityCheckingMode
 
-    init(
+    package init(
         signingEntityStorage: PackageSigningEntityStorage?,
         signingEntityCheckingMode: SigningEntityCheckingMode
     ) {

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
@@ -97,9 +97,9 @@ private func readpassword(_ prompt: String) throws -> String {
 #endif
 
 extension PackageRegistryCommand {
-    struct Login: AsyncSwiftCommand {
+    package struct Login: AsyncSwiftCommand {
 
-        static func loginURL(from registryURL: URL, loginAPIPath: String?) throws -> URL {
+        package static func loginURL(from registryURL: URL, loginAPIPath: String?) throws -> URL {
             // Login URL must be HTTPS
             var loginURLComponents = URLComponents(url: registryURL, resolvingAgainstBaseURL: true)
             loginURLComponents?.scheme = "https"
@@ -112,7 +112,7 @@ extension PackageRegistryCommand {
             return loginURL
         }
 
-        static let configuration = CommandConfiguration(
+        package static let configuration = CommandConfiguration(
             abstract: "Log in to a registry."
         )
 
@@ -123,7 +123,7 @@ extension PackageRegistryCommand {
         static let passwordBufferSize = Self.maxPasswordLength + 2
 
         @OptionGroup(visibility: .hidden)
-        var globalOptions: GlobalOptions
+        package var globalOptions: GlobalOptions
 
         @Argument(help: "The registry URL.")
         var url: URL?
@@ -152,7 +152,9 @@ extension PackageRegistryCommand {
 
         private static let PLACEHOLDER_TOKEN_USER = "token"
 
-        func run(_ swiftCommandState: SwiftCommandState) async throws {
+        package init() {}
+
+        package func run(_ swiftCommandState: SwiftCommandState) async throws {
             // We need to be able to read/write credentials
             // Make sure credentials store is available before proceeding
             let authorizationProvider: AuthorizationProvider?

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
@@ -34,15 +34,15 @@ import struct TSCBasic.SHA256
 import struct TSCUtility.Version
 
 extension PackageRegistryCommand {
-    struct Publish: AsyncSwiftCommand {
-        static let metadataFilename = "package-metadata.json"
+    package struct Publish: AsyncSwiftCommand {
+        package static let metadataFilename = "package-metadata.json"
 
-        static let configuration = CommandConfiguration(
+        package static let configuration = CommandConfiguration(
             abstract: "Publish to a registry."
         )
 
         @OptionGroup(visibility: .hidden)
-        var globalOptions: GlobalOptions
+        package var globalOptions: GlobalOptions
 
         @Argument(help: .init("The package identifier.", valueName: "package-id"))
         var packageIdentity: PackageIdentity
@@ -89,7 +89,9 @@ extension PackageRegistryCommand {
         @Flag(help: "Dry run only; prepare the archive and sign it but do not publish to the registry.")
         var dryRun: Bool = false
 
-        func run(_ swiftCommandState: SwiftCommandState) async throws {
+        package init() {}
+
+        package func run(_ swiftCommandState: SwiftCommandState) async throws {
             // Require both local and user-level registries config
             let configuration = try getRegistriesConfig(swiftCommandState, global: false).configuration
 
@@ -460,8 +462,8 @@ enum PackageArchiveSigner {
     }
 }
 
-enum PackageArchiver {
-    static func archive(
+package enum PackageArchiver {
+    package static func archive(
         packageIdentity: PackageIdentity,
         packageVersion: Version,
         packageDirectory: AbsolutePath,

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand.swift
@@ -166,7 +166,7 @@ public struct PackageRegistryCommand: AsyncParsableCommand {
 }
 
 extension URL {
-    func validateRegistryURL(allowHTTP: Bool = false) throws {
+    package func validateRegistryURL(allowHTTP: Bool = false) throws {
         guard self.scheme == "https" || (self.scheme == "http" && allowHTTP) else {
             throw PackageRegistryCommand.ValidationError.invalidURL(self)
         }

--- a/Sources/PackageSigning/SignatureProvider.swift
+++ b/Sources/PackageSigning/SignatureProvider.swift
@@ -87,7 +87,7 @@ public struct VerifierConfiguration {
     public var certificateRevocation: CertificateRevocation
 
     // for testing
-    init(
+    package init(
         trustedRoots: [[UInt8]],
         includeDefaultTrustStore: Bool,
         certificateExpiration: CertificateExpiration,
@@ -160,7 +160,7 @@ public enum SigningKeyType {
     // RSA support is internal/testing only, thus not included
 }
 
-enum SignatureAlgorithm {
+package enum SignatureAlgorithm {
     case ecdsaP256
     case rsa
 
@@ -198,11 +198,11 @@ protocol SignatureProviderProtocol {
 
 // MARK: - CMS signature provider
 
-struct CMSSignatureProvider: SignatureProviderProtocol {
+package struct CMSSignatureProvider: SignatureProviderProtocol {
     let signatureAlgorithm: SignatureAlgorithm
     let httpClient: HTTPClient
 
-    init(
+    package init(
         signatureAlgorithm: SignatureAlgorithm,
         customHTTPClient: HTTPClient? = .none
     ) {
@@ -210,7 +210,7 @@ struct CMSSignatureProvider: SignatureProviderProtocol {
         self.httpClient = customHTTPClient ?? HTTPClient()
     }
 
-    func sign(
+    package func sign(
         content: [UInt8],
         identity: SigningIdentity,
         intermediateCertificates: [[UInt8]],
@@ -264,7 +264,7 @@ struct CMSSignatureProvider: SignatureProviderProtocol {
         }
     }
 
-    func status(
+    package func status(
         signature: [UInt8],
         content: [UInt8],
         verifierConfiguration: VerifierConfiguration,

--- a/Sources/PackageSigning/SigningEntity/FilePackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/FilePackageSigningEntityStorage.swift
@@ -20,7 +20,7 @@ import struct TSCUtility.Version
 
 public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
     let fileSystem: FileSystem
-    let directoryPath: Basics.AbsolutePath
+    package let directoryPath: Basics.AbsolutePath
 
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
@@ -231,7 +231,7 @@ private enum StorageModel {
 }
 
 extension PackageIdentity {
-    var signedVersionsFilename: String {
+    package var signedVersionsFilename: String {
         "\(self.description).json"
     }
 }

--- a/Sources/PackageSigning/SigningEntity/SigningEntity.swift
+++ b/Sources/PackageSigning/SigningEntity/SigningEntity.swift
@@ -24,7 +24,7 @@ public enum SigningEntity: Hashable, Codable, CustomStringConvertible, Sendable 
     case recognized(type: SigningEntityType, name: String, organizationalUnit: String, organization: String)
     case unrecognized(name: String?, organizationalUnit: String?, organization: String?)
 
-    static func from(certificate: Certificate) -> SigningEntity {
+    package static func from(certificate: Certificate) -> SigningEntity {
         let name = certificate.subject.commonName
         let organizationalUnit = certificate.subject.organizationalUnitName
         let organization = certificate.subject.organizationName

--- a/Sources/PackageSigning/SigningIdentity.swift
+++ b/Sources/PackageSigning/SigningIdentity.swift
@@ -40,11 +40,11 @@ extension SecIdentity: SigningIdentity {}
 // MARK: - SwiftSigningIdentity is created using raw private key and certificate bytes
 
 public struct SwiftSigningIdentity: SigningIdentity {
-    let certificate: Certificate
+    package let certificate: Certificate
     let privateKey: Certificate.PrivateKey
 
     // for testing
-    init(certificate: Certificate, privateKey: Certificate.PrivateKey) {
+    package init(certificate: Certificate, privateKey: Certificate.PrivateKey) {
         self.certificate = certificate
         self.privateKey = privateKey
     }

--- a/Sources/PackageSigning/X509Extensions.swift
+++ b/Sources/PackageSigning/X509Extensions.swift
@@ -38,7 +38,7 @@ extension Certificate {
         self = try Certificate(Array(data))
     }
 
-    init(secIdentity: SecIdentity) throws {
+    package init(secIdentity: SecIdentity) throws {
         var secCertificate: SecCertificate?
         let status = SecIdentityCopyCertificate(secIdentity, &secCertificate)
         guard status == errSecSuccess, let secCertificate else {
@@ -56,15 +56,15 @@ extension Certificate {
 }
 
 extension DistinguishedName {
-    var commonName: String? {
+    package var commonName: String? {
         self.stringAttribute(oid: ASN1ObjectIdentifier.NameAttributes.commonName)
     }
 
-    var organizationalUnitName: String? {
+    package var organizationalUnitName: String? {
         self.stringAttribute(oid: ASN1ObjectIdentifier.NameAttributes.organizationalUnitName)
     }
 
-    var organizationName: String? {
+    package var organizationName: String? {
         self.stringAttribute(oid: ASN1ObjectIdentifier.NameAttributes.organizationName)
     }
 
@@ -83,7 +83,7 @@ extension DistinguishedName {
 extension Certificate {
     private static let cache = ThreadSafeKeyValueStore<[UInt8], Certificate>()
 
-    init(_ bytes: [UInt8]) throws {
+    package init(_ bytes: [UInt8]) throws {
         if let cached = Self.cache[bytes] {
             self = cached
         } else {

--- a/Sources/QueryEngine/Query.swift
+++ b/Sources/QueryEngine/Query.swift
@@ -26,28 +26,28 @@ extension CachingQuery {
 // SwiftPM has to be built with Swift 5.8 on CI and also needs to support CMake for bootstrapping on Windows.
 // This means we can't implement persistable hashing with macros (unavailable in Swift 5.8 and additional effort to
 // set up with CMake when Swift 5.9 is available for all CI jobs) and have to stick to `Encodable` for now.
-final class HashEncoder<Hash: HashFunction>: Encoder {
+package final class HashEncoder<Hash: HashFunction>: Encoder {
     enum Error: Swift.Error {
         case noCacheKeyConformance(Encodable.Type)
     }
 
-    var codingPath: [any CodingKey]
+    package var codingPath: [any CodingKey]
 
-    var userInfo: [CodingUserInfoKey: Any]
+    package var userInfo: [CodingUserInfoKey: Any]
 
-    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
+    package func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
         .init(KeyedContainer(encoder: self))
     }
 
-    func unkeyedContainer() -> any UnkeyedEncodingContainer {
+    package func unkeyedContainer() -> any UnkeyedEncodingContainer {
         self
     }
 
-    func singleValueContainer() -> any SingleValueEncodingContainer {
+    package func singleValueContainer() -> any SingleValueEncodingContainer {
         self
     }
 
-    init() {
+    package init() {
         self.hashFunction = Hash()
         self.codingPath = []
         self.userInfo = [:]
@@ -55,13 +55,13 @@ final class HashEncoder<Hash: HashFunction>: Encoder {
 
     fileprivate var hashFunction = Hash()
 
-    func finalize() -> Hash.Digest {
+    package func finalize() -> Hash.Digest {
         self.hashFunction.finalize()
     }
 }
 
 extension HashEncoder: SingleValueEncodingContainer {
-    func encodeNil() throws {
+    package func encodeNil() throws {
         // FIXME: this doesn't encode the name of the underlying optional type,
         // but `Encoder` protocol is limited and can't provide this for us.
         var str = "nil"
@@ -70,63 +70,63 @@ extension HashEncoder: SingleValueEncodingContainer {
         }
     }
 
-    func encode(_ value: Bool) throws {
+    package func encode(_ value: Bool) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: String) throws {
+    package func encode(_ value: String) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: Double) throws {
+    package func encode(_ value: Double) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: Float) throws {
+    package func encode(_ value: Float) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: Int) throws {
+    package func encode(_ value: Int) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: Int8) throws {
+    package func encode(_ value: Int8) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: Int16) throws {
+    package func encode(_ value: Int16) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: Int32) throws {
+    package func encode(_ value: Int32) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: Int64) throws {
+    package func encode(_ value: Int64) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: UInt) throws {
+    package func encode(_ value: UInt) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: UInt8) throws {
+    package func encode(_ value: UInt8) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: UInt16) throws {
+    package func encode(_ value: UInt16) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: UInt32) throws {
+    package func encode(_ value: UInt32) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode(_ value: UInt64) throws {
+    package func encode(_ value: UInt64) throws {
         value.hash(with: &self.hashFunction)
     }
 
-    func encode<T>(_ value: T) throws where T: Encodable {
+    package func encode<T>(_ value: T) throws where T: Encodable {
         if let leaf = value as? LeafCacheKey {
             leaf.hash(with: &self.hashFunction)
             return
@@ -142,20 +142,20 @@ extension HashEncoder: SingleValueEncodingContainer {
 }
 
 extension HashEncoder: UnkeyedEncodingContainer {
-    var count: Int {
+    package var count: Int {
         0
     }
 
-    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey>
+    package func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey>
     where NestedKey: CodingKey {
         KeyedEncodingContainer(KeyedContainer(encoder: self))
     }
 
-    func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
+    package func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
         self
     }
 
-    func superEncoder() -> any Encoder {
+    package func superEncoder() -> any Encoder {
         fatalError()
     }
 }

--- a/Sources/QueryEngine/QueryEngine.swift
+++ b/Sources/QueryEngine/QueryEngine.swift
@@ -36,8 +36,8 @@ package func withQueryEngine(
 /// Cacheable computations engine. Currently the engine makes an assumption that computations produce same results for
 /// the same query values and write results to a single file path.
 package actor QueryEngine {
-    private(set) var cacheHits = 0
-    private(set) var cacheMisses = 0
+    package private(set) var cacheHits = 0
+    package private(set) var cacheMisses = 0
 
     package let fileSystem: any AsyncFileSystem
     package let httpClient = HTTPClient()
@@ -51,7 +51,7 @@ package actor QueryEngine {
     /// - Parameter fileSystem: Implementation of a file system this engine should use.
     /// - Parameter cacheLocation: Location of cache storage used by the engine.
     /// - Parameter logger: Logger to use during queries execution.
-    init(
+    package init(
         _ fileSystem: any AsyncFileSystem,
         _ observabilityScope: ObservabilityScope,
         cacheLocation: SQLite.Location

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -109,7 +109,7 @@ extension BinaryModule {
 }
 
 extension Triple {
-    func withoutVersion() throws -> Triple {
+    package func withoutVersion() throws -> Triple {
         if isDarwin() {
             let stringWithoutVersion = tripleString(forPlatformVersion: "")
             return try Triple(stringWithoutVersion)

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -1164,6 +1164,10 @@ extension GitFileSystemView: @unchecked Sendable {}
 package struct GitShellError: Error, CustomStringConvertible {
     let result: AsyncProcessResult
 
+    package init(result: AsyncProcessResult) {
+        self.result = result
+    }
+
     public var description: String {
         let stdout = (try? self.result.utf8Output()) ?? ""
         let stderr = (try? self.result.utf8stderrOutput()) ?? ""

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -541,6 +541,11 @@ extension RepositoryManager {
         public let fromCache: Bool
         /// Indicates whether the repository was already present in the cache and updated or if a clean fetch was performed.
         public let updatedCache: Bool
+
+        package init(fromCache: Bool, updatedCache: Bool) {
+            self.fromCache = fromCache
+            self.updatedCache = updatedCache
+        }
     }
 }
 
@@ -609,7 +614,7 @@ extension RepositoryManager.RepositoryHandle: CustomStringConvertible {
 
 extension RepositorySpecifier {
     // relative path where the repository should be stored
-    internal func storagePath() throws -> Basics.RelativePath {
+    package func storagePath() throws -> Basics.RelativePath {
         return try RelativePath(validating: self.fileSystemIdentifier)
     }
 

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -252,7 +252,7 @@ public struct BuildDescription {
         return (BuildDescription(buildPlan: plan), bufferedOutput.bytes.description)
     }
 
-    func getBuildTarget(
+    package func getBuildTarget(
         for module: ResolvedModule,
         destination: BuildParameters.Destination
     ) -> BuildTarget? {

--- a/Sources/SwiftFixIt/SwiftFixIt.swift
+++ b/Sources/SwiftFixIt/SwiftFixIt.swift
@@ -43,7 +43,7 @@ private enum Error: Swift.Error {
 }
 
 // FIXME: An abstraction for tests to work around missing memberwise initializers in `TSCUtility.SerializedDiagnostics`.
-protocol AnySourceLocation {
+package protocol AnySourceLocation {
     var filename: String { get }
     var line: UInt64 { get }
     var column: UInt64 { get }
@@ -51,7 +51,7 @@ protocol AnySourceLocation {
 }
 
 // FIXME: An abstraction for tests to work around missing memberwise initializers in `TSCUtility.SerializedDiagnostics`.
-protocol AnyFixIt {
+package protocol AnyFixIt {
     associatedtype SourceLocation: AnySourceLocation
 
     var start: SourceLocation { get }
@@ -60,7 +60,7 @@ protocol AnyFixIt {
 }
 
 // FIXME: An abstraction for tests to work around missing memberwise initializers in `TSCUtility.SerializedDiagnostics`.
-protocol AnyDiagnostic {
+package protocol AnyDiagnostic {
     associatedtype SourceLocation: AnySourceLocation
     associatedtype FixIt: AnyFixIt where FixIt.SourceLocation == SourceLocation
 
@@ -230,7 +230,7 @@ package struct SwiftFixIt /*: ~Copyable */ { // TODO: Crashes with ~Copyable
         )
     }
 
-    init<Diagnostic: AnyDiagnostic>(
+    package init<Diagnostic: AnyDiagnostic>(
         diagnostics: some Collection<Diagnostic>,
         categories: Set<String>,
         excludedSourceDirectories: Set<AbsolutePath>,

--- a/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
@@ -122,7 +122,7 @@ public class RegistryPackageContainer: PackageContainer {
     }
 
     // marked internal for testing
-    internal func loadManifest(version: Version) async throws -> Manifest {
+    package func loadManifest(version: Version) async throws -> Manifest {
         let result = try await self.getAvailableManifestsFilesystem(version: version)
 
         let manifests = result.manifests

--- a/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
@@ -26,7 +26,7 @@ import enum TSCUtility.Git
 import struct TSCUtility.Version
 
 /// Adaptor to expose an individual repository as a package container.
-internal final class SourceControlPackageContainer: PackageContainer, CustomStringConvertible {
+package final class SourceControlPackageContainer: PackageContainer, CustomStringConvertible {
     public typealias Constraint = PackageContainerConstraint
 
     // A wrapper for getDependencies() errors. This adds additional information
@@ -75,7 +75,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
 
     /// This is used to remember if tools version of a particular version is
     /// valid or not.
-    internal var validToolsVersionsCache = ThreadSafeKeyValueStore<Version, Bool>()
+    package var validToolsVersionsCache = ThreadSafeKeyValueStore<Version, Bool>()
 
     init(
         package: PackageReference,

--- a/Sources/Workspace/ToolsVersionSpecificationRewriter.swift
+++ b/Sources/Workspace/ToolsVersionSpecificationRewriter.swift
@@ -83,7 +83,7 @@ public struct ToolsVersionSpecificationWriter {
     }
 
     /// An error that causes the access to a manifest to fails.
-    struct ManifestAccessError: Error, CustomStringConvertible {
+    package struct ManifestAccessError: Error, CustomStringConvertible {
         public init(_ kind: Kind, at path: AbsolutePath) {
             self.kind = kind
             self.path = path

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -36,7 +36,7 @@ public actor WorkspaceState {
     /// storage
     private let storage: WorkspaceStateStorage
 
-    init(
+    package init(
         fileSystem: FileSystem,
         storageDirectory: Basics.AbsolutePath,
         initializationWarningHandler: (String) -> Void

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -24,7 +24,7 @@ import func TSCBasic.memoize
 import func TSCBasic.topologicalSort
 
 /// The parameters required by `PIFBuilder`.
-struct PIFBuilderParameters {
+package struct PIFBuilderParameters {
     let triple: Basics.Triple
 
     /// Whether the toolchain supports `-package-name` option.
@@ -47,6 +47,26 @@ struct PIFBuilderParameters {
 
     /// The Swift language versions supported by the XCBuild being used for the buid.
     let supportedSwiftVersions: [SwiftLanguageVersion]
+
+    package init(
+        triple: Basics.Triple,
+        isPackageAccessModifierSupported: Bool,
+        enableTestability: Bool,
+        shouldCreateDylibForDynamicProducts: Bool,
+        toolchainLibDir: AbsolutePath,
+        pkgConfigDirectories: [AbsolutePath],
+        sdkRootPath: AbsolutePath?,
+        supportedSwiftVersions: [SwiftLanguageVersion]
+    ) {
+        self.triple = triple
+        self.isPackageAccessModifierSupported = isPackageAccessModifierSupported
+        self.enableTestability = enableTestability
+        self.shouldCreateDylibForDynamicProducts = shouldCreateDylibForDynamicProducts
+        self.toolchainLibDir = toolchainLibDir
+        self.pkgConfigDirectories = pkgConfigDirectories
+        self.sdkRootPath = sdkRootPath
+        self.supportedSwiftVersions = supportedSwiftVersions
+    }
 }
 
 /// PIF object builder for a package graph.
@@ -77,7 +97,7 @@ public final class PIFBuilder {
     ///   - parameters: The parameters used to configure the PIF.
     ///   - fileSystem: The file system to read from.
     ///   - observabilityScope: The ObservabilityScope to emit diagnostics to.
-    init(
+    package init(
         graph: ModulesGraph,
         parameters: PIFBuilderParameters,
         fileSystem: FileSystem,

--- a/Tests/BasicsTests/Archiver/TarArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/TarArchiverTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import struct Basics.TarArchiver
+import struct Basics.TarArchiver
 import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported
 import _InternalTestSupport
 import XCTest

--- a/Tests/BasicsTests/Archiver/UniversalArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/UniversalArchiverTests.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import struct Basics.TarArchiver
-@testable import struct Basics.ZipArchiver
+import struct Basics.TarArchiver
+import struct Basics.ZipArchiver
 import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported
 import _InternalTestSupport
 import XCTest

--- a/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import struct Basics.ZipArchiver
+import struct Basics.ZipArchiver
 import _InternalTestSupport
 import XCTest
 import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/BasicsTests/CancellatorTests.swift
+++ b/Tests/BasicsTests/CancellatorTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/BasicsTests/ConcurrencyHelpersTests.swift
+++ b/Tests/BasicsTests/ConcurrencyHelpersTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-@testable import Basics
+import Basics
 import TSCTestSupport
 import Testing
 

--- a/Tests/BasicsTests/DictionaryTest.swift
+++ b/Tests/BasicsTests/DictionaryTest.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import Testing
 
 struct DictionaryTests {

--- a/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-@testable import Basics
+import Basics
 import Testing
 
 struct EnvironmentKeyTests {

--- a/Tests/BasicsTests/Environment/EnvironmentTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentTests.swift
@@ -12,7 +12,6 @@
 import Foundation
 
 @_spi(SwiftPMInternal)
-@testable
 import Basics
 
 import Testing

--- a/Tests/BasicsTests/FileSystem/FileSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/FileSystemTests.swift
@@ -13,7 +13,7 @@ import Foundation
 import TSCTestSupport
 import Testing
 
-@testable import Basics
+import Basics
 
 struct FileSystemTests {
     @Test

--- a/Tests/BasicsTests/Graph/AdjacencyMatrixTests.swift
+++ b/Tests/BasicsTests/Graph/AdjacencyMatrixTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import Testing
 
 struct AdjacencyMatrixTests {

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-@testable import Basics
+import Basics
 import _Concurrency
 import _InternalTestSupport
 import Testing

--- a/Tests/BasicsTests/LegacyHTTPClientTests.swift
+++ b/Tests/BasicsTests/LegacyHTTPClientTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import Testing
 

--- a/Tests/BasicsTests/ProgressAnimationTests.swift
+++ b/Tests/BasicsTests/ProgressAnimationTests.swift
@@ -14,7 +14,6 @@ import _Concurrency
 import Testing
 
 @_spi(SwiftPMInternal)
-@testable
 import Basics
 import TSCBasic
 

--- a/Tests/BasicsTests/SQLiteBackedCacheTests.swift
+++ b/Tests/BasicsTests/SQLiteBackedCacheTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import tsan_utils
 import Testing

--- a/Tests/BasicsTests/SandboxTests.swift
+++ b/Tests/BasicsTests/SandboxTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/BasicsTests/Serialization/SerializedJSONTests.swift
+++ b/Tests/BasicsTests/Serialization/SerializedJSONTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import XCTest
 import _InternalTestSupport // for XCTSkipOnWindows
 

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import Foundation
 #if canImport(FoundationNetworking)
 // TODO: this brings OpenSSL dependency` on Linux

--- a/Tests/BuildTests/BuildOperationTests.swift
+++ b/Tests/BuildTests/BuildOperationTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Build
+import Build
 @testable import PackageModel
 
 import Basics

--- a/Tests/BuildTests/BuildOperationTests.swift
+++ b/Tests/BuildTests/BuildOperationTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Build
-@testable import PackageModel
+import PackageModel
 
 import Basics
 import LLBuildManifest

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -13,7 +13,6 @@
 import Basics
 import Build
 
-@testable
 @_spi(SwiftPMInternal)
 import DriverSupport
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import Build
+import Build
 
 @testable
 @_spi(SwiftPMInternal)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 @testable import Build
 
 @testable

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -23,7 +23,7 @@ import PackageGraph
 import PackageLoading
 
 @_spi(SwiftPMInternal)
-@testable import PackageModel
+import PackageModel
 
 import SPMBuildCore
 import _InternalBuildTestSupport

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -18,7 +18,7 @@ import Basics
 import DriverSupport
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
-@testable import PackageGraph
+import PackageGraph
 
 import PackageLoading
 

--- a/Tests/BuildTests/BuildPlanTraversalTests.swift
+++ b/Tests/BuildTests/BuildPlanTraversalTests.swift
@@ -14,7 +14,7 @@ import Foundation
 import Testing
 
 import Basics
-@testable import Build
+import Build
 
 import PackageGraph
 

--- a/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import Build
+import Build
 import PackageGraph
 import PackageModel
 import SPMBuildCore

--- a/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
+++ b/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
@@ -15,7 +15,7 @@ import class Basics.InMemoryFileSystem
 import class Basics.ObservabilitySystem
 import class Build.BuildPlan
 import class Build.ProductBuildDescription
-@testable import enum Build.ModuleBuildDescription
+import enum Build.ModuleBuildDescription
 import class Build.SwiftModuleBuildDescription
 import struct Basics.Triple
 import class PackageModel.Manifest

--- a/Tests/BuildTests/LLBuildManifestBuilderTests.swift
+++ b/Tests/BuildTests/LLBuildManifestBuilderTests.swift
@@ -12,7 +12,7 @@
 import Foundation
 
 import Basics
-@testable import Build
+import Build
 import LLBuildManifest
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import Build
+import Build
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 import PackageGraph

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -17,7 +17,7 @@ import Build
 import PackageGraph
 
 import PackageLoading
-@testable import PackageModel
+import PackageModel
 import SPMBuildCore
 import _InternalBuildTestSupport
 import _InternalTestSupport

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -14,7 +14,7 @@ import Basics
 @testable import Build
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
-@testable import PackageGraph
+import PackageGraph
 
 import PackageLoading
 @testable import PackageModel

--- a/Tests/BuildTests/PluginInvocationTests.swift
+++ b/Tests/BuildTests/PluginInvocationTests.swift
@@ -21,7 +21,7 @@ import PackageLoading
 @_spi(SwiftPMInternal)
 import PackageModel
 
-@testable import SPMBuildCore
+import SPMBuildCore
 import _InternalBuildTestSupport
 import _InternalTestSupport
 import Workspace

--- a/Tests/BuildTests/PluginInvocationTests.swift
+++ b/Tests/BuildTests/PluginInvocationTests.swift
@@ -14,7 +14,7 @@
 import Basics
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
-@testable import PackageGraph
+import PackageGraph
 
 import PackageLoading
 

--- a/Tests/BuildTests/PluginInvocationTests.swift
+++ b/Tests/BuildTests/PluginInvocationTests.swift
@@ -27,7 +27,7 @@ import _InternalTestSupport
 import Workspace
 import XCTest
 
-@testable import class Build.BuildPlan
+import class Build.BuildPlan
 import struct Build.PluginConfiguration
 
 import struct TSCUtility.SerializedDiagnostics

--- a/Tests/BuildTests/PluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/PluginsBuildPlanTests.swift
@@ -12,7 +12,7 @@
 
 import Basics
 import _InternalTestSupport
-@testable import SPMBuildCore
+import SPMBuildCore
 import XCTest
 import PackageModel
 

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -13,7 +13,7 @@
 import Build
 import Foundation
 @testable import Commands
-@testable import CoreCommands
+import CoreCommands
 import LLBuildManifest
 import _InternalTestSupport
 import TSCBasic

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -12,7 +12,7 @@
 
 import Build
 import Foundation
-@testable import Commands
+import Commands
 import CoreCommands
 import LLBuildManifest
 import _InternalTestSupport

--- a/Tests/BuildTests/ProductBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ProductBuildDescriptionTests.swift
@@ -19,7 +19,6 @@ import class Basics.ObservabilitySystem
 import class PackageModel.Manifest
 import struct PackageModel.TargetDescription
 
-@testable
 import struct PackageGraph.ResolvedProduct
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)

--- a/Tests/BuildTests/ProductBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ProductBuildDescriptionTests.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable
 import Build
 
 import class Basics.InMemoryFileSystem

--- a/Tests/BuildTests/WindowsBuildPlanTests.swift
+++ b/Tests/BuildTests/WindowsBuildPlanTests.swift
@@ -14,7 +14,7 @@ import Foundation
 import Testing
 
 import Basics
-@testable import Build
+import Build
 import LLBuildManifest
 import _InternalTestSupport
 

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 import Basics
-@testable import Commands
+import Commands
 import CoreCommands
 import PackageGraph
 import PackageLoading

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -13,7 +13,7 @@
 import Foundation
 import Basics
 @testable import Commands
-@testable import CoreCommands
+import CoreCommands
 import PackageGraph
 import PackageLoading
 import PackageModel

--- a/Tests/CommandsTests/MermaidPackageSerializerTests.swift
+++ b/Tests/CommandsTests/MermaidPackageSerializerTests.swift
@@ -22,7 +22,6 @@ import struct PackageModel.ProductDescription
 import struct PackageModel.TargetDescription
 import func _InternalTestSupport.XCTAssertNoDiagnostics
 
-@testable
 import Commands
 
 import Testing

--- a/Tests/CommandsTests/PackageRegistryCommandTests.swift
+++ b/Tests/CommandsTests/PackageRegistryCommandTests.swift
@@ -16,8 +16,7 @@ import Foundation
 import PackageLoading
 import PackageModel
 import PackageRegistry
-@testable import PackageRegistryCommand
-import struct SPMBuildCore.BuildSystemProvider
+import PackageRegistryCommand
 import PackageSigning
 import _InternalTestSupport
 import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 @testable import Build
 @testable import Commands
 @testable import CoreCommands

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -13,7 +13,7 @@
 import Basics
 import Build
 @testable import Commands
-@testable import CoreCommands
+import CoreCommands
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 import func PackageGraph.loadModulesGraph

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -19,7 +19,7 @@ import Build
 import func PackageGraph.loadModulesGraph
 
 import _InternalTestSupport
-@testable import PackageModel
+import PackageModel
 import XCTest
 
 import ArgumentParser

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import Build
+import Build
 @testable import Commands
 @testable import CoreCommands
 

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -12,7 +12,7 @@
 
 import Basics
 import Build
-@testable import Commands
+import Commands
 import CoreCommands
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -14,7 +14,7 @@ import Basics
 import _Concurrency
 
 @_spi(SwiftPMInternal)
-@testable import PackageGraph
+import PackageGraph
 import PackageLoading
 import PackageModel
 @testable import SPMBuildCore

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -17,7 +17,7 @@ import _Concurrency
 import PackageGraph
 import PackageLoading
 import PackageModel
-@testable import SPMBuildCore
+import SPMBuildCore
 import _InternalTestSupport
 import Workspace
 import Testing

--- a/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
+++ b/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
@@ -13,7 +13,7 @@
 import struct Basics.AbsolutePath
 import class Basics.InMemoryFileSystem
 import class Foundation.PropertyListDecoder
-@testable import LLBuildManifest
+import LLBuildManifest
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/PackageCollectionsModelTests/PackageCollectionModelTests.swift
+++ b/Tests/PackageCollectionsModelTests/PackageCollectionModelTests.swift
@@ -14,7 +14,7 @@ import Foundation
 import _InternalTestSupport
 import XCTest
 
-@testable import PackageCollectionsModel
+import PackageCollectionsModel
 
 class PackageCollectionModelTests: XCTestCase {
     typealias Model = PackageCollectionModel.V1

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -12,7 +12,7 @@
 
 import Basics
 import _Concurrency
-@testable import PackageCollectionsSigning
+import PackageCollectionsSigning
 import _InternalTestSupport
 import SwiftASN1
 import X509

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTests.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTests.swift
@@ -14,7 +14,7 @@ import Basics
 import _Concurrency
 import Foundation
 import PackageCollectionsModel
-@testable import PackageCollectionsSigning
+import PackageCollectionsSigning
 import _InternalTestSupport
 import X509
 import XCTest

--- a/Tests/PackageCollectionsSigningTests/SignatureTests.swift
+++ b/Tests/PackageCollectionsSigningTests/SignatureTests.swift
@@ -15,7 +15,7 @@ import Basics
 import _Concurrency
 import Crypto
 import Foundation
-@testable import PackageCollectionsSigning
+import PackageCollectionsSigning
 import _InternalTestSupport
 import X509
 import XCTest

--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -13,7 +13,7 @@
 import Basics
 import Dispatch
 import Foundation
-@testable import PackageCollectionsSigning
+import PackageCollectionsSigning
 import X509
 
 // Set `REAL_CERT_USER_ID` and `REAL_CERT_ORG_UNIT` env vars when running ENABLE_REAL_CERT_TEST tests

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -14,7 +14,7 @@ import Foundation
 import XCTest
 
 import Basics
-@testable import PackageCollections
+import PackageCollections
 import PackageModel
 import SourceControl
 import _InternalTestSupport

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -14,7 +14,7 @@ import Foundation
 import XCTest
 
 import Basics
-@testable import PackageCollections
+import PackageCollections
 import PackageCollectionsSigning
 import PackageModel
 import SourceControl

--- a/Tests/PackageCollectionsTests/PackageCollectionSourceCertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionSourceCertificatePolicyTests.swift
@@ -13,7 +13,7 @@
 import _InternalTestSupport
 import XCTest
 
-@testable import PackageCollections
+import PackageCollections
 import PackageCollectionsSigning
 
 final class PackageCollectionSourceCertificatePolicyTests: XCTestCase {

--- a/Tests/PackageCollectionsTests/PackageCollectionValidationTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionValidationTests.swift
@@ -14,7 +14,7 @@ import Foundation
 import XCTest
 
 import PackageCollections
-@testable import PackageCollectionsModel
+import PackageCollectionsModel
 import PackageModel
 
 class PackageCollectionValidationTests: XCTestCase {

--- a/Tests/PackageCollectionsTests/PackageCollectionValidationTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionValidationTests.swift
@@ -13,7 +13,7 @@
 import Foundation
 import XCTest
 
-@testable import PackageCollections
+import PackageCollections
 @testable import PackageCollectionsModel
 import PackageModel
 

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -12,7 +12,7 @@
 
 import Basics
 @testable import PackageCollections
-@testable import PackageModel
+import PackageModel
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import PackageCollections
+import PackageCollections
 import PackageModel
 import _InternalTestSupport
 import XCTest

--- a/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import PackageCollections
+import PackageCollections
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import PackageCollections
+import PackageCollections
 import _InternalTestSupport
 import tsan_utils
 import XCTest

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -15,7 +15,7 @@ import XCTest
 import _InternalTestSupport
 
 import Basics
-@testable import PackageCollections
+import PackageCollections
 import PackageModel
 import SourceControl
 

--- a/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
@@ -12,7 +12,7 @@
 
 import Basics
 import Foundation
-@testable import PackageCollections
+import PackageCollections
 import PackageModel
 import _InternalTestSupport
 import XCTest

--- a/Tests/PackageCollectionsTests/PackageIndexTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexTests.swift
@@ -12,7 +12,7 @@
 
 import Basics
 import Foundation
-@testable import PackageCollections
+import PackageCollections
 import PackageModel
 import _InternalTestSupport
 import XCTest

--- a/Tests/PackageCollectionsTests/TrieTests.swift
+++ b/Tests/PackageCollectionsTests/TrieTests.swift
@@ -12,7 +12,7 @@
 
 import Testing
 
-@testable import PackageCollections
+import PackageCollections
 
 @Suite struct TrieTests {
     @Test func testContains() {

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -14,7 +14,7 @@ import Basics
 import struct Foundation.Date
 import struct Foundation.URL
 import struct Foundation.UUID
-@testable import PackageCollections
+import PackageCollections
 import PackageCollectionsModel
 import PackageCollectionsSigning
 import PackageModel

--- a/Tests/PackageCollectionsTests/ValidationMessageTests.swift
+++ b/Tests/PackageCollectionsTests/ValidationMessageTests.swift
@@ -12,7 +12,7 @@
 
 import XCTest
 
-@testable import PackageCollections
+import PackageCollections
 
 class ValidationMessageTests: XCTestCase {
     func testMessageToError() {

--- a/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
+++ b/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
@@ -13,7 +13,7 @@
 import Basics
 import _Concurrency
 import struct Foundation.URL
-@testable import PackageFingerprint
+import PackageFingerprint
 import PackageModel
 import _InternalTestSupport
 import XCTest

--- a/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
+++ b/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable
 @_spi(SwiftPMInternal)
 import _InternalTestSupport
 

--- a/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
+++ b/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
@@ -14,7 +14,6 @@
 @_spi(SwiftPMInternal)
 import _InternalTestSupport
 
-@testable
 import PackageGraph
 
 import PackageModel

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -16,7 +16,7 @@ import PackageLoading
 import TSCUtility
 
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
-@testable import PackageGraph
+import PackageGraph
 
 import _InternalTestSupport
 import PackageModel

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -15,7 +15,7 @@ import _Concurrency
 import OrderedCollections
 import PackageGraph
 import PackageLoading
-@testable import PackageModel
+import PackageModel
 import SourceControl
 import _InternalTestSupport
 import XCTest

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -13,7 +13,7 @@
 import Basics
 import _Concurrency
 import OrderedCollections
-@testable import PackageGraph
+import PackageGraph
 import PackageLoading
 @testable import PackageModel
 import SourceControl

--- a/Tests/PackageGraphTests/ResolvedTargetTests.swift
+++ b/Tests/PackageGraphTests/ResolvedTargetTests.swift
@@ -13,7 +13,7 @@
 import XCTest
 
 import PackageGraph
-@testable import PackageModel
+import PackageModel
 import _InternalTestSupport
 
 private func XCTAssertEqualTargetIDs(

--- a/Tests/PackageGraphTests/TopologicalSortTests.swift
+++ b/Tests/PackageGraphTests/TopologicalSortTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 
-@testable import PackageGraph
+import PackageGraph
 import XCTest
 
 private func XCTAssertThrows<T: Swift.Error>(

--- a/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import PackageLoading
+import PackageLoading
 import PackageModel
 import _InternalTestSupport
 import XCTest

--- a/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 @testable import PackageLoading
 import PackageModel
 import _InternalTestSupport

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import PackageLoading
+import PackageLoading
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import PackageLoading
+import PackageLoading
 import PackageModel
 import _InternalTestSupport
 import XCTest

--- a/Tests/PackageModelTests/CanonicalPackageLocationTests.swift
+++ b/Tests/PackageModelTests/CanonicalPackageLocationTests.swift
@@ -12,7 +12,7 @@
 
 import XCTest
 
-@testable import PackageModel
+import PackageModel
 
 final class CanonicalPackageLocationTests: XCTestCase {
     func testCaseInsensitivity() {

--- a/Tests/PackageModelTests/InstalledSwiftPMConfigurationTests.swift
+++ b/Tests/PackageModelTests/InstalledSwiftPMConfigurationTests.swift
@@ -12,7 +12,7 @@
 
 import XCTest
 
-@testable import PackageModel
+import PackageModel
 
 final class InstalledSwiftPMConfigurationTests: XCTestCase {
     func testVersionDescription() {

--- a/Tests/PackageModelTests/MinimumDeploymentTargetTests.swift
+++ b/Tests/PackageModelTests/MinimumDeploymentTargetTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import PackageModel
+import PackageModel
 import XCTest
 
 import struct Basics.AsyncProcessResult

--- a/Tests/PackageModelTests/PackageIdentityParser.swift
+++ b/Tests/PackageModelTests/PackageIdentityParser.swift
@@ -12,7 +12,7 @@
 
 import XCTest
 
-@testable import PackageModel
+import PackageModel
 
 final class PackageIdentityParserTests: XCTestCase {
     func testPackageIdentityDescriptions() {

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -13,7 +13,7 @@
 import Basics
 
 @_spi(SwiftPMInternal)
-@testable import PackageModel
+import PackageModel
 
 import func TSCBasic.withTemporaryFile
 import XCTest

--- a/Tests/PackageModelTests/SnippetTests.swift
+++ b/Tests/PackageModelTests/SnippetTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import PackageModel
+import PackageModel
 import XCTest
 
 class SnippetTests: XCTestCase {

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -12,7 +12,7 @@
 
 import Basics
 @_spi(SwiftPMInternal)
-@testable import PackageModel
+import PackageModel
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -13,7 +13,7 @@
 import Basics
 
 @_spi(SwiftPMInternal)
-@testable import PackageModel
+import PackageModel
 
 @testable import SPMBuildCore
 import XCTest

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 
 @_spi(SwiftPMInternal)
 @testable import PackageModel

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -15,7 +15,7 @@ import Basics
 @_spi(SwiftPMInternal)
 import PackageModel
 
-@testable import SPMBuildCore
+import SPMBuildCore
 import XCTest
 
 private let bundleRootPath = try! AbsolutePath(validating: "/tmp/cross-toolchain")

--- a/Tests/PackageModelTests/ToolsetTests.swift
+++ b/Tests/PackageModelTests/ToolsetTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 @testable import PackageModel
 import _InternalTestSupport
 import XCTest

--- a/Tests/PackageModelTests/ToolsetTests.swift
+++ b/Tests/PackageModelTests/ToolsetTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-@testable import PackageModel
+import PackageModel
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
@@ -15,7 +15,7 @@ import Foundation
 import Basics
 import PackageModel
 @testable import PackageRegistry
-@testable import PackageSigning
+import PackageSigning
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
@@ -14,7 +14,7 @@ import Foundation
 
 import Basics
 import PackageModel
-@testable import PackageRegistry
+import PackageRegistry
 import PackageSigning
 import _InternalTestSupport
 import XCTest

--- a/Tests/PackageRegistryTests/PackageVersionChecksumTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageVersionChecksumTOFUTests.swift
@@ -15,7 +15,7 @@ import _Concurrency
 import Foundation
 import PackageFingerprint
 import PackageModel
-@testable import PackageRegistry
+import PackageRegistry
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -16,7 +16,7 @@ import Foundation
 import PackageFingerprint
 import PackageLoading
 import PackageModel
-@testable import PackageRegistry
+import PackageRegistry
 import PackageSigning
 import _InternalTestSupport
 import Testing

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -14,7 +14,7 @@ import Basics
 import _Concurrency
 import PackageModel
 import PackageLoading
-@testable import PackageRegistry
+import PackageRegistry
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/PackageRegistryTests/SignatureValidationTests.swift
+++ b/Tests/PackageRegistryTests/SignatureValidationTests.swift
@@ -13,7 +13,7 @@
 import Basics
 import Foundation
 import PackageModel
-@testable import PackageRegistry
+import PackageRegistry
 import PackageSigning
 import _InternalTestSupport
 import X509 // FIXME: need this import or else SwiftSigningIdentity init crashes

--- a/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
+++ b/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
@@ -14,7 +14,7 @@ import Foundation
 
 import Basics
 import PackageModel
-@testable import PackageSigning
+import PackageSigning
 import _InternalTestSupport
 import Testing
 

--- a/Tests/PackageSigningTests/SigningEntityTests.swift
+++ b/Tests/PackageSigningTests/SigningEntityTests.swift
@@ -14,7 +14,7 @@ import Testing
 import XCTest
 
 import Basics
-@testable import PackageSigning
+import PackageSigning
 import _InternalTestSupport
 import X509
 

--- a/Tests/PackageSigningTests/SigningIdentityTests.swift
+++ b/Tests/PackageSigningTests/SigningIdentityTests.swift
@@ -17,7 +17,7 @@ import XCTest
 import _CryptoExtras // For RSA
 import Basics
 import Crypto
-@testable import PackageSigning
+import PackageSigning
 import _InternalTestSupport
 import X509
 

--- a/Tests/PackageSigningTests/SigningTests.swift
+++ b/Tests/PackageSigningTests/SigningTests.swift
@@ -14,7 +14,7 @@ import _CryptoExtras // for RSA
 import Basics
 import Crypto
 import Foundation
-@testable import PackageSigning
+import PackageSigning
 import _InternalTestSupport
 import SwiftASN1
 @testable import X509 // need internal APIs for OCSP testing

--- a/Tests/QueryEngineTests/QueryEngineTests.swift
+++ b/Tests/QueryEngineTests/QueryEngineTests.swift
@@ -15,7 +15,7 @@ import _AsyncFileSystem
 import Basics
 import Crypto
 import struct Foundation.Data
-@testable import QueryEngine
+import QueryEngine
 import struct SystemPackage.FilePath
 import _InternalTestSupport
 import Testing

--- a/Tests/SPMBuildCoreTests/BuildParametersTests.swift
+++ b/Tests/SPMBuildCoreTests/BuildParametersTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import SPMBuildCore
+import SPMBuildCore
 import Basics
 import struct PackageModel.BuildEnvironment
 import _InternalTestSupport

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -13,7 +13,7 @@ import Foundation
 
 import Basics
 import _InternalTestSupport
-@testable import SourceControl
+import SourceControl
 import Testing
 
 struct GitRepositoryProviderTests {

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -12,7 +12,7 @@
 
 @_spi(ProcessEnvironmentBlockShim)
 import Basics
-@testable import SourceControl
+import SourceControl
 import _InternalTestSupport
 import XCTest
 

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -14,7 +14,7 @@ import Basics
 import _Concurrency
 import PackageModel
 import _InternalTestSupport
-@testable import SourceControl
+import SourceControl
 import XCTest
 
 final class RepositoryManagerTests: XCTestCase {

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Basics
+import Basics
 import _Concurrency
 import PackageModel
 import _InternalTestSupport

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -17,7 +17,7 @@ import Build
 import PackageGraph
 
 import PackageModel
-@testable import SourceKitLSPAPI
+import SourceKitLSPAPI
 import SPMBuildCore
 import _InternalTestSupport
 import XCTest

--- a/Tests/SwiftFixItTests/Utilities.swift
+++ b/Tests/SwiftFixItTests/Utilities.swift
@@ -14,7 +14,6 @@ import _InternalTestSupport
 import struct Basics.AbsolutePath
 import var Basics.localFileSystem
 import struct Foundation.UUID
-@testable
 import SwiftFixIt
 import class SwiftSyntax.SourceLocationConverter
 import Testing

--- a/Tests/WorkspaceTests/AuthorizationProviderTests.swift
+++ b/Tests/WorkspaceTests/AuthorizationProviderTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 
-@testable import Basics
+import Basics
 import _InternalTestSupport
 import Workspace
 import Testing

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -18,7 +18,7 @@ import PackageLoading
 import PackageModel
 import PackageRegistry
 import _InternalTestSupport
-@testable import Workspace
+import Workspace
 import XCTest
 
 import struct TSCUtility.Version

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -18,7 +18,7 @@ import PackageLoading
 import PackageModel
 import SourceControl
 import _InternalTestSupport
-@testable import Workspace
+import Workspace
 import XCTest
 
 import enum TSCUtility.Git

--- a/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
@@ -16,7 +16,7 @@
 
 import Basics
 import PackageModel
-@testable import Workspace
+import Workspace
 import Testing
 
 /// Test cases for `rewriteToolsVersionSpecification(toDefaultManifestIn:specifying:fileSystem:)`

--- a/Tests/WorkspaceTests/WorkspaceStateTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceStateTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 import Basics
-@testable import Workspace
+import Workspace
 import Testing
 
 fileprivate struct WorkspaceStateTests {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -13,7 +13,7 @@
 import _InternalTestSupport
 import Basics
 import PackageFingerprint
-@testable import PackageGraph
+import PackageGraph
 import PackageLoading
 import PackageModel
 import PackageRegistry

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -20,7 +20,7 @@ import PackageRegistry
 import PackageSigning
 import SourceControl
 import SPMBuildCore
-@testable import Workspace
+import Workspace
 import XCTest
 
 import struct TSCBasic.ByteString

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -21,7 +21,7 @@ import PackageModel
 import SPMBuildCore
 import _InternalTestSupport
 import _InternalBuildTestSupport
-@testable import XCBuildSupport
+import XCBuildSupport
 import XCTest
 
 final class PIFBuilderTests: XCTestCase {

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -17,7 +17,7 @@ import Foundation
 import PackageGraph
 
 import PackageLoading
-@testable import PackageModel
+import PackageModel
 import SPMBuildCore
 import _InternalTestSupport
 import _InternalBuildTestSupport


### PR DESCRIPTION
This series cleans up the vast majority of the `@testable` importing in the tests. The one that remains is for X509 which is external to this package. I intend to introduce a SPI for that API surface to help remove the last of the `@testable` importing.