### PR TITLE
Add an Xcode project to help codevelop SwiftBuild

### DIFF
--- a/Utilities/SwiftPM+SwiftBuild.xcworkspace/contents.xcworkspacedata
+++ b/Utilities/SwiftPM+SwiftBuild.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "container:../../swift-build">
+   </FileRef>
+   <FileRef
+      location = "container:../../swiftpm">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
This is actually a copy of the one in the swift-build repo. But for those of us who start in SwiftPM, it's convenient to have it here too. We'll probably add more for other repo combinations over time.
