### PR TITLE
Activate swift build support for command plugins

### DIFF
--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -353,7 +353,18 @@ struct PluginCommand: AsyncSwiftCommand {
             // Build the product referenced by the tool, and add the executable to the tool map. Product dependencies are not supported within a package, so if the tool happens to be from the same package, we instead find the executable that corresponds to the product. There is always one, because of autogeneration of implicit executables with the same name as the target if there isn't an explicit one.
             try await buildSystem.build(subset: .product(name, for: .host))
 
-            return buildParameters.buildPath.appending(path)
+            // TODO determine if there is a common way to calculate the build tool binary path that doesn't depend on the build system.
+            if buildSystemKind == .native {
+                if let builtTool = try buildSystem.buildPlan.buildProducts.first(where: {
+                    $0.product.name == name && $0.buildParameters.destination == .host
+                }) {
+                    return try builtTool.binaryPath
+                } else {
+                    return nil
+                }
+            } else {
+                return buildParameters.buildPath.appending(path)
+            }
         }
 
         // Set up a delegate to handle callbacks from the command plugin.

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -205,12 +205,17 @@ struct PluginCommand: AsyncSwiftCommand {
         swiftCommandState.shouldDisableSandbox = swiftCommandState.shouldDisableSandbox || pluginArguments.globalOptions.security
             .shouldDisableSandbox
 
+        let buildSystemKind =
+            pluginArguments.globalOptions.build.buildSystem != .native ?
+                pluginArguments.globalOptions.build.buildSystem :
+                swiftCommandState.options.build.buildSystem
+
         // At this point we know we found exactly one command plugin, so we run it. In SwiftPM CLI, we have only one root package.
         try await PluginCommand.run(
             plugin: matchingPlugins[0],
             package: packageGraph.rootPackages[packageGraph.rootPackages.startIndex],
             packageGraph: packageGraph,
-            buildSystem: pluginArguments.globalOptions.build.buildSystem,
+            buildSystem: buildSystemKind,
             options: pluginOptions,
             arguments: unparsedArguments,
             swiftCommandState: swiftCommandState
@@ -327,7 +332,9 @@ struct PluginCommand: AsyncSwiftCommand {
         let toolSearchDirs = [try swiftCommandState.getTargetToolchain().swiftCompilerPath.parentDirectory]
             + getEnvSearchPaths(pathString: Environment.current[.path], currentWorkingDirectory: .none)
 
-        let buildParameters = try swiftCommandState.toolsBuildParameters
+        var buildParameters = try swiftCommandState.toolsBuildParameters
+        buildParameters.buildSystemKind = buildSystemKind
+
         // Build or bring up-to-date any executable host-side tools on which this plugin depends. Add them and any binary dependencies to the tool-names-to-path map.
         let buildSystem = try await swiftCommandState.createBuildSystem(
             explicitBuildSystem: buildSystemKind,
@@ -342,16 +349,11 @@ struct PluginCommand: AsyncSwiftCommand {
             fileSystem: swiftCommandState.fileSystem,
             environment: buildParameters.buildEnvironment,
             for: try pluginScriptRunner.hostTriple
-        ) { name, _ in
+        ) { name, path in
             // Build the product referenced by the tool, and add the executable to the tool map. Product dependencies are not supported within a package, so if the tool happens to be from the same package, we instead find the executable that corresponds to the product. There is always one, because of autogeneration of implicit executables with the same name as the target if there isn't an explicit one.
             try await buildSystem.build(subset: .product(name, for: .host))
-            if let builtTool = try buildSystem.buildPlan.buildProducts.first(where: {
-                $0.product.name == name && $0.buildParameters.destination == .host
-            }) {
-                return try builtTool.binaryPath
-            } else {
-                return nil
-            }
+
+            return buildParameters.buildPath.appending(path)
         }
 
         // Set up a delegate to handle callbacks from the command plugin.

--- a/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
@@ -463,13 +463,22 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         let process = Foundation.Process()
         process.executableURL = URL(fileURLWithPath: command[0])
         process.arguments = Array(command.dropFirst())
-        process.environment = ProcessInfo.processInfo.environment
+
+        var env = Environment.current
+
+        // Update the environment for any runtime library paths that tools compiled
+        // for the command plugin might require after they have been built.
+        let runtimeLibPaths = self.toolchain.runtimeLibraryPaths
+        for libPath in runtimeLibPaths {
+            env.appendPath(key: .libraryPath, value: libPath.pathString)
+        }
+
 #if os(Windows)
         let pluginLibraryPath = self.toolchain.swiftPMLibrariesLocation.pluginLibraryPath.pathString
-        var env = Environment.current
         env.prependPath(key: .path, value: pluginLibraryPath)
-        process.environment = .init(env)
 #endif
+        process.environment = .init(env)
+
         process.currentDirectoryURL = workingDirectory.asURL
         
         // Set up a pipe for sending structured messages to the plugin on its stdin.

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -435,6 +435,12 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                         case .taskStarted(let info):
                             try buildState.started(task: info)
 
+                            if let commandLineDisplay = info.commandLineDisplayString {
+                                self.observabilityScope.emit(info: "\(info.executionDescription)\n\(commandLineDisplay)")
+                            } else {
+                                self.observabilityScope.emit(info: "\(info.executionDescription)")
+                            }
+
                             if self.logLevel.isVerbose {
                                 if let commandLineDisplay = info.commandLineDisplayString {
                                     self.outputStream.send("\(info.executionDescription)\n\(commandLineDisplay)")

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -316,8 +316,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                         let workspaceInfo = try await session.workspaceInfo()
 
                         configuredTargets = try [pifTargetName].map { targetName in
-                            // TODO use an API to decide if this is a dynamic target info
-                            let infos = workspaceInfo.targetInfos.filter { $0.targetName == targetName && !$0.guid.hasSuffix("-dynamic") }
+                            // TODO we filter dynamic tarts until Swift Build doesn't give them to us anymore
+                            let infos = workspaceInfo.targetInfos.filter { $0.targetName == targetName && !TargetSuffix.dynamic.hasSuffix(id: GUID($0.guid)) }
                             switch infos.count {
                             case 0:
                                 self.observabilityScope.emit(error: "Could not find target named '\(targetName)'")

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -316,7 +316,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                         let workspaceInfo = try await session.workspaceInfo()
 
                         configuredTargets = try [pifTargetName].map { targetName in
-                            // TODO we filter dynamic tarts until Swift Build doesn't give them to us anymore
+                            // TODO we filter dynamic targets until Swift Build doesn't give them to us anymore
                             let infos = workspaceInfo.targetInfos.filter { $0.targetName == targetName && !TargetSuffix.dynamic.hasSuffix(id: GUID($0.guid)) }
                             switch infos.count {
                             case 0:

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -316,7 +316,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                         let workspaceInfo = try await session.workspaceInfo()
 
                         configuredTargets = try [pifTargetName].map { targetName in
-                            let infos = workspaceInfo.targetInfos.filter { $0.targetName == targetName }
+                            // TODO use an API to decide if this is a dynamic target info
+                            let infos = workspaceInfo.targetInfos.filter { $0.targetName == targetName && !$0.guid.hasSuffix("-dynamic") }
                             switch infos.count {
                             case 0:
                                 self.observabilityScope.emit(error: "Could not find target named '\(targetName)'")

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -434,10 +434,13 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                             self.observabilityScope.emit(info: "\(String(decoding: info.data, as: UTF8.self))")
                         case .taskStarted(let info):
                             try buildState.started(task: info)
-                            if let commandLineDisplay = info.commandLineDisplayString {
-                                self.observabilityScope.emit(info: "\(info.executionDescription)\n\(commandLineDisplay)")
-                            } else {
-                                self.observabilityScope.emit(info: "\(info.executionDescription)")
+
+                            if self.logLevel.isVerbose {
+                                if let commandLineDisplay = info.commandLineDisplayString {
+                                    self.outputStream.send("\(info.executionDescription)\n\(commandLineDisplay)")
+                                } else {
+                                    self.outputStream.send("\(info.executionDescription)")
+                                }
                             }
                         case .taskComplete(let info):
                             let startedInfo = try buildState.completed(task: info)

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2880,6 +2880,8 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             await XCTAssertAsyncNoThrow(try await self.execute(["-c", "debug", "check-testability", "InternalModule", "debug", "true"], packagePath: fixturePath))
         }
 
+        if ProcessInfo.hostOperatingSystem != .macOS { throw XCTSkip("Build error building release artifacts with autolink-extract on non-macOS platforms: https://github.com/swiftlang/swift-build/issues/602") }
+
         // Overall configuration: debug, plugin build request: release -> without testability
         try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
             await XCTAssertAsyncNoThrow(try await self.execute(["-c", "debug", "check-testability", "InternalModule", "release", "false"], packagePath: fixturePath))

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2914,7 +2914,8 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             XCTAssertMatch(stdout, isEmpty)
             // Filter some unrelated output that could show up on stderr.
             let filteredStderr = stderr.components(separatedBy: "\n")
-              .filter { !$0.contains("Unable to locate libSwiftScan") }.joined(separator: "\n")
+              .filter { !$0.contains("Unable to locate libSwiftScan") }
+              .filter { !($0.contains("warning: ") && $0.contains("unable to find libclang")) }.joined(separator: "\n")
             XCTAssertMatch(filteredStderr, isEmpty)
         }
 
@@ -2924,7 +2925,8 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             XCTAssertMatch(stdout, containsLogtext)
             // Filter some unrelated output that could show up on stderr.
             let filteredStderr = stderr.components(separatedBy: "\n")
-              .filter { !$0.contains("Unable to locate libSwiftScan") }.joined(separator: "\n")
+              .filter { !$0.contains("Unable to locate libSwiftScan") }
+              .filter { !($0.contains("warning: ") && $0.contains("unable to find libclang")) }.joined(separator: "\n")
             XCTAssertMatch(filteredStderr, isEmpty)
         }
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2805,7 +2805,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
         #if os(Linux)
         let osSuffix = "-linux"
         #elseif os(Windows)
-        let ossSuffix = "-windows"
+        let osSuffix = "-windows"
         #else
         let osSuffix = ""
         #endif
@@ -2880,7 +2880,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             await XCTAssertAsyncNoThrow(try await self.execute(["-c", "debug", "check-testability", "InternalModule", "debug", "true"], packagePath: fixturePath))
         }
 
-        if ProcessInfo.hostOperatingSystem != .macOS { throw XCTSkip("Build error building release artifacts with autolink-extract on non-macOS platforms: https://github.com/swiftlang/swift-build/issues/602") }
+        if buildSystemProvider == .swiftbuild && ProcessInfo.hostOperatingSystem != .macOS { throw XCTSkip("Build error building release artifacts with autolink-extract on non-macOS platforms: https://github.com/swiftlang/swift-build/issues/602") }
 
         // Overall configuration: debug, plugin build request: release -> without testability
         try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -4140,6 +4140,11 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
     override func testCommandPluginSymbolGraphCallbacks() async throws {
         throw XCTSkip("SWBINTTODO: Symbol graph extraction does not yet work with swiftbuild build system")
     }
+
+    override func testCommandPluginBuildingCallbacks() async throws {
+        try XCTSkipOnWindows(because: "TSCBasic/Path.swift:969: Assertion failed, https://github.com/swiftlang/swift-package-manager/issues/8602")
+        try await super.testCommandPluginBuildingCallbacks()
+    }
     
     override func testCommandPluginBuildTestability() async throws {
         try await super.testCommandPluginBuildTestability()

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2804,7 +2804,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
 
         #if os(Linux)
         let osSuffix = "-linux"
-        #else if os(Windows)
+        #elseif os(Windows)
         let ossSuffix = "-windows"
         #else
         let osSuffix = ""

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2845,8 +2845,8 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             AssertNotExists(fixturePath.appending(components: releaseTarget))
         }
 
-        if self.buildSystemProvider == .swiftbuild && ProcessInfo.hostOperatingSystem == .linux {
-            throw XCTSkip("Failure to build the executable in release mode on Linux with the swiftbuild build system: https://github.com/swiftlang/swift-package-manager/issues/8855")
+        if self.buildSystemProvider == .swiftbuild && ProcessInfo.hostOperatingSystem != .macOS {
+            throw XCTSkip("Failed to find dsymutil tool: https://github.com/swiftlang/swift-package-manager/issues/8862")
         }
 
         // If the plugin requests a release binary, that is what will be built, regardless of overall configuration
@@ -2880,7 +2880,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
             await XCTAssertAsyncNoThrow(try await self.execute(["-c", "debug", "check-testability", "InternalModule", "debug", "true"], packagePath: fixturePath))
         }
 
-        if buildSystemProvider == .swiftbuild && ProcessInfo.hostOperatingSystem != .macOS { throw XCTSkip("Build error building release artifacts with autolink-extract on non-macOS platforms: https://github.com/swiftlang/swift-build/issues/602") }
+        if buildSystemProvider == .swiftbuild && ProcessInfo.hostOperatingSystem != .macOS { throw XCTSkip("Failed to find dsymutil tool: https://github.com/swiftlang/swift-package-manager/issues/8862") }
 
         // Overall configuration: debug, plugin build request: release -> without testability
         try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
@@ -3516,8 +3516,9 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                 XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("executable")))
             } catch {
                 if ProcessInfo.hostOperatingSystem != .macOS && self.buildSystemProvider == .swiftbuild {
-                    throw XCTSkip("Autolink extract failure with Linux https://github.com/swiftlang/swift-package-manager/issues/8855")
+                    throw XCTSkip("Failed to find dsymutil tool: https://github.com/swiftlang/swift-package-manager/issues/8862")
                 }
+                throw error
             }
 
             // Invoke the plugin with parameters choosing a verbose build of MyStaticLibrary for release.
@@ -3541,8 +3542,9 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                 XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("staticLibrary")))
             } catch {
                 if ProcessInfo.hostOperatingSystem != .macOS && self.buildSystemProvider == .swiftbuild {
-                    throw XCTSkip("Autolink extract failure with Linux https://github.com/swiftlang/swift-package-manager/issues/8855")
+                    throw XCTSkip("Failed to find dsymutil tool: https://github.com/swiftlang/swift-package-manager/issues/8862")
                 }
+                throw error
             }
 
             // Invoke the plugin with parameters choosing a verbose build of MyDynamicLibrary for release.
@@ -3570,8 +3572,9 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                 XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("dynamicLibrary")))
             } catch {
                 if ProcessInfo.hostOperatingSystem != .macOS && self.buildSystemProvider == .swiftbuild {
-                    throw XCTSkip("Autolink extract failure with Linux https://github.com/swiftlang/swift-package-manager/issues/8855")
+                    throw XCTSkip("Failed to find dsymutil tool: https://github.com/swiftlang/swift-package-manager/issues/8862")
                 }
+                throw error
             }
         }
     }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -4145,10 +4145,6 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
         try XCTSkipOnWindows(because: "TSCBasic/Path.swift:969: Assertion failed, https://github.com/swiftlang/swift-package-manager/issues/8602")
         try await super.testCommandPluginBuildingCallbacks()
     }
