### PR TITLE
[6.2][Commands] Migrate: Avoid duplicate fix-its and manifest updates when…

### DIFF
--- a/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Package.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+let package = Package(
+    name: "ExistentialAnyMigration",
+    targets: [
+        .target(name: "Library", dependencies: ["CommonLibrary"], plugins: [.plugin(name: "Plugin")]),
+        .plugin(name: "Plugin", capability: .buildTool, dependencies: ["Tool"]),
+        .executableTarget(name: "Tool", dependencies: ["CommonLibrary"]),
+        .target(name: "CommonLibrary"),
+    ]
+)

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Plugins/Plugin/Plugin.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Plugins/Plugin/Plugin.swift
@@ -1,0 +1,17 @@
+import PackagePlugin
+import Foundation
+
+@main struct Plugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        let tool = try context.tool(named: "Tool")
+        let output = context.pluginWorkDirectory.appending(["generated.swift"])
+        return [
+            .buildCommand(
+                displayName: "Plugin",
+                executable: tool.path,
+                arguments: [output],
+                inputFiles: [],
+                outputFiles: [output])
+        ]
+    }
+}

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Sources/CommonLibrary/Common.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Sources/CommonLibrary/Common.swift
@@ -1,0 +1,6 @@
+public func common() {}
+
+
+protocol P {}
+
+func needsMigration(_ p: P) {}

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Sources/Library/Test.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Sources/Library/Test.swift
@@ -1,0 +1,6 @@
+import CommonLibrary
+
+func bar() {
+    generatedFunction()
+    common()
+}

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Sources/Tool/tool.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Sources/Tool/tool.swift
@@ -1,0 +1,13 @@
+import Foundation
+import CommonLibrary
+
+@main struct Entry {
+    public static func main() async throws {
+        common()
+        let outputPath = CommandLine.arguments[1]
+        let contents = """
+        func generatedFunction() {}
+        """
+        FileManager.default.createFile(atPath: outputPath, contents: contents.data(using: .utf8))
+    }
+}

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Package.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+let package = Package(
+    name: "ExistentialAnyMigration",
+    targets: [
+        .target(name: "Library", plugins: [.plugin(name: "Plugin")]),
+        .plugin(name: "Plugin", capability: .buildTool, dependencies: ["Tool"]),
+        .executableTarget(name: "Tool"),
+    ]
+)

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Plugins/Plugin/Plugin.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Plugins/Plugin/Plugin.swift
@@ -1,0 +1,17 @@
+import PackagePlugin
+import Foundation
+
+@main struct Plugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        let tool = try context.tool(named: "Tool")
+        let output = context.pluginWorkDirectory.appending(["generated.swift"])
+        return [
+            .buildCommand(
+                displayName: "Plugin",
+                executable: tool.path,
+                arguments: [output],
+                inputFiles: [],
+                outputFiles: [output])
+        ]
+    }
+}

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Sources/Library/Test.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Sources/Library/Test.swift
@@ -1,0 +1,20 @@
+protocol P {
+}
+
+func test1(_: P) {
+}
+
+func test2(_: P.Protocol) {
+}
+
+func test3() {
+    let _: [P?] = []
+}
+
+func test4() {
+    var x = 42
+}
+
+func bar() {
+    generatedFunction()
+}

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Sources/Tool/tool.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Sources/Tool/tool.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+@main struct Entry {
+    public static func main() async throws {
+        let outputPath = CommandLine.arguments[1]
+        let contents = """
+        func generatedFunction() {}
+        func dontmodifyme(_: P) {}
+        """
+        FileManager.default.createFile(atPath: outputPath, contents: contents.data(using: .utf8))
+    }
+}

