### PR TITLE
Run Command: Add SwiftBuild repl support

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -399,7 +399,6 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     public func build(subset: BuildSubset, buildOutputs: [BuildOutput]) async throws -> BuildResult {
         var result = BuildResult(
             serializedDiagnosticPathsByTargetName: .failure(StringError("Building was skipped")),
-            packageGraph: try await self.getPackageGraph(),
             replArguments: nil,
         )
 
@@ -464,7 +463,6 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
         result = BuildResult(
             serializedDiagnosticPathsByTargetName: result.serializedDiagnosticPathsByTargetName,
-            packageGraph: result.packageGraph,
             symbolGraph: result.symbolGraph,
             buildPlan: buildResultBuildPlan,
             replArguments: buildResultReplArgs,

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -637,13 +637,12 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
 
     /// Creates arguments required to launch the Swift REPL that will allow
     /// importing the modules in the package graph.
-    public func createREPLArguments() throws -> [String] {
+    public func createREPLArguments() throws -> CLIArguments {
         let buildPath = self.toolsBuildParameters.buildPath.pathString
         var arguments = ["repl", "-I" + buildPath, "-L" + buildPath]
 
         // Link the special REPL product that contains all of the library targets.
-        let replProductName = self.graph.rootPackages[self.graph.rootPackages.startIndex].identity.description +
-            Product.replProductSuffix
+        let replProductName = try self.graph.getReplProductName()
         arguments.append("-l" + replProductName)
 
         // The graph should have the REPL product.

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -285,6 +285,14 @@ public struct ModulesGraph {
 
         return result
     }
+
+    public func getReplProductName() throws -> String {
+        if self.rootPackages.isEmpty {
+            throw StringError("Root package does not exist.")
+        }
+        return self.rootPackages[self.rootPackages.startIndex].identity.description +
+            Product.replProductSuffix
+    }
 }
 
 extension PackageGraphError: CustomStringConvertible {

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -47,6 +47,7 @@ public enum BuildOutput {
     // "-emit-extension-block-symbols"
     // "-emit-synthesized-members"
     case buildPlan
+    case replArguments
 }
 
 /// A protocol that represents a build system used by SwiftPM for all build operations. This allows factoring out the
@@ -91,15 +92,28 @@ public struct SymbolGraphResult {
     public let outputLocationForTarget: (String, BuildParameters) -> [String]
 }
 
+public typealias CLIArguments = [String]
+
 public struct BuildResult {
-    package init(serializedDiagnosticPathsByTargetName: Result<[String: [AbsolutePath]], Error>, symbolGraph: SymbolGraphResult? = nil, buildPlan: BuildPlan? = nil) {
+    package init(
+        serializedDiagnosticPathsByTargetName: Result<[String: [AbsolutePath]], Error>,
+        packageGraph: ModulesGraph,
+        symbolGraph: SymbolGraphResult? = nil,
+        buildPlan: BuildPlan? = nil,
+        replArguments: CLIArguments?
+    ) {
         self.serializedDiagnosticPathsByTargetName = serializedDiagnosticPathsByTargetName
+        self.packageGraph = packageGraph
         self.symbolGraph = symbolGraph
         self.buildPlan = buildPlan
+        self.replArguments = replArguments
     }
     
-    public var symbolGraph: SymbolGraphResult?
-    public var buildPlan: BuildPlan?
+    public let replArguments: CLIArguments?
+    public let packageGraph: ModulesGraph
+    public let symbolGraph: SymbolGraphResult?
+    public let buildPlan: BuildPlan?
+
     public var serializedDiagnosticPathsByTargetName: Result<[String: [AbsolutePath]], Error>
 }
 

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -97,20 +97,17 @@ public typealias CLIArguments = [String]
 public struct BuildResult {
     package init(
         serializedDiagnosticPathsByTargetName: Result<[String: [AbsolutePath]], Error>,
-        packageGraph: ModulesGraph,
         symbolGraph: SymbolGraphResult? = nil,
         buildPlan: BuildPlan? = nil,
         replArguments: CLIArguments?
     ) {
         self.serializedDiagnosticPathsByTargetName = serializedDiagnosticPathsByTargetName
-        self.packageGraph = packageGraph
         self.symbolGraph = symbolGraph
         self.buildPlan = buildPlan
         self.replArguments = replArguments
     }
     
     public let replArguments: CLIArguments?
-    public let packageGraph: ModulesGraph
     public let symbolGraph: SymbolGraphResult?
     public let buildPlan: BuildPlan?
 

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -276,6 +276,66 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         self.delegate = delegate
     }
 
+    private func createREPLArguments(
+        session: SWBBuildServiceSession,
+        request: SWBBuildRequest
+    ) async throws -> CLIArguments {
+        self.outputStream.send("Gathering repl arguments...")
+        self.outputStream.flush()
+
+        func getUniqueBuildSettingsIncludingDependencies(of targetGuid: [SWBConfiguredTarget], buildSettings: [String]) async throws -> Set<String> {
+            let dependencyGraph = try await session.computeDependencyGraph(
+                targetGUIDs: request.configuredTargets.map { SWBTargetGUID(rawValue: $0.guid)},
+                buildParameters: request.parameters,
+                includeImplicitDependencies: true,
+            )
+            var uniquePaths = Set<String>()
+            for setting in buildSettings {
+                self.outputStream.send(".")
+                self.outputStream.flush()
+                for (target, targetDependencies) in dependencyGraph {
+                    for t in [target] + targetDependencies {
+                        try await session.evaluateMacroAsStringList(
+                            setting,
+                            level: .target(t.rawValue),
+                            buildParameters: request.parameters,
+                            overrides: nil,
+                        ).forEach({
+                            uniquePaths.insert($0)
+                        })
+                    }
+                }
+
+            }
+            return uniquePaths
+        }
+
+        // TODO: Need to determine how to get the inlude path of package system library dependencies
+        let includePaths = try await getUniqueBuildSettingsIncludingDependencies(
+            of: request.configuredTargets,
+            buildSettings: [
+                "BUILT_PRODUCTS_DIR",
+                "HEADER_SEARCH_PATHS",
+                "USER_HEADER_SEARCH_PATHS",
+                "FRAMEWORK_SEARCH_PATHS",
+            ]
+        )
+
+        let graph = try await self.getPackageGraph()
+        // Link the special REPL product that contains all of the library targets.
+        let replProductName: String = try graph.getReplProductName()
+
+        // The graph should have the REPL product.
+        assert(graph.product(for: replProductName) != nil)
+
+        let arguments = ["repl", "-l\(replProductName)"] + includePaths.map {
+            "-I\($0)"
+        }
+
+        self.outputStream.send("Done.\n")
+        return arguments
+    }
+
     private func supportedSwiftVersions() throws -> [SwiftLanguageVersion] {
         // Swift Build should support any of the supported language versions of SwiftPM and the rest of the toolchain
         SwiftLanguageVersion.supportedSwiftLanguageVersions
@@ -283,17 +343,29 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
     public func build(subset: BuildSubset, buildOutputs: [BuildOutput]) async throws -> BuildResult {
         guard !buildParameters.shouldSkipBuilding else {
-            return BuildResult(serializedDiagnosticPathsByTargetName: .failure(StringError("Building was skipped")))
+            return BuildResult(
+                serializedDiagnosticPathsByTargetName: .failure(StringError("Building was skipped")),
+                packageGraph: try await self.getPackageGraph(),
+                replArguments: nil,
+            )
         }
 
         try await writePIF(buildParameters: buildParameters)
 
-        return try await startSWBuildOperation(pifTargetName: subset.pifTargetName, genSymbolGraph: buildOutputs.contains(.symbolGraph))
+        return try await startSWBuildOperation(
+            pifTargetName: subset.pifTargetName,
+            genSymbolGraph: buildOutputs.contains(.symbolGraph),
+            generateReplArguments: buildOutputs.contains(.replArguments),
+        )
     }
 
-    private func startSWBuildOperation(pifTargetName: String, genSymbolGraph: Bool) async throws -> BuildResult {
+    private func startSWBuildOperation(
+        pifTargetName: String,
+        genSymbolGraph: Bool,
+        generateReplArguments: Bool
+    ) async throws -> BuildResult {
         let buildStartTime = ContinuousClock.Instant.now
-
+        var replArguments: CLIArguments?
         return try await withService(connectionMode: .inProcessStatic(swiftbuildServiceEntryPoint)) { service in
             let derivedDataPath = self.buildParameters.dataPath
 
@@ -418,7 +490,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                                 case .note: .info
                                 case .remark: .debug
                                 }
-                                self.observabilityScope.emit(severity: severity, message: message)
+                                self.observabilityScope.emit(severity: severity, message: "\(message)\n")
 
                                 for childDiagnostic in info.childDiagnostics {
                                     emitInfoAsDiagnostic(info: childDiagnostic)
@@ -502,6 +574,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                         self.observabilityScope.emit(error: "Unexpected build state")
                         throw Diagnostics.fatalError
                     }
+
+                    replArguments = generateReplArguments ? try await self.createREPLArguments(session: session, request: request) : nil
                 }
             } catch let sessError as SessionFailedError {
                 for diagnostic in sessError.diagnostics {
@@ -512,9 +586,16 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                 throw error
             }
 
-            return BuildResult(serializedDiagnosticPathsByTargetName: .success(serializedDiagnosticPathsByTargetName), symbolGraph: SymbolGraphResult(outputLocationForTarget: { target, buildParameters in
-                return ["\(buildParameters.triple.archName)", "\(target).symbolgraphs"]
-            }))
+            return BuildResult(
+                serializedDiagnosticPathsByTargetName: .success(serializedDiagnosticPathsByTargetName),
+                packageGraph: try await self.getPackageGraph(),
+                symbolGraph: SymbolGraphResult(
+                    outputLocationForTarget: { target, buildParameters in
+                        return ["\(buildParameters.triple.archName)", "\(target).symbolgraphs"]
+                    }
+                ),
+                replArguments: replArguments,
+            )
         }
     }
 

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -345,7 +345,6 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         guard !buildParameters.shouldSkipBuilding else {
             return BuildResult(
                 serializedDiagnosticPathsByTargetName: .failure(StringError("Building was skipped")),
-                packageGraph: try await self.getPackageGraph(),
                 replArguments: nil,
             )
         }
@@ -588,7 +587,6 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
             return BuildResult(
                 serializedDiagnosticPathsByTargetName: .success(serializedDiagnosticPathsByTargetName),
-                packageGraph: try await self.getPackageGraph(),
                 symbolGraph: SymbolGraphResult(
                     outputLocationForTarget: { target, buildParameters in
                         return ["\(buildParameters.triple.archName)", "\(target).symbolgraphs"]

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -163,7 +163,6 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
     public func build(subset: BuildSubset, buildOutputs: [BuildOutput]) async throws -> BuildResult {
         let buildResult = BuildResult(
             serializedDiagnosticPathsByTargetName: .failure(StringError("XCBuild does not support reporting serialized diagnostics.")),
-            packageGraph: try await self.getPackageGraph(),
             replArguments: nil,
         )
 

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -161,7 +161,11 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
     }
 
     public func build(subset: BuildSubset, buildOutputs: [BuildOutput]) async throws -> BuildResult {
-        let buildResult = BuildResult(serializedDiagnosticPathsByTargetName: .failure(StringError("XCBuild does not support reporting serialized diagnostics.")))
+        let buildResult = BuildResult(
+            serializedDiagnosticPathsByTargetName: .failure(StringError("XCBuild does not support reporting serialized diagnostics.")),
+            packageGraph: try await self.getPackageGraph(),
+            replArguments: nil,
+        )
 
         guard !buildParameters.shouldSkipBuilding else {
             return buildResult

--- a/Sources/_InternalTestSupport/PackageGraphTesterXCTest.swift
+++ b/Sources/_InternalTestSupport/PackageGraphTesterXCTest.swift
@@ -1,0 +1,327 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+import struct Basics.IdentifiableSet
+
+import PackageModel
+import PackageGraph
+
+@available(*, deprecated, message: "Migrate to Swift Testing and use 'PackageGraphTester'")
+public func PackageGraphTesterXCTest(_ graph: ModulesGraph, _ result: (PackageGraphResultXCTest) throws -> Void) rethrows {
+    try result(PackageGraphResultXCTest(graph))
+}
+
+@available(*, deprecated, message: "Migrate to Swift Testing and use 'PackageGraphResult'")
+public final class PackageGraphResultXCTest {
+    public let graph: ModulesGraph
+
+    public init(_ graph: ModulesGraph) {
+        self.graph = graph
+    }
+
+    public func check(roots: PackageIdentity..., file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(graph.rootPackages.map{$0.identity }.sorted(), roots.sorted(), file: file, line: line)
+    }
+
+    public func check(packages: PackageIdentity..., file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(graph.packages.map {$0.identity }.sorted(), packages.sorted(), file: file, line: line)
+    }
+
+    public func check(modules: String..., file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(
+            graph.allModules
+                .filter { $0.type != .test }
+                .map { $0.name }
+                .sorted(), modules.sorted(), file: file, line: line)
+    }
+
+    public func check(products: String..., file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(Set(graph.allProducts.map { $0.name }), Set(products), file: file, line: line)
+    }
+
+    public func check(reachableTargets: String..., file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(Set(graph.reachableModules.map { $0.name }), Set(reachableTargets), file: file, line: line)
+    }
+
+    public func check(reachableProducts: String..., file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(Set(graph.reachableProducts.map { $0.name }), Set(reachableProducts), file: file, line: line)
+    }
+
+    public func check(
+        reachableBuildTargets: String...,
+        in environment: BuildEnvironment,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        let targets = Set(try self.reachableBuildTargets(in: environment).map({ $0.name }))
+        XCTAssertEqual(targets, Set(reachableBuildTargets), file: file, line: line)
+    }
+
+    public func check(
+        reachableBuildProducts: String...,
+        in environment: BuildEnvironment,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        let products = Set(try self.reachableBuildProducts(in: environment).map({ $0.name }))
+        XCTAssertEqual(products, Set(reachableBuildProducts), file: file, line: line)
+    }
+
+    public func checkTarget(
+        _ name: String,
+        file: StaticString = #file,
+        line: UInt = #line,
+        body: (ResolvedTargetResultXCTest) -> Void
+    ) {
+        let target = graph.module(for: name)
+
+        guard let target else {
+            return XCTFail("Target \(name) not found", file: file, line: line)
+        }
+
+        body(ResolvedTargetResultXCTest(target))
+    }
+
+    package func checkTargets(
+        _ name: String,
+        file: StaticString = #file,
+        line: UInt = #line,
+        body: ([ResolvedTargetResultXCTest]) throws -> Void
+    ) rethrows {
+        try body(graph.allModules.filter { $0.name == name }.map(ResolvedTargetResultXCTest.init))
+    }
+
+    public func checkProduct(
+        _ name: String,
+        file: StaticString = #file,
+        line: UInt = #line,
+        body: (ResolvedProductResultXCTest) -> Void
+    ) {
+        let product = graph.product(for: name)
+
+        guard let product else {
+            return XCTFail("Product \(name) not found", file: file, line: line)
+        }
+
+        body(ResolvedProductResultXCTest(product))
+    }
+
+    package func checkPackage(
+        _ name: String,
+        file: StaticString = #file,
+        line: UInt = #line,
+        body: (ResolvedPackage) -> Void
+    ) {
+        guard let package = find(package: .init(stringLiteral: name)) else {
+            return XCTFail("Product \(name) not found", file: file, line: line)
+        }
+        body(package)
+    }
+
+    public func check(testModules: String..., file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(
+            graph.allModules
+                .filter{ $0.type == .test }
+                .map{ $0.name }
+                .sorted(), testModules.sorted(), file: file, line: line)
+    }
+
+    public func find(package: PackageIdentity) -> ResolvedPackage? {
+        return graph.package(for: package)
+    }
+
+    private func reachableBuildTargets(in environment: BuildEnvironment) throws -> IdentifiableSet<ResolvedModule> {
+        let inputTargets = graph.inputPackages.lazy.flatMap { $0.modules }
+        let recursiveBuildTargetDependencies = try inputTargets
+            .flatMap { try $0.recursiveDependencies(satisfying: environment) }
+            .compactMap { $0.module }
+        return IdentifiableSet(inputTargets).union(recursiveBuildTargetDependencies)
+    }
+
+    private func reachableBuildProducts(in environment: BuildEnvironment) throws -> IdentifiableSet<ResolvedProduct> {
+        let recursiveBuildProductDependencies = try graph.inputPackages
+            .lazy
+            .flatMap { $0.modules }
+            .flatMap { try $0.recursiveDependencies(satisfying: environment) }
+            .compactMap { $0.product }
+        return IdentifiableSet(graph.inputPackages.flatMap { $0.products }).union(recursiveBuildProductDependencies)
+    }
+}
+
+@available(*, deprecated, message: "Migrate to Swift Testing and use 'ResolvedTargetResult'")
+public final class ResolvedTargetResultXCTest {
+    public let target: ResolvedModule
+
+    init(_ target: ResolvedModule) {
+        self.target = target
+    }
+
+    public func check(dependencies: String..., file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(Set(dependencies), Set(target.dependencies.map({ $0.name })), file: file, line: line)
+    }
+
+    public func check(dependencies: [String], file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(Set(dependencies), Set(target.dependencies.map({ $0.name })), file: file, line: line)
+    }
+
+    public func checkDependency(
+        _ name: String,
+        file: StaticString = #file,
+        line: UInt = #line,
+        body: (ResolvedTargetDependencyResultXCTest) -> Void
+    ) {
+        guard let dependency = target.dependencies.first(where: { $0.name == name }) else {
+            return XCTFail("Dependency \(name) not found", file: file, line: line)
+        }
+        body(ResolvedTargetDependencyResultXCTest(dependency))
+    }
+
+    public func check(type: Module.Kind, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(type, target.type, file: file, line: line)
+    }
+
+    public func checkDeclaredPlatforms(_ platforms: [String: String], file: StaticString = #file, line: UInt = #line) {
+        let targetPlatforms = Dictionary(
+            uniqueKeysWithValues: target.supportedPlatforms.map { ($0.platform.name, $0.version.versionString) }
+        )
+        XCTAssertEqual(platforms, targetPlatforms, file: file, line: line)
+    }
+
+    public func checkDerivedPlatforms(_ platforms: [String: String], file: StaticString = #file, line: UInt = #line) {
+        let derived = platforms.map {
+            let platform = PlatformRegistry.default.platformByName[$0.key] ?? PackageModel.Platform
+                .custom(name: $0.key, oldestSupportedVersion: $0.value)
+            return self.target.getSupportedPlatform(for: platform, usingXCTest: self.target.type == .test)
+        }
+        let targetPlatforms = Dictionary(
+            uniqueKeysWithValues: derived.map { ($0.platform.name, $0.version.versionString) }
+        )
+        XCTAssertEqual(platforms, targetPlatforms, file: file, line: line)
+    }
+
+    public func checkDerivedPlatformOptions(
+        _ platform: PackageModel.Platform,
+        options: [String],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let platform = self.target.getSupportedPlatform(for: platform, usingXCTest: target.type == .test)
+        XCTAssertEqual(platform.options, options, file: file, line: line)
+    }
+
+    package func checkBuildSetting(
+        declaration: BuildSettings.Declaration,
+        assignments: Set<BuildSettings.Assignment>?,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            target.underlying.buildSettings.assignments[declaration].flatMap { Set($0) },
+            assignments,
+            file: file,
+            line: line
+        )
+    }
+}
+
+@available(*, deprecated, message: "Migrate to Swift Testing and use 'ResolvedTargetDependencyResult'")
+public final class ResolvedTargetDependencyResultXCTest {
+    private let dependency: ResolvedModule.Dependency
+
+    init(_ dependency: ResolvedModule.Dependency) {
+        self.dependency = dependency
+    }
+
+    public func checkConditions(satisfy environment: BuildEnvironment, file: StaticString = #file, line: UInt = #line) {
+        XCTAssert(dependency.conditions.allSatisfy({ $0.satisfies(environment) }), file: file, line: line)
+    }
+
+    public func checkConditions(
+        dontSatisfy environment: BuildEnvironment,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssert(!dependency.conditions.allSatisfy({ $0.satisfies(environment) }), file: file, line: line)
+    }
+
+    public func checkTarget(
+        file: StaticString = #file,
+        line: UInt = #line,
+        body: (ResolvedTargetResultXCTest) -> Void
+    ) {
+        guard case let .module(target, _) = self.dependency else {
+            return XCTFail("Dependency \(dependency) is not a target", file: file, line: line)
+        }
+        body(ResolvedTargetResultXCTest(target))
+    }
+
+    public func checkProduct(
+        file: StaticString = #file,
+        line: UInt = #line,
+        body: (ResolvedProductResultXCTest) -> Void
+    ) {
+        guard case let .product(product, _) = self.dependency else {
+            return XCTFail("Dependency \(dependency) is not a product", file: file, line: line)
+        }
+        body(ResolvedProductResultXCTest(product))
+    }
+}
+
+@available(*, deprecated, message: "Migrate to Swift Testing and use 'ResolvedProductResult'")
+public final class ResolvedProductResultXCTest {
+    private let product: ResolvedProduct
+
+    init(_ product: ResolvedProduct) {
+        self.product = product
+    }
+
+    public func check(modules: String..., file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(Set(modules), Set(product.modules.map({ $0.name })), file: file, line: line)
+    }
+
+    public func check(type: ProductType, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(type, product.type, file: file, line: line)
+    }
+
+    public func checkDeclaredPlatforms(_ platforms: [String: String], file: StaticString = #file, line: UInt = #line) {
+        let targetPlatforms = Dictionary(uniqueKeysWithValues: product.supportedPlatforms.map({ ($0.platform.name, $0.version.versionString) }))
+        XCTAssertEqual(platforms, targetPlatforms, file: file, line: line)
+    }
+
+    public func checkDerivedPlatforms(_ platforms: [String: String], file: StaticString = #file, line: UInt = #line) {
+        let derived = platforms.map {
+            let platform = PlatformRegistry.default.platformByName[$0.key] ?? PackageModel.Platform.custom(name: $0.key, oldestSupportedVersion: $0.value)
+            return product.getSupportedPlatform(for: platform, usingXCTest: product.isLinkingXCTest)
+        }
+        let targetPlatforms = Dictionary(uniqueKeysWithValues: derived.map({ ($0.platform.name, $0.version.versionString) }))
+        XCTAssertEqual(platforms, targetPlatforms, file: file, line: line)
+    }
+
+    public func checkDerivedPlatformOptions(_ platform: PackageModel.Platform, options: [String], file: StaticString = #file, line: UInt = #line) {
+        let platform = product.getSupportedPlatform(for: platform, usingXCTest: product.isLinkingXCTest)
+        XCTAssertEqual(platform.options, options, file: file, line: line)
+    }
+
+    public func checkTarget(
+        _ name: String,
+        file: StaticString = #file,
+        line: UInt = #line,
+        body: (ResolvedTargetResultXCTest) -> Void
+    ) {
+        guard let target = product.modules.first(where: { $0.name == name }) else {
+            return XCTFail("Target \(name) not found", file: file, line: line)
+        }
+        body(ResolvedTargetResultXCTest(target))
+    }
+}

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -48,6 +48,17 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
+    /// Test required setting ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION define
+    public static var requiresTargetBasedDependencyResolution: Self {
+        enabled("enabled as target based dependency resolution is defined") {
+            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
+                true
+            #else
+                false
+            #endif
+        }
+    }
+
     /// Skip test if built by XCode.
     public static func skipIfXcodeBuilt() -> Self {
         disabled("Tests built by Xcode") {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3453,7 +3453,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         )
         #endif
 
-        let graphResult = PackageGraphResult(graph)
+        let graphResult = PackageGraphResultXCTest(graph)
         graphResult.check(reachableProducts: "aexec", "BLibrary")
         graphResult.check(reachableTargets: "ATarget", "BTarget1")
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
@@ -3554,7 +3554,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let graphResult = PackageGraphResult(graph)
+        let graphResult = PackageGraphResultXCTest(graph)
 
         do {
             let linuxDebug = BuildEnvironment(platform: .linux, configuration: .debug)

--- a/Tests/BuildTests/PluginInvocationTests.swift
+++ b/Tests/BuildTests/PluginInvocationTests.swift
@@ -86,7 +86,7 @@ final class PluginInvocationTests: XCTestCase {
 
         // Check the basic integrity before running plugins.
         XCTAssertNoDiagnostics(observability.diagnostics)
-        PackageGraphTester(graph) { graph in
+        PackageGraphTesterXCTest(graph) { graph in
             graph.check(packages: "Foo")
             graph.check(modules: "Foo", "FooPlugin", "FooTool", "FooToolLib")
             graph.checkTarget("Foo") { target in

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -269,7 +269,7 @@ struct RunCommandTests {
                 let cwd = try #require(localFileSystem.currentWorkingDirectory, "Current working directory should not be nil")
                 let (stdout, stderr) = try await execute([filePath, "1", "2"], packagePath: fixturePath, buildSystem: buildSystem)
                 #expect(stdout.contains(#""\#(cwd)" "1" "2""#))
-                #expect(stderr.contains("warning: 'swift run file.swift' command to interpret swift files is deprecated; use 'swift file.swift' instead"))
+                #expect(stderr.contains("warning: 'swift run \(filePath)' command to interpret swift files is deprecated; use 'swift \(filePath)' instead"))
             }
         } when: {
             ProcessInfo.hostOperatingSystem == .windows

--- a/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
+++ b/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
@@ -23,7 +23,7 @@ import XCTest
 final class CrossCompilationPackageGraphTests: XCTestCase {
     func testTrivialPackage() throws {
         let graph = try trivialPackageGraph().graph
-        PackageGraphTester(graph) { result in
+        PackageGraphTesterXCTest(graph) { result in
             result.check(packages: "Pkg")
             // "SwiftSyntax" is included for both host and target triples and is not pruned on this level
             result.check(modules: "app", "lib")
@@ -42,7 +42,7 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
 
     func testMacros() throws {
         let graph = try macrosPackageGraph().graph
-        PackageGraphTester(graph) { result in
+        PackageGraphTesterXCTest(graph) { result in
             result.check(packages: "swift-firmware", "swift-mmio", "swift-syntax")
             result.check(
                 modules: "Core",
@@ -78,7 +78,7 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
 
     func testMacrosTests() throws {
         let graph = try macrosTestsPackageGraph().graph
-        PackageGraphTester(graph) { result in
+        PackageGraphTesterXCTest(graph) { result in
             result.check(packages: "swift-mmio", "swift-syntax")
             // "SwiftSyntax" is included for both host and target triples and is not pruned on this level
             result.check(

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -94,7 +94,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(path: "./Baz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
         ]
         try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo", "Quix")
                 result.check(modules: "Bar", "Baz", "Foo", "Quix")
@@ -380,7 +380,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Bar", "Foo")
                 result.check(packages: "Bar", "Baz", "Foo")
                 result.checkTarget("Foo") { result in result.check(dependencies: "Baz") }
@@ -446,7 +446,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo", "Bar", "Overridden/bazzz"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "bar", "Foo", "bazzz")
                 result.check(packages: "bar", "bazzz", "foo")
                 result.checkTarget("Foo") { result in result.check(dependencies: "Baz") }
@@ -555,7 +555,7 @@ final class WorkspaceTests: XCTestCase {
                 ),
             ]
         ) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "foo-package", "bar-package")
                 result.check(packages: "foo-package", "bar-package")
                 result.checkTarget("FooTarget") { result in result.check(dependencies: "BarProduct") }
@@ -610,7 +610,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo", "Baz"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Baz", "Foo")
                 result.check(packages: "Baz", "Foo")
                 result.check(modules: "BazA", "BazB", "Foo")
@@ -671,7 +671,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Load only Foo right now so Baz is loaded from remote.
         try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo")
                 result.check(modules: "Baz", "Foo")
@@ -691,7 +691,7 @@ final class WorkspaceTests: XCTestCase {
         // Now load with Baz as a root package.
         workspace.delegate.clear()
         try await workspace.checkPackageGraph(roots: ["Foo", "Baz"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Baz", "Foo")
                 result.check(packages: "Baz", "Foo")
                 result.check(modules: "BazA", "BazB", "Foo")
@@ -762,7 +762,7 @@ final class WorkspaceTests: XCTestCase {
         ]
 
         try await workspace.checkPackageGraph(dependencies: dependencies) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "Bar", "Foo")
                 result.check(modules: "Bar", "Foo")
                 result.checkTarget("Foo") { result in result.check(dependencies: "Bar") }
@@ -829,7 +829,7 @@ final class WorkspaceTests: XCTestCase {
                 .sourceControl(path: "./A", requirement: .exact("1.0.0"), products: .specific(["A"])),
             ]
             try await workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(packages: "A", "AA")
                     result.check(modules: "A", "AA")
                     result.checkTarget("A") { result in result.check(dependencies: "AA") }
@@ -852,7 +852,7 @@ final class WorkspaceTests: XCTestCase {
                 .sourceControl(path: "./A", requirement: .exact("1.0.1"), products: .specific(["A"])),
             ]
             try await workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.checkTarget("A") { result in result.check(dependencies: "AA") }
                 }
                 XCTAssertNoDiagnostics(diagnostics)
@@ -1515,7 +1515,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["A", "B", "C"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "A", "B", "C")
                 result.check(modules: "A", "B", "C")
             }
@@ -1586,7 +1586,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(path: "./Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
         try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
             }
@@ -1602,7 +1602,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertNoDiagnostics(diagnostics)
         }
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -1675,7 +1675,7 @@ final class WorkspaceTests: XCTestCase {
         ]
 
         try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -1708,7 +1708,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(expectedChange, change)
         }
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -1951,7 +1951,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Load the graph with one root.
         try await workspace.checkPackageGraph(roots: ["Root1"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "Foo", "Root1")
             }
             XCTAssertNoDiagnostics(diagnostics)
@@ -1968,7 +1968,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Load the graph with both roots.
         try await workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "Bar", "Foo", "Root1", "Root2")
             }
             XCTAssertNoDiagnostics(diagnostics)
@@ -2102,7 +2102,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(path: "./Bar", requirement: .revision(barRevision), products: .specific(["Bar"])),
         ]
         try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
             }
@@ -2149,7 +2149,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Load initial version.
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -2213,7 +2213,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Load the graph.
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -2223,7 +2223,7 @@ final class WorkspaceTests: XCTestCase {
         try fs.removeFileTree(workspace.getOrCreateWorkspace().location.repositoriesCheckoutsDirectory)
 
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -2400,7 +2400,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Load the graph.
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: .plain("Root"))
                 result.check(packages: .plain("bar"), .plain("foo"), .plain("Root"))
             }
@@ -2508,7 +2508,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: .plain("Root"))
                 result.check(packages: .plain("root"), .plain("Foo"))
             }
@@ -2617,7 +2617,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Load the graph and edit foo.
         try await workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "Foo")
             }
             XCTAssertNoDiagnostics(diagnostics)
@@ -2711,7 +2711,7 @@ final class WorkspaceTests: XCTestCase {
         ]
         // Load the graph.
         try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
             }
@@ -2841,7 +2841,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Load the graph.
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -2855,7 +2855,7 @@ final class WorkspaceTests: XCTestCase {
             .fileSystem(path: "./Foo", products: .specific(["Foo"])),
         ]
         try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Bar", "Root")
             }
@@ -2905,7 +2905,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Initial resolution.
         try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Bar", "Foo")
             }
@@ -2999,7 +2999,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Load the graph.
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -3129,7 +3129,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["Root"], deps: []) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "Bar", "Foo", "Root")
             }
         }
@@ -3154,7 +3154,7 @@ final class WorkspaceTests: XCTestCase {
 
         // reload graph after "external" change
         try await workspace.checkPackageGraph(roots: ["Root"], deps: []) { graph, _ in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "Bar", "Foo", "Root")
             }
         }
@@ -3268,7 +3268,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Bar", "Baz", "Foo")
                 result.check(modules: "Bar", "Baz", "Foo")
@@ -3346,7 +3346,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Foo")
                 result.check(modules: "Foo")
@@ -3394,7 +3394,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Bar", "Foo")
             }
@@ -3448,7 +3448,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Foo")
                 result.check(modules: "Foo")
@@ -3502,7 +3502,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(path: "./Foo", requirement: .branch("develop"), products: .specific(["Foo"])),
         ]
         try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -3571,7 +3571,7 @@ final class WorkspaceTests: XCTestCase {
             .fileSystem(path: "./Foo", products: .specific(["Foo"])),
         ]
         try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -3651,7 +3651,7 @@ final class WorkspaceTests: XCTestCase {
             .fileSystem(path: "./Foo", products: .specific(["Foo"])),
         ]
         try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -3720,7 +3720,7 @@ final class WorkspaceTests: XCTestCase {
             .fileSystem(path: "./Foo", products: .specific(["Foo"])),
         ]
         try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -3799,7 +3799,7 @@ final class WorkspaceTests: XCTestCase {
         ]
         try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
@@ -4266,7 +4266,7 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
                 }
@@ -4296,7 +4296,7 @@ final class WorkspaceTests: XCTestCase {
             try await workspace.closeWorkspace(resetResolvedFile: false)
             // run resolution again, now it should rely on the resolved file
             try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
                 }
@@ -4322,7 +4322,7 @@ final class WorkspaceTests: XCTestCase {
 
             // run resolution again, but change requirements
             try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
                 }
@@ -4347,7 +4347,7 @@ final class WorkspaceTests: XCTestCase {
             try fs.writeFileContents(rootManifestPath, string: manifestContent)
             // run resolution again, now it should rely on the resolved file
             try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
                 }
@@ -4372,7 +4372,7 @@ final class WorkspaceTests: XCTestCase {
             ]
             // run resolution again, but change requirements
             try await workspace.checkPackageGraph(roots: ["Root"], dependencies: changedDeps) { graph, diagnostics in
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Baz", "Foo", "Root")
                 }
@@ -4395,7 +4395,7 @@ final class WorkspaceTests: XCTestCase {
             try await workspace.closeWorkspace(resetResolvedFile: false)
             // run resolution again, but change requirements back to original
             try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
                 }
@@ -4418,7 +4418,7 @@ final class WorkspaceTests: XCTestCase {
             try await workspace.closeWorkspace(resetResolvedFile: false)
             // run resolution again, now it should rely on the resolved file
             try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
                 }
@@ -4439,7 +4439,7 @@ final class WorkspaceTests: XCTestCase {
             try await workspace.closeWorkspace(resetResolvedFile: true)
             // run resolution again
             try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "Bar", "Foo", "Root")
                 }
