### PR TITLE
Add a comment about LD_RUNPATH_SEARCH_PATHS being incompatible with -static

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -769,6 +769,7 @@ extension PackagePIFProjectBuilder {
         //   A (executable) -> B (dynamicLibrary) -> C (objectFile)
         //
         // An imparted build setting on C will propagate back to both B and A.
+        // FIXME: -rpath should not be given if -static is
         impartedSettings[.LD_RUNPATH_SEARCH_PATHS] =
             ["$(RPATH_ORIGIN)"] +
             (impartedSettings[.LD_RUNPATH_SEARCH_PATHS] ?? ["$(inherited)"])


### PR DESCRIPTION
We'll need to resolve this to support Swift Embedded use cases, among others. This logic should maybe move down into the Swift Build layer, and have it automatically ignore -rpath when -static is present.