### PR TITLE
Package: Update Swift Tool Support Core references

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -840,8 +840,7 @@ let package = Package(
             name: "_IntegrationTestSupport",
             dependencies: [
                 "_InternalTestSupport",
-                .product(name: "TSCTestSupport", package: "swift-tools-support-core"),
-            ],
+            ] + swiftTSCTestSupportDeps,
         ),
 
         .target(
@@ -1052,9 +1051,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] ==
             dependencies: [
                 "_IntegrationTestSupport",
                 "_InternalTestSupport",
-                .product(name: "TSCTestSupport", package: "swift-tools-support-core"),
-                .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-            ],
+            ] + swiftTSCTestSupportDeps + swiftToolsCoreSupportAutoDeps,
         ),
         .testTarget(
             name: "CommandsTests",


### PR DESCRIPTION
When the Integration Tests were merged with the Tests, the Package.swift added dependencies on Swift Tools Support Core. However, the declaration did not take into account when the SWIFTPM_SWBUILD_FRAMEWORK environment variable was defined.

Update the declaration of any Swift Tools Support Core dependencies to use the respective local variables.