@@ -4542,7 +4542,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "BazMirror", "Foo", "Dep")
                 result.check(modules: "Bar", "Baz", "Foo", "Dep")
@@ -4646,7 +4646,7 @@ final class WorkspaceTests: XCTestCase {
         ]
 
         try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "Foo", "Dep")
                 result.check(modules: "Bar", "Foo", "Dep")
@@ -4734,7 +4734,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "bar-mirror", "baz-mirror", "foo", "dep")
                 result.check(modules: "Bar", "Baz", "Foo", "Dep")
@@ -4840,7 +4840,7 @@ final class WorkspaceTests: XCTestCase {
         ]
 
         try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "bar-mirror", "foo", "dep")
                 result.check(modules: "Bar", "Foo", "Dep")
@@ -4911,7 +4911,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "org.bar-mirror", "baz", "foo")
                 result.check(modules: "Bar", "Baz", "Foo")
@@ -4981,7 +4981,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "bar-mirror", "org.baz", "foo")
                 result.check(modules: "Bar", "Baz", "Foo")
@@ -5098,7 +5098,7 @@ final class WorkspaceTests: XCTestCase {
         ]
         try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
             }
@@ -5128,7 +5128,7 @@ final class WorkspaceTests: XCTestCase {
         ]
         try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
             }
