### PR TITLE
Use swiftCompilerTag for the swift compiler version

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -228,7 +228,12 @@ public final class UserToolchain: Toolchain {
     }
 
     private static func computeSwiftCompilerVersion(targetInfo: JSON) -> String? {
-        // Get the compiler version from the target info
+        // Use the new swiftCompilerTag if it's there
+        if let swiftCompilerTag: String = targetInfo.get("swiftCompilerTag") {
+            return swiftCompilerTag
+        }
+
+        // Default to the swift portion of the compilerVersion
         let compilerVersion: String
         do {
             compilerVersion = try targetInfo.get("compilerVersion")

--- a/Sources/Workspace/Workspace+Prebuilts.swift
+++ b/Sources/Workspace/Workspace+Prebuilts.swift
@@ -221,6 +221,11 @@ extension Workspace {
                             identity: .plain("swift-syntax"),
                             kind: .remoteSourceControl("https://github.com/swiftlang/swift-syntax.git")
                         ),
+                        // The old site that's being redirected but still in use.
+                        .init(
+                            identity: .plain("swift-syntax"),
+                            kind: .remoteSourceControl("https://github.com/apple/swift-syntax.git")
+                        ),
                         .init(
                             identity: .plain("swift-syntax"),
                             kind: .remoteSourceControl("git@github.com:swiftlang/swift-syntax.git")

--- a/Tests/WorkspaceTests/PrebuiltsTests.swift
+++ b/Tests/WorkspaceTests/PrebuiltsTests.swift
@@ -393,6 +393,67 @@ final class PrebuiltsTests: XCTestCase {
         }
     }
 
+    func testRedirectURL() async throws {
+        let sandbox = AbsolutePath("/tmp/ws")
+        let fs = InMemoryFileSystem()
+        let artifact = Data()
+
+        try await with(fileSystem: fs, artifact: artifact, swiftSyntaxVersion: "600.0.1", swiftSyntaxURL: "https://github.com/apple/swift-syntax.git") {
+            manifest, rootCertPath, rootPackage, swiftSyntax in
+
+            let manifestData = try JSONEncoder().encode(manifest)
+
+            let httpClient = HTTPClient { request, progressHandler in
+                guard case .download(let fileSystem, let destination) = request.kind else {
+                    throw StringError("invalid request \(request.kind)")
+                }
+
+                if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-manifest.json" {
+                    try fileSystem.writeFileContents(destination, data: manifestData)
+                    return .okay()
+                } else if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport-macos_aarch64.zip" {
+                    try fileSystem.writeFileContents(destination, data: artifact)
+                    return .okay()
+                } else {
+                    XCTFail("Unexpected URL \(request.url)")
+                    return .notFound()
+                }
+            }
+
+            let archiver = MockArchiver(handler: { _, archivePath, destination, completion in
+                XCTAssertEqual(archivePath, sandbox.appending(components: ".build", "prebuilts", "swift-syntax", "600.0.1", "\(self.swiftVersion)-MacroSupport-macos_aarch64.zip"))
+                XCTAssertEqual(destination, sandbox.appending(components: ".build", "prebuilts", "swift-syntax", "600.0.1", "\(self.swiftVersion)-MacroSupport-macos_aarch64"))
+                completion(.success(()))
+            })
+
+            let workspace = try await MockWorkspace(
+                sandbox: sandbox,
+                fileSystem: fs,
+                roots: [
+                    rootPackage
+                ],
+                packages: [
+                    swiftSyntax
+                ],
+                prebuiltsManager: .init(
+                    swiftVersion: swiftVersion,
+                    httpClient: httpClient,
+                    archiver: archiver,
+                    hostPlatform: .macos_aarch64,
+                    rootCertPath: rootCertPath
+                )
+            )
+
+            try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
+                XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
+                let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
+                try checkSettings(rootPackage, "FooMacros", usePrebuilt: true)
+                try checkSettings(rootPackage, "FooTests", usePrebuilt: true)
+                try checkSettings(rootPackage, "Foo", usePrebuilt: false)
+                try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
+            }
+        }
+    }
     func testCachedArtifact() async throws {
         let sandbox = AbsolutePath("/tmp/ws")
         let fs = InMemoryFileSystem()


### PR DESCRIPTION
The swiftCompilerTag field has been recently added to the swiftc -print-target-info JSON we use to determine the swift compiler version for prebuilts. Use this field as the default value, falling back to extracting the swift compiler version from  the compilerVersion field using a regex.

This gives us much better version numbers since it matches the tags for the toolchain.

Also add in the redirect url, https://github.com/apple/swift-syntax.git, as a supported option.