### PR TITLE
[6.2][Commands] Allow omitting the target triple for swift sdk configure

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigure.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SDK/SDKConfigure.md
@@ -8,7 +8,21 @@
 Manages configuration options for installed Swift SDKs.
 
 ```
-sdk configure [--package-path=<package-path>] [--cache-path=<cache-path>] [--config-path=<config-path>] [--security-path=<security-path>] [--scratch-path=<scratch-path>]     [--swift-sdks-path=<swift-sdks-path>] [--toolset=<toolset>...] [--pkg-config-path=<pkg-config-path>...]   [--sdk-root-path=<sdk-root-path>] [--swift-resources-path=<swift-resources-path>] [--swift-static-resources-path=<swift-static-resources-path>] [--include-search-path=<include-search-path>...] [--library-search-path=<library-search-path>...] [--toolset-path=<toolset-path>...] [--reset] [--show-configuration] <sdk-id> <target-triple> [--version] [--help]
+sdk configure [--package-path=<package-path>]
+  [--cache-path=<cache-path>] [--config-path=<config-path>]
+  [--security-path=<security-path>]
+  [--scratch-path=<scratch-path>]
+  [--swift-sdks-path=<swift-sdks-path>]
+  [--toolset=<toolset>...]
+  [--pkg-config-path=<pkg-config-path>...]
+  [--sdk-root-path=<sdk-root-path>]
+  [--swift-resources-path=<swift-resources-path>]
+  [--swift-static-resources-path=<swift-static-resources-path>]
+  [--include-search-path=<include-search-path>...]
+  [--library-search-path=<library-search-path>...]
+  [--toolset-path=<toolset-path>...] [--reset]
+  [--show-configuration] <sdk-id> [target-triple...] [--version]
+  [--help]
 ```
 
 - term **--package-path=\<package-path\>**:

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -340,7 +340,9 @@ public struct SwiftSDK: Equatable {
             swiftSDKDirectory: Basics.AbsolutePath? = nil
         ) throws where Path == Basics.AbsolutePath {
             self.init(
-                sdkRootPath: try AbsolutePath(validating: properties.sdkRootPath, relativeTo: swiftSDKDirectory),
+                sdkRootPath: try properties.sdkRootPath.map {
+                    try AbsolutePath(validating: $0, relativeTo: swiftSDKDirectory)
+                },
                 swiftResourcesPath: try properties.swiftResourcesPath.map {
                     try AbsolutePath(validating: $0, relativeTo: swiftSDKDirectory)
                 },
@@ -1175,7 +1177,7 @@ struct SerializedDestinationV3: Decodable {
 struct SwiftSDKMetadataV4: Decodable {
     struct TripleProperties: Codable {
         /// Path relative to `swift-sdk.json` containing SDK root.
-        var sdkRootPath: String
+        var sdkRootPath: String?
 
         /// Path relative to `swift-sdk.json` containing Swift resources for dynamic linking.
         var swiftResourcesPath: String?

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
@@ -70,7 +70,7 @@ public final class SwiftSDKBundleStore {
     let fileSystem: any FileSystem
 
     /// Observability scope used for logging.
-    private let observabilityScope: ObservabilityScope
+    let observabilityScope: ObservabilityScope
 
     /// Closure invoked for output produced by this store during its operation.
     private let outputHandler: (Output) -> Void

--- a/Sources/SwiftSDKCommand/ConfigureSwiftSDK.swift
+++ b/Sources/SwiftSDKCommand/ConfigureSwiftSDK.swift
@@ -90,7 +90,7 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
     var sdkID: String
 
     @Argument(help: "The target triple of the Swift SDK to configure.")
-    var targetTriple: String
+    var targetTriple: String?
 
     /// The file system used by default by this command.
     private var fileSystem: FileSystem { localFileSystem }
@@ -132,101 +132,21 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
                 hostTimeTriple: triple,
                 swiftSDKBundleStore: bundleStore
             )
-            let targetTriple = try Triple(self.targetTriple)
-
-            guard let swiftSDK = try configurationStore.readConfiguration(
+            let config = SwiftSDK.PathsConfiguration(
+                sdkRootPath: self.sdkRootPath,
+                swiftResourcesPath: self.swiftResourcesPath,
+                swiftStaticResourcesPath: self.swiftStaticResourcesPath,
+                includeSearchPaths: self.includeSearchPath,
+                librarySearchPaths: self.librarySearchPath,
+                toolsetPaths: self.toolsetPath
+            )
+            if try !configurationStore.configure(
                 sdkID: sdkID,
-                targetTriple: targetTriple
-            ) else {
-                throw SwiftSDKError.swiftSDKNotFound(
-                    artifactID: sdkID,
-                    hostTriple: triple,
-                    targetTriple: targetTriple
-                )
-            }
-
-            if self.shouldShowConfiguration {
-                print(swiftSDK.pathsConfiguration)
-                return
-            }
-
-            var configuration = swiftSDK.pathsConfiguration
-            if self.shouldReset {
-                if try !configurationStore.resetConfiguration(sdkID: sdkID, targetTriple: targetTriple) {
-                    observabilityScope.emit(
-                        warning: "No configuration for Swift SDK `\(sdkID)`"
-                    )
-                } else {
-                    observabilityScope.emit(
-                        info: """
-                        All configuration properties of Swift SDK `\(sdkID)` for target triple \
-                        `\(targetTriple)` were successfully reset.
-                        """
-                    )
-                }
-            } else {
-                var updatedProperties = [String]()
-
-                let currentWorkingDirectory: AbsolutePath? = fileSystem.currentWorkingDirectory
-
-                if let sdkRootPath {
-                    configuration.sdkRootPath = try AbsolutePath(validating: sdkRootPath, relativeTo: currentWorkingDirectory)
-                    updatedProperties.append(CodingKeys.sdkRootPath.stringValue)
-                }
-
-                if let swiftResourcesPath {
-                    configuration.swiftResourcesPath =
-                        try AbsolutePath(validating: swiftResourcesPath, relativeTo: currentWorkingDirectory)
-                    updatedProperties.append(CodingKeys.swiftResourcesPath.stringValue)
-                }
-
-                if let swiftStaticResourcesPath {
-                    configuration.swiftResourcesPath =
-                        try AbsolutePath(validating: swiftStaticResourcesPath, relativeTo: currentWorkingDirectory)
-                    updatedProperties.append(CodingKeys.swiftStaticResourcesPath.stringValue)
-                }
-
-                if !includeSearchPath.isEmpty {
-                    configuration.includeSearchPaths =
-                        try includeSearchPath.map { try AbsolutePath(validating: $0, relativeTo: currentWorkingDirectory) }
-                    updatedProperties.append(CodingKeys.includeSearchPath.stringValue)
-                }
-
-                if !librarySearchPath.isEmpty {
-                    configuration.librarySearchPaths =
-                        try librarySearchPath.map { try AbsolutePath(validating: $0, relativeTo: currentWorkingDirectory) }
-                    updatedProperties.append(CodingKeys.librarySearchPath.stringValue)
-                }
-
-                if !toolsetPath.isEmpty {
-                    configuration.toolsetPaths =
-                        try toolsetPath.map { try AbsolutePath(validating: $0, relativeTo: currentWorkingDirectory) }
-                    updatedProperties.append(CodingKeys.toolsetPath.stringValue)
-                }
-
-                guard !updatedProperties.isEmpty else {
-                    observabilityScope.emit(
-                        error: """
-                        No properties of Swift SDK `\(sdkID)` for target triple `\(targetTriple)` were updated \
-                        since none were specified. Pass `--help` flag to see the list of all available properties.
-                        """
-                    )
-                    return
-                }
-
-                var swiftSDK = swiftSDK
-                swiftSDK.pathsConfiguration = configuration
-                try configurationStore.updateConfiguration(sdkID: sdkID, swiftSDK: swiftSDK)
-
-                observabilityScope.emit(
-                    info: """
-                    These properties of Swift SDK `\(sdkID)` for target triple \
-                    `\(targetTriple)` were successfully updated: \(updatedProperties.joined(separator: ", ")).
-                    """
-                )
-            }            
-
-            if observabilityScope.errorsReported {
+                targetTriple: targetTriple,
+                showConfiguration: shouldShowConfiguration,
+                resetConfiguration: shouldReset,
+                config: config
+            ) {
                 throw ExitCode.failure
             }
         } catch {
@@ -238,16 +158,6 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
 
         if let commandError {
             throw commandError
-        }
-    }
-}
-
-extension AbsolutePath {
-    fileprivate init(validating string: String, relativeTo basePath: AbsolutePath?) throws {
-        if let basePath {
-            try self.init(validating: string, relativeTo: basePath)
-        } else {
-            try self.init(validating: string)
         }
     }
 }

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -551,4 +551,120 @@ final class SwiftSDKBundleTests: XCTestCase {
             ),
         ])
     }
+
+    func testConfigureSDKRootPath() async throws {
+        func createConfigurationStore() async throws -> (SwiftSDKConfigurationStore, FileSystem) {
+            let (fileSystem, bundles, swiftSDKsDirectory) = try generateTestFileSystem(
+                bundleArtifacts: [
+                    .init(id: testArtifactID, supportedTriples: [arm64Triple, i686Triple]),
+                ]
+            )
+            let system = ObservabilitySystem.makeForTesting()
+
+            var output = [SwiftSDKBundleStore.Output]()
+            let store = SwiftSDKBundleStore(
+                swiftSDKsDirectory: swiftSDKsDirectory,
+                hostToolchainBinDir: "/tmp",
+                fileSystem: fileSystem,
+                observabilityScope: system.topScope,
+                outputHandler: {
+                    output.append($0)
+                }
+            )
+
+            let archiver = MockArchiver()
+            for bundle in bundles {
+                try await store.install(bundlePathOrURL: bundle.path, archiver)
+            }
+
+            let hostTriple = try Triple("arm64-apple-macosx14.0")
+            let sdk = try store.selectBundle(
+                matching: testArtifactID,
+                hostTriple: hostTriple
+            )
+
+            XCTAssertEqual(sdk.targetTriple, targetTriple)
+            XCTAssertEqual(output, [
+                .installationSuccessful(
+                    bundlePathOrURL: bundles[0].path,
+                    bundleName: AbsolutePath(bundles[0].path).components.last!
+                )
+            ])
+
+            let config = try SwiftSDKConfigurationStore(
+                hostTimeTriple: hostTriple,
+                swiftSDKBundleStore: store
+            )
+
+            return (config, fileSystem)
+        }
+
+        do {
+            let (config, _) = try await createConfigurationStore()
+            let args = SwiftSDK.PathsConfiguration<String>()
+            let configSuccess = try config.configure(
+                sdkID: testArtifactID,
+                targetTriple: nil,
+                showConfiguration: false,
+                resetConfiguration: false,
+                config: args
+            )
+            XCTAssertEqual(configSuccess, false, "Expected failure for SwiftSDKConfigurationStore.configure with no updated properties")
+        }
+
+        let targetTripleConfigPath = AbsolutePath("/sdks/configuration/\(testArtifactID)_\(targetTriple.tripleString).json")
+
+        #if os(Windows)
+        let sdkRootPath = "C:\\some\\sdk\\root\\path"
+        #else
+        let sdkRootPath = "/some/sdk/root/path"
+        #endif
+
+        do {
+            let (config, fileSystem) = try await createConfigurationStore()
+            var args = SwiftSDK.PathsConfiguration<String>()
+            args.sdkRootPath = sdkRootPath
+            let configSuccess = try config.configure(
+                sdkID: testArtifactID,
+                targetTriple: targetTriple.tripleString,
+                showConfiguration: false,
+                resetConfiguration: false,
+                config: args
+            )
+            XCTAssertTrue(configSuccess)
+            XCTAssertTrue(fileSystem.isFile(targetTripleConfigPath))
+
+            let updatedConfig = try config.readConfiguration(
+                sdkID: testArtifactID,
+                targetTriple: targetTriple
+            )
+            XCTAssertEqual(args.sdkRootPath, updatedConfig?.pathsConfiguration.sdkRootPath?.pathString)
+        }
+
+        do {
+            let (config, fileSystem) = try await createConfigurationStore()
+            var args = SwiftSDK.PathsConfiguration<String>()
+            args.sdkRootPath = sdkRootPath
+            // an empty targetTriple will configure all triples
+            let configSuccess = try config.configure(
+                sdkID: testArtifactID,
+                targetTriple: nil,
+                showConfiguration: false,
+                resetConfiguration: false,
+                config: args
+            )
+            XCTAssertTrue(configSuccess)
+            XCTAssertTrue(fileSystem.isFile(targetTripleConfigPath))
+
+            let resetSuccess = try config.configure(
+                sdkID: testArtifactID,
+                targetTriple: nil,
+                showConfiguration: false,
+                resetConfiguration: true,
+                config: args
+            )
+            XCTAssertTrue(resetSuccess, "Reset configuration should succeed")
+            XCTAssertFalse(fileSystem.isFile(targetTripleConfigPath), "Reset configuration should clear configuration folder")
+        }
+    }
 }


