### PR TITLE
Cherry-pick Fix --quiet option not working with swift run #8844 (#8858)

### DIFF
--- a/Fixtures/Miscellaneous/SwiftBuild/Package.swift
+++ b/Fixtures/Miscellaneous/SwiftBuild/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "TestableExe",
+    targets: [
+        .executableTarget(
+            name: "Test",
+            path: "."
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/SwiftBuild/main.swift
+++ b/Fixtures/Miscellaneous/SwiftBuild/main.swift
@@ -1,0 +1,1 @@
+print("done")

--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -443,6 +443,14 @@ public struct Diagnostic: Sendable, CustomStringConvertible {
         public var isBold: Bool {
             return true
         }
+
+        public var isVerbose: Bool {
+            self <= .info
+        }
+
+        public var isQuiet: Bool {
+            self >= .error
+        }
     }
 }
 

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -1044,9 +1044,3 @@ extension BuildSubset {
         }
     }
 }
-
-extension Basics.Diagnostic.Severity {
-    var isVerbose: Bool {
-        return self <= .info
-    }
-}

--- a/Sources/CoreCommands/SwiftCommandObservabilityHandler.swift
+++ b/Sources/CoreCommands/SwiftCommandObservabilityHandler.swift
@@ -221,9 +221,3 @@ extension ObservabilityMetadata {
         }
     }
 }
-
-extension Basics.Diagnostic.Severity {
-    fileprivate var isVerbose: Bool {
-        return self <= .info
-    }
-}

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -355,6 +355,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                     }
 
                     func emitEvent(_ message: SwiftBuild.SwiftBuildMessage, buildState: inout BuildState) throws {
+                        guard !self.logLevel.isQuiet else { return }
                         switch message {
                         case .buildCompleted(let info):
                             progressAnimation.complete(success: info.result == .ok)
@@ -432,6 +433,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
                     switch operation.state {
                     case .succeeded:
+                        guard !self.logLevel.isQuiet else { return }
                         progressAnimation.update(step: 100, total: 100, text: "")
                         progressAnimation.complete(success: true)
                         let duration = ContinuousClock.Instant.now - buildStartTime
@@ -740,12 +742,6 @@ extension String {
         #else
         return self.spm_shellEscaped()
         #endif
-    }
-}
-
-extension Basics.Diagnostic.Severity {
-    var isVerbose: Bool {
-        self <= .info
     }
 }
 

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -240,6 +240,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
             throw Diagnostics.fatalError
         }
 
+        guard !self.logLevel.isQuiet else { return }
         self.outputStream.send("Build complete!\n")
         self.outputStream.flush()
     }
@@ -406,11 +407,5 @@ extension BuildSubset {
         case .allIncludingTests:
             PIFBuilder.allIncludingTestsTargetName
         }
-    }
-}
-
-extension Basics.Diagnostic.Severity {
-    var isVerbose: Bool {
-        self <= .info
     }
 }

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -1354,8 +1354,11 @@ struct BuildCommandTestCases {
                  #expect(stdout.isEmpty)
             }
          } when: {
-             ProcessInfo.hostOperatingSystem == .windows &&
-             buildSystem == .swiftbuild
+             buildSystem == .swiftbuild && (
+                ProcessInfo.hostOperatingSystem == .windows || (
+                    ProcessInfo.hostOperatingSystem == .linux && configuration == .release
+                )
+            )
          }
     }
 

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -1330,6 +1330,82 @@ struct BuildCommandTestCases {
         }
     }
 
