### PR TITLE
Traits docs

### DIFF
--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -201,7 +201,9 @@ extension Package {
 // MARK: - file system
 
 extension Package.Dependency {
-    /// Adds a dependency to a package located at the given path.
+    /// Adds a dependency to a package located at the path you provide.
+    ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
     ///
     /// The Swift Package Manager uses the package dependency as-is
     /// and does not perform any source control access. Local package dependencies
@@ -217,7 +219,7 @@ extension Package.Dependency {
         return .init(name: nil, path: path, traits: nil)
     }
 
-    /// Adds a dependency to a package located at the given path.
+    /// Adds a dependency to a package located at the path and with an optional set of traits you provide.
     ///
     /// The Swift Package Manager uses the package dependency as-is
     /// and does not perform any source control access. Local package dependencies
@@ -225,7 +227,7 @@ extension Package.Dependency {
     /// on multiple tightly coupled packages.
     ///
     /// - Parameter path: The file system path to the package.
-    /// - Parameter traits: The trait configuration of this dependency. Defaults to enabling the default traits.
+    /// - Parameter traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A package dependency.
     @available(_PackageDescription, introduced: 6.1)
@@ -236,7 +238,9 @@ extension Package.Dependency {
         return .init(name: nil, path: path, traits: traits)
     }
 
-    /// Adds a dependency to a package located at the given path on the filesystem.
+    /// Adds a dependency to a named package located at the path you provide.
+    ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
     ///
     /// Swift Package Manager uses the package dependency as-is and doesn't perform any source
     /// control access. Local package dependencies are especially useful during
@@ -256,7 +260,7 @@ extension Package.Dependency {
         return .init(name: name, path: path, traits: nil)
     }
 
-    /// Adds a dependency to a package located at the given path on the filesystem.
+    /// Adds a dependency to a named package located at the path and with an optional set of traits you provide.
     ///
     /// Swift Package Manager uses the package dependency as-is and doesn't perform any source
     /// control access. Local package dependencies are especially useful during
@@ -266,7 +270,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///   - name: The name of the Swift package.
     ///   - path: The file system path to the package.
-    ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
+    ///   - traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A package dependency.
     @available(_PackageDescription, introduced: 6.1)
@@ -298,6 +302,8 @@ extension Package.Dependency {
     ///```swift
     ///.package(url: "https://example.com/example-package.git", from: "1.2.3"),
     ///```
+    ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
     ///
     /// - Parameters:
     ///    - url: The valid Git URL of the package.
@@ -331,7 +337,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///    - url: The valid Git URL of the package.
     ///    - version: The minimum version requirement.
-    ///    - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
+    ///    - traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 6.1)
@@ -384,6 +390,8 @@ extension Package.Dependency {
     /// .package(url: "https://example.com/example-package.git", branch: "main"),
     /// ```
     ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
+    ///
     /// - Parameters:
     ///   - url: The valid Git URL of the package.
     ///   - branch: A dependency requirement. See static methods on ``Requirement-swift.enum`` for available options.
@@ -406,7 +414,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///   - url: The valid Git URL of the package.
     ///   - branch: A dependency requirement. See static methods on ``Requirement-swift.enum`` for available options.
-    ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
+    ///   - traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 6.1)
@@ -445,6 +453,8 @@ extension Package.Dependency {
     /// .package(url: "https://example.com/example-package.git", revision: "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"),
     /// ```
     ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
+    ///
     /// - Parameters:
     ///   - url: The valid Git URL of the package.
     ///   - revision: A dependency requirement. See static methods on ``Requirement-swift.enum`` for available options.
@@ -467,7 +477,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///   - url: The valid Git URL of the package.
     ///   - revision: A dependency requirement. See static methods on ``Requirement-swift.enum`` for available options.
-    ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
+    ///   - traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 6.1)
@@ -510,6 +520,8 @@ extension Package.Dependency {
     /// .package(url: "https://example.com/example-package.git", "1.2.3"..<"1.2.6"),
     /// ```
     ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
+    ///
     /// - Parameters:
     ///   - url: The valid Git URL of the package.
     ///   - range: The custom version range requirement.
@@ -535,7 +547,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///   - url: The valid Git URL of the package.
     ///   - range: The custom version range requirement.
-    ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
+    ///   - traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 6.1)
@@ -556,6 +568,8 @@ extension Package.Dependency {
     /// ```swift
     /// .package(url: "https://example.com/example-package.git", "1.2.3"..<"1.2.6"),
     /// ```
+    ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
     ///
     /// - Parameters:
     ///   - name: The name of the package, or `nil` to deduce it from the URL.
@@ -582,6 +596,8 @@ extension Package.Dependency {
     /// .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
     /// ```
     ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
+    ///
     /// - Parameters:
     ///   - url: The valid Git URL of the package.
     ///   - range: The closed version range requirement.
@@ -607,7 +623,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///   - url: The valid Git URL of the package.
     ///   - range: The closed version range requirement.
-    ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
+    ///   - traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 6.1)
@@ -643,6 +659,8 @@ extension Package.Dependency {
     /// .package(url: "https://example.com/example-package.git", .upToNextMinor(from: "1.0.0"),
     /// ```
     ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
+    ///
     /// - Parameters:
     ///   - name: The name of the package, or `nil` to deduce it from the URL.
     ///   - url: The valid Git URL of the package.
@@ -667,6 +685,8 @@ extension Package.Dependency {
     /// ```swift
     /// .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
     /// ```
+    ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
     ///
     /// - Parameters:
     ///   - name: The name of the package, or `nil` to deduce it from the URL.
@@ -702,7 +722,7 @@ extension Package.Dependency {
     ///   - name: The name of the package, or `nil` to deduce it from the URL.
     ///   - url: The valid Git URL of the package.
     ///   - range: The closed version range requirement.
-    ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
+    ///   - traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A `Package.Dependency` instance.
     private static func package(
@@ -740,6 +760,8 @@ extension Package.Dependency {
     /// .package(url: "https://example.com/example-package.git", exact: "1.2.3"),
     /// ```
     ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
+    ///
     /// - Parameters:
     ///   - url: The valid Git URL of the package.
     ///   - version: The exact version of the dependency for this requirement.
@@ -769,7 +791,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///   - url: The valid Git URL of the package.
     ///   - version: The exact version of the dependency for this requirement.
-    ///   - traits: The trait configuration of this dependency.  Defaults to enabling the default traits.
+    ///   - traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 6.1)
@@ -855,6 +877,8 @@ extension Package.Dependency {
     /// .package(id: "scope.name", from: "1.2.3"),
     /// ```
     ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
+    ///
     /// - Parameters:
     ///   - id: The identity of the package.
     ///   - version: The minimum version requirement.
@@ -888,7 +912,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///   - id: The identity of the package.
     ///   - version: The minimum version requirement.
-    ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
+    ///   - traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 6.1)
@@ -912,6 +936,8 @@ extension Package.Dependency {
     /// ```swift
     /// .package(id: "scope.name", exact: "1.2.3"),
     /// ```
+    ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
     ///
     /// - Parameters:
     ///   - id: The identity of the package.
@@ -942,7 +968,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///   - id: The identity of the package.
     ///   - version: The exact version of the dependency for this requirement.
-    ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
+    ///   - traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 6.1)
@@ -977,6 +1003,8 @@ extension Package.Dependency {
     /// ```swift
     /// .package(id: "scope.name", .upToNextMinor(from: "1.0.0"),
     /// ```
+    ///
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
     ///
     /// - Parameters:
     ///   - id: The identity of the package.
@@ -1018,7 +1046,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///   - id: The identity of the package.
     ///   - range: The custom version range requirement.
-    ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
+    ///   - traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 6.1)
@@ -1039,6 +1067,8 @@ extension Package.Dependency {
     /// ```swift
     /// .package(id: "scope.name", "1.2.3"..."1.2.6"),
     /// ```
+    /// 
+    /// If the dependency defines traits, the package manager uses the dependency with its default set of traits.
     ///
     /// - Parameters:
     ///   - id: The identity of the package.
@@ -1072,7 +1102,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///   - id: The identity of the package.
     ///   - range: The closed version range requirement.
-    ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
+    ///   - traits: The trait configuration of this dependency. The default value enables the default traits of the package.
     ///
     /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 6.1)

--- a/Sources/PackageDescription/PackageDependencyTrait.swift
+++ b/Sources/PackageDescription/PackageDependencyTrait.swift
@@ -11,13 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 extension Package.Dependency {
-    /// A struct that represents an enabled trait of a dependency.
+    /// An enabled trait of a dependency.
     @available(_PackageDescription, introduced: 6.1)
     public struct Trait: Hashable, Sendable, ExpressibleByStringLiteral {
-        /// Enables all default traits of the dependency..
+        /// Enables all default traits of the dependency.
         public static let defaults = Self.init(name: "default")
 
-        /// A condition that limits the application of a trait for a dependency..
+        /// A condition that limits the application of a trait for a dependency.
         public struct Condition: Hashable, Sendable {
             /// The set of traits that enable the dependencies trait.
             let traits: Set<String>?

--- a/Sources/PackageDescription/PackageDependencyTrait.swift
+++ b/Sources/PackageDescription/PackageDependencyTrait.swift
@@ -11,21 +11,22 @@
 //===----------------------------------------------------------------------===//
 
 extension Package.Dependency {
-    /// A struct representing an enabled trait of a dependency.
+    /// A struct that represents an enabled trait of a dependency.
     @available(_PackageDescription, introduced: 6.1)
     public struct Trait: Hashable, Sendable, ExpressibleByStringLiteral {
-        /// Enables all default traits of a package.
+        /// Enables all default traits of the dependency..
         public static let defaults = Self.init(name: "default")
 
-        /// A condition that limits the application of a dependencies trait.
+        /// A condition that limits the application of a trait for a dependency..
         public struct Condition: Hashable, Sendable {
-            /// The set of traits of this package that enable the dependencie's trait.
+            /// The set of traits that enable the dependencies trait.
             let traits: Set<String>?
 
             /// Creates a package dependency trait condition.
             ///
-            /// - Parameter traits: The set of traits that enable the dependencies trait. If any of the traits are enabled on this package
-            /// the dependencies trait will be enabled.
+            /// If any of the traits you provide are enabled on this package, the package manager enables the dependency to which the condition applies.
+            ///
+            /// - Parameter traits: The set of traits that enable the dependencies trait.
             public static func when(
                 traits: Set<String>
             ) -> Self? {
@@ -39,7 +40,7 @@ extension Package.Dependency {
         /// The condition under which the trait is enabled.
         public var condition: Condition?
 
-        /// Initializes a new enabled trait.
+        /// Creates a new enabled trait.
         ///
         /// - Parameters:
         ///   - name: The name of the enabled trait.
@@ -56,7 +57,7 @@ extension Package.Dependency {
             self.init(name: value)
         }
 
-        /// Initializes a new enabled trait.
+        /// Creates a new enabled trait.
         ///
         /// - Parameters:
         ///   - name: The name of the enabled trait.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Dependency-Trait.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Dependency-Trait.md
@@ -1,0 +1,19 @@
+# ``PackageDescription/Package/Dependency/Trait``
+
+## Topics
+
+### Declaring a Dependency Trait
+
+- ``trait(name:condition:)``
+- ``defaults``
+
+### Creating a Dependency Trait
+
+- ``init(name:condition:)``
+- ``init(stringLiteral:)``
+- ``Condition``
+
+### Inspecting a Dependency Trait
+
+- ``name``
+- ``condition``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Dependency.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Dependency.md
@@ -41,16 +41,12 @@
 - ``Trait``
 - ``RegistryRequirement``
 - ``SourceControlRequirement``
-- ``requirement-swift.property``
-- ``Requirement-swift.enum``
 
 ### Describing a Package Dependency
 
 - ``kind-swift.property``
 - ``Kind``
 - ``Version``
-- ``name``
-- ``url``
 
 ### Deprecated methods
 
@@ -63,3 +59,5 @@
 - ``package(url:_:)-(_,Package.Dependency.Requirement)``
 - ``name``
 - ``url``
+- ``requirement-swift.property``
+- ``Requirement-swift.enum``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Package.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Package.md
@@ -6,11 +6,10 @@
 
 - ``Package/init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageModes:cLanguageStandard:cxxLanguageStandard:)``
 - ``Package/init(name:defaultLocalization:platforms:pkgConfig:providers:products:traits:dependencies:targets:swiftLanguageModes:cLanguageStandard:cxxLanguageStandard:)``
-- ``Package/init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)``
 - ``Package/init(name:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)``
 - ``Package/init(name:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)-(_,_,_,_,_,_,[Int]?,_,_)``
 - ``Package/init(name:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)-(_,_,_,_,_,_,[SwiftVersion]?,_,_)``
-
+- ``Package/init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)``
 
 ### Naming the Package
 

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Trait.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Trait.md
@@ -1,0 +1,20 @@
+# ``PackageDescription/Trait``
+
+## Topics
+
+### Declaring Traits
+
+- ``trait(name:description:enabledTraits:)``
+- ``default(enabledTraits:)``
+
+### Creating Traits
+
+- ``init(name:description:enabledTraits:)``
+- ``init(stringLiteral:)``
+
+### Inspecting Traits
+
+- ``name``
+- ``description``
+- ``enabledTraits``
+

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -97,7 +97,7 @@ public final class Package {
     /// The list of products that this package vends and that clients can use.
     public var products: [Product]
 
-    /// The set of traits of this package.
+    /// The set of traits this package provides.
     @available(_PackageDescription, introduced: 6.1)
     public var traits: Set<Trait>
 
@@ -344,7 +344,7 @@ public final class Package {
     ///   `<name>.pc` file to get the additional flags required for a system target.
     ///   - providers: The package providers for a system target.
     ///   - products: The list of products that this package makes available for clients to use.
-    ///   - traits: The set of traits of this package.
+    ///   - traits: The set of traits this package provides.
     ///   - dependencies: The list of package dependencies.
     ///   - targets: The list of targets that are part of this package.
     ///   - swiftLanguageModes: The list of Swift language modes with which this package is compatible.

--- a/Sources/PackageDescription/Trait.swift
+++ b/Sources/PackageDescription/Trait.swift
@@ -10,11 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A struct representing a package's trait.
+/// A struct that represents a package's trait.
 ///
-/// Traits can be used for expressing conditional compilation and optional dependencies.
+/// Use traits to represent and expose extended API for a package.
+/// When you define a trait on a package, the package manager exposes the name of that trait as a conditional block to conditionally enable imports or code paths.
+/// For example, a trait with the canonical name `MyTrait` allows you to use the name as a conditional block:
 ///
-/// - Important: Traits must be strictly additive and enabling a trait **must not** remove API.
+/// ```swift
+/// #if Trait1
+/// // additional imports or APIs that Trait1 enables
+/// #endif // Trait1
+/// ```
+///
+/// - Important: Traits must be strictly additive. Enabling a trait **must not** remove API.
 @available(_PackageDescription, introduced: 6.1)
 public struct Trait: Hashable, ExpressibleByStringLiteral {
     /// Declares the default traits for this package.
@@ -28,25 +36,25 @@ public struct Trait: Hashable, ExpressibleByStringLiteral {
 
     /// The trait's canonical name.
     ///
-    /// This is used when enabling the trait or when referring to it from other modifiers in the manifest.
+    /// Use the trait's name to enable the trait or when referring to it from other modifiers in the manifest.
     ///
     /// The following rules are enforced on trait names:
     /// - The first character must be a [Unicode XID start character](https://unicode.org/reports/tr31/#Figure_Code_Point_Categories_for_Identifier_Parsing)
     /// (most letters), a digit, or `_`.
     /// - Subsequent characters must be a [Unicode XID continue character](https://unicode.org/reports/tr31/#Figure_Code_Point_Categories_for_Identifier_Parsing)
     /// (a digit, `_`, or most letters), `-`, or `+`.
-    /// - `default` and `defaults` (in any letter casing combination) are not allowed as trait names to avoid confusion with default traits.
+    /// - The names `default` and `defaults` (in any letter casing combination) aren't allowed as trait names to avoid confusion with default traits.
     public var name: String
 
     /// The trait's description.
     ///
-    /// Use this to explain what functionality this trait enables.
+    /// Use the description to explain the functionality the trait enables.
     public var description: String?
 
     /// A set of other traits of this package that this trait enables.
     public var enabledTraits: Set<String>
 
-    /// Initializes a new trait.
+    /// Creates a new trait with a name, and optionally a description and set of enabled traits.
     ///
     /// - Parameters:
     ///   - name: The trait's canonical name.
@@ -62,11 +70,13 @@ public struct Trait: Hashable, ExpressibleByStringLiteral {
         self.enabledTraits = enabledTraits
     }
 
+    /// Creates a trait with the name you provide.
+    /// - Parameter value: The trait's canonical name.
     public init(stringLiteral value: StringLiteralType) {
         self.init(name: value)
     }
 
-    /// Initializes a new trait.
+    /// Creates a new trait with a name, and optionally a description and set of enabled traits.
     ///
     /// - Parameters:
     ///   - name: The trait's canonical name.

--- a/Sources/PackageDescription/Trait.swift
+++ b/Sources/PackageDescription/Trait.swift
@@ -10,9 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A struct that represents a package's trait.
+/// A package trait.
 ///
-/// Use traits to represent and expose extended API for a package.
+/// A trait is a package feature to express conditional compilation and potentially optional dependencies, typically used to expose additional extended API for the package.
+///
 /// When you define a trait on a package, the package manager exposes the name of that trait as a conditional block to conditionally enable imports or code paths.
 /// For example, a trait with the canonical name `MyTrait` allows you to use the name as a conditional block:
 ///

--- a/Sources/PackageManagerDocs/Documentation.docc/AddingDependencies.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/AddingDependencies.md
@@ -1,6 +1,6 @@
 # Adding dependencies to a Swift package
 
-Use other swift packages, system libraries, or binary dependencies in your package.
+Use other Swift packages, system libraries, or binary dependencies in your package.
 
 ## Overview
 
@@ -8,7 +8,7 @@ To depend on another Swift package, define a dependency and the requirements for
 
 A remote dependency requires a location, represented by a URL, and a requirement on the versions the package manager may use.
 
-The following example illustrates a package that depends on [PlayingCard](https://github.com/apple/example-package-playingcard), using `from` to require at least version `3.0.4`, and allow any other version up to the next major version that is available at the time of dependency resolution.
+The following example illustrates a package that depends on [PlayingCard](https://github.com/apple/example-package-playingcard), using `from` to require at least version `4.0.0`, and allow any other version up to the next major version that is available at the time of dependency resolution.
 It then uses the product `PlayingCard` as a dependency for the target `MyPackage`:
 
 ```swift
@@ -19,7 +19,7 @@ let package = Package(
     name: "MyPackage",
     dependencies: [
         .package(url: "https://github.com/apple/example-package-playingcard.git", 
-                 from: "3.0.4"),
+                 from: "4.0.0"),
     ],
     targets: [
         .target(
@@ -43,8 +43,8 @@ For more information on resolving package versions, see <doc:ResolvingPackageVer
 
 ### Constraining dependency versions
 
-Constrain the version of a remote dependency when you when you declare the dependency.
-The package manager uses git tags interpretted as semantic versions to identify eligible versions of packages.
+Constrain the version of a remote dependency when you declare the dependency.
+The package manager uses git tags, each interpreted as a semantic version, to identify eligible versions of packages.
 
 > Note: tags for package versions should include all three components of a semantic version: major, minor, and patch. 
 > Tags that only include one or two of those components are not interpreted as semantic versions.
@@ -52,6 +52,38 @@ The package manager uses git tags interpretted as semantic versions to identify 
 Use the version requirement when you declare the dependency to limit what the package manager can choose.
 The version requirement can be a range of possible semantic versions, a specific semantic version, a branch name, or a commit hash.
 The API reference documentation for [Package.Dependency](https://developer.apple.com/documentation/packagedescription/package/dependency) defines the methods to use.   
+
+### Packages with Traits
+
+Traits, introduced with Swift 6.1, allow packages to offer additional API that may include optional dependencies.
+Packages offer traits to provide expanded API beyond the core of a package.
+For example, a package may provide experimental API, optional API that requires additional dependencies, or otherwise default functionality that a developer may want to disable in specific circumstances.
+If a package offers traits, using that package as a dependency without any declared traits uses the default traits defined by the package.
+In the following example dependency declaration, the package uses the default set of traits from the dependency, if any are defined:
+```swift
+dependencies: [
+  .package(url: "https://github.com/swiftlang/example-package-playingcard", 
+           from: "4.0.0")
+]
+```
+
+To determine what traits a package offers, including its defaults, inspect its `Package.swift` manifest.
+
+Adding a trait should only expand the API offered by a package.
+If a package offers default traits, you can choose to not use those traits by declaring an empty set of traits when you declare the dependency.
+The following example dependency declaration uses the dependency with no traits, even if the package normally provides a set of default traits to enable:
+
+```swift
+dependencies: [
+  .package(url: "https://github.com/swiftlang/example-package-playingcard", 
+           from: "4.0.0",
+           traits: [])
+]
+```
+
+> Note: By disabling any default traits, you may be removing available APIs from the dependency you use. 
+
+To learn how to provide packages with traits, see <doc:PackageTraits>.
 
 ### Local Dependencies
 
@@ -77,6 +109,7 @@ For more information on creating a binary target, see [Creating a multiplatform 
 ## Topics
 
 - <doc:ResolvingPackageVersions>
+- <doc:PackageTraits>
 - <doc:ResolvingDependencyFailures>
 - <doc:AddingSystemLibraryDependency>
 - <doc:ExampleSystemLibraryPkgConfig>

--- a/Sources/PackageManagerDocs/Documentation.docc/Dependencies/PackageTraits.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Dependencies/PackageTraits.md
@@ -1,0 +1,134 @@
+# Provide configurable packages using traits.
+
+Define one or more traits to offer default and configurable features for a package.
+
+Prior to Swift 6.1, packages offered a non-configurable API surface for each version.
+With Swift 6.1, packages may offer traits, which express a configurable API surface from a package.
+
+Use traits to enable additional API that extends beyond the core of what the package provides.
+For example, a trait may enable experimental API, optional extended functionality that requires additional dependencies, or a functionality that isn't critical that a developer may want to disable in specific circumstances.
+
+> Note: Traits should always *enable* additional code, never "remove" or disable API when a trait is enabled.
+
+Within the package, traits express conditional compilation, and may also declare additional dependencies that are enabled when that trait is active.
+
+Traits are identified by their names, which are name-spaced within the package hosting them.
+Trait names must start with a [Unicode XID start character](https://unicode.org/reports/tr31/#Figure_Code_Point_Categories_for_Identifier_Parsing) (most letters), a digit, or `_`, with subsequent characters a [Unicode XID continue character](https://unicode.org/reports/tr31/#Figure_Code_Point_Categories_for_Identifier_Parsing) or the characters `-` or `+`.
+The trait names `default` and `defaults` (regardless of any capitalization) aren't allowed to avoid confusion with the default traits a package defines.
+
+Enabled traits are exposed as conditional blocks (`#if YourTrait`) that you can use to conditionally enable imports or otherwise block out different compilation paths in code.
+
+## Overview
+
+### Declaring Traits
+
+Create a trait to define a discrete amount of additional functionality, and define them in the [traits](https://docs.swift.org/swiftpm/documentation/packagedescription/package/traits) property of the package manifest.
+Use [`.default(enabledTraits:)`](https://docs.swift.org/swiftpm/documentation/packagedescription/trait/default(enabledtraits:)) to provide the set of traits that the package uses as a default.
+If you don't define a default set of traits to enable, no traits are enabled by default.
+
+```swift
+// ...
+traits: [
+    .trait(name: "FeatureA"),
+    .default(enabledTraits: ["FeatureA"]),
+],
+// ...
+```
+
+Traits may also be used to represent a set of other traits, which allows you to group features together.
+The following example illustrates defining three small traits, and an additional trait (`B-and-C`) that enable both traits `FeatureB` and `FeatureC`:
+
+```swift
+// ...
+traits: [
+    .trait(name: "FeatureA"),
+    .trait(name: "FeatureB"),
+    .trait(name: "FeatureC"),
+    .trait(name: "B-and-C", enabledTraits: ["FeatureB", "FeatureC"]).
+    .default(enabledTraits: ["FeatureA"]),
+],
+// ...
+```
+
+> Note: Changing the default set of traits should be considered a major semantic version change, as it can potentially remove API surface. 
+
+#### Mutually Exclusive Traits
+
+The package manifest format doesn't support declaring mutually exclusive traits.
+In the rare case that you need to offer mutually exclusive traits, protect that scenario in code:
+
+```swift
+#if FeatureA && FeatureC
+#error("FeatureA and FeatureC are mutually exclusive")
+#endif // FeatureA && FeatureC
+```
+
+### Using traits in your code
+
+Use the names of traits for conditional compilation.
+Wrap the additional API surface and functionality you offer for specific trait within a conditional compilation block.
+For example, if the trait `FeatureA` is defined and enabled, the following conditional compilation is enabled:
+
+```swift
+#if FeatureA
+public func additionalAPI() {
+  // ...
+}
+#endif // FeatureA
+```
+
+### Using a trait to enable conditional dependencies
+
+You can use a trait to optionally include a dependency, or a dependency with specific traits enabled, for the additional functionality that you expose with a trait.
+To do so, add the dependency you need to the manifest's `dependencies` declaration.
+Then use a conditional dependency that uses the traits defined in the package to add that dependency to a target.
+
+The following example illustrates the relevant portions of a manifest that defines a trait `FeatureB`, a local dependency that defines a trait to enable additional functionality on that dependency, and a conditional flag on the target that uses that dependency for the target when `FeatureB` is enabled:
+
+```swift
+// ...
+traits: [
+    "FeatureB" 
+    // this trait exists only within *this* package
+],
+dependencies: [
+    .package( 
+        path: "../some/local/path",
+        traits: ["DependencyFeatureTrait"] 
+    // this enables the trait DependencyFeatureTrait on 
+    // the local dependency at ../some/local/path.
+    )
+]
+// ... 
+targets: [
+    .target(
+        name: "MyTarget",
+        dependencies: [
+            .product(
+                name: "MyAPI",
+                package: "MyDependency",
+                condition: .when(traits: ["FeatureB"]) 
+    // if the FeatureB trait is enabled in *this* package, then
+    // the `MyAPI` product is included as a dependency for `MyTarget`.
+            )
+        ]
+    ),
+]
+```
+
+With the above example, the following code illustrates wrapping the import that brings in the dependency with the trait's conditional compilation, and later defines more API that uses that dependency:
+
+```swift
+#if FeatureB
+    import MyAPI
+#endif // FeatureB
+
+// ...
+
+#if FeatureB
+    public func additionalAPI() {
+        MyAPI.provideExtraFunctionality()
+        // ...
+    }
+#endif // MyTrait
+```


### PR DESCRIPTION
Adds documentation for the Swift 6.1 traits feature

### Motivation:

- Show how to consume packages that provide traits
- Show how to present traits from your package(s)
- Updating PackageDescription API to use slightly more readable content related to traits.

### Modifications:

- updated PackageDescription API around traits
- added curation (organization) for Traits and Package/Dependency/Traits
- extended `Using Dependencies` article to touch on traits and how to consume packages that provide them
- added an article to share patterns to use when providing a traits from your own package

### Result:

Updated content and one additional article in the central documentation for Swift Package Manager that illustrates how to consume and provide packages with traits.