### PR DESCRIPTION
- **Explanation**:
This is a cherry-pick of https://github.com/swiftlang/swift-package-manager/pull/8856 and https://github.com/swiftlang/swift-package-manager/pull/8687, which fixes https://github.com/swiftlang/swift-package-manager/issues/8584 an enables the `swift sdk configure` command to be run with just a triple argument to update the configuration of all the matching SDKs.
- **Scope**:
This shouldn't affect any existing code. The `swift sdk configure` command is rarely (if ever) used by anything other than Android, whose SDK is currently in development.
- **Issues**:
https://github.com/swiftlang/swift-package-manager/issues/8584
- **Original PRs**:
https://github.com/swiftlang/swift-package-manager/pull/8856
https://github.com/swiftlang/swift-package-manager/pull/8687
- **Risk**:
Low. This only affects the `swift sdk configure` command, which isn't in active use by any known existing cross-compilation SDKs.
- **Testing**:
[Tests aded at https://github.com/swiftlang/swift-package-manager/compare/release/6.2...swift-everywhere:swift-package-manager:6.2-sdk-configure?expand=1#diff-f0541842d88690661fe076fc7f751af90a6a8dc36edee3ccdc04374abb57f486
](https://github.com/swift-everywhere/swift-package-manager/blob/8d65c3d647ca76955e1daa70e02f1bcb2eb758c4/Tests/PackageModelTests/SwiftSDKTests.swift#L524-L531)
- **Reviewers**:
@MaxDesiatov, @jakepetroules CC: @finagolfin 