### PR TITLE
swift-package-migrate: Hide global options

### DIFF
--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -57,7 +57,7 @@ extension SwiftPackageCommand {
             abstract: "Migrate a package or its individual targets to use the given set of features."
         )
 
-        @OptionGroup()
+        @OptionGroup(visibility: .hidden)
         public var globalOptions: GlobalOptions
 
         @OptionGroup()

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2106,6 +2106,15 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
         }
     }
 
+    func testMigrateCommandHelp() async throws {
+        let (stdout, _) = try await self.execute(
+            ["migrate", "--help"],
+        )
+
+        // Global options are hidden.
+        XCTAssertNoMatch(stdout, .contains("--package-path"))
+    }
+
     func testMigrateCommand() async throws {
         try XCTSkipIf(
             !UserToolchain.default.supportesSupportedFeatures,


### PR DESCRIPTION
### Motivation:

Currently, options that are specific to `swift package migrate` are shown at the very bottom, following all the global options.

All anonymous option groups get coalesced into the default "OPTIONS" section, which always comes last. So there is no proper way to hoist subcommand options above all the base/global options other than giving the subcommand option group a title.

Using "options" as the title would give us 2 "OPTIONS" sections, whereas a custom title, such as "migrate options", would introduce yet another design inconsistency. Instead, address this by hiding global options, as most other package subcommands do.
