### PR TITLE
Delete wrong doc comment for Package.name

### DIFF
--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -72,9 +72,6 @@
 /// package's manifest or losing access to existing packages.
 public final class Package {
     /// The name of the Swift package.
-    ///
-    /// If the name of the package is `nil`, Swift Package Manager deduces the name of the
-    /// package using its Git URL.
     public var name: String
 
     /// The list of minimum versions for platforms supported by the package.


### PR DESCRIPTION
Deletes a sentence from the doc comments for `Package.name` that wrongly talks about the possibility of `name` being `nil`.

### Motivation:

`Package.name` is a non-Optional property so it can never be `nil`, so [the current documentation for it](https://developer.apple.com/documentation/packagedescription/package/name) is factually wrong:

> The name of the Swift package.
>
> **Discussion**
>
> If the name of the package is `nil`, Swift Package Manager deduces the name of the package using its Git URL.

### Modifications:

- Deleted part of a doc comment.