@@ -5701,7 +5701,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try await workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Bar", "Baz", "Foo")
                 result.checkTarget("Foo") { result in result.check(dependencies: "Bar", "Baz") }
@@ -11840,7 +11840,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "bar", "baz", "foo", "Root", "qux")
                 let package = result.find(package: "foo")
                 XCTAssertEqual(package?.manifest.packageLocation, "https://github.com/org/foo.git")
@@ -11982,7 +11982,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "bar", "baz", "foo", "Root")
                 let package = result.find(package: "foo")
                 XCTAssertEqual(package?.manifest.packageLocation, "git@github.com:org/foo.git")
@@ -12125,7 +12125,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "bar", "foo", "Root")
                 let package = result.find(package: "foo")
                 XCTAssertEqual(package?.manifest.packageLocation, "git@github.com:org/foo.git")
@@ -12147,7 +12147,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["Root2"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "bar", "baz", "foo", "Root2")
                 let package = result.find(package: "foo")
                 XCTAssertEqual(package?.manifest.packageLocation, "git@github.com:org/foo.git")
@@ -12242,7 +12242,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "foo", "Root")
                 let package = result.find(package: "foo")
                 XCTAssertEqual(package?.manifest.packageLocation, "https://github.com/org/foo.git")
@@ -12267,7 +12267,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["Root2"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "foo", "Root2")
                 let package = result.find(package: "foo")
                 XCTAssertEqual(package?.manifest.packageLocation, "git@github.com:org/foo.git")
