### PR TITLE
Cherry-pick Allow C targets to import the compatibility header generated for Swift libraries #8736

### DIFF
--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -910,15 +910,20 @@ public final class SwiftModuleBuildDescription {
         try self.fileSystem.writeFileContents(path, bytes: .init(encodingAsUTF8: content), atomically: true)
     }
 
+    /// Directory for the the compatibility header and module map generated for this target.
+    /// The whole directory should be usable as a header search path.
+    private var compatibilityHeaderDirectory: AbsolutePath {
+        tempsPath.appending("include")
+    }
+
     /// Generates the module map for the Swift target and returns its path.
     private func generateModuleMap() throws -> AbsolutePath {
-        let path = self.tempsPath.appending(component: moduleMapFilename)
+        let path = self.compatibilityHeaderDirectory.appending(component: moduleMapFilename)
 
         let bytes = ByteString(
             #"""
             module \#(self.target.c99name) {
                 header "\#(self.objCompatibilityHeaderPath.pathString)"
-                requires objc
             }
 
             """#.utf8
@@ -937,7 +942,7 @@ public final class SwiftModuleBuildDescription {
 
     /// Returns the path to the ObjC compatibility header for this Swift target.
     var objCompatibilityHeaderPath: AbsolutePath {
-        self.tempsPath.appending("\(self.target.name)-Swift.h")
+        self.compatibilityHeaderDirectory.appending("\(self.target.name)-Swift.h")
     }
 
     /// Returns the build flags from the declared build settings.

--- a/Sources/Build/BuildPlan/BuildPlan+Clang.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Clang.swift
@@ -30,7 +30,8 @@ extension BuildPlan {
             case is SwiftModule:
                 if case let .swift(dependencyTargetDescription)? = description {
                     if let moduleMap = dependencyTargetDescription.moduleMap {
-                        clangTarget.additionalFlags += ["-fmodule-map-file=\(moduleMap.pathString)"]
+                        // C languages clients should either import the module or include the compatibility header next to it.
+                        clangTarget.additionalFlags += ["-I", moduleMap.dirname]
                     }
                 }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2029,7 +2029,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
 
         // D
         do {
-            let expectedBModuleMap = AbsolutePath("/path/to/build/\(triple)/debug/B.build/module.modulemap").pathString
+            let expectedBInclude = AbsolutePath("/path/to/build/\(triple)/debug/B.build/include").pathString
             let expectedCModuleMap = AbsolutePath("/path/to/build/\(triple)/debug/C.build/module.modulemap").pathString
             let expectedDModuleMap = AbsolutePath("/path/to/build/\(triple)/debug/D.build/module.modulemap").pathString
             let expectedModuleCache = AbsolutePath("/path/to/build/\(triple)/debug/ModuleCache").pathString
@@ -2051,13 +2051,11 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 ]
             )
 
-#if os(macOS)
             try XCTAssertMatchesSubSequences(
                 result.moduleBuildDescription(for: "D").symbolGraphExtractArguments(),
                 // Swift Module dependencies
-                ["-Xcc", "-fmodule-map-file=\(expectedBModuleMap)"]
+                ["-Xcc", "-I", "-Xcc", "\(expectedBInclude)"]
             )
-#endif
         }
     }
 
@@ -5981,7 +5979,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 .anySequence,
                 "-emit-objc-header",
                 "-emit-objc-header-path",
-                "\(buildPath.appending(components: "Foo.build", "Foo-Swift.h"))",
+                "\(buildPath.appending(components: "Foo.build", "include", "Foo-Swift.h"))",
                 .anySequence,
             ]
         )
@@ -5991,7 +5989,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             barTarget,
             [
                 .anySequence,
-                "-fmodule-map-file=\(buildPath.appending(components: "Foo.build", "module.modulemap"))",
+                "-I", "\(buildPath.appending(components: "Foo.build", "include"))",
                 .anySequence,
             ]
         )
@@ -6066,7 +6064,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 .anySequence,
                 "-emit-objc-header",
                 "-emit-objc-header-path",
-                "\(buildPath.appending(components: "Foo.build", "Foo-Swift.h"))",
+                "\(buildPath.appending(components: "Foo.build", "include", "Foo-Swift.h"))",
                 .anySequence,
             ]
         )
@@ -6076,7 +6074,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             barTarget,
             [
                 .anySequence,
-                "-fmodule-map-file=\(buildPath.appending(components: "Foo.build", "module.modulemap"))",
+                "-I", "\(buildPath.appending(components: "Foo.build", "include"))",
                 .anySequence,
             ]
         )
@@ -6156,7 +6154,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 .anySequence,
                 "-emit-objc-header",
                 "-emit-objc-header-path",
-                "\(buildPath.appending(components: "Foo.build", "Foo-Swift.h"))",
+                "\(buildPath.appending(components: "Foo.build", "include", "Foo-Swift.h"))",
                 .anySequence,
             ]
         )
@@ -6166,7 +6164,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             barTarget,
             [
                 .anySequence,
-                "-fmodule-map-file=\(buildPath.appending(components: "Foo.build", "module.modulemap"))",
+                "-I", "\(buildPath.appending(components: "Foo.build", "include"))",
                 .anySequence,
             ]
         )

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -737,19 +737,19 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertMatch(
             fooLoggingArgs,
             [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
-             "\(buildPath.appending(components: "FooLogging.build", "FooLogging-Swift.h"))",
+             "\(buildPath.appending(components: "FooLogging.build", "include", "FooLogging-Swift.h"))",
              .anySequence]
         )
         XCTAssertMatch(
             barLoggingArgs,
             [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
-             "\(buildPath.appending(components: "BarLogging.build", "BarLogging-Swift.h"))",
+             "\(buildPath.appending(components: "BarLogging.build", "include", "BarLogging-Swift.h"))",
              .anySequence]
         )
         XCTAssertMatch(
             loggingArgs,
             [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
-             "\(buildPath.appending(components: "Logging.build", "Logging-Swift.h"))",
+             "\(buildPath.appending(components: "Logging.build", "include", "Logging-Swift.h"))",
              .anySequence]
         )
     }
@@ -843,13 +843,13 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertMatch(
             otherLoggingArgs,
             [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
-             "\(buildPath.appending(components: "OtherLogging.build", "OtherLogging-Swift.h"))",
+             "\(buildPath.appending(components: "OtherLogging.build", "include", "OtherLogging-Swift.h"))",
              .anySequence]
         )
         XCTAssertMatch(
             loggingArgs,
             [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
-             "\(buildPath.appending(components: "Logging.build", "Logging-Swift.h"))",
+             "\(buildPath.appending(components: "Logging.build", "include", "Logging-Swift.h"))",
              .anySequence]
         )
     }


### PR DESCRIPTION
Cherry-pick #8736 to 6.2

Address two issues preventing a C source file to import the generated compatibility header:

Don't mark the module map generated for the compatibility header as requires objc. This triggers an error when importing it from a C source file. The compatibility header is already printed in a way where the Objective-C code is protected behind a language check. C clients can safely import it even if they may not see any content. Plus we're adding C content to the compatibility header with the official support for @cdecl that is independent of Objective-C.

Emit the generated compatibility header and module map in a new include directory under the temporary build directory of each Swift library. This directory is then used as a header search path for the dependent clang targets.

This replaces the previous strategy that relied only the generated module map to resolve imports. It was incompatible with C source files and non-modular textual includes. The use of a header search path preserves the support for module imports via the same module map and supports textual includes of the compatibility header.