### PR TITLE
Require explicit build system when initializing BuildParameters

### DIFF
--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -154,7 +154,7 @@ public struct BuildParameters: Encodable {
         toolchain: Toolchain,
         triple: Triple? = nil,
         flags: BuildFlags,
-        buildSystemKind: BuildSystemProvider.Kind = .native,
+        buildSystemKind: BuildSystemProvider.Kind,
         pkgConfigDirectories: [Basics.AbsolutePath] = [],
         architectures: [String]? = nil,
         workers: UInt32 = UInt32(ProcessInfo.processInfo.activeProcessorCount),


### PR DESCRIPTION
This default value is not currently used, and removing it helps prevent accidentally introducing a dependency on the .native build system