### PR TITLE
Inherit current environment in build tool plugin custom tasks

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -359,15 +359,16 @@ public final class PIFBuilder {
                             buildCommands: result.buildCommands.map( { buildCommand in
                                 var newEnv: Environment = buildCommand.configuration.environment
 
-                                // TODO decide on the precedence of these environment settings
-                                for (key, value) in Environment.current {
-                                    newEnv[key] = value
-                                }
-
                                 let runtimeLibPaths = buildParameters.toolchain.runtimeLibraryPaths
 
+                                // Add paths to swift standard runtime libraries to the library path so that they can be found at runtime
                                 for libPath in runtimeLibPaths {
                                     newEnv.appendPath(key: .libraryPath, value: libPath.pathString)
+                                }
+
+                                // Append the system path at the end so that necessary system tool paths can be found
+                                if let pathValue = Environment.current[EnvironmentKey.path] {
+                                    newEnv.appendPath(key: .path, value: pathValue)
                                 }
 
                                 let writableDirectories: [AbsolutePath] = [pluginOutputDir]

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -359,6 +359,11 @@ public final class PIFBuilder {
                             buildCommands: result.buildCommands.map( { buildCommand in
                                 var newEnv: Environment = buildCommand.configuration.environment
 
+                                // TODO decide on the precedence of these environment settings
+                                for (key, value) in Environment.current {
+                                    newEnv[key] = value
+                                }
+
                                 let runtimeLibPaths = buildParameters.toolchain.runtimeLibraryPaths
 
                                 for libPath in runtimeLibPaths {

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -310,6 +310,8 @@ final class PluginTests {
                 #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n(stdout)")
             } else if buildSystem == .swiftbuild {
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            } else {
+                Issue.record("Test has no expectation for \(buildSystem)")
             }
         }
     }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -299,13 +299,18 @@ final class PluginTests {
 
     @Test(
         .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
-        .enabled(if: ProcessInfo.hostOperatingSystem == .macOS, "Test is only supported on macOS")
+        .enabled(if: ProcessInfo.hostOperatingSystem == .macOS, "Test is only supported on macOS"),
+        arguments: [BuildSystemProvider.Kind.native, .swiftbuild]
     )
-    func testUseOfVendedBinaryTool() async throws {
+    func testUseOfVendedBinaryTool(buildSystem: BuildSystemProvider.Kind) async throws {
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MyBinaryToolPlugin"), configuration: .debug, extraArgs: ["--product", "MyLocalTool"])
-            #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
-            #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
+            let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MyBinaryToolPlugin"), configuration: .debug, extraArgs: ["--product", "MyLocalTool"], buildSystem: buildSystem)
+            if buildSystem == .native {
+                #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n(stdout)")
+            } else if buildSystem == .swiftbuild {
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            }
         }
     }
 


### PR DESCRIPTION
The native build system is extending the calling environment, such as the
PATH to the build tool invocations. Update the PIF Builder to do the same.
Enable testing of vendored binary build tools on macOS with the swiftbuild
build system.