### PR TITLE
[6.1] Frequent crashes in LLBuildProgressTracker while building swift-java on linux and swift 6.1.2

### DIFF
--- a/Sources/Build/LLBuildProgressTracker.swift
+++ b/Sources/Build/LLBuildProgressTracker.swift
@@ -277,6 +277,9 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
         guard command.shouldShowStatus else { return }
         guard !self.swiftParsers.keys.contains(command.name) else { return }
 
+        let commandName = command.name
+        let commandDescription = command.description
+
         self.queue.async {
             if result == .cancelled {
                 self.cancelled = true
@@ -286,8 +289,8 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
             self.delegate?.buildSystem(self.buildSystem, didFinishCommand: BuildSystemCommand(command))
 
             if !self.logLevel.isVerbose {
-                let targetName = self.swiftParsers[command.name]?.targetName
-                self.taskTracker.commandFinished(command, result: result, targetName: targetName)
+                let targetName = self.swiftParsers[commandName]?.targetName
+                self.taskTracker.commandFinished(commandDescription, result: result, targetName: targetName)
                 self.updateProgress()
             }
         }
@@ -343,12 +346,15 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
         // FIXME: This should really happen at the command-level and is just a stopgap measure.
         let shouldFilterOutput = !self.logLevel.isVerbose && command.verboseDescription.hasPrefix("codesign ") && result
             .result != .failed
+
+        let commandName = command.name
+
         self.queue.async {
-            if let buffer = self.nonSwiftMessageBuffers[command.name], !shouldFilterOutput {
+            if let buffer = self.nonSwiftMessageBuffers[commandName], !shouldFilterOutput {
                 self.progressAnimation.clear()
                 self.outputStream.send(buffer)
                 self.outputStream.flush()
-                self.nonSwiftMessageBuffers[command.name] = nil
+                self.nonSwiftMessageBuffers[commandName] = nil
             }
         }
 
@@ -360,13 +366,13 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
             // The command failed, so we queue up an asynchronous task to see if we have any error messages from the
             // target to provide advice about.
             self.queue.async {
-                guard let target = self.swiftParsers[command.name]?.targetName else { return }
+                guard let target = self.swiftParsers[commandName]?.targetName else { return }
                 guard let errorMessages = self.errorMessagesByTarget[target] else { return }
                 for errorMessage in errorMessages {
                     // Emit any advice that's provided for each error message.
                     if let adviceMessage = self.buildExecutionContext.buildErrorAdviceProvider?.provideBuildErrorAdvice(
                         for: target,
-                        command: command.name,
+                        command: commandName,
                         message: errorMessage
                     ) {
                         self.outputStream.send("note: \(adviceMessage)\n")
@@ -530,8 +536,8 @@ private struct CommandTaskTracker {
         }
     }
 
-    mutating func commandFinished(_ command: SPMLLBuild.Command, result: CommandResult, targetName: String?) {
-        let progressTextValue = self.progressText(of: command, targetName: targetName)
+    mutating func commandFinished(_ commandDescription: String, result: CommandResult, targetName: String?) {
+        let progressTextValue = self.progressText(of: commandDescription, targetName: targetName)
         self.onTaskProgressUpdateText?(progressTextValue, targetName)
 
         self.latestFinishedText = progressTextValue
@@ -558,14 +564,14 @@ private struct CommandTaskTracker {
         }
     }
 
-    private func progressText(of command: SPMLLBuild.Command, targetName: String?) -> String {
+    private func progressText(of commandDescription: String, targetName: String?) -> String {
         // Transforms descriptions like "Linking ./.build/x86_64-apple-macosx/debug/foo" into "Linking foo".
-        if let firstSpaceIndex = command.description.firstIndex(of: " "),
-           let lastDirectorySeparatorIndex = command.description.lastIndex(of: "/")
+        if let firstSpaceIndex = commandDescription.firstIndex(of: " "),
+           let lastDirectorySeparatorIndex = commandDescription.lastIndex(of: "/")
         {
-            let action = command.description[..<firstSpaceIndex]
-            let fileNameStartIndex = command.description.index(after: lastDirectorySeparatorIndex)
-            let fileName = command.description[fileNameStartIndex...]
+            let action = commandDescription[..<firstSpaceIndex]
+            let fileNameStartIndex = commandDescription.index(after: lastDirectorySeparatorIndex)
+            let fileName = commandDescription[fileNameStartIndex...]
 
             if let targetName {
                 return "\(action) \(targetName) \(fileName)"
@@ -573,7 +579,7 @@ private struct CommandTaskTracker {
                 return "\(action) \(fileName)"
             }
         } else {
-            return command.description
+            return commandDescription
         }
     }
 


### PR DESCRIPTION
### Explanation:
(cherry picked from commit 16452e1305d5f635cc714146201ca9753bcfea3f)

Frequent crashes in LLBuildProgressTracker while building swift-java on linux and swift 6.1.2

This was a race condition because the 
Command is associated with a handle (pointer) that may be reclaimed when this function finishes.

### Scope:
Minimal, copy variables into locals before accessing them from async block.

### Issues:
https://github.com/swiftlang/swift-java/issues/314 almost all CI runs fail with this race condition due to the timing of the command being influenced by the gradle build in swift-java.

### Original PRs:
https://github.com/swiftlang/swift-package-manager/pull/8998

### Risk:
Minimal.  Change explicitly copies variables prior to usage in async block. This avoided a race condition that would manifest before as null pointer crashes when trying to access these variables.


Change has been tested in main and 6.2

### Testing:
Confirmed fixed in main and 6.2. Manually verified in always reproducing project.

