### PR TITLE
Correctly pass linker flags to Swift Build backend

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -36,59 +36,6 @@ extension String {
     }
 }
 
-extension [String] {
-    /// Converts a set of C compiler flags into an equivalent set to be
-    /// indirected through the Swift compiler instead.
-    func asSwiftcCCompilerFlags() -> Self {
-        self.flatMap { ["-Xcc", $0] }
-    }
-
-    /// Converts a set of C++ compiler flags into an equivalent set to be
-    /// indirected through the Swift compiler instead.
-    func asSwiftcCXXCompilerFlags() -> Self {
-        _ = self.flatMap { ["-Xcxx", $0] }
-        // TODO: Pass -Xcxx flags to swiftc (#6491)
-        // Remove fatal error when downstream support arrives.
-        fatalError("swiftc does support -Xcxx flags yet.")
-    }
-
-    /// Converts a set of linker flags into an equivalent set to be indirected
-    /// through the Swift compiler instead.
-    ///
-    /// Some arguments can be passed directly to the Swift compiler. We omit
-    /// prefixing these arguments (in both the "-option value" and
-    /// "-option[=]value" forms) with "-Xlinker". All other arguments are
-    /// prefixed with "-Xlinker".
-    func asSwiftcLinkerFlags() -> Self {
-        // Arguments that can be passed directly to the Swift compiler and
-        // doesn't require -Xlinker prefix.
-        //
-        // We do this to avoid sending flags like linker search path at the end
-        // of the search list.
-        let directSwiftLinkerArgs = ["-L"]
-
-        var flags: [String] = []
-        var it = self.makeIterator()
-        while let flag = it.next() {
-            if directSwiftLinkerArgs.contains(flag) {
-                // `<option> <value>` variant.
-                flags.append(flag)
-                guard let nextFlag = it.next() else {
-                    // We expected a flag but don't have one.
-                    continue
-                }
-                flags.append(nextFlag)
-            } else if directSwiftLinkerArgs.contains(where: { flag.hasPrefix($0) }) {
-                // `<option>[=]<value>` variant.
-                flags.append(flag)
-            } else {
-                flags += ["-Xlinker", flag]
-            }
-        }
-        return flags
-    }
-}
-
 extension BuildParameters {
     /// Returns the directory to be used for module cache.
     public var moduleCache: Basics.AbsolutePath {

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -686,8 +686,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         settings["OTHER_LDFLAGS"] = (
             verboseFlag + // clang will be invoked to link so the verbose flag is valid for it
                 ["$(inherited)"]
-                + buildParameters.toolchain.extraFlags.linkerFlags.map { $0.shellEscaped() }
-                + buildParameters.flags.linkerFlags.map { $0.shellEscaped() }
+                + buildParameters.toolchain.extraFlags.linkerFlags.asSwiftcLinkerFlags().map { $0.shellEscaped() }
+                + buildParameters.flags.linkerFlags.asSwiftcLinkerFlags().map { $0.shellEscaped() }
         ).joined(separator: " ")
 
         // Optionally also set the list of architectures to build for.


### PR DESCRIPTION
These are expected to be prefixed with -Xlinker, like the native build system does. This solves linker failures with linker flags coming from toolset.json, especially for Swift Embedded workflows.