### PR TITLE
SwiftBuildSupport: Revert patch required when we were using '#if canImport(SwiftBuild)' checks

### DIFF
--- a/Sources/SwiftBuildSupport/BuildSystem.swift
+++ b/Sources/SwiftBuildSupport/BuildSystem.swift
@@ -14,7 +14,7 @@ extension BuildSubset {
     var pifTargetName: String {
         switch self {
         case .product(let name, _):
-            targetName(forProductName: name)
+            PackagePIFBuilder.targetName(forProductName: name)
         case .target(let name, _):
             name
         case .allExcludingTests:

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -55,12 +55,6 @@ import struct PackageGraph.ResolvedProduct
 
 import func PackageLoading.pkgConfigArgs
 
-// TODO: Move this back to `PackagePIFBuilder` once we get rid of `#if canImport(SwiftBuild)`.
-func targetName(forProductName name: String, suffix: String? = nil) -> String {
-    let suffix = suffix ?? ""
-    return "\(name)\(suffix)-product"
-}
-
 import enum SwiftBuild.ProjectModel
 
 // MARK: - PIF GUID Helpers
@@ -74,7 +68,7 @@ enum TargetSuffix: String {
 }
 
 extension TargetSuffix? {
-    func description(forName name: String) -> String {
+    func uniqueDescription(forName name: String) -> String {
         switch self {
         case .some(let suffix):
             "-\(String(name.hash, radix: 16, uppercase: true))-\(suffix.rawValue)"
@@ -132,7 +126,7 @@ extension PackagePIFBuilder {
     /// This format helps make sure that there is no collision with any other PIF targets,
     /// and in particular that a PIF target and a PIF product can have the same name (as they often do).
     static func targetGUID(forModuleName name: String, suffix: TargetSuffix? = nil) -> GUID {
-        let suffixDescription = suffix.description(forName: name)
+        let suffixDescription = suffix.uniqueDescription(forName: name)
         return "PACKAGE-TARGET:\(name)\(suffixDescription)"
     }
 
@@ -141,15 +135,17 @@ extension PackagePIFBuilder {
     /// This format helps make sure that there is no collision with any other PIF targets,
     /// and in particular that a PIF target and a PIF product can have the same name (as they often do).
     static func targetGUID(forProductName name: String, suffix: TargetSuffix? = nil) -> GUID {
-        let suffixDescription = suffix.description(forName: name)
+        let suffixDescription = suffix.uniqueDescription(forName: name)
         return "PACKAGE-PRODUCT:\(name)\(suffixDescription)"
     }
     
     /// Helper function to consistently generate a target name string for a product in a package.
-    /// This format helps make sure that targets and products with the same name (as they often have) have different
-    /// target names in the PIF.
+    ///
+    /// This format helps make sure that modules and products with the same name (as they often have)
+    /// have different target names in the PIF.
     static func targetName(forProductName name: String, suffix: TargetSuffix? = nil) -> String {
-        return SwiftBuildSupport.targetName(forProductName: name, suffix: suffix?.rawValue)
+        let suffix = suffix?.rawValue ?? ""
+        return "\(name)\(suffix)-product"
     }
 }
 

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -450,7 +450,7 @@ extension PackagePIFProjectBuilder {
                 }
 
                 // We have to give each target a unique name.
-                settings[.TARGET_NAME] = sourceModule.name + targetSuffix.description(forName: sourceModule.name)
+                settings[.TARGET_NAME] = sourceModule.name + targetSuffix.uniqueDescription(forName: sourceModule.name)
 
                 // Redirect the built executable into a separate directory so it won't conflict with the real one.
                 settings[.TARGET_BUILD_DIR] = "$(TARGET_BUILD_DIR)/ExecutableModules"


### PR DESCRIPTION
### Motivation:

We couldn't call `SwiftBuildSupport.PackagePIFBuilder` from `SwiftBuildSupport/BuildSystem.swift` given the prior `#if canImport(SwiftBuild)` checks in former. This is no longer the case.

### Modifications:

Provides a minor code cleanup in `PackagePIFBuilder+Helpers.swift`.

This is tracked by: rdar://139545019