+    @Test(
+         .bug("https://github.com/swiftlang/swift-package-manager/issues/8844"),
+         arguments: SupportedBuildSystemOnPlatform,  BuildConfiguration.allCases
+     )
+     func swiftBuildQuietLogLevel(
+         buildSystem: BuildSystemProvider.Kind,
+         configuration: BuildConfiguration
+     ) async throws {
+         try await withKnownIssue {
+             // GIVEN we have a simple test package
+             try await fixture(name: "Miscellaneous/SwiftBuild") { fixturePath in
+                //WHEN we build with the --quiet option
+                let (stdout, stderr) = try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: configuration,
+                    extraArgs: ["--quiet"],
+                    buildSystem: buildSystem
+                )
+                // THEN we should not see any output in stderr
+                 #expect(stderr.isEmpty)
+                // AND no content in stdout
+                 #expect(stdout.isEmpty)
+            }
+         } when: {
+             ProcessInfo.hostOperatingSystem == .windows &&
+             buildSystem == .swiftbuild
+         }
+    }
+
+    @Test(
+         .bug("https://github.com/swiftlang/swift-package-manager/issues/8844"),
+         arguments: SupportedBuildSystemOnPlatform,  BuildConfiguration.allCases
+     )
+     func swiftBuildQuietLogLevelWithError(
+         buildSystem: BuildSystemProvider.Kind,
+         configuration: BuildConfiguration
+     ) async throws {
+         // GIVEN we have a simple test package
+         try await fixture(name: "Miscellaneous/SwiftBuild") { fixturePath in
+             let mainFilePath = fixturePath.appending("main.swift")
+             try localFileSystem.removeFileTree(mainFilePath)
+             try localFileSystem.writeFileContents(
+                mainFilePath,
+                string: """
+                 print("done"
+                 """
+             )
+
+             //WHEN we build with the --quiet option
+             let error = await #expect(throws: SwiftPMError.self) {
+                 try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: .debug,
+                    extraArgs: ["--quiet"],
+                    buildSystem: buildSystem
+                 )
+             }
+
+             guard case SwiftPMError.executionFailure(_, let stdout, let stderr) = try #require(error) else {
+                 Issue.record("Incorrect error was raised.")
+                 return
+             }
+
+             if buildSystem == .swiftbuild {
+                 // THEN we should see output in stderr
+                 #expect(stderr.isEmpty == false)
+                 // AND no content in stdout
+                 #expect(stdout.isEmpty)
+             } else {
+                 // THEN we should see content in stdout
+                 #expect(stdout.isEmpty == false)
+                 // AND no output in stderr
+                 #expect(stderr.isEmpty)
+             }
+         }
+     }
 }
 
 extension Triple {

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -420,9 +420,7 @@ struct RunCommandTests {
                 #expect(stdout == "done\n")
            }
         } when: {
-            buildSystem == .swiftbuild &&
-            ProcessInfo.hostOperatingSystem == .linux &&
-            configuration == .release
+            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .linux
         }
     }
 

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -420,9 +420,9 @@ struct RunCommandTests {
                 #expect(stdout == "done\n")
            }
         } when: {
-            ProcessInfo.hostOperatingSystem == .linux &&
             buildSystem == .swiftbuild &&
-            CiEnvironment.runningInSelfHostedPipeline
+            ProcessInfo.hostOperatingSystem == .linux &&
+            configuration == .release
         }
     }
 

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -420,7 +420,9 @@ struct RunCommandTests {
                 #expect(stdout == "done\n")
            }
         } when: {
-            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .linux
+            buildSystem == .swiftbuild &&
+            ProcessInfo.hostOperatingSystem == .linux &&
+            configuration == .release
         }
     }
 

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -403,7 +403,7 @@ struct RunCommandTests {
         buildSystem: BuildSystemProvider.Kind,
         configuration: BuildConfiguration
     ) async throws {
-        try await withKnownIssue {
+        try await withKnownIssue(isIntermittent: true) {
             // GIVEN we have a simple test package
             try await fixture(name: "Miscellaneous/SwiftRun") { fixturePath in
                //WHEN we run with the --quiet option
@@ -420,9 +420,7 @@ struct RunCommandTests {
                 #expect(stdout == "done\n")
            }
         } when: {
-            buildSystem == .swiftbuild &&
-            ProcessInfo.hostOperatingSystem == .linux &&
-            configuration == .release
+            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .linux
         }
     }
 


### PR DESCRIPTION
Cherry-pick #8858 to 6.2.

Fixes an issue where the --quiet option had no effect when used with swift run and swift build command.

Motivation:

When using the --quiet option with swift run only error messages should be logged.

Modifications:

Add isQuiet property to filter out messages based on the log level during build phases of the native, xcode and swiftbuild build system.
Remove duplicated declaration of the isVerbose property from different targets.
Result:

When the --quiet option is used with the swift run and swift build command only error messages are logged.