### PR TITLE
Cherry pick: Only enable unsafe flags if version 6.2 or newer

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1079,7 +1079,8 @@ public final class PackageBuilder {
                 declaredSwiftVersions: self.declaredSwiftVersions(),
                 buildSettings: buildSettings,
                 buildSettingsDescription: manifestTarget.settings,
-                usesUnsafeFlags: manifestTarget.usesUnsafeFlags,
+                // unsafe flags check disabled in 6.2
+                usesUnsafeFlags: manifest.toolsVersion >= .v6_2 ? false : manifestTarget.usesUnsafeFlags,
                 implicit: false
             )
         } else {
@@ -1125,7 +1126,8 @@ public final class PackageBuilder {
                 dependencies: dependencies,
                 buildSettings: buildSettings,
                 buildSettingsDescription: manifestTarget.settings,
-                usesUnsafeFlags: manifestTarget.usesUnsafeFlags,
+                // unsafe flags check disabled in 6.2
+                usesUnsafeFlags: manifest.toolsVersion >= .v6_2 ? false : manifestTarget.usesUnsafeFlags,
                 implicit: false
             )
         }
@@ -2024,8 +2026,7 @@ extension Sequence {
 
 extension TargetDescription {
     fileprivate var usesUnsafeFlags: Bool {
-        // We no longer restrict unsafe flags
-        false
+        settings.filter(\.kind.isUnsafeFlags).isEmpty == false
     }
 
     fileprivate func isMacroTest(in manifest: Manifest) -> Bool {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -5746,7 +5746,7 @@ final class WorkspaceTests: XCTestCase {
                     products: [
                         MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
-                    versions: ["1.0.0", nil]
+                    versions: ["1.0.0", nil],
                 ),
                 MockPackage(
                     name: "Foo",
@@ -5769,7 +5769,7 @@ final class WorkspaceTests: XCTestCase {
                     products: [
                         MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
-                    versions: ["1.0.0", nil]
+                    versions: ["1.0.0", nil],
                 ),
                 MockPackage(
                     name: "Baz",
@@ -5786,7 +5786,8 @@ final class WorkspaceTests: XCTestCase {
                     dependencies: [
                         .sourceControl(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
-                    versions: ["1.0.0", "1.5.0"]
+                    versions: ["1.0.0", "1.5.0"],
+                    toolsVersion: .minimumRequired
                 ),
             ]
         )
@@ -5794,7 +5795,18 @@ final class WorkspaceTests: XCTestCase {
         // We should only see errors about use of unsafe flag in the version-based dependency.
         try await workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { _, diagnostics in
             // We have disabled the check so there shouldn't be any errors.
-            XCTAssert(diagnostics.filter({ $0.severity == .error }).isEmpty)
+            testDiagnostics(diagnostics) { result in
+                let diagnostic1 = result.checkUnordered(
+                    diagnostic: .equal("the target 'Baz' in product 'Baz' contains unsafe build flags"),
+                    severity: .error
+                )
+                XCTAssertEqual(diagnostic1?.metadata?.packageIdentity, .plain("foo"))
+                XCTAssertEqual(diagnostic1?.metadata?.moduleName, "Foo")
+
+                // since Bar is using the current tools version and we've disabled the check since 6.2,
+                // the result should now be empty.
+                result.checkIsEmpty()
+            }
         }
     }
 


### PR DESCRIPTION
Cherry pick of #8951 

As we disable checking for unsafe flags, make sure they are still checked when the swift-tools-version is earlier than 6.2. This ensures consumers of the package don't get unsafe flags errors when using older toolchains. They will need to upgrade their toolchains to use packages with unsafe flags.
