### PR TITLE
test helpers: do not use default build system

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -11,6 +11,7 @@
 
 import class Foundation.FileManager
 import class Foundation.ProcessInfo
+import class PackageModel.UserToolchain
 import Basics
 import Testing
 
@@ -26,6 +27,13 @@ extension Trait where Self == Testing.ConditionTrait {
     public static func skipHostOS(_ os: OperatingSystem, _ comment: Comment? = nil) -> Self {
         disabled(comment ?? "This test cannot run on a \(os) host OS.") {
             ProcessInfo.hostOperatingSystem == os
+        }
+    }
+
+    /// Enabled only if toolchain support swift concurrency
+    public static var requiresSwiftConcurrencySupport: Self {
+        enabled("skipping because test environment doesn't support concurrency") {
+            (try? UserToolchain.default)!.supportsSwiftConcurrency()
         }
     }
 

--- a/Sources/_InternalTestSupport/XCTAssertHelpers.swift
+++ b/Sources/_InternalTestSupport/XCTAssertHelpers.swift
@@ -154,7 +154,7 @@ public func XCTAssertBuilds(
     env: Environment? = nil,
     file: StaticString = #file,
     line: UInt = #line,
-    buildSystem: BuildSystemProvider.Kind = .native
+    buildSystem: BuildSystemProvider.Kind,
 ) async {
     for conf in configurations {
         await XCTAssertAsyncNoThrow(
@@ -184,7 +184,7 @@ public func XCTAssertSwiftTest(
     env: Environment? = nil,
     file: StaticString = #file,
     line: UInt = #line,
-    buildSystem: BuildSystemProvider.Kind = .native
+    buildSystem: BuildSystemProvider.Kind,
 ) async {
     await XCTAssertAsyncNoThrow(
         try await executeSwiftTest(
@@ -211,7 +211,7 @@ public func XCTAssertBuildFails(
     env: Environment? = nil,
     file: StaticString = #file,
     line: UInt = #line,
-    buildSystem: BuildSystemProvider.Kind = .native
+    buildSystem: BuildSystemProvider.Kind,
 ) async -> CommandExecutionError? {
     var failure: CommandExecutionError? = nil
     await XCTAssertThrowsCommandExecutionError(
@@ -337,6 +337,6 @@ public func XCTExhibitsGitHubIssue(_ number: Int) throws {
 
     try XCTSkipIf(
         ProcessInfo.processInfo.environment[envVar] != nil,
-        "https://github.com/swiftlang/swift-package-manager/issues/\(number): \(envVar)environment variable is set"
+        "https://github.com/swiftlang/swift-package-manager/issues/\(number): \(envVar) environment variable is set"
     )
 }

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -395,7 +395,7 @@ public func executeSwiftBuild(
     Xld: [String] = [],
     Xswiftc: [String] = [],
     env: Environment? = nil,
-    buildSystem: BuildSystemProvider.Kind = .native,
+    buildSystem: BuildSystemProvider.Kind,
     throwIfCommandFails: Bool = true,
 ) async throws -> (stdout: String, stderr: String) {
     let args = swiftArgs(
@@ -419,7 +419,7 @@ public func executeSwiftRun(
     Xld: [String] = [],
     Xswiftc: [String] = [],
     env: Environment? = nil,
-    buildSystem: BuildSystemProvider.Kind
+    buildSystem: BuildSystemProvider.Kind,
 ) async throws -> (stdout: String, stderr: String) {
     var args = swiftArgs(
         configuration: configuration,
@@ -444,7 +444,7 @@ public func executeSwiftPackage(
     Xld: [String] = [],
     Xswiftc: [String] = [],
     env: Environment? = nil,
-    buildSystem: BuildSystemProvider.Kind = .native
+    buildSystem: BuildSystemProvider.Kind,
 ) async throws -> (stdout: String, stderr: String) {
     let args = swiftArgs(
         configuration: configuration,
@@ -466,7 +466,7 @@ public func executeSwiftPackageRegistry(
     Xld: [String] = [],
     Xswiftc: [String] = [],
     env: Environment? = nil,
-    buildSystem: BuildSystemProvider.Kind = .native
+    buildSystem: BuildSystemProvider.Kind,
 ) async throws -> (stdout: String, stderr: String) {
     let args = swiftArgs(
         configuration: configuration,
@@ -489,7 +489,7 @@ public func executeSwiftTest(
     Xswiftc: [String] = [],
     env: Environment? = nil,
     throwIfCommandFails: Bool = false,
-    buildSystem: BuildSystemProvider.Kind = .native
+    buildSystem: BuildSystemProvider.Kind,
 ) async throws -> (stdout: String, stderr: String) {
     let args = swiftArgs(
         configuration: configuration,

--- a/Tests/BuildTests/BuildSystemDelegateTests.swift
+++ b/Tests/BuildTests/BuildSystemDelegateTests.swift
@@ -24,7 +24,7 @@ final class BuildSystemDelegateTests: XCTestCase {
             // These linker diagnostics are only produced on macOS.
             try XCTSkipIf(true, "test is only supported on macOS")
             #endif
-            let (fullLog, _) = try await executeSwiftBuild(fixturePath)
+            let (fullLog, _) = try await executeSwiftBuild(fixturePath, buildSystem: .native)
             XCTAssertTrue(fullLog.contains("ld: warning: search path 'foobar' not found"), "log didn't contain expected linker diagnostics")
         }
     }
@@ -40,11 +40,11 @@ final class BuildSystemDelegateTests: XCTestCase {
         let executableExt = ""
         #endif
         try await fixtureXCTest(name: "Miscellaneous/TestableExe") { fixturePath in
-            _ = try await executeSwiftBuild(fixturePath)
+            _ = try await executeSwiftBuild(fixturePath, buildSystem: .native)
             let execPath = fixturePath.appending(components: ".build", "debug", "TestableExe1\(executableExt)")
             XCTAssertTrue(localFileSystem.exists(execPath), "executable not found at '\(execPath)'")
             try localFileSystem.removeFileTree(execPath)
-            let (fullLog, _) = try await executeSwiftBuild(fixturePath)
+            let (fullLog, _) = try await executeSwiftBuild(fixturePath, buildSystem: .native)
             XCTAssertFalse(fullLog.contains("replacing existing signature"), "log contained non-fatal codesigning messages")
         }
     }

--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -42,7 +42,7 @@ final class IncrementalBuildTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
         try await fixtureXCTest(name: "CFamilyTargets/CLibrarySources") { fixturePath in
             // Build it once and capture the log (this will be a full build).
-            let (fullLog, _) = try await executeSwiftBuild(fixturePath)
+            let (fullLog, _) = try await executeSwiftBuild(fixturePath, buildSystem: .native)
 
             // Check various things that we expect to see in the full build log.
             // FIXME:  This is specific to the format of the log output, which
@@ -64,7 +64,7 @@ final class IncrementalBuildTests: XCTestCase {
             let llbuildContents1: String = try localFileSystem.readFileContents(llbuildManifest)
 
             // Now build again.  This should be an incremental build.
-            let (log2, _) = try await executeSwiftBuild(fixturePath)
+            let (log2, _) = try await executeSwiftBuild(fixturePath, buildSystem: .native)
             XCTAssertMatch(log2, .contains("Compiling CLibrarySources Foo.c"))
 
             // Read the second llbuild manifest.
@@ -72,7 +72,7 @@ final class IncrementalBuildTests: XCTestCase {
 
             // Now build again without changing anything.  This should be a null
             // build.
-            let (log3, _) = try await executeSwiftBuild(fixturePath)
+            let (log3, _) = try await executeSwiftBuild(fixturePath, buildSystem: .native)
             XCTAssertNoMatch(log3, .contains("Compiling CLibrarySources Foo.c"))
 
             // Read the third llbuild manifest.
@@ -91,7 +91,7 @@ final class IncrementalBuildTests: XCTestCase {
             )
 
             // Now build again.  This should be an incremental build.
-            let (log4, _) = try await executeSwiftBuild(fixturePath)
+            let (log4, _) = try await executeSwiftBuild(fixturePath, buildSystem: .native)
             XCTAssertMatch(log4, .contains("Compiling CLibrarySources Foo.c"))
         }
     }
@@ -101,7 +101,7 @@ final class IncrementalBuildTests: XCTestCase {
         try await fixtureXCTest(name: "ValidLayouts/SingleModule/Library") { fixturePath in
             @discardableResult
             func build() async throws -> String {
-                return try await executeSwiftBuild(fixturePath).stdout
+                return try await executeSwiftBuild(fixturePath, buildSystem: .native).stdout
             }
 
             // Perform a full build.
@@ -135,7 +135,11 @@ final class IncrementalBuildTests: XCTestCase {
         try await fixtureXCTest(name: "ValidLayouts/SingleModule/Library") { fixturePath in
             @discardableResult
             func build() async throws -> String {
-                return try await executeSwiftBuild(fixturePath, extraArgs: ["--disable-build-manifest-caching"]).stdout
+                return try await executeSwiftBuild(
+                    fixturePath,
+                    extraArgs: ["--disable-build-manifest-caching"],
+                    buildSystem: .native,
+                ).stdout
             }
 
             // Perform a full build.
@@ -166,7 +170,11 @@ final class IncrementalBuildTests: XCTestCase {
 
             let newSdkPathStr = "/tmp/../\(sdkPathStr)"
             // Perform a full build again because SDK changed.
-            let log1 = try await executeSwiftBuild(fixturePath, env: ["SDKROOT": newSdkPathStr]).stdout
+            let log1 = try await executeSwiftBuild(
+                fixturePath,
+                env: ["SDKROOT": newSdkPathStr],
+                buildSystem: .native,
+            ).stdout
             XCTAssertMatch(log1, .contains("Compiling Library"))
         }
 #endif

--- a/Tests/BuildTests/PluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/PluginsBuildPlanTests.swift
@@ -21,7 +21,7 @@ final class PluginsBuildPlanTests: XCTestCase {
         try XCTSkipOnWindows(because: "Fails to build the project to due to incorrect Path handling.  Possibly related to https://github.com/swiftlang/swift-package-manager/issues/8511")
 
         try await fixtureXCTest(name: "Miscellaneous/Plugins/MySourceGenPlugin") { fixturePath in
-            let (stdout, _) = try await executeSwiftBuild(fixturePath)
+            let (stdout, _) = try await executeSwiftBuild(fixturePath, buildSystem: .native)
             XCTAssertMatch(stdout, .contains("Build complete!"))
             // FIXME: This is temporary until build of plugin tools is extracted into its own command.
             XCTAssertTrue(localFileSystem.exists(fixturePath.appending(RelativePath(".build/plugin-tools.db"))))
@@ -49,7 +49,11 @@ final class PluginsBuildPlanTests: XCTestCase {
 
         // By default, plugin dependencies are built for the host platform
         try await fixtureXCTest(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftPackage(fixturePath, extraArgs: ["-v", "build-plugin-dependency"])
+            let (stdout, stderr) = try await executeSwiftPackage(
+                fixturePath,
+                extraArgs: ["-v", "build-plugin-dependency"],
+                buildSystem: .native,
+            )
             XCTAssertMatch(stdout, .contains("Hello from dependencies-stub"))
             XCTAssertMatch(stderr, .contains("Build of product 'plugintool' complete!"))
             XCTAssertTrue(
@@ -66,7 +70,11 @@ final class PluginsBuildPlanTests: XCTestCase {
 
         // When cross compiling the final product, plugin dependencies should still be built for the host
         try await fixtureXCTest(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftPackage(fixturePath, extraArgs: ["--triple", targetTriple, "-v", "build-plugin-dependency"])
+            let (stdout, stderr) = try await executeSwiftPackage(
+                fixturePath,
+                extraArgs: ["--triple", targetTriple, "-v", "build-plugin-dependency"],
+                buildSystem: .native,
+            )
             XCTAssertMatch(stdout, .contains("Hello from dependencies-stub"))
             XCTAssertMatch(stderr, .contains("Build of product 'plugintool' complete!"))
             XCTAssertTrue(

--- a/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
+++ b/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
@@ -24,11 +24,11 @@
 //    @discardableResult
 //    func execute(args: [String] = [], packagePath: AbsolutePath) async throws -> (stdout: String, stderr: String) {
 //        // FIXME: We should pass the SWIFT_EXEC at lower level.
-//        try await SwiftPM.Build.execute(args + [], packagePath: packagePath, env: ["SWIFT_EXEC": UserToolchain.default.swiftCompilerPath.pathString])
+//        try await executeSwiftBuild(packagePath, extraArgs: args + [], env: ["SWIFT_EXEC": UserToolchain.default.swiftCompilerPath.pathString], buildSystem: .native)
 //    }
 //
 //    func clean(packagePath: AbsolutePath) async throws {
-//        _ = try await SwiftPM.Package.execute(["clean"], packagePath: packagePath)
+//        _ = try await executeSwiftPackage(packagePath, extraArgs: ["clean"], buildSystem: .native)
 //    }
 //
 //    func testTrivialPackageFullBuild() throws {

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -37,7 +37,7 @@ private func XCTAssertDirectoryContainsFile(dir: AbsolutePath, filename: String,
 final class CFamilyTargetTestCase: XCTestCase {
     func testCLibraryWithSpaces() async throws {
         try await fixtureXCTest(name: "CFamilyTargets/CLibraryWithSpaces") { fixturePath in
-            await XCTAssertBuilds(fixturePath)
+            await XCTAssertBuilds(fixturePath, buildSystem: .native)
             let debugPath = fixturePath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Bar.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
@@ -47,7 +47,7 @@ final class CFamilyTargetTestCase: XCTestCase {
     func testCUsingCAndSwiftDep() async throws {
         try await fixtureXCTest(name: "DependencyResolution/External/CUsingCDep") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
-            await XCTAssertBuilds(packageRoot)
+            await XCTAssertBuilds(packageRoot, buildSystem: .native)
             let debugPath = fixturePath.appending(components: "Bar", ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Sea.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
@@ -58,7 +58,7 @@ final class CFamilyTargetTestCase: XCTestCase {
 
     func testModuleMapGenerationCases() async throws {
         try await fixtureXCTest(name: "CFamilyTargets/ModuleMapGenerationCases") { fixturePath in
-            await XCTAssertBuilds(fixturePath)
+            await XCTAssertBuilds(fixturePath, buildSystem: .native)
             let debugPath = fixturePath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Jaz.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "main.swift.o")
@@ -69,7 +69,13 @@ final class CFamilyTargetTestCase: XCTestCase {
     
     func testNoIncludeDirCheck() async throws {
         try await fixtureXCTest(name: "CFamilyTargets/CLibraryNoIncludeDir") { fixturePath in
-            await XCTAssertAsyncThrowsError(try await executeSwiftBuild(fixturePath), "This build should throw an error") { err in
+            await XCTAssertAsyncThrowsError(
+                try await executeSwiftBuild(
+                    fixturePath,
+                    buildSystem: .native,
+                ),
+                "This build should throw an error",
+            ) { err in
                 // The err.localizedDescription doesn't capture the detailed error string so interpolate
                 let errStr = "\(err)"
                 let missingIncludeDirStr = "\(ModuleError.invalidPublicHeadersDirectory("Cfactorial"))"
@@ -81,7 +87,7 @@ final class CFamilyTargetTestCase: XCTestCase {
     func testCanForwardExtraFlagsToClang() async throws {
         // Try building a fixture which needs extra flags to be able to build.
         try await fixtureXCTest(name: "CFamilyTargets/CDynamicLookup") { fixturePath in
-            await XCTAssertBuilds(fixturePath, Xld: ["-undefined", "dynamic_lookup"])
+            await XCTAssertBuilds(fixturePath, Xld: ["-undefined", "dynamic_lookup"], buildSystem: .native)
             let debugPath = fixturePath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
@@ -93,16 +99,16 @@ final class CFamilyTargetTestCase: XCTestCase {
         #endif
         try await fixtureXCTest(name: "CFamilyTargets/ObjCmacOSPackage") { fixturePath in
             // Build the package.
-            await XCTAssertBuilds(fixturePath)
+            await XCTAssertBuilds(fixturePath, buildSystem: .native)
             XCTAssertDirectoryContainsFile(dir: fixturePath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug"), filename: "HelloWorldExample.m.o")
             // Run swift-test on package.
-            await XCTAssertSwiftTest(fixturePath)
+            await XCTAssertSwiftTest(fixturePath, buildSystem: .native)
         }
     }
     
     func testCanBuildRelativeHeaderSearchPaths() async throws {
         try await fixtureXCTest(name: "CFamilyTargets/CLibraryParentSearchPath") { fixturePath in
-            await XCTAssertBuilds(fixturePath)
+            await XCTAssertBuilds(fixturePath, buildSystem: .native)
             XCTAssertDirectoryContainsFile(dir: fixturePath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug"), filename: "HeaderInclude.swiftmodule")
         }
     }

--- a/Tests/FunctionalTests/MacroTests.swift
+++ b/Tests/FunctionalTests/MacroTests.swift
@@ -26,7 +26,11 @@ class MacroTests: XCTestCase {
         try XCTSkipIf(!localFileSystem.exists(libSwiftSyntaxMacrosPath), "test need `libSwiftSyntaxMacros` to exist in the host toolchain")
 
         try fixtureXCTest(name: "Macros") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("MacroPackage"), configuration: .debug)
+            let (stdout, _) = try executeSwiftBuild(
+                fixturePath.appending("MacroPackage"),
+                configuration: .debug,
+                buildSystem: .native,
+            )
             XCTAssert(stdout.contains("@__swiftmacro_11MacroClient11fontLiteralfMf_.swift as Font"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -22,11 +22,18 @@ final class ModuleAliasingFixtureTests: XCTestCase {
         try await fixtureXCTest(name: "ModuleAliasing/DirectDeps1") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
             let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug")
-            await XCTAssertBuilds(pkgPath, extraArgs: ["--vv"])
+            await XCTAssertBuilds(
+                pkgPath,
+                extraArgs: ["--vv"],
+                buildSystem: .native,
+            )
             XCTAssertFileExists(buildPath.appending(components: executableName("App")))
             XCTAssertFileExists(buildPath.appending(components: "Modules", "GameUtils.swiftmodule"))
             XCTAssertFileExists(buildPath.appending(components: "Modules", "Utils.swiftmodule"))
-            _ = try await SwiftPM.Build.execute(packagePath: pkgPath)
+            _ = try await executeSwiftBuild(
+                pkgPath,
+                buildSystem: .native,
+            )
         }
     }
 
@@ -34,11 +41,18 @@ final class ModuleAliasingFixtureTests: XCTestCase {
         try await fixtureXCTest(name: "ModuleAliasing/DirectDeps2") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
             let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug")
-            await XCTAssertBuilds(pkgPath, extraArgs: ["--vv"])
+            await XCTAssertBuilds(
+                pkgPath,
+                extraArgs: ["--vv"],
+                buildSystem: .native,
+            )
             XCTAssertFileExists(buildPath.appending(components: executableName("App")))
             XCTAssertFileExists(buildPath.appending(components: "Modules", "AUtils.swiftmodule"))
             XCTAssertFileExists(buildPath.appending(components: "Modules", "BUtils.swiftmodule"))
-            _ = try await SwiftPM.Build.execute(packagePath: pkgPath)
+            _ = try await executeSwiftBuild(
+                pkgPath,
+                buildSystem: .native,
+            )
         }
     }
 
@@ -46,7 +60,11 @@ final class ModuleAliasingFixtureTests: XCTestCase {
         try await fixtureXCTest(name: "ModuleAliasing/NestedDeps1") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
             let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug")
-            await XCTAssertBuilds(pkgPath, extraArgs: ["--vv"])
+            await XCTAssertBuilds(
+                pkgPath,
+                extraArgs: ["--vv"],
+                buildSystem: .native,
+            )
             XCTAssertFileExists(buildPath.appending(components: executableName("App")))
             XCTAssertFileExists(buildPath.appending(components: "Modules", "A.swiftmodule"))
             XCTAssertFileExists(buildPath.appending(components: "Modules", "AFooUtils.swiftmodule"))
@@ -54,7 +72,10 @@ final class ModuleAliasingFixtureTests: XCTestCase {
             XCTAssertFileExists(buildPath.appending(components: "Modules", "X.swiftmodule"))
             XCTAssertFileExists(buildPath.appending(components: "Modules", "XFooUtils.swiftmodule"))
             XCTAssertFileExists(buildPath.appending(components: "Modules", "XUtils.swiftmodule"))
-            _ = try await SwiftPM.Build.execute(packagePath: pkgPath)
+            _ = try await executeSwiftBuild(
+                pkgPath,
+                buildSystem: .native,
+            )
         }
     }
 
@@ -62,13 +83,20 @@ final class ModuleAliasingFixtureTests: XCTestCase {
         try await fixtureXCTest(name: "ModuleAliasing/NestedDeps2") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
             let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug")
-            await XCTAssertBuilds(pkgPath, extraArgs: ["--vv"])
+            await XCTAssertBuilds(
+                pkgPath,
+                extraArgs: ["--vv"],
+                buildSystem: .native,
+            )
             XCTAssertFileExists(buildPath.appending(components: executableName("App")))
             XCTAssertFileExists(buildPath.appending(components: "Modules", "A.swiftmodule"))
             XCTAssertFileExists(buildPath.appending(components: "Modules", "BUtils.swiftmodule"))
             XCTAssertFileExists(buildPath.appending(components: "Modules", "CUtils.swiftmodule"))
             XCTAssertFileExists(buildPath.appending(components: "Modules", "XUtils.swiftmodule"))
-            _ = try await SwiftPM.Build.execute(packagePath: pkgPath)
+            _ = try await executeSwiftBuild(
+                pkgPath,
+                buildSystem: .native,
+            )
         }
     }
 }

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -44,7 +44,11 @@ final class ModuleMapsTestCase: XCTestCase {
     func testDirectDependency() async throws {
          try XCTSkipOnWindows(because: "fails to build on windows (maybe not supported?)")
         try await fixtureXCTest(name: "ModuleMaps/Direct", cModuleName: "CFoo", rootpkg: "App") { fixturePath, Xld in
-            await XCTAssertBuilds(fixturePath.appending("App"), Xld: Xld)
+            await XCTAssertBuilds(
+                fixturePath.appending("App"),
+                Xld: Xld,
+                buildSystem: .native,
+            )
 
             let triple = try UserToolchain.default.targetTriple
             let targetPath = fixturePath.appending(components: "App", ".build", triple.platformBuildPathComponent)
@@ -62,7 +66,11 @@ final class ModuleMapsTestCase: XCTestCase {
     func testTransitiveDependency() async throws {
         try XCTSkipOnWindows(because: "fails to build on windows (maybe not supported?)")
         try await fixtureXCTest(name: "ModuleMaps/Transitive", cModuleName: "packageD", rootpkg: "packageA") { fixturePath, Xld in
-            await XCTAssertBuilds(fixturePath.appending("packageA"), Xld: Xld)
+            await XCTAssertBuilds(
+                fixturePath.appending("packageA"),
+                Xld: Xld,
+                buildSystem: .native,
+            )
             
             func verify(_ conf: String) async throws {
                 let triple = try UserToolchain.default.targetTriple

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -28,12 +28,17 @@ final class PluginTests {
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8791"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testUseOfBuildToolPluginTargetByExecutableInSamePackage() async throws {
         try await withKnownIssue {
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MySourceGenPlugin"), configuration: .debug, extraArgs: ["--product", "MyLocalTool"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("MySourceGenPlugin"),
+                    configuration: .debug,
+                    extraArgs: ["--product", "MyLocalTool"],
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
@@ -46,7 +51,12 @@ final class PluginTests {
         try await withKnownIssue {
             // Try again with the Swift Build build system
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MySourceGenPlugin"), configuration: .debug, extraArgs: ["--product", "MyLocalTool", "--build-system", "swiftbuild"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("MySourceGenPlugin"),
+                    configuration: .debug,
+                    extraArgs: ["--product", "MyLocalTool", "--build-system", "swiftbuild"],
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
         } when: { ProcessInfo.hostOperatingSystem == .linux || ProcessInfo.hostOperatingSystem == .windows }
@@ -55,12 +65,15 @@ final class PluginTests {
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8786"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testUseOfBuildToolPluginTargetNoPreBuildCommands() async throws {
         try await withKnownIssue {
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (_, stderr) = try await executeSwiftTest(fixturePath.appending("MySourceGenPluginNoPreBuildCommands"))
+                let (_, stderr) = try await executeSwiftTest(
+                    fixturePath.appending("MySourceGenPluginNoPreBuildCommands"),
+                    buildSystem: .native,
+                )
                 #expect(stderr.contains("file(s) which are unhandled; explicitly declare them as resources or exclude from the target"), "expected warning not emitted")
             }
         } when: {
@@ -70,7 +83,11 @@ final class PluginTests {
         // Try again with the Swift Build build system
         await withKnownIssue {
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (_, stderr) = try await executeSwiftTest(fixturePath.appending("MySourceGenPluginNoPreBuildCommands"), extraArgs: ["--build-system", "swiftbuild"])
+                let (_, stderr) = try await executeSwiftTest(
+                    fixturePath.appending("MySourceGenPluginNoPreBuildCommands"),
+                    extraArgs: ["--build-system", "swiftbuild"],
+                    buildSystem: .native,
+                )
                 #expect(stderr.contains("file(s) which are unhandled; explicitly declare them as resources or exclude from the target"), "expected warning not emitted")
             }
         }
@@ -79,12 +96,17 @@ final class PluginTests {
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testUseOfBuildToolPluginProductByExecutableAcrossPackages() async throws {
         try await withKnownIssue {
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MySourceGenClient"), configuration: .debug, extraArgs: ["--product", "MyTool"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("MySourceGenClient"),
+                    configuration: .debug,
+                    extraArgs: ["--product", "MyTool"],
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Linking MyTool"), "stdout:\n\(stdout)")
@@ -97,7 +119,12 @@ final class PluginTests {
         try await withKnownIssue {
             // Try again with the Swift Build build system
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MySourceGenClient"), configuration: .debug, extraArgs: ["--build-system", "swiftbuild", "--product", "MyTool"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("MySourceGenClient"),
+                    configuration: .debug,
+                    extraArgs: ["--build-system", "swiftbuild", "--product", "MyTool"],
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
         } when: {
@@ -108,12 +135,17 @@ final class PluginTests {
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testUseOfPrebuildPluginTargetByExecutableAcrossPackages() async throws {
         try await withKnownIssue {
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MySourceGenPlugin"), configuration: .debug, extraArgs: ["--product", "MyOtherLocalTool"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("MySourceGenPlugin"),
+                    configuration: .debug,
+                    extraArgs: ["--product", "MyOtherLocalTool"],
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Compiling MyOtherLocalTool bar.swift"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Compiling MyOtherLocalTool baz.swift"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Linking MyOtherLocalTool"), "stdout:\n\(stdout)")
@@ -126,7 +158,12 @@ final class PluginTests {
         try await withKnownIssue {
             // Try again with the Swift Build build system
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MySourceGenPlugin"), configuration: .debug, extraArgs: ["--build-system", "swiftbuild", "--product", "MyOtherLocalTool"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("MySourceGenPlugin"),
+                    configuration: .debug,
+                    extraArgs: ["--build-system", "swiftbuild", "--product", "MyOtherLocalTool"],
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
         } when: {
@@ -137,12 +174,15 @@ final class PluginTests {
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testUseOfPluginWithInternalExecutable() async throws {
         try await withKnownIssue {
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("ClientOfPluginWithInternalExecutable"))
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("ClientOfPluginWithInternalExecutable"),
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Compiling PluginExecutable main.swift"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Linking PluginExecutable"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
@@ -153,7 +193,11 @@ final class PluginTests {
 
             // Try again with the Swift Build build system
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("ClientOfPluginWithInternalExecutable"), extraArgs: ["--build-system", "swiftbuild"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("ClientOfPluginWithInternalExecutable"),
+                    extraArgs: ["--build-system", "swiftbuild"],
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
         } when: {
@@ -162,12 +206,15 @@ final class PluginTests {
     }
 
     @Test(
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testInternalExecutableAvailableOnlyToPlugin() async throws {
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let error = try await #require(throws: SwiftPMError.self, "Illegally used internal executable") {
-                try await executeSwiftBuild(fixturePath.appending("InvalidUseOfInternalPluginExecutable"))
+                try await executeSwiftBuild(
+                    fixturePath.appending("InvalidUseOfInternalPluginExecutable"),
+                    buildSystem: .native,
+                )
             }
 
             guard case SwiftPMError.executionFailure(_, _, let stderr) = error else {
@@ -182,7 +229,10 @@ final class PluginTests {
 
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let error =  try await #require(throws: SwiftPMError.self, "Illegally used internal executable") {
-                try await executeSwiftBuild(fixturePath.appending("InvalidUseOfInternalPluginExecutable"))
+                try await executeSwiftBuild(
+                    fixturePath.appending("InvalidUseOfInternalPluginExecutable"),
+                    buildSystem: .native,
+                )
             }
 
             guard case SwiftPMError.executionFailure(_, _, _) = error else {
@@ -195,12 +245,15 @@ final class PluginTests {
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testLocalBuildToolPluginUsingRemoteExecutable() async throws {
         try await withKnownIssue {
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("LibraryWithLocalBuildToolPluginUsingRemoteTool"))
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("LibraryWithLocalBuildToolPluginUsingRemoteTool"),
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Compiling MySourceGenBuildTool main.swift"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Generating generated.swift from generated.dat"), "stdout:\n\(stdout)")
@@ -214,7 +267,11 @@ final class PluginTests {
         try await withKnownIssue {
             // Try again with the Swift Build build system
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("LibraryWithLocalBuildToolPluginUsingRemoteTool"), extraArgs: ["--build-system", "swiftbuild"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("LibraryWithLocalBuildToolPluginUsingRemoteTool"),
+                    extraArgs: ["--build-system", "swiftbuild"],
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
         } when: {
@@ -226,12 +283,15 @@ final class PluginTests {
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8791"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testBuildToolPluginDependencies() async throws {
         try await withKnownIssue {
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MyBuildToolPluginDependencies"))
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("MyBuildToolPluginDependencies"),
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Compiling MySourceGenBuildTool main.swift"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
@@ -245,7 +305,11 @@ final class PluginTests {
         try await withKnownIssue {
             // Try again with the Swift Build build system
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MyBuildToolPluginDependencies"), extraArgs: ["--build-system", "swiftbuild"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("MyBuildToolPluginDependencies"),
+                    extraArgs: ["--build-system", "swiftbuild"],
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
         } when: { ProcessInfo.hostOperatingSystem == .windows || ProcessInfo.hostOperatingSystem == .linux }
@@ -254,12 +318,17 @@ final class PluginTests {
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testContrivedTestCases() async throws {
         try await withKnownIssue {
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("ContrivedTestPlugin"), configuration: .debug, extraArgs: ["--product", "MyLocalTool"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("ContrivedTestPlugin"),
+                    configuration: .debug,
+                    extraArgs: ["--product", "MyLocalTool"],
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
@@ -271,7 +340,12 @@ final class PluginTests {
 
         try await withKnownIssue {
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("ContrivedTestPlugin"), configuration: .debug, extraArgs: ["--build-system", "swiftbuild", "--product", "MyLocalTool", "--disable-sandbox"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("ContrivedTestPlugin"),
+                    configuration: .debug,
+                    extraArgs: ["--build-system", "swiftbuild", "--product", "MyLocalTool", "--disable-sandbox"],
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
         } when: {
@@ -280,31 +354,46 @@ final class PluginTests {
     }
 
     @Test(
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
+        .requiresSwiftConcurrencySupport,
         .enabled(if: ProcessInfo.hostOperatingSystem == .macOS, "Test is only supported on macOS")
     )
     func testPluginScriptSandbox() async throws {
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("SandboxTesterPlugin"), configuration: .debug, extraArgs: ["--product", "MyLocalTool"])
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath.appending("SandboxTesterPlugin"),
+                configuration: .debug,
+                extraArgs: ["--product", "MyLocalTool"],
+                    buildSystem: .native,
+                )
             #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
             #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
         }
 
         // Try again with Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("SandboxTesterPlugin"), configuration: .debug, extraArgs: ["--build-system", "swiftbuild", "--product", "MyLocalTool"])
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath.appending("SandboxTesterPlugin"),
+                configuration: .debug,
+                extraArgs: ["--build-system", "swiftbuild", "--product", "MyLocalTool"],
+                    buildSystem: .native,
+                )
             #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
     }
 
     @Test(
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
+        .requiresSwiftConcurrencySupport,
         .enabled(if: ProcessInfo.hostOperatingSystem == .macOS, "Test is only supported on macOS"),
         arguments: [BuildSystemProvider.Kind.native, .swiftbuild]
     )
     func testUseOfVendedBinaryTool(buildSystem: BuildSystemProvider.Kind) async throws {
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("MyBinaryToolPlugin"), configuration: .debug, extraArgs: ["--product", "MyLocalTool"], buildSystem: buildSystem)
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath.appending("MyBinaryToolPlugin"),
+                configuration: .debug,
+                extraArgs: ["--product", "MyLocalTool"],
+                buildSystem: buildSystem,
+            )
             if buildSystem == .native {
                 #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n(stdout)")
@@ -317,12 +406,17 @@ final class PluginTests {
     }
 
     @Test(
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
+        .requiresSwiftConcurrencySupport,
         .enabled(if: ProcessInfo.hostOperatingSystem == .macOS, "Test is only supported on macOS")
     )
     func testUseOfBinaryToolVendedAsProduct() async throws {
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("BinaryToolProductPlugin"), configuration: .debug, extraArgs: ["--product", "MyLocalTool"])
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath.appending("BinaryToolProductPlugin"),
+                configuration: .debug,
+                extraArgs: ["--product", "MyLocalTool"],
+                    buildSystem: .native,
+                )
             #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
             #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
         }
@@ -331,9 +425,12 @@ final class PluginTests {
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8794"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
+        .requiresSwiftConcurrencySupport,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
-    func testBuildToolWithoutOutputs() async throws {
+    func testBuildToolWithoutOutputs(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
         func createPackageUnderTest(packageDir: AbsolutePath, toolsVersion: ToolsVersion) throws {
             let manifestFile = packageDir.appending("Package.swift")
             try localFileSystem.createDirectory(manifestFile.parentDirectory, recursive: true)
@@ -381,33 +478,39 @@ final class PluginTests {
         }
 
         try await withKnownIssue {
-            for buildSystem in ["native", "swiftbuild"] {
-                try await testWithTemporaryDirectory { tmpPath in
-                    let packageDir = tmpPath.appending(components: "MyPackage")
-                    let pathOfGeneratedFile = packageDir.appending(components: [".build", "plugins", "outputs", "mypackage", "SomeTarget", "destination", "Plugin", "best.txt"])
+            try await testWithTemporaryDirectory { tmpPath in
+                let packageDir = tmpPath.appending(components: "MyPackage")
+                let pathOfGeneratedFile = packageDir.appending(components: [".build", "plugins", "outputs", "mypackage", "SomeTarget", "destination", "Plugin", "best.txt"])
 
-                    try await withKnownIssue {
-                        try createPackageUnderTest(packageDir: packageDir, toolsVersion: .v5_9)
-                        let (_, stderr) = try await executeSwiftBuild(packageDir, extraArgs: ["--build-system", buildSystem], env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"])
-                        #expect(stderr.contains("warning: Build tool command 'empty' (applied to target 'SomeTarget') does not declare any output files"), "expected warning not emitted")
-                        #expect(!localFileSystem.exists(pathOfGeneratedFile), "plugin generated file unexpectedly exists at \(pathOfGeneratedFile.pathString)")
-                    } when: {
-                        buildSystem == "swiftbuild"
-                    }
-
-                    try createPackageUnderTest(packageDir: packageDir, toolsVersion: .v6_0)
-                    let (stdout, stderr2) = try await executeSwiftBuild(packageDir, extraArgs: ["--build-system", buildSystem], env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"])
-                    #expect(stdout.contains("Build complete!"))
-                    #expect(!stderr2.contains("error:"))
-                    #expect(localFileSystem.exists(pathOfGeneratedFile), "plugin did not run, generated file does not exist at \(pathOfGeneratedFile.pathString)")
+                try await withKnownIssue {
+                    try createPackageUnderTest(packageDir: packageDir, toolsVersion: .v5_9)
+                    let (_, stderr) = try await executeSwiftBuild(
+                        packageDir,
+                        env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"],
+                        buildSystem: buildSystem,
+                    )
+                    #expect(stderr.contains("warning: Build tool command 'empty' (applied to target 'SomeTarget') does not declare any output files"), "expected warning not emitted")
+                    #expect(!localFileSystem.exists(pathOfGeneratedFile), "plugin generated file unexpectedly exists at \(pathOfGeneratedFile.pathString)")
+                } when: {
+                    buildSystem == .swiftbuild
                 }
+
+                try createPackageUnderTest(packageDir: packageDir, toolsVersion: .v6_0)
+                let (stdout, stderr2) = try await executeSwiftBuild(
+                    packageDir,
+                    env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"],
+                    buildSystem: buildSystem,
+                )
+                #expect(stdout.contains("Build complete!"))
+                #expect(!stderr2.contains("error:"))
+                #expect(localFileSystem.exists(pathOfGeneratedFile), "plugin did not run, generated file does not exist at \(pathOfGeneratedFile.pathString)")
             }
         } when: { ProcessInfo.hostOperatingSystem == .windows }
     }
 
     @Test(
         .bug("rdar://117870608"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
+        .requiresSwiftConcurrencySupport,
         .disabled()
     )
     func testCommandPluginInvocation() async throws {
@@ -760,13 +863,18 @@ final class PluginTests {
 
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
+        .requiresSwiftConcurrencySupport,
         arguments: [BuildSystemProvider.Kind.native, .swiftbuild]
     )
     func testLocalAndRemoteToolDependencies(buildSystem: BuildSystemProvider.Kind) async throws {
         try await withKnownIssue (isIntermittent: true) {
             try await fixture(name: "Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool") { path in
-                let (stdout, stderr) = try await executeSwiftPackage(path.appending("MyLibrary"), configuration: .debug, extraArgs: ["--build-system", buildSystem.rawValue, "plugin", "my-plugin"])
+                let (stdout, stderr) = try await executeSwiftPackage(
+                    path.appending("MyLibrary"),
+                    configuration: .debug,
+                    extraArgs: ["plugin", "my-plugin"],
+                    buildSystem: buildSystem,
+                )
                 if buildSystem == .native {
                     // Native build system is more explicit about what it's doing in stderr
                     #expect(stderr.contains("Linking RemoteTool"), "stdout:\n\(stderr)\n\(stdout)")
@@ -784,7 +892,7 @@ final class PluginTests {
     }
 
     @Test(
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
+        .requiresSwiftConcurrencySupport,
     )
     func testPluginUsageDoesntAffectTestTargetMappings() async throws {
         try await fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { packageDir in
@@ -822,7 +930,7 @@ final class PluginTests {
 
     @Test(
         .bug("rdar://88792829"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
+        .requiresSwiftConcurrencySupport,
         .disabled(if: ProcessInfo.hostOperatingSystem == .windows, "This hangs intermittently on windows in CI")
     )
     func testCommandPluginCancellation() async throws {
@@ -1238,35 +1346,53 @@ final class PluginTests {
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
+        .requiresSwiftConcurrencySupport,
     )
     func testSnippetSupport() async throws {
         try await fixture(name: "Miscellaneous/Plugins") { path in
-            let (stdout, stderr) = try await executeSwiftPackage(path.appending("PluginsAndSnippets"), configuration: .debug, extraArgs: ["do-something"])
+            let (stdout, stderr) = try await executeSwiftPackage(
+                path.appending("PluginsAndSnippets"),
+                configuration: .debug,
+                extraArgs: ["do-something"],
+                buildSystem: .native,
+            )
             #expect(stdout.contains("type of snippet target: snippet"), "output:\n\(stderr)\n\(stdout)")
         }
 
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { path in
-            let (stdout, stderr) = try await executeSwiftPackage(path.appending("PluginsAndSnippets"), configuration: .debug, extraArgs: ["--build-system", "swiftbuild", "do-something"])
+            let (stdout, stderr) = try await executeSwiftPackage(
+                path.appending("PluginsAndSnippets"),
+                configuration: .debug,
+                extraArgs: ["--build-system", "swiftbuild", "do-something"],
+                buildSystem: .native,
+            )
             #expect(stdout.contains("type of snippet target: snippet"), "output:\n\(stderr)\n\(stdout)")
         }
     }
 
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
+        .requiresSwiftConcurrencySupport,
     )
     func testIncorrectDependencies() async throws {
         try await fixture(name: "Miscellaneous/Plugins") { path in
-            let (stdout, stderr) = try await executeSwiftBuild(path.appending("IncorrectDependencies"), extraArgs: ["--build-tests"])
+            let (stdout, stderr) = try await executeSwiftBuild(
+                path.appending("IncorrectDependencies"),
+                extraArgs: ["--build-tests"],
+                buildSystem: .native,
+            )
             #expect(stdout.contains("Build complete!"), "output:\n\(stderr)\n\(stdout)")
         }
 
         try await withKnownIssue (isIntermittent: true) {
             // Try again with the Swift Build build system
             try await fixture(name: "Miscellaneous/Plugins") { path in
-                let (stdout, stderr) = try await executeSwiftBuild(path.appending("IncorrectDependencies"), extraArgs: ["--build-system", "swiftbuild", "--build-tests"])
+                let (stdout, stderr) = try await executeSwiftBuild(
+                    path.appending("IncorrectDependencies"),
+                    extraArgs: ["--build-tests"],
+                    buildSystem: .swiftbuild,
+                )
                 #expect(stdout.contains("Build complete!"), "output:\n\(stderr)\n\(stdout)")
             }
         } when: { ProcessInfo.hostOperatingSystem == .windows || (ProcessInfo.hostOperatingSystem == .linux && CiEnvironment.runningInSmokeTestPipeline) }
@@ -1274,48 +1400,69 @@ final class PluginTests {
 
     @Test(
         .enabled(if: ProcessInfo.hostOperatingSystem == .macOS, "sandboxing tests are only supported on macOS"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency"),
+        .requiresSwiftConcurrencySupport,
+        arguments: [BuildSystemProvider.Kind.native], // FIXME: enable swiftbuild testing once pre-build plugins are working
     )
-    func testSandboxViolatingBuildToolPluginCommands() async throws {
-        for buildSystem in [BuildSystemProvider.Kind.native] { // FIXME: enable swiftbuild testing once pre-build plugins are working
-            // Check that the build fails with a sandbox violation by default.
-            try await fixture(name: "Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands") { path in
-                let error = try await #require(throws: Error.self) {
-                    try await executeSwiftBuild(path.appending("MyLibrary"), configuration: .debug, buildSystem: buildSystem)
-                }
-
-                #expect("\(error)".contains("You don’t have permission to save the file “generated” in the folder “MyLibrary”."))
+    func testSandboxViolatingBuildToolPluginCommands(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        // Check that the build fails with a sandbox violation by default.
+        try await fixture(name: "Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands") { path in
+            let error = try await #require(throws: Error.self) {
+                try await executeSwiftBuild(
+                    path.appending("MyLibrary"),
+                    configuration: .debug,
+                    buildSystem: buildSystem,
+                )
             }
 
-            // Check that the build succeeds if we disable the sandbox.
-            try await fixture(name: "Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands") { path in
-                let (stdout, stderr) = try await executeSwiftBuild(path.appending("MyLibrary"), configuration: .debug, extraArgs: ["--disable-sandbox"], buildSystem: buildSystem)
-                #expect(stdout.contains("Compiling MyLibrary foo.swift"), "[STDOUT]\n\(stdout)\n[STDERR]\n\(stderr)\n")
-            }
+            #expect("\(error)".contains("You don’t have permission to save the file “generated” in the folder “MyLibrary”."))
+        }
+
+        // Check that the build succeeds if we disable the sandbox.
+        try await fixture(name: "Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands") { path in
+            let (stdout, stderr) = try await executeSwiftBuild(
+                path.appending("MyLibrary"),
+                configuration: .debug,
+                extraArgs: ["--disable-sandbox"],
+                buildSystem: buildSystem,
+            )
+            #expect(stdout.contains("Compiling MyLibrary foo.swift"), "[STDOUT]\n\(stdout)\n[STDERR]\n\(stderr)\n")
         }
     }
 
-    @Test(.enabled(if: ProcessInfo.hostOperatingSystem == .macOS, "sandboxing tests are only supported on macOS"))
-    func testBuildToolPluginSwiftFileExecutable() async throws {
-        for buildSystem in ["native", "swiftbuild"] {
-            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, stderr) = try await executeSwiftBuild(fixturePath.appending("SwiftFilePlugin"), configuration: .debug, extraArgs: ["--build-system", buildSystem, "--verbose"])
-                if buildSystem == "native" {
-                    #expect(stdout.contains("Hello, Build Tool Plugin!"), "stdout:\n\(stdout)")
-                } else {
-                    #expect(stderr.contains("Hello, Build Tool Plugin!"), "stderr:\n\(stderr)")
-                }
+    @Test(
+        .enabled(if: ProcessInfo.hostOperatingSystem == .macOS, "sandboxing tests are only supported on macOS"),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func testBuildToolPluginSwiftFileExecutable(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
+            let (stdout, stderr) = try await executeSwiftBuild(
+                fixturePath.appending("SwiftFilePlugin"),
+                configuration: .debug,
+                extraArgs: [ "--verbose"],
+                buildSystem: buildSystem,
+            )
+            if buildSystem == .native {
+                #expect(stdout.contains("Hello, Build Tool Plugin!"), "stdout:\n\(stdout)")
+            } else {
+                #expect(stderr.contains("Hello, Build Tool Plugin!"), "stderr:\n\(stderr)")
             }
         }
     }
 
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testTransitivePluginOnlyDependency() async throws {
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("TransitivePluginOnlyDependency"))
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath.appending("TransitivePluginOnlyDependency"),
+                buildSystem: .native,
+            )
             #expect(stdout.contains("Compiling plugin MyPlugin"), "stdout:\n\(stdout)")
             #expect(stdout.contains("Compiling Library Library.swift"), "stdout:\n\(stdout)")
             #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
@@ -1324,7 +1471,10 @@ final class PluginTests {
         try await withKnownIssue {
             // Try again with Swift Build build system
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("TransitivePluginOnlyDependency"), extraArgs: ["--build-system", "swiftbuild"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("TransitivePluginOnlyDependency"),
+                    buildSystem: .swiftbuild,
+                )
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
         } when: {
@@ -1335,21 +1485,18 @@ final class PluginTests {
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
-    func testMissingPlugin() async throws {
+    func testMissingPlugin(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
             do {
-                try await executeSwiftBuild(fixturePath.appending("MissingPlugin"))
-            } catch SwiftPMError.executionFailure(_, _, let stderr) {
-                #expect(stderr.contains("error: 'missingplugin': no plugin named 'NonExistingPlugin' found"), "stderr:\n\(stderr)")
-            }
-        }
-
-        // Try again with Swift Build build system
-        try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            do {
-                try await executeSwiftBuild(fixturePath.appending("MissingPlugin"), extraArgs: ["--build-system", "swiftbuild"])
+                try await executeSwiftBuild(
+                    fixturePath.appending("MissingPlugin"),
+                    buildSystem: buildSystem,
+                )
             } catch SwiftPMError.executionFailure(_, _, let stderr) {
                 #expect(stderr.contains("error: 'missingplugin': no plugin named 'NonExistingPlugin' found"), "stderr:\n\(stderr)")
             }
@@ -1358,11 +1505,14 @@ final class PluginTests {
 
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testPluginCanBeReferencedByProductName() async throws {
         try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("PluginCanBeReferencedByProductName"))
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath.appending("PluginCanBeReferencedByProductName"),
+                buildSystem: .native,
+            )
             #expect(stdout.contains("Compiling plugin MyPlugin"), "stdout:\n\(stdout)")
             #expect(stdout.contains("Compiling PluginCanBeReferencedByProductName gen.swift"), "stdout:\n\(stdout)")
             #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
@@ -1371,7 +1521,10 @@ final class PluginTests {
         try await withKnownIssue {
             // Try again with the Swift Build build system
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath.appending("PluginCanBeReferencedByProductName"), extraArgs: ["--build-system", "swiftbuild"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath.appending("PluginCanBeReferencedByProductName"),
+                    buildSystem: .swiftbuild,
+                )
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
         } when: { ProcessInfo.hostOperatingSystem == .windows }
@@ -1380,7 +1533,7 @@ final class PluginTests {
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8791"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testPluginCanBeAffectedByXBuildToolsParameters() async throws {
         try await withKnownIssue {
@@ -1388,7 +1541,8 @@ final class PluginTests {
                 let (stdout, _) = try await executeSwiftBuild(
                     fixturePath.appending(component: "MySourceGenPlugin"),
                     configuration: .debug,
-                    extraArgs: ["--product", "MyLocalTool", "-Xbuild-tools-swiftc", "-DUSE_CREATE"]
+                    extraArgs: ["--product", "MyLocalTool", "-Xbuild-tools-swiftc", "-DUSE_CREATE"],
+                    buildSystem: .native,
                 )
                 #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
                 #expect(stdout.contains("Creating foo.swift from foo.dat"), "stdout:\n\(stdout)")
@@ -1402,7 +1556,8 @@ final class PluginTests {
                 let (stdout, stderr) = try await executeSwiftBuild(
                     fixturePath.appending(component: "MySourceGenPlugin"),
                     configuration: .debug,
-                    extraArgs: ["-v", "--product", "MyLocalTool", "-Xbuild-tools-swiftc", "-DUSE_CREATE", "--build-system", "swiftbuild"]
+                    extraArgs: ["-v", "--product", "MyLocalTool", "-Xbuild-tools-swiftc", "-DUSE_CREATE",],
+                    buildSystem: .swiftbuild,
                 )
                 #expect(stdout.contains("MySourceGenBuildTool-product"), "stdout:\n\(stdout)\nstderr:\n\(stderr)")
                 #expect(stderr.contains("Creating foo.swift from foo.dat"), "stdout:\n\(stdout)\nstderr:\n\(stderr)")
@@ -1414,12 +1569,16 @@ final class PluginTests {
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8602"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8791"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
     )
     func testURLBasedPluginAPI() async throws {
         try await withKnownIssue {
             try await fixture(name: "Miscellaneous/Plugins/MySourceGenPluginUsingURLBasedAPI") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath, configuration: .debug)
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: .debug,
+                    buildSystem: .native,
+                )
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
         } when: {
@@ -1429,7 +1588,11 @@ final class PluginTests {
         try await withKnownIssue {
             // Try again with the Swift Build build system
             try await fixture(name: "Miscellaneous/Plugins/MySourceGenPluginUsingURLBasedAPI") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath, configuration: .debug, extraArgs: ["--build-system", "swiftbuild"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: .debug,
+                    buildSystem: .swiftbuild,
+                )
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
         } when: { ProcessInfo.hostOperatingSystem == .linux || ProcessInfo.hostOperatingSystem == .windows }
@@ -1437,19 +1600,22 @@ final class PluginTests {
 
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
-        .enabled(if: (try? UserToolchain.default)!.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        .requiresSwiftConcurrencySupport,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
-    func testDependentPlugins() async throws {
-        try await fixture(name: "Miscellaneous/Plugins/DependentPlugins") { fixturePath in
-            let (stdout, _) = try await executeSwiftBuild(fixturePath)
-            #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-        }
-
+    func testDependentPlugins(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
         try await withKnownIssue {
             try await fixture(name: "Miscellaneous/Plugins/DependentPlugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(fixturePath, extraArgs: ["--build-system", "swiftbuild"])
+                let (stdout, _) = try await executeSwiftBuild(
+                    fixturePath,
+                    buildSystem: buildSystem,
+                )
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
-        } when: { ProcessInfo.hostOperatingSystem == .windows }
+        } when: { 
+            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
+        }
     }
 }

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -34,7 +34,11 @@ final class ResourcesTests: XCTestCase {
             #endif
 
             for execName in executables {
-                let (output, _) = try await executeSwiftRun(fixturePath, execName, buildSystem: .native)
+                let (output, _) = try await executeSwiftRun(
+                    fixturePath,
+                    execName,
+                    buildSystem: .native,
+                )
                 XCTAssertTrue(output.contains("foo"), output)
             }
         }
@@ -42,7 +46,10 @@ final class ResourcesTests: XCTestCase {
 
     func testLocalizedResources() async throws {
         try await fixtureXCTest(name: "Resources/Localized") { fixturePath in
-            try await executeSwiftBuild(fixturePath)
+            try await executeSwiftBuild(
+                fixturePath,
+                buildSystem: .native,
+            )
 
             let exec = AbsolutePath(".build/debug/exe", relativeTo: fixturePath)
             // Note: <rdar://problem/59738569> Source from LANG and -AppleLanguages on command line for Linux resources
@@ -63,7 +70,11 @@ final class ResourcesTests: XCTestCase {
         #endif
 
         try await fixtureXCTest(name: "Resources/Simple") { fixturePath in
-            await XCTAssertBuilds(fixturePath, extraArgs: ["--target", "MixedClangResource"])
+            await XCTAssertBuilds(
+                fixturePath,
+                extraArgs: ["--target", "MixedClangResource"],
+                buildSystem: .native,
+            )
         }
     }
 
@@ -77,12 +88,22 @@ final class ResourcesTests: XCTestCase {
             #endif
 
             let binPath = try AbsolutePath(validating:
-                await executeSwiftBuild(fixturePath, configuration: .release, extraArgs: ["--show-bin-path"]).stdout
+                await executeSwiftBuild(
+                    fixturePath,
+                    configuration: .release,
+                    extraArgs: ["--show-bin-path"],
+                    buildSystem: .native,
+                ).stdout
                     .trimmingCharacters(in: .whitespacesAndNewlines)
             )
 
             for execName in executables {
-                _ = try await executeSwiftBuild(fixturePath, configuration: .release, extraArgs: ["--product", execName])
+                _ = try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: .release,
+                    extraArgs: ["--product", execName],
+                    buildSystem: .native,
+                )
 
                 try await withTemporaryDirectory(prefix: execName) { tmpDirPath in
                     defer {
@@ -112,7 +133,8 @@ final class ResourcesTests: XCTestCase {
         try await fixtureXCTest(name: "Resources/FoundationlessClient/UtilsWithFoundationPkg") { fixturePath in
             await XCTAssertBuilds(
                 fixturePath,
-                Xswiftc: ["-warnings-as-errors"]
+                Xswiftc: ["-warnings-as-errors"],
+                buildSystem: .native,
             )
         }
     }
@@ -124,14 +146,21 @@ final class ResourcesTests: XCTestCase {
         #endif
 
         try await fixtureXCTest(name: "Resources/Simple") { fixturePath in
-            await XCTAssertSwiftTest(fixturePath, extraArgs: ["--filter", "ClangResourceTests"])
+            await XCTAssertSwiftTest(
+                fixturePath,
+                extraArgs: ["--filter", "ClangResourceTests"],
+                buildSystem: .native,
+            )
         }
     }
 
     func testResourcesEmbeddedInCode() async throws {
         try await fixtureXCTest(name: "Resources/EmbedInCodeSimple") { fixturePath in
             let execPath = fixturePath.appending(components: ".build", "debug", "EmbedInCodeSimple")
-            try await executeSwiftBuild(fixturePath)
+            try await executeSwiftBuild(
+                fixturePath,
+                buildSystem: .native,
+            )
             let result = try await AsyncProcess.checkNonZeroExit(args: execPath.pathString)
             XCTAssertMatch(result, .contains("hello world"))
             let resourcePath = fixturePath.appending(
@@ -139,13 +168,16 @@ final class ResourcesTests: XCTestCase {
 
             // Check incremental builds
             for i in 0..<2 {
-              let content = "Hi there \(i)!"
-              // Update the resource file.
-              try localFileSystem.writeFileContents(resourcePath, string: content)
-              try await executeSwiftBuild(fixturePath)
-              // Run the executable again.
-              let result2 = try await AsyncProcess.checkNonZeroExit(args: execPath.pathString)
-              XCTAssertMatch(result2, .contains("\(content)"))
+                let content = "Hi there \(i)!"
+                // Update the resource file.
+                try localFileSystem.writeFileContents(resourcePath, string: content)
+                try await executeSwiftBuild(
+                    fixturePath,
+                    buildSystem: .native,
+                )
+                 // Run the executable again.
+                let result2 = try await AsyncProcess.checkNonZeroExit(args: execPath.pathString)
+                XCTAssertMatch(result2, .contains("\(content)"))
             }
         }
     }
@@ -181,7 +213,11 @@ final class ResourcesTests: XCTestCase {
             try localFileSystem.createDirectory(resource.parentDirectory, recursive: true)
             try localFileSystem.writeFileContents(resource, string: "best")
 
-            let (_, stderr) = try await executeSwiftBuild(packageDir, env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"])
+            let (_, stderr) = try await executeSwiftBuild(
+                packageDir,
+                env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"],
+                buildSystem: .native,
+            )
             // Filter some unrelated output that could show up on stderr.
             let filteredStderr = stderr.components(separatedBy: "\n").filter { !$0.contains("[logging]") }
                                                                      .filter { !$0.contains("Unable to locate libSwiftScan") }.joined(separator: "\n")

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -90,7 +90,10 @@ final class VersionSpecificTests: XCTestCase {
                     """
             )
             // This build should fail, because of the invalid package.
-            await XCTAssertBuildFails(primaryPath)
+            await XCTAssertBuildFails(
+                primaryPath,
+                buildSystem: .native,
+            )
 
             // Create a file which requires a version 1.1.0 resolution.
             try fs.writeFileContents(
@@ -123,8 +126,15 @@ final class VersionSpecificTests: XCTestCase {
             try repo.tag(name: "1.1.0@swift-\(SwiftVersion.current.major)")
 
             // The build should work now.
-            _ = try await SwiftPM.Package.execute(["reset"], packagePath: primaryPath)
-            await XCTAssertBuilds(primaryPath)
+            _ = try await executeSwiftPackage(
+                primaryPath,
+                extraArgs: ["reset"],
+                buildSystem: .native,
+            )
+            await XCTAssertBuilds(
+                primaryPath,
+                buildSystem: .native,
+            )
         }
     }
 }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -86,7 +86,10 @@ final class InitTests: XCTestCase {
             XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources").appending("Foo")), ["Foo.swift"])
-            await XCTAssertBuilds(path)
+            await XCTAssertBuilds(
+                path,
+                buildSystem: .native,
+            )
             let triple = try UserToolchain.default.targetTriple
             let binPath = path.appending(components: ".build", triple.platformBuildPathComponent, "debug")
 #if os(Windows)
@@ -115,7 +118,10 @@ final class InitTests: XCTestCase {
             try initPackage.writePackageStructure()
 
             XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources").appending("main")), ["MainEntrypoint.swift"])
-            await XCTAssertBuilds(path)
+            await XCTAssertBuilds(
+                path,
+                buildSystem: .native,
+            )
         }
     }
 
@@ -165,7 +171,10 @@ final class InitTests: XCTestCase {
             XCTAssertMatch(testFileContents, .contains("func testExample() throws"))
 
             // Try building it
-            await XCTAssertBuilds(path)
+            await XCTAssertBuilds(
+                path,
+                buildSystem: .native,
+            )
             let triple = try UserToolchain.default.targetTriple
             XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
         }
@@ -201,7 +210,10 @@ final class InitTests: XCTestCase {
 
 #if canImport(TestingDisabled)
             // Try building it
-            await XCTAssertBuilds(path)
+            await XCTAssertBuilds(
+                path,
+                buildSystem: .native,
+            )
             let triple = try UserToolchain.default.targetTriple
             XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
 #endif
@@ -238,7 +250,10 @@ final class InitTests: XCTestCase {
 
 #if canImport(TestingDisabled)
             // Try building it
-            await XCTAssertBuilds(path)
+            await XCTAssertBuilds(
+                path,
+                buildSystem: .native,
+            )
             let triple = try UserToolchain.default.targetTriple
             XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
 #endif
@@ -272,7 +287,10 @@ final class InitTests: XCTestCase {
 
 #if canImport(TestingDisabled)
             // Try building it
-            await XCTAssertBuilds(path)
+            await XCTAssertBuilds(
+                path,
+                buildSystem: .native,
+            )
             let triple = try UserToolchain.default.targetTriple
             XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
 #endif
@@ -371,7 +389,10 @@ final class InitTests: XCTestCase {
             try initPackage.writePackageStructure()
 
             // Try building it.
-            await XCTAssertBuilds(packageRoot)
+            await XCTAssertBuilds(
+                packageRoot,
+                buildSystem: .native,
+            )
             let triple = try UserToolchain.default.targetTriple
             XCTAssertFileExists(packageRoot.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "some_package.swiftmodule"))
         }
@@ -394,7 +415,10 @@ final class InitTests: XCTestCase {
             )
             try initPackage.writePackageStructure()
             
-            await XCTAssertBuilds(packageRoot)
+            await XCTAssertBuilds(
+                packageRoot,
+                buildSystem: .native,
+            )
         }
     }
 


### PR DESCRIPTION
Many of the `executeSwift*` command helpers accept a build system provider, which was defaulted to the native build system.  Since we are augmenting the tests to also run against the SwiftBuild, setting a default value may lead to an undesirable test behaviour.

Update all the `executeSwift*` commands to no set a default build system provider.