### PR TITLE
build-using-self: Do not set unnecessary env var

### DIFF
--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -137,9 +137,6 @@ def set_environment(
 ) -> None:
     os.environ["SWIFTCI_IS_SELF_HOSTED"] = "1"
 
-    # Set the SWIFTPM_CUSTOM_BIN_DIR path
-    os.environ["SWIFTPM_CUSTOM_BIN_DIR"] = str(swiftpm_bin_dir)
-
     # Ensure SDKROOT is configure
     if is_on_darwin():
         sdk_root = call_output(shlex.split("xcrun --show-sdk-path --sdk macosx"))


### PR DESCRIPTION
The SWIFTPM_CUSTOM_BIN_DIR environment variable was set as it was required by the Integration Tests when they were standalone Package. Since merging the Integration Tests Package with the SwiftPM package Tests, setting the environment variable is no longer necessary.

Update the `build-using-self` script to no longer set this environment variable.