### PR TITLE
Bump swift-syntax in template to 602.0.0-latest

### DIFF
--- a/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
+++ b/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
@@ -37,7 +37,7 @@ public struct InstalledSwiftPMConfiguration {
         return .init(
             version: 0,
             swiftSyntaxVersionForMacroTemplate: .init(
-                major: 600,
+                major: 602,
                 minor: 0,
                 patch: 0,
                 prereleaseIdentifier: "latest"

--- a/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
+++ b/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
@@ -491,7 +491,7 @@ class ManifestEditTests: XCTestCase {
             let package = Package(
                 name: "packages",
                 dependencies: [
-                    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-latest"),
+                    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0-latest"),
                 ],
                 targets: [
                     .macro(

--- a/Utilities/config.json
+++ b/Utilities/config.json
@@ -1,3 +1,3 @@
 {"version":1,
-  "swiftSyntaxVersionForMacroTemplate":{"major":600,"minor":0,"patch":0, "prereleaseIdentifier":"latest"},
+  "swiftSyntaxVersionForMacroTemplate":{"major":602,"minor":0,"patch":0, "prereleaseIdentifier":"latest"},
   "swiftTestingVersionForTestTemplate":{"major":0,"minor":8,"patch":0}}


### PR DESCRIPTION
`swift package init --type macro `generates a manifest that still points to swift-syntax version 6.0.0 although main has moved on to 6.0.2.

Motivation:

`swift package init --type macro` is outdated

Modifications:

Modified config.json that is shipped as part of the SDK and version provided by InstalledSwiftPMConfiguration

Result:

Locally verified that swift package init --type macro generates a manifest with the updated version.
Performed a `swift build` using the updated manifest and confirmed version 6.2 of swift-syntax was used:

> MacBook-Pro-207:package-testing rconnell$ swift build
> Fetching https://github.com/swiftlang/swift-syntax.git from cache
> Fetched https://github.com/swiftlang/swift-syntax.git from cache
(0.65s)
> Computing version for https://github.com/swiftlang/swift-syntax.git
...
> Computed https://github.com/swiftlang/swift-syntax.git at
602.0.0-prerelease-2025-06-26 (13.67s)

swift package init --type macro will output the latest version