### PR TITLE
Add initial support for "none" triples using the Swift Build backend

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -666,6 +666,16 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             }
         }
 
+        // FIXME: "none" triples get a placeholder SDK/platform and don't support any specific triple by default. Unlike most platforms, where the vendor and environment is implied as a function of the arch and "platform", bare metal operates in terms of triples directly. We need to replace this bringup convenience with a more idiomatic mechanism, perhaps in the build request.
+        if buildParameters.triple.os == .noneOS {
+            settings["ARCHS"] = buildParameters.triple.archName
+            settings["VALID_ARCHS"] = buildParameters.triple.archName
+            settings["LLVM_TARGET_TRIPLE_VENDOR"] = buildParameters.triple.vendorName
+            if !buildParameters.triple.environmentName.isEmpty {
+                settings["LLVM_TARGET_TRIPLE_SUFFIX"] = "-" + buildParameters.triple.environmentName
+            }
+        }
+
         settings["LIBRARY_SEARCH_PATHS"] = try "$(inherited) \(buildParameters.toolchain.toolchainLibDir.pathString)"
         settings["OTHER_CFLAGS"] = (
             ["$(inherited)"]


### PR DESCRIPTION
This will need to be cleaned up later as we refine how target triples are communicated through the build request, but will allow us to start experimenting with more Swift Embedded workflows in the meantime.