### PR TITLE
adds traits to dependency output in show-dependencies --json and --text

### DIFF
--- a/Sources/Commands/Utilities/DependenciesSerializer.swift
+++ b/Sources/Commands/Utilities/DependenciesSerializer.swift
@@ -34,7 +34,14 @@ final class PlainTextDumper: DependenciesDumper {
 
                 let pkgVersion = package.manifest.version?.description ?? "unspecified"
 
-                stream.send("\(hanger)\(package.identity.description)<\(package.manifest.packageLocation)@\(pkgVersion)>\n")
+                let traitsEnabled: String
+                if let enabled = package.enabledTraits, !enabled.isEmpty {
+                    traitsEnabled = "(traits: \(package.enabledTraits?.joined(separator: ", ") ?? ""))"
+                } else {
+                    traitsEnabled = ""
+                }
+
+                stream.send("\(hanger)\(package.identity.description)<\(package.manifest.packageLocation)@\(pkgVersion)>\(traitsEnabled)\n")
 
                 if !package.dependencies.isEmpty {
                     let replacement = (index == packages.count - 1) ?  "    " : "│   "
@@ -130,6 +137,7 @@ final class JSONDumper: DependenciesDumper {
                 "url": .string(package.manifest.packageLocation),
                 "version": .string(package.manifest.version?.description ?? "unspecified"),
                 "path": .string(package.path.pathString),
+                "traits": .array(package.enabledTraits?.map { .string($0) } ?? []),
                 "dependencies": .array(package.dependencies.compactMap { graph.packages[$0] }.map(convert)),
             ])
         }


### PR DESCRIPTION
Adds traits to the output of the show-dependencies command for `--text` and `--json` output.

### Motivation:

Exposes the default traits, if any, that are enabled by the dependencies a package.

Resolves: #9033 

### Modifications:

Extended the logic in show-dependencies to add in the `enabledTraits` for a resolved package.

### Result:

The output of show-dependencies includes output akin to `(traits: FirstTrait, SecondTrait)` is the resolved package has traits and includes the traits that it has. If the package doesn't offer traits, no additional/new content is displayed in `--text`.
The JSON provided from `show-dependencies --json` includes a `traits` property, empty if there aren't any traits enabled.