@@ -12396,7 +12396,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "bar", "foo", "Root")
                 let package = result.find(package: "foo")
                 XCTAssertEqual(package?.manifest.packageLocation, "https://github.com/org/foo.git")
@@ -12427,7 +12427,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["Root2"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(packages: "bar", "foo", "Root2")
                 let package = result.find(package: "foo")
                 XCTAssertEqual(package?.manifest.packageLocation, "git@github.com:org/foo.git")
@@ -12625,7 +12625,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "bar", "foo", "Root")
                 result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -12834,7 +12834,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "MyPackage")
                 result.check(packages: "Bar", "Foo", "MyPackage")
                 result.check(modules: "Foo", "Bar", "MyTarget1", "MyTarget2")
@@ -12967,7 +12967,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "MyPackage")
                 result.check(packages: "Bar", "Baz", "Foo", "MyPackage")
                 result.check(modules: "Foo", "Bar", "Baz", "MyTarget1", "MyTarget2")
@@ -13084,7 +13084,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "MyPackage")
                 result.check(packages: "org.bar", "org.foo", "mypackage")
                 result.check(modules: "Foo", "Bar", "MyTarget1", "MyTarget2")
@@ -13217,7 +13217,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "MyPackage")
                 result.check(packages: "org.bar", "org.baz", "org.foo", "mypackage")
                 result.check(modules: "Foo", "Bar", "Baz", "MyTarget1", "MyTarget2")
