### PR TITLE
Revert "Add SwiftBuildSupport to the primary libSwiftPM product (#8780)"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -81,7 +81,6 @@ let swiftPMProduct = (
         "LLBuildManifest",
         "SourceKitLSPAPI",
         "SPMLLBuild",
-        "SwiftBuildSupport",
     ]
 )
 


### PR DESCRIPTION
This reverts commit f8104e54c9f27983455bc88f05a0be5decfdae68.