### PR TITLE
Support swift package migrate with --build-system swiftbuild

### DIFF
--- a/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Package.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+let package = Package(
+    name: "ExistentialAnyMigration",
+    targets: [
+        .target(name: "Library", dependencies: ["CommonLibrary"], plugins: [.plugin(name: "Plugin")]),
+        .plugin(name: "Plugin", capability: .buildTool, dependencies: ["Tool"]),
+        .executableTarget(name: "Tool", dependencies: ["CommonLibrary"]),
+        .target(name: "CommonLibrary"),
+    ]
+)

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Plugins/Plugin/Plugin.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Plugins/Plugin/Plugin.swift
@@ -1,0 +1,17 @@
+import PackagePlugin
+import Foundation
+
+@main struct Plugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        let tool = try context.tool(named: "Tool")
+        let output = context.pluginWorkDirectory.appending(["generated.swift"])
+        return [
+            .buildCommand(
+                displayName: "Plugin",
+                executable: tool.path,
+                arguments: [output],
+                inputFiles: [],
+                outputFiles: [output])
+        ]
+    }
+}

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Sources/CommonLibrary/Common.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Sources/CommonLibrary/Common.swift
@@ -1,0 +1,6 @@
+public func common() {}
+
+
+protocol P {}
+
+func needsMigration(_ p: P) {}

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Sources/Library/Test.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Sources/Library/Test.swift
@@ -1,0 +1,6 @@
+import CommonLibrary
+
+func bar() {
+    generatedFunction()
+    common()
+}

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Sources/Tool/tool.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Sources/Tool/tool.swift
@@ -1,0 +1,13 @@
+import Foundation
+import CommonLibrary
+
+@main struct Entry {
+    public static func main() async throws {
+        common()
+        let outputPath = CommandLine.arguments[1]
+        let contents = """
+        func generatedFunction() {}
+        """
+        FileManager.default.createFile(atPath: outputPath, contents: contents.data(using: .utf8))
+    }
+}

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Package.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+let package = Package(
+    name: "ExistentialAnyMigration",
+    targets: [
+        .target(name: "Library", plugins: [.plugin(name: "Plugin")]),
+        .plugin(name: "Plugin", capability: .buildTool, dependencies: ["Tool"]),
+        .executableTarget(name: "Tool"),
+    ]
+)

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Plugins/Plugin/Plugin.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Plugins/Plugin/Plugin.swift
@@ -1,0 +1,17 @@
+import PackagePlugin
+import Foundation
+
+@main struct Plugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        let tool = try context.tool(named: "Tool")
+        let output = context.pluginWorkDirectory.appending(["generated.swift"])
+        return [
+            .buildCommand(
+                displayName: "Plugin",
+                executable: tool.path,
+                arguments: [output],
+                inputFiles: [],
+                outputFiles: [output])
+        ]
+    }
+}

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Sources/Library/Test.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Sources/Library/Test.swift
@@ -1,0 +1,20 @@
+protocol P {
+}
+
+func test1(_: P) {
+}
+
+func test2(_: P.Protocol) {
+}
+
+func test3() {
+    let _: [P?] = []
+}
+
+func test4() {
+    var x = 42
+}
+
+func bar() {
+    generatedFunction()
+}

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Sources/Tool/tool.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Sources/Tool/tool.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+@main struct Entry {
+    public static func main() async throws {
+        let outputPath = CommandLine.arguments[1]
+        let contents = """
+        func generatedFunction() {}
+        func dontmodifyme(_: P) {}
+        """
+        FileManager.default.createFile(atPath: outputPath, contents: contents.data(using: .utf8))
+    }
+}

--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -90,7 +90,7 @@ extension SwiftPackageCommand {
                 features.append(feature)
             }
 
