### PR TITLE
Fix: Generate tests for executable/tool with `--enable-swift-testing`

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -660,10 +660,16 @@ public final class InitPackage {
             return
         }
 
+        // Intentionally exhaustive switch without `default` case - forces compilation failure when new
+        // `PackageType`` cases are added, ensuring explicit consideration of case behavior.
+        // Using `default` would silently group future cases, hiding new cases and introducing potential bugs.
         switch packageType {
-        case .empty, .executable, .tool, .buildToolPlugin, .commandPlugin: return
-            default: break
+        case .empty, .buildToolPlugin, .commandPlugin:
+            return
+        case .library, .executable, .tool, .macro:
+            break
         }
+
         let tests = destinationPath.appending("Tests")
         guard self.fileSystem.exists(tests) == false else {
             return
@@ -873,9 +879,11 @@ public final class InitPackage {
         try makeDirectories(testModule)
 
         let testClassFile = try AbsolutePath(validating: "\(moduleName)Tests.swift", relativeTo: testModule)
+
         switch packageType {
-        case .empty, .buildToolPlugin, .commandPlugin, .executable, .tool: break
-        case .library:
+        case .empty, .buildToolPlugin, .commandPlugin:
+            break
+        case .library, .executable, .tool: // Added .executable and .tool here
             try writeLibraryTestsFile(testClassFile)
         case .macro:
             try writeMacroTestsFile(testClassFile)

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -660,9 +660,6 @@ public final class InitPackage {
             return
         }
 
-        // Intentionally exhaustive switch without `default` case - forces compilation failure when new
-        // `PackageType`` cases are added, ensuring explicit consideration of case behavior.
-        // Using `default` would silently group future cases, hiding new cases and introducing potential bugs.
         switch packageType {
         case .empty, .buildToolPlugin, .commandPlugin:
             return
@@ -883,7 +880,7 @@ public final class InitPackage {
         switch packageType {
         case .empty, .buildToolPlugin, .commandPlugin:
             break
-        case .library, .executable, .tool: // Added .executable and .tool here
+        case .library, .executable, .tool:
             try writeLibraryTestsFile(testClassFile)
         case .macro:
             try writeMacroTestsFile(testClassFile)

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -297,6 +297,62 @@ final class InitTests: XCTestCase {
         }
     }
 
+    func testInitPackageExecutableWithSwiftTesting() async throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let fs = localFileSystem
+            let path = tmpPath.appending("Foo")
+            let name = path.basename
+            try fs.createDirectory(path)
+            // Create the package
+            let initPackage = try InitPackage(
+                name: name,
+                packageType: .executable,
+                supportedTestingLibraries: [.swiftTesting],
+                destinationPath: path,
+                fileSystem: localFileSystem
+            )
+
+            try initPackage.writePackageStructure()
+            // Verify basic file system content that we expect in the package
+            let manifest = path.appending("Package.swift")
+            XCTAssertFileExists(manifest)
+            let testFile = path.appending("Tests").appending("FooTests").appending("FooTests.swift")
+            let testFileContents: String = try localFileSystem.readFileContents(testFile)
+            XCTAssertMatch(testFileContents, .contains(#"import Testing"#))
+            XCTAssertNoMatch(testFileContents, .contains(#"import XCTest"#))
+            XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
+            XCTAssertNoMatch(testFileContents, .contains("func testExample() throws"))
+        }
+    }
+
+    func testInitPackageToolWithSwiftTesting() async throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let fs = localFileSystem
+            let path = tmpPath.appending("Foo")
+            let name = path.basename
+            try fs.createDirectory(path)
+            // Create the package
+            let initPackage = try InitPackage(
+                name: name,
+                packageType: .tool,
+                supportedTestingLibraries: [.swiftTesting],
+                destinationPath: path,
+                fileSystem: localFileSystem
+            )
+
+            try initPackage.writePackageStructure()
+            // Verify basic file system content that we expect in the package
+            let manifest = path.appending("Package.swift")
+            XCTAssertFileExists(manifest)
+            let testFile = path.appending("Tests").appending("FooTests").appending("FooTests.swift")
+            let testFileContents: String = try localFileSystem.readFileContents(testFile)
+            XCTAssertMatch(testFileContents, .contains(#"import Testing"#))
+            XCTAssertNoMatch(testFileContents, .contains(#"import XCTest"#))
+            XCTAssertMatch(testFileContents, .contains(#"@Test func example() async throws"#))
+            XCTAssertNoMatch(testFileContents, .contains("func testExample() throws"))
+        }
+    }
+
     func testInitPackageCommandPlugin() throws {
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem


### PR DESCRIPTION
Updated `InitPackage` to handle `.executable` and `.tool` types when generating test files with SwiftTesting. Added corresponding tests to verify correct test file content for these package types.

### Motivation:

The `swift package init` command did not generate a `Tests` directory for executable or tool packages when the `--enable-swift-testing` flag was used. This was caused by logic in `Sources/Workspace/InitPackage.swift` that incorrectly skipped test generation for these package types. This change fixes that behavior, ensuring that tests are created as expected.

### Modifications:

- In `Sources/Workspace/InitPackage.swift`, the `writeTests()` function was modified to proceed with test generation for `.executable` and `.tool` package types.
- In the same file, the `writeTestFileStubs()` function was updated to include `.executable` and `.tool` types, allowing the creation of standard library-style test files for them.

### Result:

After this change, running `swift package init --type executable --enable-swift-testing` or `swift package init --type tool --enable-swift-testing` correctly generates a `Tests` directory with sample test files, aligning the tool's behavior with its intended functionality.

### Reproduction and Verification:

#### Reproducing the Issue (on `main` branch):

1. Create a temporary directory: `mkdir -p /tmp/test-repro && cd /tmp/test-repro`
2. Run `swift package init --type executable --enable-swift-testing`.
3. Verify that no `Tests` directory is created by running `ls -F`.

#### Verifying the Fix (on this branch):

1. Build the package manager: `swift build`
2. Find the built executable: `find .build -name swift-package`
3. Create a temporary directory: `mkdir -p /tmp/test-fix && cd /tmp/test-fix`
4. Run the newly built package manager to init a project: `../.build/arm64-apple-macosx/debug/swift-package init --type executable --enable-swift-testing` (adjust path as needed).
5. Verify that a `Tests` directory is now created by running `ls -F`.
