### PR TITLE
[Commands] Update `AddTarget` command to add auxiliary files for new …

### DIFF
--- a/Sources/Commands/Utilities/RefactoringSupport.swift
+++ b/Sources/Commands/Utilities/RefactoringSupport.swift
@@ -42,46 +42,5 @@ package extension PackageEdit {
         if verbose {
             print(" done.")
         }
-
-        // Write all of the auxiliary files.
-        for (auxiliaryFileRelPath, auxiliaryFileSyntax) in auxiliaryFiles {
-            // If the file already exists, skip it.
-            let filePath = try rootPath.appending(RelativePath(validating: auxiliaryFileRelPath))
-            if filesystem.exists(filePath) {
-                if verbose {
-                    print("Skipping \(filePath.relative(to: rootPath)) because it already exists.")
-                }
-
-                continue
-            }
-
-            // If the directory does not exist yet, create it.
-            let fileDir = filePath.parentDirectory
-            if !filesystem.exists(fileDir) {
-                if verbose {
-                    print("Creating directory \(fileDir.relative(to: rootPath))...", terminator: "")
-                }
-
-                try filesystem.createDirectory(fileDir, recursive: true)
-
-                if verbose {
-                    print(" done.")
-                }
-            }
-
-            // Write the file.
-            if verbose {
-                print("Writing \(filePath.relative(to: rootPath))...", terminator: "")
-            }
-
-            try filesystem.writeFileContents(
-                filePath,
-                string: auxiliaryFileSyntax.description
-            )
-
-            if verbose {
-                print(" done.")
-            }
-        }
     }
 }


### PR DESCRIPTION
…targets

### Motivation:

The command currently relies on the refactoring action to supply it with auxiliary files to add, but we'd like refactoring actions to only be responsible for manifest updates and everything else should be done either by a command itself or trigger additional commands in case the refactoring is happening via something like sourcekit-lsp.

### Modifications:

- Add `addAuxiliaryFiles` and `createAuxiliaryFile` (previously part of `PackageEdit.applyEdits`) methods to `AddTarget` command to add new primary and other files to the target directory once the manifest has been updated.

### Result:

This helps us to remove `ManifestEditRefactoringProvider` (all of the manifest refactoring actions are going to conform to `EditRefactoringProvider` protocol directly) and `PackageEdit` types from swift-syntax and adjust all of the package manifest refactoring actions to produce `[SourceEdit]` instead. 
