### PR TITLE
CI: Minor improvement to build-using-self

### DIFF
--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -20,6 +20,8 @@ import pathlib
 import platform
 import shlex
 import sys
+from datetime import datetime
+
 import typing as t
 
 from helpers import (
@@ -81,14 +83,6 @@ def get_arguments() -> argparse.Namespace:
         "--build-system",
         type=str,
         dest="build_system",
-    )
-    parser.add_argument(
-        "--enable-swift-testing",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--enable-xctest",
-        action="store_true",
     )
     parser.add_argument(
         "--additional-build-args",
@@ -206,6 +200,7 @@ def main() -> None:
         )
     )
     logging.debug("Global Args: %r", global_args)
+    start_time = datetime.now()
     with change_directory(REPO_ROOT_PATH):
         swiftpm_bin_dir = get_swiftpm_bin_dir(config=args.config)
         set_environment(swiftpm_bin_dir=swiftpm_bin_dir)
@@ -246,14 +241,13 @@ def main() -> None:
                 [
                     "swift",
                     "run",
+                    *ignore_args,
                     *args.additional_run_args.split(" "),
                     "swift-test",
                     *global_args,
                     "--configuration",
                     args.config,
                     "--parallel",
-                    "--enable-swift-testing" if args.enable_swift_testing else None,
-                    "--enable-xctest" if args.enable_swift_testing else None,
                     "--scratch-path",
                     ".test",
                     *ignore_args,
@@ -293,7 +287,11 @@ def main() -> None:
 
     if is_on_darwin() and not args.skip_bootstrap:
         run_bootstrap(swiftpm_bin_dir=swiftpm_bin_dir)
-    logging.info("Done")
+
+    end_time = datetime.now()
+    elapsed_time = end_time - start_time
+
+    logging.info("Done (%s)", str(elapsed_time))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update `build-using-self` to include the ignore argument in the process which executes the test and also include an execution duration in the emitted "Done" log.
