### PR TITLE
Frequent crashes in LLBuildProgressTracker while building swift-java on linux and swift 6.1.2

### DIFF
--- a/Sources/Build/LLBuildProgressTracker.swift
+++ b/Sources/Build/LLBuildProgressTracker.swift
@@ -279,6 +279,9 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
         guard command.shouldShowStatus else { return }
         guard !self.swiftParsers.keys.contains(command.name) else { return }
 
+        let commandName = command.name
+        let commandDescription = command.description
+
         self.queue.async {
             if result == .cancelled {
                 self.cancelled = true
@@ -288,8 +291,8 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
             self.delegate?.buildSystem(self.buildSystem, didFinishCommand: BuildSystemCommand(command))
 
             if !self.logLevel.isVerbose && !self.logLevel.isQuiet {
-                let targetName = self.swiftParsers[command.name]?.targetName
-                self.taskTracker.commandFinished(command, result: result, targetName: targetName)
+                let targetName = self.swiftParsers[commandName]?.targetName
+                self.taskTracker.commandFinished(commandDescription, result: result, targetName: targetName)
                 self.updateProgress()
             }
         }
@@ -539,8 +542,8 @@ private struct CommandTaskTracker {
         }
     }
 
-    mutating func commandFinished(_ command: SPMLLBuild.Command, result: CommandResult, targetName: String?) {
-        let progressTextValue = self.progressText(of: command, targetName: targetName)
+    mutating func commandFinished(_ commandDescription: String, result: CommandResult, targetName: String?) {
+        let progressTextValue = self.progressText(of: commandDescription, targetName: targetName)
         self.onTaskProgressUpdateText?(progressTextValue, targetName)
 
         self.latestFinishedText = progressTextValue
@@ -567,19 +570,19 @@ private struct CommandTaskTracker {
         }
     }
 
-    private func progressText(of command: SPMLLBuild.Command, targetName: String?) -> String {
+    private func progressText(of commandDescription: String, targetName: String?) -> String {
 #if os(Windows)
     let pathSep: Character = "\\"
 #else
     let pathSep: Character = "/"
 #endif
         // Transforms descriptions like "Linking ./.build/x86_64-apple-macosx/debug/foo" into "Linking foo".
-        if let firstSpaceIndex = command.description.firstIndex(of: " "),
-           let lastDirectorySeparatorIndex = command.description.lastIndex(of: pathSep)
+        if let firstSpaceIndex = commandDescription.firstIndex(of: " "),
+           let lastDirectorySeparatorIndex = commandDescription.lastIndex(of: pathSep)
         {
-            let action = command.description[..<firstSpaceIndex]
-            let fileNameStartIndex = command.description.index(after: lastDirectorySeparatorIndex)
-            let fileName = command.description[fileNameStartIndex...]
+            let action = commandDescription[..<firstSpaceIndex]
+            let fileNameStartIndex = commandDescription.index(after: lastDirectorySeparatorIndex)
+            let fileName = commandDescription[fileNameStartIndex...]
 
             if let targetName {
                 return "\(action) \(targetName) \(fileName)"
@@ -587,7 +590,7 @@ private struct CommandTaskTracker {
                 return "\(action) \(fileName)"
             }
         } else {
-            return command.description
+            return commandDescription
         }
     }
 


### PR DESCRIPTION
Frequent crashes in LLBuildProgressTracker while building swift-java on linux and swift 6.1.2

### Motivation:

> Thread 4 crashed:
> 
> 0                         0x00007f1559da359a swift_slowAlloc + 74 in [libswiftCore.so](http://libswiftcore.so/)
> 1 [ra]                    0x00007f1559da3877 swift_allocObject + 38 in [libswiftCore.so](http://libswiftcore.so/)
> 2 [ra]                    0x00007f1559b85571 _allocateStringStorage(codeUnitCapacity:) + 160 in [libswiftCore.so](http://libswiftcore.so/)
> 3 [ra]                    0x00007f1559d03452 _StringGuts.grow(_:) + 273 in [libswiftCore.so](http://libswiftcore.so/)
> 4 [ra]                    0x00007f1559bf7e88 specialized static String._fromUTF8Repairing(_:) + 999 in [libswiftCore.so](http://libswiftcore.so/)
> 5 [ra] [inlined] [system] 0x000056315a96e7ef specialized String.init<A, B>(decoding:as:) in swift-package at //<compiler-generated>
> 6 [ra] [inlined]          0x000056315a96e7ef stringFromData(_:) in swift-package at /home/build-user/llbuild/products/llbuildSwift/Internals.swift:49:12
> 7 [ra]                    0x000056315a96e7ef Command.name.getter + 78 in swift-package at /home/build-user/llbuild/products/llbuildSwift/BuildSystemBindings.swift:720:20
> 8 [ra]                    0x00005631593a61a2 closure #1 in LLBuildProgressTracker.commandProcessFinished(_:process:result:) + 33 in swift-package at /home/build-user/swiftpm/Sources/Build/LLBuildProgressTracker.swift:347:65
> 9 [ra] [thunk]            0x00005631592f6989 thunk for @escaping @callee_guaranteed @Sendable () -> () + 24 in swift-package at //<compiler-generated>

### Modifications:

Command is associated with a handle (pointer) that may be reclaimed when this function finishes.

### Result:

Do not access command attributes asynchronously
