### PR TITLE
Tests: Mark test as intermittent failing

### DIFF
--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -38,7 +38,7 @@ struct TraitTests {
     func traits_whenNoFlagPassed(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue {
+        try await withKnownIssue("Does not fail in some pipelines", isIntermittent: (ProcessInfo.hostOperatingSystem == .linux)) {
         try await fixture(name: "Traits") { fixturePath in
             let (stdout, stderr) = try await executeSwiftRun(
                 fixturePath.appending("Example"),


### PR DESCRIPTION
The TraitTests.traits_whenNoFlagPassed(buildSystem:) is known to fail in some SwiftPM CI environent, however, the known issue is not recorded in some OSS pieplines. namely when running in a Linux host.