### PR TITLE
Add bootstrap option to install without building.

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -121,6 +121,10 @@ def add_global_args(parser):
         "--reconfigure",
         action="store_true",
         help="whether to always reconfigure cmake")
+    parser.add_argument(
+        "--install-only",
+        action="store_true",
+        default=False)
 
 @log_entry_exit
 def add_build_args(parser):
@@ -494,7 +498,10 @@ def test(args):
 @log_entry_exit
 def install(args):
     """Builds SwiftPM, then installs its build products."""
-    build(args)
+    if args.install_only:
+        parse_build_args(args)
+    else:
+        build(args)
 
     # Install swiftpm content in all of the passed prefixes.
     for prefix in args.install_prefixes:


### PR DESCRIPTION
The Utilities/bootstrap process can optionally install swiftpm without rebuilding swiftpm.

### Motivation:

This allows the build action to be decoupled from the install action, so packaging systems that expect to be able to do discrete installation steps post-build can do so cheaply, without having to effectively start the build over from scratch.

This is only intended solely for that use-case, so this is not wired up to other part of the swiftpm build process and defaults to being disabled.

### Modifications:

* Added a new flag to Utilities/bootstrap.
* When the flag is true, build flag are parsed (necessarily) but the build does not occur.

### Result:

No change, other than when the `--install-only` flag is passed and the `install` action is specified, the built swiftpm is installed only, and not rebuilt.
