### PR TITLE
Revert "Activate swift build support for command plugins"

### DIFF
--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -205,17 +205,12 @@ struct PluginCommand: AsyncSwiftCommand {
         swiftCommandState.shouldDisableSandbox = swiftCommandState.shouldDisableSandbox || pluginArguments.globalOptions.security
             .shouldDisableSandbox
 
-        let buildSystemKind =
-            pluginArguments.globalOptions.build.buildSystem != .native ?
-                pluginArguments.globalOptions.build.buildSystem :
-                swiftCommandState.options.build.buildSystem
-
         // At this point we know we found exactly one command plugin, so we run it. In SwiftPM CLI, we have only one root package.
         try await PluginCommand.run(
             plugin: matchingPlugins[0],
             package: packageGraph.rootPackages[packageGraph.rootPackages.startIndex],
             packageGraph: packageGraph,
-            buildSystem: buildSystemKind,
+            buildSystem: pluginArguments.globalOptions.build.buildSystem,
             options: pluginOptions,
             arguments: unparsedArguments,
             swiftCommandState: swiftCommandState
@@ -332,9 +327,7 @@ struct PluginCommand: AsyncSwiftCommand {
         let toolSearchDirs = [try swiftCommandState.getTargetToolchain().swiftCompilerPath.parentDirectory]
             + getEnvSearchPaths(pathString: Environment.current[.path], currentWorkingDirectory: .none)
 
-        var buildParameters = try swiftCommandState.toolsBuildParameters
-        buildParameters.buildSystemKind = buildSystemKind
-
+        let buildParameters = try swiftCommandState.toolsBuildParameters
         // Build or bring up-to-date any executable host-side tools on which this plugin depends. Add them and any binary dependencies to the tool-names-to-path map.
         let buildSystem = try await swiftCommandState.createBuildSystem(
             explicitBuildSystem: buildSystemKind,
@@ -349,21 +342,15 @@ struct PluginCommand: AsyncSwiftCommand {
             fileSystem: swiftCommandState.fileSystem,
             environment: buildParameters.buildEnvironment,
             for: try pluginScriptRunner.hostTriple
-        ) { name, path in
+        ) { name, _ in
             // Build the product referenced by the tool, and add the executable to the tool map. Product dependencies are not supported within a package, so if the tool happens to be from the same package, we instead find the executable that corresponds to the product. There is always one, because of autogeneration of implicit executables with the same name as the target if there isn't an explicit one.
             try await buildSystem.build(subset: .product(name, for: .host))
-
-            // TODO determine if there is a common way to calculate the build tool binary path that doesn't depend on the build system.
-            if buildSystemKind == .native {
-                if let builtTool = try buildSystem.buildPlan.buildProducts.first(where: {
-                    $0.product.name == name && $0.buildParameters.destination == .host
-                }) {
-                    return try builtTool.binaryPath
-                } else {
-                    return nil
-                }
+            if let builtTool = try buildSystem.buildPlan.buildProducts.first(where: {
+                $0.product.name == name && $0.buildParameters.destination == .host
+            }) {
+                return try builtTool.binaryPath
             } else {
-                return buildParameters.buildPath.appending(path)
+                return nil
             }
         }
 

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -181,39 +181,30 @@ final class PluginDelegate: PluginInvocationDelegate {
         // Run the build. This doesn't return until the build is complete.
         let success = await buildSystem.buildIgnoringError(subset: buildSubset)
 
-        let packageGraph = try await buildSystem.getPackageGraph()
-
-        var builtArtifacts: [PluginInvocationBuildResult.BuiltArtifact] = []
-
-        for rootPkg in packageGraph.rootPackages {
-            let builtProducts = rootPkg.products.filter {
-                switch subset {
-                case .all(let includingTests):
-                    return includingTests ? true : $0.type != .test
-                case .product(let name):
-                    return $0.name == name
-                case .target(let name):
-                    return $0.name == name
-                }
+        // Create and return the build result record based on what the delegate collected and what's in the build plan.
+        let builtProducts = try buildSystem.buildPlan.buildProducts.filter {
+            switch subset {
+            case .all(let includingTests):
+                return includingTests ? true : $0.product.type != .test
+            case .product(let name):
+                return $0.product.name == name
+            case .target(let name):
+                return $0.product.name == name
             }
-
-            let artifacts: [PluginInvocationBuildResult.BuiltArtifact] = try builtProducts.compactMap {
-                switch $0.type {
-                case .library(let kind):
-                    return .init(
-                        path: try buildParameters.binaryPath(for: $0).pathString,
-                        kind: (kind == .dynamic) ? .dynamicLibrary : .staticLibrary
-                    )
-                case .executable:
-                    return .init(path: try buildParameters.binaryPath(for: $0).pathString, kind: .executable)
-                default:
-                    return nil
-                }
-            }
-
-            builtArtifacts.append(contentsOf: artifacts)
         }
-
+        let builtArtifacts: [PluginInvocationBuildResult.BuiltArtifact] = try builtProducts.compactMap {
+            switch $0.product.type {
+            case .library(let kind):
+                return try .init(
+                    path: $0.binaryPath.pathString,
+                    kind: (kind == .dynamic) ? .dynamicLibrary : .staticLibrary
+                )
+            case .executable:
+                return try .init(path: $0.binaryPath.pathString, kind: .executable)
+            default:
+                return nil
+            }
+        }
         return PluginInvocationBuildResult(
             succeeded: success,
             logText: bufferedOutputStream.bytes.cString,

--- a/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
@@ -463,22 +463,13 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         let process = Foundation.Process()
         process.executableURL = URL(fileURLWithPath: command[0])
         process.arguments = Array(command.dropFirst())
-
-        var env = Environment.current
-
-        // Update the environment for any runtime library paths that tools compiled
-        // for the command plugin might require after they have been built.
-        let runtimeLibPaths = self.toolchain.runtimeLibraryPaths
-        for libPath in runtimeLibPaths {
-            env.appendPath(key: .libraryPath, value: libPath.pathString)
-        }
-
+        process.environment = ProcessInfo.processInfo.environment
 #if os(Windows)
         let pluginLibraryPath = self.toolchain.swiftPMLibrariesLocation.pluginLibraryPath.pathString
+        var env = Environment.current
         env.prependPath(key: .path, value: pluginLibraryPath)
-#endif
         process.environment = .init(env)
-
+#endif
         process.currentDirectoryURL = workingDirectory.asURL
         
         // Set up a pipe for sending structured messages to the plugin on its stdin.

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -317,8 +317,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                         let workspaceInfo = try await session.workspaceInfo()
 
                         configuredTargets = try [pifTargetName].map { targetName in
-                            // TODO we filter dynamic targets until Swift Build doesn't give them to us anymore
-                            let infos = workspaceInfo.targetInfos.filter { $0.targetName == targetName && !TargetSuffix.dynamic.hasSuffix(id: GUID($0.guid)) }
+                            let infos = workspaceInfo.targetInfos.filter { $0.targetName == targetName }
                             switch infos.count {
                             case 0:
                                 self.observabilityScope.emit(error: "Could not find target named '\(targetName)'")
@@ -398,19 +397,10 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                             self.observabilityScope.emit(info: "\(String(decoding: info.data, as: UTF8.self))")
                         case .taskStarted(let info):
                             try buildState.started(task: info)
-
                             if let commandLineDisplay = info.commandLineDisplayString {
                                 self.observabilityScope.emit(info: "\(info.executionDescription)\n\(commandLineDisplay)")
                             } else {
                                 self.observabilityScope.emit(info: "\(info.executionDescription)")
-                            }
-
-                            if self.logLevel.isVerbose {
-                                if let commandLineDisplay = info.commandLineDisplayString {
-                                    self.outputStream.send("\(info.executionDescription)\n\(commandLineDisplay)")
-                                } else {
-                                    self.outputStream.send("\(info.executionDescription)")
-                                }
                             }
                         case .taskComplete(let info):
                             let startedInfo = try buildState.completed(task: info)

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -752,27 +752,18 @@ final class PluginTests {
     }
 
     @Test(
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
         .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
-        arguments: [BuildSystemProvider.Kind.native, .swiftbuild]
     )
-    func testLocalAndRemoteToolDependencies(buildSystem: BuildSystemProvider.Kind) async throws {
-        try await withKnownIssue (isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool") { path in
-                let (stdout, stderr) = try await executeSwiftPackage(path.appending("MyLibrary"), configuration: .debug, extraArgs: ["--build-system", buildSystem.rawValue, "plugin", "my-plugin"])
-                if buildSystem == .native {
-                    // Native build system is more explicit about what it's doing in stderr
-                    #expect(stderr.contains("Linking RemoteTool"), "stdout:\n\(stderr)\n\(stdout)")
-                    #expect(stderr.contains("Linking LocalTool"), "stdout:\n\(stderr)\n\(stdout)")
-                    #expect(stderr.contains("Linking ImpliedLocalTool"), "stdout:\n\(stderr)\n\(stdout)")
-                    #expect(stderr.contains("Build of product 'ImpliedLocalTool' complete!"), "stdout:\n\(stderr)\n\(stdout)")
-                }
-                #expect(stdout.contains("A message from the remote tool."), "stdout:\n\(stderr)\n\(stdout)")
-                #expect(stdout.contains("A message from the local tool."), "stdout:\n\(stderr)\n\(stdout)")
-                #expect(stdout.contains("A message from the implied local tool."), "stdout:\n\(stderr)\n\(stdout)")
-            }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows // Intermittent depending on the file path length
+    func testLocalAndRemoteToolDependencies() async throws {
+        try await fixture(name: "Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool") { path in
+            let (stdout, stderr) = try await executeSwiftPackage(path.appending("MyLibrary"), configuration: .debug, extraArgs: ["plugin", "my-plugin"])
+            #expect(stderr.contains("Linking RemoteTool"), "stdout:\n\(stderr)\n\(stdout)")
+            #expect(stderr.contains("Linking LocalTool"), "stdout:\n\(stderr)\n\(stdout)")
+            #expect(stderr.contains("Linking ImpliedLocalTool"), "stdout:\n\(stderr)\n\(stdout)")
+            #expect(stderr.contains("Build of product 'ImpliedLocalTool' complete!"), "stdout:\n\(stderr)\n\(stdout)")
+            #expect(stdout.contains("A message from the remote tool."), "stdout:\n\(stderr)\n\(stdout)")
+            #expect(stdout.contains("A message from the local tool."), "stdout:\n\(stderr)\n\(stdout)")
+            #expect(stdout.contains("A message from the implied local tool."), "stdout:\n\(stderr)\n\(stdout)")
         }
     }
 

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -487,20 +487,15 @@ struct TraitTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         try await fixture(name: "Traits") { fixturePath in
-            // The swiftbuild build system doesn't yet have the ability for command plugins to request symbol graphs
-            try await withKnownIssue {
-                let (stdout, _) = try await executeSwiftPackage(
-                    fixturePath.appending("Package10"),
-                    extraArgs: ["plugin", "extract", "--experimental-prune-unused-dependencies"],
-                    buildSystem: buildSystem,
-                )
-                let path = String(stdout.split(whereSeparator: \.isNewline).first!)
-                let symbolGraph = try String(contentsOfFile: "\(path)/Package10Library1.symbols.json", encoding: .utf8)
-                #expect(symbolGraph.contains("TypeGatedByPackage10Trait1"))
-                #expect(symbolGraph.contains("TypeGatedByPackage10Trait2"))
-            } when: {
-              buildSystem == .swiftbuild
-            }
+            let (stdout, _) = try await executeSwiftPackage(
+                fixturePath.appending("Package10"),
+                extraArgs: ["plugin", "extract", "--experimental-prune-unused-dependencies"],
+                buildSystem: buildSystem,
+            )
+            let path = String(stdout.split(whereSeparator: \.isNewline).first!)
+            let symbolGraph = try String(contentsOfFile: "\(path)/Package10Library1.symbols.json", encoding: .utf8)
+            #expect(symbolGraph.contains("TypeGatedByPackage10Trait1"))
+            #expect(symbolGraph.contains("TypeGatedByPackage10Trait2"))
         }
     }
 


### PR DESCRIPTION
Reverts swiftlang/swift-package-manager#8845

An attempt to see if this is going to fix PR testing issues in swift repository:

```
19:31:38      error: Linker command failed with exit code 1 (use -v to see invocation)
19:31:38      info: //<compiler-generated>:0: error: undefined reference to '$sSS20FoundationEssentialsE14CompareOptionsVN'
19:31:38      /tmp/Miscellaneous_Plugins.TjSZ7p/MySourceGenPlugin/Sources/MySourceGenBuildToolLib/library.swift:7: error: undefined reference to '$sSy10FoundationE20replacingOccurrences2of4with7options5rangeSSqd___qd_0_SS0A10EssentialsE14CompareOptionsVSnySS5IndexVGSgtSyRd__SyRd_0_r0_lF'
19:31:38      /tmp/Miscellaneous_Plugins.TjSZ7p/MySourceGenPlugin/Sources/MySourceGenBuildToolLib/library.swift:8: error: undefined reference to '$sSy10FoundationE20replacingOccurrences2of4with7options5rangeSSqd___qd_0_SS0A10EssentialsE14CompareOptionsVSnySS5IndexVGSgtSyRd__SyRd_0_r0_lF'
19:31:38      clang: error: linker command failed with exit code 1 (use -v to see invocation)
19:31:38      error: Ld /tmp/Miscellaneous_Plugins.TjSZ7p/MySourceGenPlugin/.build/x86_64-unknown-linux-gnu/Products/Debug-linux/MyLocalTool normal failed with a nonzero exit code
19:31:38      error: Build failed
```