### PR TITLE
Cannot use Metal properly with Swift Packages

### DIFF
--- a/Sources/Basics/Sandbox.swift
+++ b/Sources/Basics/Sandbox.swift
@@ -133,6 +133,9 @@ fileprivate func macOSSandboxProfile(
     // This is needed to use the UniformTypeIdentifiers API.
     contents += "(allow mach-lookup (global-name \"com.apple.lsd.mapdb\"))\n"
 
+    // For downloadable Metal toolchain lookups.
+    contents += "(allow mach-lookup (global-name \"com.apple.mobileassetd.v2\"))\n"
+
     if allowNetworkConnections.filter({ $0 != .none }).isEmpty == false {
         // this is used by the system for caching purposes and will lead to log spew if not allowed
         contents += "(allow file-write* (regex \"/Users/*/Library/Caches/*/Cache.db*\"))"


### PR DESCRIPTION
Cannot use Metal properly with Swift Packages — even with Apple-recommended plugin workaround

The summary here is that when using xcrun to locate metal, xcodebuild is invoked which queries MobileAssets for the location of the metal toolchain. The query to MobileAssets requires the added entitlement.

Reference: https://github.com/swiftlang/swift-package-manager/issues/8930

### Modifications:

Add expected entitlement

