### PR TITLE
Use only enabled traits when loading package

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1262,8 +1262,7 @@ extension Workspace {
                     prebuilts: [:],
                     fileSystem: self.fileSystem,
                     observabilityScope: observabilityScope,
-                    // For now we enable all traits
-                    enabledTraits: Set(manifest.traits.map(\.name))
+                    enabledTraits: try manifest.enabledTraits(using: .default)
                 )
                 return try builder.construct()
             }
@@ -1330,8 +1329,7 @@ extension Workspace {
             createREPLProduct: self.configuration.createREPLProduct,
             fileSystem: self.fileSystem,
             observabilityScope: observabilityScope,
-            // For now we enable all traits
-            enabledTraits: Set(manifest.traits.map(\.name))
+            enabledTraits: try manifest.enabledTraits(using: .default)
         )
         return try builder.construct()
     }


### PR DESCRIPTION
Both `loadPackage` and `loadRootPackage` specified all traits as enabled when loading a package. Narrow this to only the enabled traits so that the returned `Package` accurately reflects the enabled traits.
