### PR TITLE
Only fetch swiftc target info when needed.

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -578,8 +578,7 @@ public class Workspace {
 
         var prebuiltsManager: PrebuiltsManager?
         if configuration.usePrebuilts,
-           let hostPlatform = customPrebuiltsManager?.hostPlatform ?? PrebuiltsManifest.Platform.hostPlatform,
-           let swiftCompilerVersion = hostToolchain.swiftCompilerVersion
+           let hostPlatform = customPrebuiltsManager?.hostPlatform ?? PrebuiltsManifest.Platform.hostPlatform
         {
             let rootCertPath: AbsolutePath?
             if let path = configuration.prebuiltsRootCertPath {
@@ -591,10 +590,10 @@ public class Workspace {
             let prebuiltsManagerObj = PrebuiltsManager(
                 fileSystem: fileSystem,
                 hostPlatform: hostPlatform,
-                swiftCompilerVersion: customPrebuiltsManager?.swiftVersion ?? swiftCompilerVersion,
                 authorizationProvider: authorizationProvider,
                 scratchPath: location.prebuiltsDirectory,
                 cachePath: customPrebuiltsManager?.useCache == false || !configuration.sharedDependenciesCacheEnabled ? .none : location.sharedPrebuiltsCacheDirectory,
+                customSwiftCompilerVersion: customPrebuiltsManager?.swiftVersion,
                 customHTTPClient: customPrebuiltsManager?.httpClient,
                 customArchiver: customPrebuiltsManager?.archiver,
                 delegate: delegate.map(WorkspacePrebuiltsManagerDelegate.init(workspaceDelegate:)),


### PR DESCRIPTION
We added fetching of the swift compiler version using swiftc -print-target-info in the init of UserToolchain so that it can be passed to the PrebuiltsManager to calculate the manifest and prebuilts zip file names.

However, there are cases where we pass in the triple for the current SDK which was intended to avoid the call to swiftc. We now call it all the time which causes an extra call to swiftc that isn't always needed.

To address this, we make the calculation of the target info lazy and move the call to fetch the swift version to the point we need it in the PrebuiltsManager. If prebuilts aren't required, the call is avoided.

To properly test this we need to run a test that calls out to swiftc. However, we don't have integration tests yet for prebuilts since they would take a long time to execute. I have instead manually tested this using a staged version of the prebuilts.