--- a/Sources/SwiftFixIt/SwiftFixIt.swift
+++ b/Sources/SwiftFixIt/SwiftFixIt.swift
@@ -124,9 +124,11 @@ private struct PrimaryDiagnosticFilter<Diagnostic: AnyDiagnostic>: ~Copyable {
     private var uniquePrimaryDiagnostics: Set<DiagnosticID> = []
 
     let categories: Set<String>
+    let excludedSourceDirectories: Set<AbsolutePath>
 
-    init(categories: Set<String>) {
+    init(categories: Set<String>, excludedSourceDirectories: Set<AbsolutePath>) {
         self.categories = categories
+        self.excludedSourceDirectories = excludedSourceDirectories
     }
 
     /// Returns a Boolean value indicating whether to skip the given primary
@@ -149,6 +151,13 @@ private struct PrimaryDiagnosticFilter<Diagnostic: AnyDiagnostic>: ~Copyable {
         // belong to any of them.
         if !self.categories.isEmpty {
             guard let category = diagnostic.category, self.categories.contains(category) else {
+                return true
+            }
+        }
+
+        // Skip if the source file the diagnostic appears in is in an excluded directory.
+        if let sourceFilePath = try? diagnostic.location.map({ try AbsolutePath(validating: $0.filename) }) {
+            guard !self.excludedSourceDirectories.contains(where: { $0.isAncestor(of: sourceFilePath) }) else {
                 return true
             }
         }
@@ -201,6 +210,7 @@ package struct SwiftFixIt /*: ~Copyable */ { // TODO: Crashes with ~Copyable
     package init(
         diagnosticFiles: [AbsolutePath],
         categories: Set<String> = [],
+        excludedSourceDirectories: Set<AbsolutePath> = [],
         fileSystem: any FileSystem
     ) throws {
         // Deserialize the diagnostics.
@@ -212,6 +222,7 @@ package struct SwiftFixIt /*: ~Copyable */ { // TODO: Crashes with ~Copyable
         self = try SwiftFixIt(
             diagnostics: diagnostics,
             categories: categories,
+            excludedSourceDirectories: excludedSourceDirectories,
             fileSystem: fileSystem
         )
     }
@@ -219,11 +230,15 @@ package struct SwiftFixIt /*: ~Copyable */ { // TODO: Crashes with ~Copyable
     init<Diagnostic: AnyDiagnostic>(
         diagnostics: some Collection<Diagnostic>,
         categories: Set<String>,
+        excludedSourceDirectories: Set<AbsolutePath>,
         fileSystem: any FileSystem
     ) throws {
         self.fileSystem = fileSystem
 
-        var filter = PrimaryDiagnosticFilter<Diagnostic>(categories: categories)
+        var filter = PrimaryDiagnosticFilter<Diagnostic>(
+            categories: categories,
+            excludedSourceDirectories: excludedSourceDirectories
+        )
         _ = consume categories
 
         // Build a map from source files to `SwiftDiagnostics` diagnostics.

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2158,6 +2158,44 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
         try await doMigration(featureName: "InferIsolatedConformances", expectedSummary: "Applied 3 fix-its in 2 files")
     }
 
+    func testMigrateCommandWithBuildToolPlugins() async throws {
+        try XCTSkipIf(
+            !UserToolchain.default.supportesSupportedFeatures,
+            "skipping because test environment compiler doesn't support `-print-supported-features`"
+        )
+
+        try await fixture(name: "SwiftMigrate/ExistentialAnyWithPluginMigration") { fixturePath in
+            let (stdout, _) = try await self.execute(
+                ["migrate", "--to-feature", "ExistentialAny"],
+                packagePath: fixturePath
+            )
+
+            // Check the plugin target in the manifest wasn't updated
+            let manifestContent = try localFileSystem.readFileContents(fixturePath.appending(component: "Package.swift")).description
+            XCTAssertTrue(manifestContent.contains(".plugin(name: \"Plugin\", capability: .buildTool, dependencies: [\"Tool\"]),"))
+
+            // Building the package produces migration fix-its in both an authored and generated source file. Check we only applied fix-its to the hand-authored one.
+            XCTAssertMatch(stdout, .regex("> \("Applied 3 fix-its in 1 file")" + #" \([0-9]\.[0-9]{1,3}s\)"#))
+        }
+    }
+
+    func testMigrateCommandWhenDependencyBuildsForHostAndTarget() async throws {
+        try XCTSkipIf(
+            !UserToolchain.default.supportesSupportedFeatures,
+            "skipping because test environment compiler doesn't support `-print-supported-features`"
+        )
+
+        try await fixture(name: "SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration") { fixturePath in
+            let (stdout, _) = try await self.execute(
+                ["migrate", "--to-feature", "ExistentialAny"],
+                packagePath: fixturePath
+            )
+
+            // Even though the CommonLibrary dependency built for both the host and destination, we should only apply a single fix-it once to its sources.
+            XCTAssertMatch(stdout, .regex("> \("Applied 1 fix-it in 1 file")" + #" \([0-9]\.[0-9]{1,3}s\)"#))
+        }
+    }
+
     func testBuildToolPlugin() async throws {
         try await testBuildToolPlugin(staticStdlib: false)
     }
@@ -4105,6 +4143,14 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
     }
 
     override func testMigrateCommand() async throws {
+        throw XCTSkip("SWBINTTODO: Build plan is not currently supported")
+    }
+
+    override func testMigrateCommandWithBuildToolPlugins() async throws {
+        throw XCTSkip("SWBINTTODO: Build plan is not currently supported")
+    }
+
+    override func testMigrateCommandWhenDependencyBuildsForHostAndTarget() async throws {
         throw XCTSkip("SWBINTTODO: Build plan is not currently supported")
     }
 

--- a/Tests/SwiftFixItTests/Utilities.swift
+++ b/Tests/SwiftFixItTests/Utilities.swift
@@ -233,6 +233,7 @@ private func _testAPI(
     let swiftFixIt = try SwiftFixIt(
         diagnostics: flatDiagnostics,
         categories: categories,
+        excludedSourceDirectories: [],
         fileSystem: localFileSystem
     )
     let actualSummary = try swiftFixIt.applyFixIts()


### PR DESCRIPTION
… building target for both host and destination

- Explanation:

  This is a limited cherry-pick of https://github.com/swiftlang/swift-package-manager/pull/8888

  For example if a target is a dependency of a plugin we build it for host and destination and produce the same fix-it twice and attempt to update manifest twice because uniquing is done on the ModuleBuildDescriptions.

  The changes do the following:

  - Coalesce all the diagnostic files for the same target regardless of host or destination build to make it possible for`SwiftFixIt` to filter duplicate fix-its;
  - Unique based on module identity to prevent duplicate setting insertion.

- Resolves: rdar://155569285

- Main Branch PR: https://github.com/swiftlang/swift-package-manager/pull/8888

- Risk: Very Low. This is a narrow fix for `swift package migrate` command.
 
- Reviewed By: Me and @AnthonyLatsis reviewed the work in the main PR.

- Testing: Added new test-cases to the suite.
