### PR TITLE
Only enable unsafe flags if version 6.2 or newer.

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1079,7 +1079,7 @@ public final class PackageBuilder {
                 declaredSwiftVersions: self.declaredSwiftVersions(),
                 buildSettings: buildSettings,
                 buildSettingsDescription: manifestTarget.settings,
-                // unsafe flags disabled in 6.2
+                // unsafe flags check disabled in 6.2
                 usesUnsafeFlags: manifest.toolsVersion >= .v6_2 ? false : manifestTarget.usesUnsafeFlags,
                 implicit: false
             )
@@ -1126,7 +1126,7 @@ public final class PackageBuilder {
                 dependencies: dependencies,
                 buildSettings: buildSettings,
                 buildSettingsDescription: manifestTarget.settings,
-                // unsafe flags disabled in 6.2
+                // unsafe flags check disabled in 6.2
                 usesUnsafeFlags: manifest.toolsVersion >= .v6_2 ? false : manifestTarget.usesUnsafeFlags,
                 implicit: false
             )

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1079,7 +1079,8 @@ public final class PackageBuilder {
                 declaredSwiftVersions: self.declaredSwiftVersions(),
                 buildSettings: buildSettings,
                 buildSettingsDescription: manifestTarget.settings,
-                usesUnsafeFlags: manifestTarget.usesUnsafeFlags,
+                // unsafe flags disabled in 6.2
+                usesUnsafeFlags: manifest.toolsVersion >= .v6_2 ? false : manifestTarget.usesUnsafeFlags,
                 implicit: false
             )
         } else {
@@ -1125,7 +1126,8 @@ public final class PackageBuilder {
                 dependencies: dependencies,
                 buildSettings: buildSettings,
                 buildSettingsDescription: manifestTarget.settings,
-                usesUnsafeFlags: manifestTarget.usesUnsafeFlags,
+                // unsafe flags disabled in 6.2
+                usesUnsafeFlags: manifest.toolsVersion >= .v6_2 ? false : manifestTarget.usesUnsafeFlags,
                 implicit: false
             )
         }
@@ -2024,8 +2026,7 @@ extension Sequence {
 
 extension TargetDescription {
     fileprivate var usesUnsafeFlags: Bool {
-        // We no longer restrict unsafe flags
-        false
+        settings.filter(\.kind.isUnsafeFlags).isEmpty == false
     }
 
     fileprivate func isMacroTest(in manifest: Manifest) -> Bool {


### PR DESCRIPTION
As we disable checking for unsafe flags, make sure they are still checked when the swift-tools-version is earlier than 6.2. This ensures consumers of the package don't get unsafe flags errors when using older toolchains. They will need to upgrade their toolchains to use packages with unsafe flags.
