### PR TITLE
[6.2] swift-package-migrate: Miscellaneous low-risk improvements and more tests

### DIFF
--- a/Fixtures/SwiftMigrate/UpdateManifest/Package.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+var swiftSettings: [SwiftSetting] = []
+
+let package = Package(
+    name: "WithErrors",
+    targets: [
+        .target(
+            name: "CannotFindSettings",
+            swiftSettings: swiftSettings
+        ),
+        .target(name: "A"),
+        .target(name: "B"),
+    ]
+)
+
+package.targets.append(
+    .target(
+        name: "CannotFindTarget",
+        swiftSettings: swiftSettings
+    ),
+)

--- a/Fixtures/SwiftMigrate/UpdateManifest/Package.updated.targets-A-B.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Package.updated.targets-A-B.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+var swiftSettings: [SwiftSetting] = []
+
+let package = Package(
+    name: "WithErrors",
+    targets: [
+        .target(
+            name: "CannotFindSettings",
+            swiftSettings: swiftSettings
+        ),
+        .target(name: "A",swiftSettings: [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InferIsolatedConformances"),]),
+        .target(name: "B",swiftSettings: [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InferIsolatedConformances"),]),
+    ]
+)
+
+package.targets.append(
+    .target(
+        name: "CannotFindTarget",
+        swiftSettings: swiftSettings
+    ),
+)

--- a/Fixtures/SwiftMigrate/UpdateManifest/Package.updated.targets-A.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Package.updated.targets-A.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+var swiftSettings: [SwiftSetting] = []
+
+let package = Package(
+    name: "WithErrors",
+    targets: [
+        .target(
+            name: "CannotFindSettings",
+            swiftSettings: swiftSettings
+        ),
+        .target(name: "A",swiftSettings: [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InferIsolatedConformances"),]),
+        .target(name: "B"),
+    ]
+)
+
+package.targets.append(
+    .target(
+        name: "CannotFindTarget",
+        swiftSettings: swiftSettings
+    ),
+)

--- a/Fixtures/SwiftMigrate/UpdateManifest/Package.updated.targets-all.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Package.updated.targets-all.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+var swiftSettings: [SwiftSetting] = []
+
+let package = Package(
+    name: "WithErrors",
+    targets: [
+        .target(
+            name: "CannotFindSettings",
+            swiftSettings: swiftSettings
+        ),
+        .target(name: "A",swiftSettings: [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InferIsolatedConformances"),]),
+        .target(name: "B",swiftSettings: [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InferIsolatedConformances"),]),
+    ]
+)
+
+package.targets.append(
+    .target(
+        name: "CannotFindTarget",
+        swiftSettings: swiftSettings
+    ),
+)

--- a/Fixtures/SwiftMigrate/UpdateManifest/Sources/A/File.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Sources/A/File.swift
@@ -1,0 +1,1 @@
+public func foo() {}

--- a/Fixtures/SwiftMigrate/UpdateManifest/Sources/B/File.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Sources/B/File.swift
@@ -1,0 +1,1 @@
+public func foo() {}

--- a/Fixtures/SwiftMigrate/UpdateManifest/Sources/CannotFindSettings/File.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Sources/CannotFindSettings/File.swift
@@ -1,0 +1,1 @@
+public func foo() {}

--- a/Fixtures/SwiftMigrate/UpdateManifest/Sources/CannotFindTarget/File.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Sources/CannotFindTarget/File.swift
@@ -1,0 +1,1 @@
+public func foo() {}

--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -23,6 +23,7 @@ import OrderedCollections
 
 import PackageGraph
 import PackageModel
+import enum PackageModelSyntax.ManifestEditError
 
 import SPMBuildCore
 import SwiftFixIt
@@ -153,9 +154,12 @@ extension SwiftPackageCommand {
 
             // Once the fix-its were applied, it's time to update the
             // manifest with newly adopted feature settings.
+            //
+            // Loop over a sorted array to produce deterministic results and
+            // order of diagnostics.
 
             print("> Updating manifest")
-            for (name, _) in modules {
+            for name in modules.keys.sorted() {
                 swiftCommandState.observabilityScope.emit(debug: "Adding feature(s) to '\(name)'")
                 try self.updateManifest(
                     for: name,
@@ -166,6 +170,8 @@ extension SwiftPackageCommand {
         }
 
         /// Resolves the requested feature names.
+        ///
+        /// - Returns: An array of resolved features, sorted by name.
         private func resolveRequestedFeatures(
             _ swiftCommandState: SwiftCommandState
         ) throws -> [SwiftCompilerFeature] {
@@ -200,7 +206,9 @@ extension SwiftPackageCommand {
                 resolvedFeatures.append(feature)
             }
 
-            return resolvedFeatures
+            return resolvedFeatures.sorted { lhs, rhs in
+                lhs.name < rhs.name
+            }
         }
 
         private func createBuildSystem(
@@ -266,15 +274,37 @@ extension SwiftPackageCommand {
                     verbose: !self.globalOptions.logging.quiet
                 )
             } catch {
-                try swiftCommandState.observabilityScope.emit(
-                    error: """
-                    Could not update manifest for '\(target)' (\(error)). \
-                    Please enable '\(
-                        features.map { try $0.swiftSettingDescription }
-                            .joined(separator: ", ")
-                    )' features manually
-                    """
-                )
+                var message =
+                    "Could not update manifest to enable requested features for target '\(target)' (\(error))"
+
+                // Do not suggest manual addition if something else is wrong or
+                // if the error implies that it cannot be done.
+                if let error = error as? ManifestEditError {
+                    switch error {
+                    case .cannotFindPackage,
+                         .cannotAddSettingsToPluginTarget,
+                         .existingDependency:
+                        break
+                    case .cannotFindArrayLiteralArgument,
+                         // This means the target could not be found
+                         // syntactically, not that it does not exist.
+                         .cannotFindTargets,
+                         .cannotFindTarget,
+                         // This means the swift-tools-version is lower than
+                         // the version where one of the setting was introduced.
+                         .oldManifest:
+                        let settings = try features.map {
+                            try $0.swiftSettingDescription
+                        }.joined(separator: ", ")
+
+                        message += """
+                        . Please enable them manually by adding the following Swift settings to the target: \
+                        '\(settings)'
+                        """
+                    }
+                }
+
+                swiftCommandState.observabilityScope.emit(error: message)
             }
         }
 

--- a/Sources/Commands/PackageCommands/Migrate.swift
+++ b/Sources/Commands/PackageCommands/Migrate.swift
@@ -32,7 +32,7 @@ import var TSCBasic.stdoutStream
 struct MigrateOptions: ParsableArguments {
     @Option(
         name: .customLong("target"),
-        help: "The targets to migrate to specified set of features."
+        help: "A comma-separated list of targets to migrate. (default: all Swift targets)"
     )
     var _targets: String?
 
@@ -42,7 +42,7 @@ struct MigrateOptions: ParsableArguments {
 
     @Option(
         name: .customLong("to-feature"),
-        help: "The Swift language upcoming/experimental feature to migrate to."
+        help: "A comma-separated list of Swift language features to migrate to."
     )
     var _features: String
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2115,6 +2115,49 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
         XCTAssertNoMatch(stdout, .contains("--package-path"))
     }
 
+    func testMigrateCommandNoFeatures() async throws {
+        try await XCTAssertThrowsCommandExecutionError(
+            await self.execute(["migrate"])
+        ) { error in
+            XCTAssertMatch(
+                error.stderr,
+                .contains("error: Missing expected argument '--to-feature <to-feature>'")
+            )
+        }
+    }
+
+    func testMigrateCommandUnknownFeature() async throws {
+        try XCTSkipIf(
+            !UserToolchain.default.supportesSupportedFeatures,
+            "skipping because test environment compiler doesn't support `-print-supported-features`"
+        )
+
+        try await XCTAssertThrowsCommandExecutionError(
+            await self.execute(["migrate", "--to-feature", "X"])
+        ) { error in
+            XCTAssertMatch(
+                error.stderr,
+                .contains("error: Unsupported feature 'X'. Available features:")
+            )
+        }
+    }
+
+    func testMigrateCommandNonMigratableFeature() async throws {
+        try XCTSkipIf(
+            !UserToolchain.default.supportesSupportedFeatures,
+            "skipping because test environment compiler doesn't support `-print-supported-features`"
+        )
+
+        try await XCTAssertThrowsCommandExecutionError(
+            await self.execute(["migrate", "--to-feature", "StrictConcurrency"])
+        ) { error in
+            XCTAssertMatch(
+                error.stderr,
+                .contains("error: Feature 'StrictConcurrency' is not migratable")
+            )
+        }
+    }
+
     func testMigrateCommand() async throws {
         try XCTSkipIf(
             !UserToolchain.default.supportesSupportedFeatures,


### PR DESCRIPTION
- **Explanation**:
  * Improve command-line option descriptions. Be clear that both options accept a comma-separated list, which is not at all obvious, and also state the default for `--target`.
  * Add tests for feature resolution errors. This change also extracts feature resolution into a method and removes a superfluous colon from the 'unsupported feature' error message.
  * Add more clarity to manifest update error message along with some tests for it.
- **Scope**: `swift package migrate`, essentially diagnosticQoI changes and NFC amendments to string literals.
- **Issues**: —
- **Original PRs**: https://github.com/swiftlang/swift-package-manager/pull/8965.
- **Risk**: Very low.
- **Testing**: Regression test added.
- **Reviewers**: @bkhouri 
