### PR TITLE
Recognize visionOS and DriverKit triples correctly

### DIFF
--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -133,6 +133,10 @@ extension Triple.OS {
             return "tvos"
         case .watchos:
             return "watchos"
+        case .visionos:
+            return "xros"
+        case .driverkit:
+            return "driverkit"
         default:
             return nil // XCFrameworks do not support any of these platforms today.
         }

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -97,6 +97,8 @@ public struct BuildParameters: Encodable {
     var currentPlatform: PackageModel.Platform {
         if self.triple.isDarwin() {
             switch self.triple.darwinPlatform {
+            case .driverKit:
+                return .driverKit
             case .iOS(.catalyst):
                 return .macCatalyst
             case .iOS(.device), .iOS(.simulator):
@@ -105,6 +107,8 @@ public struct BuildParameters: Encodable {
                 return .tvOS
             case .watchOS:
                 return .watchOS
+            case .visionOS:
+                return .visionOS
             case .macOS, nil:
                 return .macOS
             }
@@ -118,8 +122,10 @@ public struct BuildParameters: Encodable {
             return .openbsd
         } else if self.triple.isFreeBSD() {
             return .freebsd
-        } else {
+        } else if self.triple.isLinux() {
             return .linux
+        } else {
+            return .custom(name: "unknown", oldestSupportedVersion: .unknown)
         }
     }
 

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -128,9 +128,9 @@ struct PackagePIFProjectBuilder {
             .iOS: moduleDeploymentTargets?[.iOS],
             .tvOS: moduleDeploymentTargets?[.tvOS],
             .watchOS: moduleDeploymentTargets?[.watchOS],
+            .visionOS: moduleDeploymentTargets?[.visionOS],
             .driverKit: moduleDeploymentTargets?[.driverKit],
         ]
-        deploymentTargets[.visionOS] = moduleDeploymentTargets?[.visionOS]
         let declaredPlatforms = firstModule?.declaredPlatforms
 
         // Compute the names of all explicitly dynamic library products, we need to avoid

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -869,6 +869,10 @@ fileprivate extension Triple {
             return "TVOS_DEPLOYMENT_TARGET"
         case (.watchos, _):
             return "WATCHOS_DEPLOYMENT_TARGET"
+        case (.visionos, _):
+            return "XROS_DEPLOYMENT_TARGET"
+        case (.driverkit, _):
+            return "DRIVERKIT_DEPLOYMENT_TARGET"
         case (_, .android):
             return "ANDROID_DEPLOYMENT_TARGET"
         default:

--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -985,6 +985,7 @@ public enum PIF {
             case iOS = "ios"
             case tvOS = "tvos"
             case watchOS = "watchos"
+            case visionOS = "visionos"
             case driverKit = "driverkit"
             case linux
 
@@ -995,6 +996,7 @@ public enum PIF {
                 case .iOS: return .iOS
                 case .tvOS: return .tvOS
                 case .watchOS: return .watchOS
+                case .visionOS: return .visionOS
                 case .driverKit: return .driverKit
                 case .linux: return .linux
                 }

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -319,7 +319,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         settings[.ENABLE_TESTING_SEARCH_PATHS] = "YES"
 
         // XCTest search paths should only be specified for certain platforms (watchOS doesn't have XCTest).
-        for platform: PIF.BuildSettings.Platform in [.macOS, .iOS, .tvOS] {
+        for platform: PIF.BuildSettings.Platform in [.macOS, .iOS, .tvOS, .visionOS] {
             settings[.FRAMEWORK_SEARCH_PATHS, for: platform, default: ["$(inherited)"]]
                 .append("$(PLATFORM_DIR)/Developer/Library/Frameworks")
         }
@@ -1949,6 +1949,7 @@ extension PIF.BuildSettings.Platform {
         case .macOS: .macOS
         case .tvOS: .tvOS
         case .watchOS: .watchOS
+        case .visionOS: .visionOS
         case .driverKit: .driverKit
         default: nil
         }

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -43,6 +43,8 @@ struct TripleTests {
             (tripleName: "x86_64-apple-macosx", isApple: true, isDarwin: true),
             (tripleName: "x86_64-apple-macosx10.15", isApple: true, isDarwin: true),
             (tripleName: "x86_64h-apple-darwin", isApple: true, isDarwin: true),
+            (tripleName: "x86_64-apple-driverkit", isApple: true, isDarwin: true),
+            (tripleName: "arm64-apple-driverkit", isApple: true, isDarwin: true),
             (tripleName: "i686-pc-windows-msvc", isApple: false, isDarwin: false),
             (tripleName: "i686-pc-windows-gnu", isApple: false, isDarwin: false),
             (tripleName: "i686-pc-windows-cygnus", isApple: false, isDarwin: false),
@@ -246,6 +248,15 @@ struct TripleTests {
                 expectedOs: .wasi,
                 expectedEnvironment: nil,
                 expectedObjectFormat: .wasm
+            ),
+            DataKnownTripleParsing(
+                tripleName: "arm64-apple-driverkit19.0",
+                expectedArch: .aarch64,
+                expectedSubArch: nil,
+                expectedVendor: .apple,
+                expectedOs: .driverkit,
+                expectedEnvironment: nil,
+                expectedObjectFormat: .macho
             )
         ]
     )


### PR DESCRIPTION
This makes visionOS and DriverKit builds work correctly using the Swift Build backend.