### PR TITLE
[SwiftBuild] Use `hostBuildTool` product type for SPM build plugin targets

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -39,7 +39,7 @@ extension PackagePIFProjectBuilder {
         let pluginTargetKeyPath = try self.project.addTarget { _ in
             ProjectModel.Target(
                 id: pluginModule.pifTargetGUID,
-                productType: .executable,
+                productType: .hostBuildTool,
                 name: pluginModule.name,
                 productName: pluginModule.name
             )


### PR DESCRIPTION
Match how macros are handled and use the `hostBuildTool` product type.

rdar://155792370