@@ -13333,7 +13333,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "org.bar", "org.foo", "Root")
                 result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -13421,7 +13421,7 @@ final class WorkspaceTests: XCTestCase {
 
             try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "org.bar", "foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -13444,7 +13444,7 @@ final class WorkspaceTests: XCTestCase {
 
             try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "org.bar", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -13467,7 +13467,7 @@ final class WorkspaceTests: XCTestCase {
 
             try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "org.bar", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -13529,7 +13529,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "org.foo", "Root")
                 result.check(modules: "FooTarget", "RootTarget")
@@ -13746,7 +13746,7 @@ final class WorkspaceTests: XCTestCase {
                     )
                 }
 
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "bar", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -13770,7 +13770,7 @@ final class WorkspaceTests: XCTestCase {
             try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
 
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "bar", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -13793,7 +13793,7 @@ final class WorkspaceTests: XCTestCase {
 
             try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "bar", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -13909,7 +13909,7 @@ final class WorkspaceTests: XCTestCase {
                         severity: .warning
                     )
                 }
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "org.bar", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -13932,7 +13932,7 @@ final class WorkspaceTests: XCTestCase {
 
             try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "org.bar", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -14181,7 +14181,7 @@ final class WorkspaceTests: XCTestCase {
                         )
                     }
                 }
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "org.bar", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -14204,7 +14204,7 @@ final class WorkspaceTests: XCTestCase {
 
             try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "org.bar", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -14469,7 +14469,7 @@ final class WorkspaceTests: XCTestCase {
                         )
                     }
                 }
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "org.bar", "org.baz", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "BazTarget", "RootTarget")
@@ -14497,7 +14497,7 @@ final class WorkspaceTests: XCTestCase {
 
             try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 XCTAssertNoDiagnostics(diagnostics)
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "org.bar", "org.baz", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "BazTarget", "RootTarget")
@@ -14757,7 +14757,7 @@ final class WorkspaceTests: XCTestCase {
                         severity: .warning
                     )
                 }
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "org.bar", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -14787,7 +14787,7 @@ final class WorkspaceTests: XCTestCase {
                         severity: .warning
                     )
                 }
