### PR TITLE
[WIP] Fix for trait-guarded deps being included in resolution

### DIFF
--- a/Sources/PackageGraph/GraphLoadingNode.swift
+++ b/Sources/PackageGraph/GraphLoadingNode.swift
@@ -30,14 +30,15 @@ public struct GraphLoadingNode: Equatable, Hashable {
     public let productFilter: ProductFilter
 
     /// The enabled traits for this package.
-    package var enabledTraits: Set<String>
+    package var enabledTraits: Set<String>?
 
     public init(
         identity: PackageIdentity,
         manifest: Manifest,
         productFilter: ProductFilter,
-        enabledTraits: Set<String>
+        enabledTraits: Set<String>?
     ) throws {
+//        print("\(identity) enabled TRAITSSSSSS : \(enabledTraits)")
         self.identity = identity
         self.manifest = manifest
         self.productFilter = productFilter

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -137,6 +137,7 @@ public struct PackageGraphRoot {
             // Check that the dependency is used in at least one of the manifests.
             // If not, then we can omit this dependency if pruning unused dependencies
             // is enabled.
+            // TODO bp: assure that trait-guarded deps are pruned regardless
             return manifests.values.reduce(false) { result, manifest in
                 guard manifest.pruneDependencies else { return true }
                 let enabledTraits: Set<String>? = enableTraitsMap[manifest.packageIdentity]

--- a/Sources/PackageModel/Manifest/Manifest+Traits.swift
+++ b/Sources/PackageModel/Manifest/Manifest+Traits.swift
@@ -336,6 +336,10 @@ extension Manifest {
             let traitGuardedDeps = try target.dependencies.filter { dep in
                 let traits = dep.condition?.traits ?? []
 
+                // If traits is empty, then we must manually validate the explicitly enabled traits.
+                if traits.isEmpty {
+                    try validateEnabledTraits(enabledTraits)
+                }
                 // For each trait that is a condition on this target dependency, assure that
                 // each one is enabled in the manifest.
                 return try traits.allSatisfy({ try isTraitEnabled(.init(stringLiteral: $0), enabledTraits) })
@@ -433,14 +437,95 @@ extension Manifest {
     }
     /// Determines whether a given package dependency is used by this manifest given a set of enabled traits.
     public func isPackageDependencyUsed(_ dependency: PackageDependency, enabledTraits: Set<String>?) throws -> Bool {
-        let usedDependencies = try self.usedDependencies(withTraits: enabledTraits)
-        let foundKnownPackage = usedDependencies.knownPackage.contains(where: {
-            $0.caseInsensitiveCompare(dependency.identity.description) == .orderedSame
-        })
+        // TODO bp: assure that we are still pruning trait-guarded dependencies here
 
-        // if there is a target dependency referenced by name and the package it originates from is unknown, default to
-        // tentatively marking the package dependency as used. to be resolved later on.
-        return foundKnownPackage || (!foundKnownPackage && !usedDependencies.unknownPackage.isEmpty)
+        // have package dependency -- seek out all target dependencies that reference this package dep
+        // for each target dep, see whether they're all trait-guarded - if each reference to the package dep is trait-guarded, then we can safely prune it
+        if self.pruneDependencies {
+            let usedDependencies = try self.usedDependencies(withTraits: enabledTraits)
+            let foundKnownPackage = usedDependencies.knownPackage.contains(where: {
+                $0.caseInsensitiveCompare(dependency.identity.description) == .orderedSame
+            })
+
+            // if there is a target dependency referenced by name and the package it originates from is unknown, default to
+            // tentatively marking the package dependency as used. to be resolved later on.
+            return foundKnownPackage || (!foundKnownPackage && !usedDependencies.unknownPackage.isEmpty)
+        } else {
+            // alternate path to compute trait-guarded package dependencies if the prune deps feature is not enabled
+//            let traitGuardedTargetDependencies = traitGuardedTargetDependencies()
+//            let traitGuardedPackageDependencies = traitGuardedTargetDependencies.flatMap({ $0.value }).reduce(into: [String: Set<String>]()) { guardedPackages, targetDep in
+//                guard let package = targetDep.package, let traits = targetDep.condition?.traits else {
+//                    return
+//                }
+//
+//                guardedPackages[package, default: []].formUnion(traits)
+//            }
+//            print("manifest \(displayName) and traits \(enabledTraits)")
+            try validateEnabledTraits(enabledTraits)
+
+            let targetDependenciesForPackageDependency = self.targets.flatMap({ $0.dependencies })
+                .filter({
+                $0.package?.caseInsensitiveCompare(dependency.identity.description) == .orderedSame
+            })
+
+            // if target deps is empty, default to returning true here.
+            let isTraitGuarded = targetDependenciesForPackageDependency.isEmpty ? false : targetDependenciesForPackageDependency.compactMap({ $0.condition?.traits }).allSatisfy({
+                let condition = $0.subtracting(enabledTraits ?? [])
+//                if let obsScope {
+//                    obsScope.emit(warning: "condition: \(condition) where enabled traits are: \(enabledTraits ?? []) and guarding traits are: \($0)")
+//                }
+//                return !$0.subtracting(enabledTraits ?? []).isEmpty
+                return !condition.isEmpty
+            })
+
+            let isUsedWithoutTraitGuarding = !targetDependenciesForPackageDependency.filter({ $0.condition?.traits == nil }).isEmpty
+
+//            if let obsScope {
+//                obsScope.emit(warning: "\(dependency.identity) isUsedWithoutTraitGuarding: \(isUsedWithoutTraitGuarding)")
+//                obsScope.emit(warning: "\(dependency.identity) isTraitGuarded: \(isTraitGuarded)")
+//            }
+            // Special case until we allow for pruning dependencies
+//            if !isUsedWithoutTraitGuarding && !isTraitGuarded {
+//                return true
+//            } else if isUsedWithoutTraitGuarding && isTraitGuarded {
+//                return true
+//            } else if !isUsedWithoutTraitGuarding && isTraitGuarded {
+//                return false
+//            } else if isUsedWithoutTraitGuarding && !isTraitGuarded {
+//                return true
+//            }
+
+            // Until the pruning unused dependencies features is fully implemented, this is how we will compute whether
+            // to omit a trait-guarded package dependency.
+//            if !isUsedWithoutTraitGuarding && isTraitGuarded {
+//                return false
+//            }
+
+            return isUsedWithoutTraitGuarding || !isTraitGuarded
+//            return isUsedWithoutTraitGuarding || !isTraitGuarded
+//                .reduce(into: [String: [TargetDescription.Dependency]]()) { packageTargetDeps, targetDep in
+//                if let packageName = targetDep.package {
+//                    packageTargetDeps[packageName, default: []].append(targetDep)
+//                }
+//            }
+
+
+
+            // Check that this package dependency is potentially guarded by traits.
+            // Note that this package dependency can also be referenced by target dependencies without being
+            // guarded by traits...
+//            if let guardingTraits = traitGuardedPackageDependencies[dependency.identity.description] {
+//                let isTraitGuarded = guardingTraits.isSubset(of: enabledTraits ?? [])
+                // Depending on whether this dependency is used elsewhere without any trait guarding, this
+                // will determine whether we can prune this from the dependency graph.
+//                let isTraitGuarded = !guardingTraits.subtracting(enabledTraits ?? []).isEmpty
+//            }
+
+//            return true
+//            if let enabledTraits = enabledTraits, let guardingTraits = traitGuardedPackageDependencies[dependency.identity.description] {
+//                return !guardingTraits.subtracting(enabledTraits).isEmpty
+//            }
+        }
     }
 }
 

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -287,21 +287,31 @@ public final class Manifest: Sendable {
 
         guard self.toolsVersion >= .v5_2 && !self.packageKind.isRoot else {
             var dependencies = self.dependencies
-            if pruneDependencies {
+//            if pruneDependencies {
+//            if let obsScope {
+//                obsScope.emit(warning: "\(self.displayName) DEPENDENCIES: \(dependencies)")
+//            }
+//            print("dependencies required for \(self.displayName) and traits: \(enabledTraits)")
                 dependencies = try dependencies.filter({
-                    return try self.isPackageDependencyUsed($0, enabledTraits: enabledTraits)
+                    let isUsed = try self.isPackageDependencyUsed($0, enabledTraits: enabledTraits)
+//                    return try self.isPackageDependencyUsed($0, enabledTraits: enabledTraits)
+//                    if let obsScope {
+//                        obsScope.emit(warning: "is used? \(isUsed)")
+//                    }
+                    return isUsed
                 })
-            }
+//            }
             return dependencies
         }
 
         // using .nothing as cache key while ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION is false
         if var dependencies = self._requiredDependencies[.nothing] {
-            if self.pruneDependencies {
+//            if self.pruneDependencies {
+//            print("dependencies required for \(self.displayName) and traits: \(enabledTraits)")
                 dependencies = try dependencies.filter({
                     return try self.isPackageDependencyUsed($0, enabledTraits: enabledTraits)
                 })
-            }
+//            }
             return dependencies
         } else {
             var requiredDependencies: Set<PackageIdentity> = []

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -43,7 +43,7 @@ struct TraitTests {
             let (stdout, stderr) = try await executeSwiftRun(
                 fixturePath.appending("Example"),
                 "Example",
-                extraArgs: ["--experimental-prune-unused-dependencies"],
+//                extraArgs: ["--experimental-prune-unused-dependencies"],
                 buildSystem: buildSystem,
             )
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
@@ -81,7 +81,7 @@ struct TraitTests {
             let (stdout, stderr) = try await executeSwiftRun(
                 fixturePath.appending("Example"),
                 "Example",
-                extraArgs: ["--traits", "default,Package9,Package10", "--experimental-prune-unused-dependencies"],
+                extraArgs: ["--traits", "default,Package9,Package10"/*, "--experimental-prune-unused-dependencies"*/],
                 buildSystem: buildSystem,
             )
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
@@ -122,7 +122,7 @@ struct TraitTests {
             let (stdout, stderr) = try await executeSwiftRun(
                 fixturePath.appending("Example"),
                 "Example",
-                extraArgs: ["--traits", "default,Package9", "--experimental-prune-unused-dependencies"],
+                extraArgs: ["--traits", "default,Package9"/*, "--experimental-prune-unused-dependencies"*/],
                 buildSystem: buildSystem,
             )
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
@@ -164,7 +164,7 @@ struct TraitTests {
                 extraArgs: [
                     "--traits",
                     "default,Package5,Package7,BuildCondition3",
-                    "--experimental-prune-unused-dependencies",
+                    //"--experimental-prune-unused-dependencies",
                 ],
                 buildSystem: buildSystem,
             )
@@ -205,7 +205,7 @@ struct TraitTests {
             let (stdout, stderr) = try await executeSwiftRun(
                 fixturePath.appending("Example"),
                 "Example",
-                extraArgs: ["--disable-default-traits", "--experimental-prune-unused-dependencies"],
+                extraArgs: ["--disable-default-traits"/*"--experimental-prune-unused-dependencies"*/],
                 buildSystem: buildSystem,
             )
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
@@ -238,7 +238,7 @@ struct TraitTests {
             let (stdout, stderr) = try await executeSwiftRun(
                 fixturePath.appending("Example"),
                 "Example",
-                extraArgs: ["--traits", "Package5,Package7", "--experimental-prune-unused-dependencies"],
+                extraArgs: ["--traits", "Package5,Package7"/*, "--experimental-prune-unused-dependencies"*/],
                 buildSystem: buildSystem,
             )
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
@@ -274,7 +274,7 @@ struct TraitTests {
             let (stdout, stderr) = try await executeSwiftRun(
                 fixturePath.appending("Example"),
                 "Example",
-                extraArgs: ["--enable-all-traits", "--experimental-prune-unused-dependencies"],
+                extraArgs: ["--enable-all-traits"/*, "--experimental-prune-unused-dependencies"*/],
                 buildSystem: buildSystem,
             )
             // We expect no warnings to be produced. Specifically no unused dependency warnings.
@@ -321,7 +321,7 @@ struct TraitTests {
                 extraArgs: [
                     "--enable-all-traits",
                     "--disable-default-traits",
-                    "--experimental-prune-unused-dependencies",
+//                    "--experimental-prune-unused-dependencies",
                 ],
                 buildSystem: buildSystem,
             )
@@ -384,7 +384,7 @@ struct TraitTests {
         try await fixture(name: "Traits") { fixturePath in
             let (stdout, _) = try await executeSwiftTest(
                 fixturePath.appending("Example"),
-                extraArgs: ["--experimental-prune-unused-dependencies"],
+//                extraArgs: ["--experimental-prune-unused-dependencies"],
                 buildSystem: buildSystem,
             )
             let expectedOut = """
@@ -421,7 +421,7 @@ struct TraitTests {
                     extraArgs: [
                         "--enable-all-traits",
                         "--disable-default-traits",
-                        "--experimental-prune-unused-dependencies",
+                       // "--experimental-prune-unused-dependencies",
                     ],
                     buildSystem: buildSystem,
                 )
@@ -461,7 +461,7 @@ struct TraitTests {
         try await fixture(name: "Traits") { fixturePath in
             let (stdout, _) = try await executeSwiftPackage(
                 fixturePath.appending("Package10"),
-                extraArgs: ["dump-symbol-graph", "--experimental-prune-unused-dependencies"],
+                extraArgs: ["dump-symbol-graph"/*, "--experimental-prune-unused-dependencies"*/],
                 buildSystem: buildSystem,
             )
             let optionalPath = stdout
@@ -489,7 +489,7 @@ struct TraitTests {
         try await fixture(name: "Traits") { fixturePath in
             let (stdout, _) = try await executeSwiftPackage(
                 fixturePath.appending("Package10"),
-                extraArgs: ["plugin", "extract", "--experimental-prune-unused-dependencies"],
+                extraArgs: ["plugin", "extract"/*, "--experimental-prune-unused-dependencies"*/],
                 buildSystem: buildSystem,
             )
             let path = String(stdout.split(whereSeparator: \.isNewline).first!)


### PR DESCRIPTION
Trait-guarded dependencies were still being considered during dependency resolution, when they should be excluded if they aren't being used in any other scenario.

### Modifications:

Since we have the `--experimental-prune-unused-dependencies` feature behind an experimental flag, we'll now consider an alternate path that will prune trait-guarded package dependencies from the dependency graph **_if and only if_** said dependency is not used in any other unguarded context.

### Result:

Trait-guarded dependencies are excluded from dependency resolution.