-    
-    override func testCommandPluginBuildTestability() async throws {
-        try await super.testCommandPluginBuildTestability()
-    }
 
     override func testMigrateCommand() async throws {
         throw XCTSkip("SWBINTTODO: Build plan is not currently supported")

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -3462,9 +3462,11 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                 let (stdout, _) = try await self.execute(["my-build-tester", "--product", "MyExecutable", "--print-commands"], packagePath: packageDir)
                 XCTAssertMatch(stdout, .contains("Building for debugging..."))
                 XCTAssertNoMatch(stdout, .contains("Building for production..."))
-                XCTAssertMatch(stdout, .contains("-module-name MyExecutable"))
-                XCTAssertMatch(stdout, .contains("-DEXTRA_SWIFT_FLAG"))
-                XCTAssertMatch(stdout, .contains("Build of product 'MyExecutable' complete!"))
+                if buildSystemProvider == .native {
+                    XCTAssertMatch(stdout, .contains("-module-name MyExecutable"))
+                    XCTAssertMatch(stdout, .contains("-DEXTRA_SWIFT_FLAG"))
+                    XCTAssertMatch(stdout, .contains("Build of product 'MyExecutable' complete!"))
+                }
                 XCTAssertMatch(stdout, .contains("succeeded: true"))
                 switch buildSystemProvider {
                 case .native:
@@ -3483,7 +3485,9 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                 XCTAssertMatch(stdout, .contains("Building for production..."))
                 XCTAssertNoMatch(stdout, .contains("Building for debug..."))
                 XCTAssertNoMatch(stdout, .contains("-module-name MyExecutable"))
-                XCTAssertMatch(stdout, .contains("Build of product 'MyExecutable' complete!"))
+                if buildSystemProvider == .native {
+                    XCTAssertMatch(stdout, .contains("Build of product 'MyExecutable' complete!"))
+                }
                 XCTAssertMatch(stdout, .contains("succeeded: true"))
                 switch buildSystemProvider {
                 case .native:
@@ -3502,7 +3506,9 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                 XCTAssertMatch(stdout, .contains("Building for production..."))
                 XCTAssertNoMatch(stdout, .contains("Building for debug..."))
                 XCTAssertNoMatch(stdout, .contains("-module-name MyLibrary"))
-                XCTAssertMatch(stdout, .contains("Build of product 'MyStaticLibrary' complete!"))
+                if buildSystemProvider == .native {
+                    XCTAssertMatch(stdout, .contains("Build of product 'MyStaticLibrary' complete!"))
+                }
                 XCTAssertMatch(stdout, .contains("succeeded: true"))
                 switch buildSystemProvider {
                 case .native:
@@ -3521,7 +3527,9 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                 XCTAssertMatch(stdout, .contains("Building for production..."))
                 XCTAssertNoMatch(stdout, .contains("Building for debug..."))
                 XCTAssertNoMatch(stdout, .contains("-module-name MyLibrary"))
-                XCTAssertMatch(stdout, .contains("Build of product 'MyDynamicLibrary' complete!"))
+                if buildSystemProvider == .native {
+                    XCTAssertMatch(stdout, .contains("Build of product 'MyDynamicLibrary' complete!"))
+                }
                 XCTAssertMatch(stdout, .contains("succeeded: true"))
                 switch buildSystemProvider {
                 case .native:
@@ -4107,7 +4115,6 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
     }
 
     override func testCommandPluginTestingCallbacks() async throws {
-        throw XCTSkip("SWBINTTODO: Requires PIF generation to adopt new test runner product type")
         try XCTSkipOnWindows(because: "TSCBasic/Path.swift:969: Assertion failed, https://github.com/swiftlang/swift-package-manager/issues/8602")
         try await super.testCommandPluginTestingCallbacks()
     }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -3512,6 +3512,10 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                     XCTFail("unimplemented assertion for --build-system xcode")
                 }
                 XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("executable")))
+            } catch {
+                if ProcessInfo.hostOperatingSystem != .macOS && self.buildSystemProvider == .swiftbuild {
+                    throw XCTSkip("Autolink extract failure with Linux https://github.com/swiftlang/swift-package-manager/issues/8855")
+                }
             }
 
             // Invoke the plugin with parameters choosing a verbose build of MyStaticLibrary for release.