-                PackageGraphTester(graph) { result in
+                PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "org.bar", "org.foo", "Root")
                     result.check(modules: "FooTarget", "BarTarget", "RootTarget")
@@ -14880,7 +14880,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(url: bazURL, requirement: .exact("1.0.0")),
         ]
         try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo")
                 result.check(modules: "Bar", "Baz", "Foo")
@@ -15423,7 +15423,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 guard let foo = result.find(package: "org.foo") else {
                     return XCTFail("missing package")
                 }
@@ -15495,7 +15495,7 @@ final class WorkspaceTests: XCTestCase {
 
         try await workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 XCTAssertNotNil(result.find(package: "org.foo"), "missing package")
             }
         }
@@ -15709,7 +15709,7 @@ final class WorkspaceTests: XCTestCase {
             PackageIdentity.plain("org.bar"): XCTUnwrap(actualMetadata.signature?.signedBy),
         ]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 XCTAssertNotNil(result.find(package: "ecorp.bar"), "missing package")
                 XCTAssertNil(result.find(package: "org.bar"), "unexpectedly present package")
             }
@@ -15875,7 +15875,7 @@ final class WorkspaceTests: XCTestCase {
         ]
 
         try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo")
                 result.check(modules: "Bar", "Baz", "Foo")
@@ -15962,7 +15962,7 @@ final class WorkspaceTests: XCTestCase {
         ]
 
         try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo", "Boo")
                 result.check(modules: "Bar", "Baz", "Boo", "Foo")
@@ -16041,7 +16041,7 @@ final class WorkspaceTests: XCTestCase {
         ]
 
         try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo")
                 result.check(modules: "Bar", "Baz", "Foo")
@@ -16122,7 +16122,7 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(path: "./Boo", requirement: .exact("1.0.0"), products: .specific(["Boo"])),
         ]
         try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
+            PackageGraphTesterXCTest(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Boo", "Foo")
                 result.check(modules: "Bar", "Baz", "Boo", "Foo")


### PR DESCRIPTION
The `swift run --repl` was explicitly using the Native build system. This change modified the `swift run --repl` command to respect the `--build-system <arg>` command line option.  The change introduces a new build output request `replArguments`.  When provided, the build system is responsible for providing the arguments required for the REPL in the
BuildResult.
    
The Swift Run Command will inspect the build result for this property. If it's unavailable, the command provides an error indicating repl support is unavailable.
    
A caveat, more work is required to get proper REPL integration with the Package.  At the moment, the System Library paths are not provided by the SwiftBuild System when a repl session is requested via the `run` command.
    
Relates to: #8846
issue: rdar://153822861

Depends on : #8942 