### PR TITLE
SwiftBuild: Enable traits support

### DIFF
--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -120,7 +120,8 @@ private struct SwiftBuildSystemFactory: BuildSystemFactory {
             buildParameters: productsBuildParameters ?? self.swiftCommandState.productsBuildParameters,
             packageGraphLoader: packageGraphLoader ?? {
                 try await self.swiftCommandState.loadPackageGraph(
-                    explicitProduct: explicitProduct
+                    explicitProduct: explicitProduct,
+                    traitConfiguration: traitConfiguration,
                 )
             },
             packageManagerResourcesDirectory: swiftCommandState.packageManagerResourcesDirectory,


### PR DESCRIPTION
When Creasting the SwiftBuildSystem Factory, the traits configuration was not passed when loading the package graph.

Update the factory to pass the traits configuration during package resolution, and remove the `withKnownIssues` in TraitTests as it relates to SwiftBuild.

There are some know issues, which are tracked via the automated tests.