### PR TITLE
Explicitly import _Concurrency in PackageDescription/BuildSettings.swift

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
+
 /// The build configuration, such as debug or release.
 public struct BuildConfiguration: Sendable {
     /// The configuration of the build. Valid values are `debug` and `release`.


### PR DESCRIPTION
In order to reference `MainActor.Type` in certain circumstances `_Concurrency` must be imported.
