### PR TITLE
Docs/interoperability mode

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -575,12 +575,15 @@ public struct SwiftSetting: Sendable {
             name: "strictMemorySafety", value: ["ON"], condition: condition)
     }
 
+    /// The interoperability mode
     public enum InteroperabilityMode: String {
+        /// Interoperate as C
         case C
+        /// Interoperate as Cxx
         case Cxx
     }
 
-    /// Enable Swift interoperability with a given language.
+    /// Enables Swift interoperability with a given language.
     ///
     /// This is useful for enabling interoperability between Swift and C++ for
     /// a given target.

--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -577,9 +577,9 @@ public struct SwiftSetting: Sendable {
 
     /// The interoperability mode
     public enum InteroperabilityMode: String {
-        /// Interoperate as C
+        /// Emit code compatible with being imported from C and Objective-C.
         case C
-        /// Interoperate as Cxx
+        /// Emit code compatible with being imported from C++ and Objective-C++.
         case Cxx
     }
 
@@ -594,7 +594,7 @@ public struct SwiftSetting: Sendable {
     /// - Since: First available in PackageDescription 5.9.
     ///
     /// - Parameters:
-    ///   - mode: The language mode, either C or Cxx.
+    ///   - mode: The interoperability mode, either C-compatible or C++-compatible.
     ///   - condition: A condition that restricts the application of the build
     /// setting.
     @available(_PackageDescription, introduced: 5.9)

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/SwiftSetting.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/SwiftSetting.md
@@ -13,6 +13,11 @@
 
 - ``swiftLanguageMode(_:_:)``
 
+### Configuring Swift Concurrency
+
+- ``strictMemorySafety(_:)``
+- ``defaultIsolation(_:_:)``
+
 ### Configuring Swift Experimental and Upcoming Features
 
 - ``enableExperimentalFeature(_:_:)``
@@ -22,11 +27,6 @@
 
 - ``interoperabilityMode(_:_:)``
 - ``InteroperabilityMode``
-
-### Configuring Swift Concurrency
-
-- ``strictMemorySafety(_:)``
-- ``defaultIsolation(_:_:)``
 
 ### Deprecated configurations
 

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/SwiftSetting.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/SwiftSetting.md
@@ -6,11 +6,28 @@
 
 - ``define(_:_:)``
 - ``unsafeFlags(_:_:)``
-- ``strictMemorySafety(_:)``
+- ``treatAllWarnings(as:_:)``
+- ``treatWarning(_:as:_:)``
+
+### Configuring Swift Language Mode
+
 - ``swiftLanguageMode(_:_:)``
-- ``defaultIsolation(_:_:)``
+
+### Configuring Swift Experimental and Upcoming Features
+
 - ``enableExperimentalFeature(_:_:)``
 - ``enableUpcomingFeature(_:_:)``
+
+### Configuring Swift Interoperability
+
 - ``interoperabilityMode(_:_:)``
 - ``InteroperabilityMode``
+
+### Configuring Swift Concurrency
+
+- ``strictMemorySafety(_:)``
+- ``defaultIsolation(_:_:)``
+
+### Deprecated configurations
+
 - ``swiftLanguageVersion(_:_:)``

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -30,8 +30,7 @@
 /// Alternatively, exclude resource files from a target by passing them to the
 /// target initializer's ``Target/exclude`` parameter.
 ///
-/// To learn more about package resources, see
-/// <doc:bundling-resources-with-a-swift-package>.
+/// To learn more about package resources, see [Bundling resources as a Swift Package](https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package).
 @available(_PackageDescription, introduced: 5.3)
 public struct Resource: Sendable {
 

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -210,8 +210,7 @@ public final class Target {
     /// package compute-checksum path/to/MyFramework.zip` at the command line to
     /// make sure you create a correct SHA256 checksum.
     ///
-    /// For more information, see
-    /// <doc:distributing-binary-frameworks-as-swift-packages>.
+    /// For more information, see [Distributing binary frameworks as Swift packages](https://developer.apple.com/documentation/xcode/distributing-binary-frameworks-as-swift-packages).
     @available(_PackageDescription, introduced: 5.3)
     public var checksum: String?
 


### PR DESCRIPTION
Adds in abstracts and documentation for interoperability mode

ref: rdar://136526756

### Motivation:

InteroperabilityMode was missing abstracts within PackageDescription.

### Modifications:

Added abstracts to provide consistency, re-curated (organized) the SwiftSettings into more readable sections, and changed a few local doc references to Xcode documentation into HTML links to support external rendering without warnings.

### Result:

Interoperability has documentation, and the SwiftSettings has been re-organized.
The doc build runs locally without warnings.
