### PR TITLE
Accept arbitrary strings in Swift Testing event stream version options

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -111,15 +111,18 @@ struct TestEventStreamOptions: ParsableArguments {
             help: .hidden)
     var eventStreamOutputPath: AbsolutePath?
 
-    /// Legacy equivalent of ``eventStreamVersion``.
+    /// The experimental version number of Swift Testing's event stream to use.
+    ///
+    /// Unlike ``eventStreamVersion``, this permits specifying a version which
+    /// is experimental.
     @Option(name: .customLong("experimental-event-stream-version"),
             help: .private)
-    var experimentalEventStreamVersion: Int?
+    var experimentalEventStreamVersion: String?
 
-    /// The schema version of swift-testing's JSON input/output.
+    /// The version number of Swift Testing's event stream to use.
     @Option(name: .customLong("event-stream-version"),
             help: .hidden)
-    var eventStreamVersion: Int?
+    var eventStreamVersion: String?
 
     /// Experimental path for writing attachments (Swift Testing only.)
     @Option(name: .customLong("experimental-attachments-path"),


### PR DESCRIPTION
This modifies the `swift test` command line `@Option` properties which represent a Swift Testing event stream version (primarily `--event-stream-version <...>`) to accept arbitrary `String` arguments.

### Motivation:

In Swift Testing we are moving towards making the entry point and event stream versions aligned with the Swift version, rather than having an independent versioning scheme which users must look up or keep track of. Once this and other work lands, this means that in order to use the event stream format included in (for example) Swift 6.2, a user would pass `--event-stream-version 6.2`.

However, until now these CLI options have required an integer argument like `--event-stream-version 0`. This change relaxes this requirement so that any arbitrary string will be accepted. In a separate PR, the Swift Testing library will perform additional validation of the format of this string to ensure it's valid, but we will need to continue accepting the current integers (e.g. `0`) in addition to newer Swift versions (e.g. `6.2`, `6.3`, …) going forward.

### Modifications:

- Replace `Int?` type of these options with `String?`.
- Update the documentation.

### Result:

In local testing, I'm able to pass any string argument now.