@@ -3533,6 +3537,10 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                     XCTFail("unimplemented assertion for --build-system xcode")
                 }
                 XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("staticLibrary")))
+            } catch {
+                if ProcessInfo.hostOperatingSystem != .macOS && self.buildSystemProvider == .swiftbuild {
+                    throw XCTSkip("Autolink extract failure with Linux https://github.com/swiftlang/swift-package-manager/issues/8855")
+                }
             }
 
             // Invoke the plugin with parameters choosing a verbose build of MyDynamicLibrary for release.
@@ -3558,6 +3566,10 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                     XCTFail("unimplemented assertion for --build-system xcode")
                 }
                 XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("dynamicLibrary")))
+            } catch {
+                if ProcessInfo.hostOperatingSystem != .macOS && self.buildSystemProvider == .swiftbuild {
+                    throw XCTSkip("Autolink extract failure with Linux https://github.com/swiftlang/swift-package-manager/issues/8855")
+                }
             }
         }
     }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -752,22 +752,27 @@ final class PluginTests {
     }
 
     @Test(
+        .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
         .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
         arguments: [BuildSystemProvider.Kind.native, .swiftbuild]
     )
     func testLocalAndRemoteToolDependencies(buildSystem: BuildSystemProvider.Kind) async throws {
-        try await fixture(name: "Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool") { path in
-            let (stdout, stderr) = try await executeSwiftPackage(path.appending("MyLibrary"), configuration: .debug, extraArgs: ["--build-system", buildSystem.rawValue, "plugin", "my-plugin"])
-            if buildSystem == .native {
-                // Native build system is more explicit about what it's doing in stderr
-                #expect(stderr.contains("Linking RemoteTool"), "stdout:\n\(stderr)\n\(stdout)")
-                #expect(stderr.contains("Linking LocalTool"), "stdout:\n\(stderr)\n\(stdout)")
-                #expect(stderr.contains("Linking ImpliedLocalTool"), "stdout:\n\(stderr)\n\(stdout)")
-                #expect(stderr.contains("Build of product 'ImpliedLocalTool' complete!"), "stdout:\n\(stderr)\n\(stdout)")
+        try await withKnownIssue (isIntermittent: true) {
+            try await fixture(name: "Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool") { path in
+                let (stdout, stderr) = try await executeSwiftPackage(path.appending("MyLibrary"), configuration: .debug, extraArgs: ["--build-system", buildSystem.rawValue, "plugin", "my-plugin"])
+                if buildSystem == .native {
+                    // Native build system is more explicit about what it's doing in stderr
+                    #expect(stderr.contains("Linking RemoteTool"), "stdout:\n\(stderr)\n\(stdout)")
+                    #expect(stderr.contains("Linking LocalTool"), "stdout:\n\(stderr)\n\(stdout)")
+                    #expect(stderr.contains("Linking ImpliedLocalTool"), "stdout:\n\(stderr)\n\(stdout)")
+                    #expect(stderr.contains("Build of product 'ImpliedLocalTool' complete!"), "stdout:\n\(stderr)\n\(stdout)")
+                }
+                #expect(stdout.contains("A message from the remote tool."), "stdout:\n\(stderr)\n\(stdout)")
+                #expect(stdout.contains("A message from the local tool."), "stdout:\n\(stderr)\n\(stdout)")
+                #expect(stdout.contains("A message from the implied local tool."), "stdout:\n\(stderr)\n\(stdout)")
             }
-            #expect(stdout.contains("A message from the remote tool."), "stdout:\n\(stderr)\n\(stdout)")
-            #expect(stdout.contains("A message from the local tool."), "stdout:\n\(stderr)\n\(stdout)")
-            #expect(stdout.contains("A message from the implied local tool."), "stdout:\n\(stderr)\n\(stdout)")
+        } when: {
+            ProcessInfo.hostOperatingSystem == .windows // Intermittent depending on the file path length
         }
     }
 

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -487,15 +487,19 @@ struct TraitTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         try await fixture(name: "Traits") { fixturePath in
-            let (stdout, _) = try await executeSwiftPackage(
-                fixturePath.appending("Package10"),
-                extraArgs: ["plugin", "extract", "--experimental-prune-unused-dependencies"],
-                buildSystem: buildSystem,
-            )
-            let path = String(stdout.split(whereSeparator: \.isNewline).first!)
-            let symbolGraph = try String(contentsOfFile: "\(path)/Package10Library1.symbols.json", encoding: .utf8)
-            #expect(symbolGraph.contains("TypeGatedByPackage10Trait1"))
-            #expect(symbolGraph.contains("TypeGatedByPackage10Trait2"))
+            try await withKnownIssue {
+                let (stdout, _) = try await executeSwiftPackage(
+                    fixturePath.appending("Package10"),
+                    extraArgs: ["plugin", "extract", "--experimental-prune-unused-dependencies"],
+                    buildSystem: buildSystem,
+                )
+                let path = String(stdout.split(whereSeparator: \.isNewline).first!)
+                let symbolGraph = try String(contentsOfFile: "\(path)/Package10Library1.symbols.json", encoding: .utf8)
+                #expect(symbolGraph.contains("TypeGatedByPackage10Trait1"))
+                #expect(symbolGraph.contains("TypeGatedByPackage10Trait2"))
+            } when: {
+              buildSystem == .swiftbuild
+            }
         }
     }
 

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -487,6 +487,7 @@ struct TraitTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         try await fixture(name: "Traits") { fixturePath in
+            // The swiftbuild build system doesn't yet have the ability for command plugins to request symbol graphs
             try await withKnownIssue {
                 let (stdout, _) = try await executeSwiftPackage(
                     fixturePath.appending("Package10"),


### PR DESCRIPTION
Be consistent in the detection of the build system settings so that both the
build system and the build parameters are using the same setting. Use the
build system setting given after the command plugin name as the highest
precedence, followed by the one (if any) provided after the package subcommand.

When building a specific target with the swiftbuild build system, set the configured
target in the build request to be the one that isn't a dynamic target.

Tag the `TraitTest.packagePluginGetSymbolGraph_enablesAllTraits` with a known
issue when using the swiftbuild build system since the symbol graph extraction
is not yet working there.

Add the toolchain's runtime environment to the environment used when running
command plugins so that the tools have the necessary runtime dependencies when
the plugin decides to run them on platforms like Linux.