-            let targets = self.options.targets
+            var targets = self.options.targets
 
             let buildSystem = try await createBuildSystem(
                 swiftCommandState,
@@ -100,49 +100,29 @@ extension SwiftPackageCommand {
 
             // Next, let's build all of the individual targets or the
             // whole project to get diagnostic files.
-
             print("> Starting the build")
+            var diagnosticsPaths: [String: [AbsolutePath]] = [:]
             if !targets.isEmpty {
                 for target in targets {
-                    try await buildSystem.build(subset: .target(target))
+                    let buildResult = try await buildSystem.build(subset: .target(target))
+                    diagnosticsPaths.merge(try buildResult.serializedDiagnosticPathsByTargetName.get(), uniquingKeysWith: { $0 + $1 })
                 }
             } else {
-                try await buildSystem.build(subset: .allIncludingTests)
+                diagnosticsPaths = try await buildSystem.build(subset: .allIncludingTests).serializedDiagnosticPathsByTargetName.get()
             }
-
-            // Determine all of the targets we need up update.
-            let buildPlan = try buildSystem.buildPlan
-
-            var modules: [any ModuleBuildDescription] = []
-            if !targets.isEmpty {
-                for buildDescription in buildPlan.buildModules
-                    where targets.contains(buildDescription.module.name) {
-                    modules.append(buildDescription)
-                }
-            } else {
-                let graph = try await buildSystem.getPackageGraph()
-                for buildDescription in buildPlan.buildModules
-                    where graph.isRootPackage(buildDescription.package)
-                {
-                    let module = buildDescription.module
-                    guard module.type != .plugin, !module.implicit else {
-                        continue
-                    }
-                    modules.append(buildDescription)
-                }
-            }
-
-            // If the build suceeded, let's extract all of the diagnostic
-            // files from build plan and feed them to the fix-it tool.
-
-            print("> Applying fix-its")
 
             var summary = SwiftFixIt.Summary(numberOfFixItsApplied: 0, numberOfFilesChanged: 0)
+            let graph = try await buildSystem.getPackageGraph()
+            if targets.isEmpty {
+                targets = OrderedSet(graph.rootPackages.flatMap { $0.manifest.targets.filter { $0.type != .plugin }.map(\.name) })
+            }
+            print("> Applying fix-its")
             let fixItDuration = try ContinuousClock().measure {
-                for module in modules {
+                for target in targets {
                     let fixit = try SwiftFixIt(
-                        diagnosticFiles: module.diagnosticFiles,
+                        diagnosticFiles: Array(diagnosticsPaths[target] ?? []),
                         categories: Set(features.flatMap(\.categories)),
+                        excludedSourceDirectories: [swiftCommandState.scratchDirectory],
                         fileSystem: swiftCommandState.fileSystem
                     )
                     summary += try fixit.applyFixIts()
@@ -176,10 +156,10 @@ extension SwiftPackageCommand {
             // manifest with newly adopted feature settings.
 
             print("> Updating manifest")
-            for module in modules.map(\.module) {
-                swiftCommandState.observabilityScope.emit(debug: "Adding feature(s) to '\(module.name)'")
+            for target in targets {
+                swiftCommandState.observabilityScope.emit(debug: "Adding feature(s) to '\(target)'")
                 try self.updateManifest(
-                    for: module.name,
+                    for: target,
                     add: features,
                     using: swiftCommandState
                 )

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -50,7 +50,8 @@ public protocol BuildSystem: Cancellable {
     /// Builds a subset of the package graph.
     /// - Parameters:
     ///   - subset: The subset of the package graph to build.
-    func build(subset: BuildSubset) async throws
+    @discardableResult
+    func build(subset: BuildSubset) async throws -> BuildResult
 
     var buildPlan: BuildPlan { get throws }
 
@@ -59,9 +60,18 @@ public protocol BuildSystem: Cancellable {
 
 extension BuildSystem {
     /// Builds the default subset: all targets excluding tests.
-    public func build() async throws {
+    @discardableResult
+    public func build() async throws -> BuildResult {
         try await build(subset: .allExcludingTests)
     }
+}
+
+public struct BuildResult {
+    package init(serializedDiagnosticPathsByTargetName: Result<[String: [AbsolutePath]], Error>) {
+        self.serializedDiagnosticPathsByTargetName = serializedDiagnosticPathsByTargetName
+    }
+    
+    public var serializedDiagnosticPathsByTargetName: Result<[String: [AbsolutePath]], Error>
 }
 
 public protocol ProductBuildDescription {

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -41,20 +41,22 @@ struct SessionFailedError: Error {
     var diagnostics: [SwiftBuild.SwiftBuildMessage.DiagnosticInfo]
 }
 
-func withService(
+func withService<T>(
     connectionMode: SWBBuildServiceConnectionMode = .default,
     variant: SWBBuildServiceVariant = .default,
     serviceBundleURL: URL? = nil,
-    body: @escaping (_ service: SWBBuildService) async throws -> Void
-) async throws {
+    body: @escaping (_ service: SWBBuildService) async throws -> T
+) async throws -> T {
     let service = try await SWBBuildService(connectionMode: connectionMode, variant: variant, serviceBundleURL: serviceBundleURL)
+    let result: T
     do {
-        try await body(service)
+        result = try await body(service)
     } catch {
         await service.close()
         throw error
     }
     await service.close()
+    return result
 }
 
 public func createSession(
@@ -279,20 +281,20 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         SwiftLanguageVersion.supportedSwiftLanguageVersions
     }
 
-    public func build(subset: BuildSubset) async throws {
+    public func build(subset: BuildSubset) async throws -> BuildResult {
         guard !buildParameters.shouldSkipBuilding else {
-            return
+            return BuildResult(serializedDiagnosticPathsByTargetName: .failure(StringError("Building was skipped")))
         }
 
         try await writePIF(buildParameters: buildParameters)
 
-        try await startSWBuildOperation(pifTargetName: subset.pifTargetName)
+        return try await startSWBuildOperation(pifTargetName: subset.pifTargetName)
     }
 
-    private func startSWBuildOperation(pifTargetName: String) async throws {
+    private func startSWBuildOperation(pifTargetName: String) async throws -> BuildResult {
         let buildStartTime = ContinuousClock.Instant.now
 
-        try await withService(connectionMode: .inProcessStatic(swiftbuildServiceEntryPoint)) { service in
+        return try await withService(connectionMode: .inProcessStatic(swiftbuildServiceEntryPoint)) { service in
             let derivedDataPath = self.buildParameters.dataPath
 
             let progressAnimation = ProgressAnimation.percent(
@@ -302,6 +304,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                 isColorized: self.buildParameters.outputParameters.isColorized
             )
 
+            var serializedDiagnosticPathsByTargetName: [String: [Basics.AbsolutePath]] = [:]
             do {
                 try await withSession(service: service, name: self.buildParameters.pifManifest.pathString, toolchainPath: self.buildParameters.toolchain.toolchainDir, packageManagerResourcesDirectory: self.packageManagerResourcesDirectory) { session, _ in
                     self.outputStream.send("Building for \(self.buildParameters.configuration == .debug ? "debugging" : "production")...\n")
@@ -451,6 +454,11 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                             }
                             let targetInfo = try buildState.target(for: startedInfo)
                             self.delegate?.buildSystem(self, didFinishCommand: BuildSystemCommand(startedInfo, targetInfo: targetInfo))
+                            if let targetName = targetInfo?.targetName {
+                                serializedDiagnosticPathsByTargetName[targetName, default: []].append(contentsOf: startedInfo.serializedDiagnosticsPaths.compactMap {
+                                    try? Basics.AbsolutePath(validating: $0.pathString)
+                                })
+                            }
                         case .targetStarted(let info):
                             try buildState.started(target: info)
                         case .planningOperationStarted, .planningOperationCompleted, .reportBuildDescription, .reportPathMap, .preparedForIndex, .backtraceFrame, .buildStarted, .preparationComplete, .targetUpToDate, .targetComplete, .taskUpToDate:
@@ -503,6 +511,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             } catch {
                 throw error
             }
+            return BuildResult(serializedDiagnosticPathsByTargetName: .success(serializedDiagnosticPathsByTargetName))
         }
     }
 

--- a/Sources/SwiftFixIt/SwiftFixIt.swift
+++ b/Sources/SwiftFixIt/SwiftFixIt.swift
@@ -124,9 +124,11 @@ private struct PrimaryDiagnosticFilter<Diagnostic: AnyDiagnostic>: ~Copyable {
     private var uniquePrimaryDiagnostics: Set<DiagnosticID> = []
 
     let categories: Set<String>
+    let excludedSourceDirectories: Set<AbsolutePath>
 
-    init(categories: Set<String>) {
+    init(categories: Set<String>, excludedSourceDirectories: Set<AbsolutePath>) {
         self.categories = categories
+        self.excludedSourceDirectories = excludedSourceDirectories
     }
 
     /// Returns a Boolean value indicating whether to skip the given primary
@@ -149,6 +151,13 @@ private struct PrimaryDiagnosticFilter<Diagnostic: AnyDiagnostic>: ~Copyable {
         // belong to any of them.
         if !self.categories.isEmpty {
             guard let category = diagnostic.category, self.categories.contains(category) else {
+                return true
+            }
+        }
+
+        // Skip if the source file the diagnostic appears in is in an excluded directory.
+        if let sourceFilePath = try? diagnostic.location.map({ try AbsolutePath(validating: $0.filename) }) {
+            guard !self.excludedSourceDirectories.contains(where: { $0.isAncestor(of: sourceFilePath) }) else {
                 return true
             }
         }
@@ -201,6 +210,7 @@ package struct SwiftFixIt /*: ~Copyable */ { // TODO: Crashes with ~Copyable
     package init(
         diagnosticFiles: [AbsolutePath],
         categories: Set<String> = [],
+        excludedSourceDirectories: Set<AbsolutePath> = [],
         fileSystem: any FileSystem
     ) throws {
         // Deserialize the diagnostics.
@@ -212,6 +222,7 @@ package struct SwiftFixIt /*: ~Copyable */ { // TODO: Crashes with ~Copyable
         self = try SwiftFixIt(
             diagnostics: diagnostics,
             categories: categories,
+            excludedSourceDirectories: excludedSourceDirectories,
             fileSystem: fileSystem
         )
     }
@@ -219,11 +230,12 @@ package struct SwiftFixIt /*: ~Copyable */ { // TODO: Crashes with ~Copyable
     init<Diagnostic: AnyDiagnostic>(
         diagnostics: some Collection<Diagnostic>,
         categories: Set<String>,
+        excludedSourceDirectories: Set<AbsolutePath>,
         fileSystem: any FileSystem
     ) throws {
         self.fileSystem = fileSystem
 
-        var filter = PrimaryDiagnosticFilter<Diagnostic>(categories: categories)
+        var filter = PrimaryDiagnosticFilter<Diagnostic>(categories: categories, excludedSourceDirectories: excludedSourceDirectories)
         _ = consume categories
 
         // Build a map from source files to `SwiftDiagnostics` diagnostics.

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -160,9 +160,9 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         return []
     }
 
-    public func build(subset: BuildSubset) async throws {
+    public func build(subset: BuildSubset) async throws -> BuildResult {
         guard !buildParameters.shouldSkipBuilding else {
-            return
+            return BuildResult(serializedDiagnosticPathsByTargetName: .failure(StringError("XCBuild does not support reporting serialized diagnostics.")))
         }
 
         let pifBuilder = try await getPIFBuilder()
@@ -244,9 +244,12 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
             throw Diagnostics.fatalError
         }
 
-        guard !self.logLevel.isQuiet else { return }
-        self.outputStream.send("Build complete!\n")
-        self.outputStream.flush()
+        if !logLevel.isQuiet {
+            self.outputStream.send("Build complete!\n")
+            self.outputStream.flush()
+        }
+
+        return BuildResult(serializedDiagnosticPathsByTargetName: .failure(StringError("XCBuild does not support reporting serialized diagnostics.")))
     }
 
     func createBuildParametersFile() throws -> AbsolutePath {

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2156,6 +2156,44 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
         try await doMigration(featureName: "InferIsolatedConformances", expectedSummary: "Applied 1 fix-it in 1 file")
     }
 
+    func testMigrateCommandWithBuildToolPlugins() async throws {
+        try XCTSkipIf(
+            !UserToolchain.default.supportesSupportedFeatures,
+            "skipping because test environment compiler doesn't support `-print-supported-features`"
+        )
+
+        try await fixture(name: "SwiftMigrate/ExistentialAnyWithPluginMigration") { fixturePath in
+            let (stdout, _) = try await self.execute(
+                ["migrate", "--to-feature", "ExistentialAny"],
+                packagePath: fixturePath
+            )
+
+            // Check the plugin target in the manifest wasn't updated
+            let manifestContent = try localFileSystem.readFileContents(fixturePath.appending(component: "Package.swift")).description
+            XCTAssertTrue(manifestContent.contains(".plugin(name: \"Plugin\", capability: .buildTool, dependencies: [\"Tool\"]),"))
+
+            // Building the package produces migration fix-its in both an authored and generated source file. Check we only applied fix-its to the hand-authored one.
+            XCTAssertMatch(stdout, .regex("> \("Applied 3 fix-its in 1 file")" + #" \([0-9]\.[0-9]{1,3}s\)"#))
+        }
+    }
+
+    func testMigrateCommandWhenDependencyBuildsForHostAndTarget() async throws {
+        try XCTSkipIf(
+            !UserToolchain.default.supportesSupportedFeatures,
+            "skipping because test environment compiler doesn't support `-print-supported-features`"
+        )
+
+        try await fixture(name: "SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration") { fixturePath in
+            let (stdout, _) = try await self.execute(
+                ["migrate", "--to-feature", "ExistentialAny"],
+                packagePath: fixturePath
+            )
+
+            // Even though the CommonLibrary dependency built for both the host and destination, we should only apply a single fix-it once to its sources.
+            XCTAssertMatch(stdout, .regex("> \("Applied 1 fix-it in 1 file")" + #" \([0-9]\.[0-9]{1,3}s\)"#))
+        }
+    }
+
     func testBuildToolPlugin() async throws {
         try await testBuildToolPlugin(staticStdlib: false)
     }
@@ -4123,10 +4161,6 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
     override func testCommandPluginBuildingCallbacks() async throws {
         try XCTSkipOnWindows(because: "TSCBasic/Path.swift:969: Assertion failed, https://github.com/swiftlang/swift-package-manager/issues/8602")
         try await super.testCommandPluginBuildingCallbacks()
-    }
-
-    override func testMigrateCommand() async throws {
-        throw XCTSkip("SWBINTTODO: Build plan is not currently supported")
     }
 
     override func testCommandPluginTestingCallbacks() async throws {

--- a/Tests/SwiftFixItTests/Utilities.swift
+++ b/Tests/SwiftFixItTests/Utilities.swift
@@ -233,6 +233,7 @@ private func _testAPI(
     let swiftFixIt = try SwiftFixIt(
         diagnostics: flatDiagnostics,
         categories: categories,
+        excludedSourceDirectories: [],
         fileSystem: localFileSystem
     )
     let actualSummary = try swiftFixIt.applyFixIts()


### PR DESCRIPTION
Similar to the API digester integration, pass along a build system delegate to capture serialized diagnostic paths from the build and pass them to the fix-it application infra.

Builds on the changes in https://github.com/swiftlang/swift-package-manager/pull/8857, only the second commit is new