### PR TITLE
Cherry picks FreeBSD fix to main

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -980,6 +980,7 @@ extension ProjectModel.BuildSettings.Platform {
         case .windows: .windows
         case .wasi: .wasi
         case .openbsd: .openbsd
+        case .freebsd: .freebsd
         default: preconditionFailure("Unexpected platform: \(platform.name)")
         }
     }


### PR DESCRIPTION
Cherry picks #8550 *again* to `main`.

PS. Looks like my previous `main`PR (ie, #8550) got lost somehow during merging/rebasing, etc...