### PR TITLE
Tests: Migrate PluginsBuildPlanTests to SwiftTesting and augment

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
@@ -13,18 +13,6 @@ import Testing
 
 public func expectFileExists(
     at path: AbsolutePath,
-    sourceLocation: SourceLocation = #_sourceLocation,
-) {
-
-    #expect(
-        localFileSystem.exists(path),
-        "Files '\(path)' does not exist.",
-        sourceLocation: sourceLocation,
-    )
-}
-
-public func expectFileDoesNotExists(
-    at fixturePath: AbsolutePath,
     _ comment: Comment? = nil,
     sourceLocation: SourceLocation = #_sourceLocation,
 ) {
@@ -34,9 +22,39 @@ public func expectFileDoesNotExists(
         } else {
             ""
         }
+    let msgSuffix: String
+    do {
+        msgSuffix = try "Directory contents: \(localFileSystem.getDirectoryContents(path.parentDirectory))"
+    } catch {
+        msgSuffix = ""
+    }
     #expect(
-        !localFileSystem.exists(fixturePath),
-        "\(commentPrefix)\(fixturePath) does not exist",
+        localFileSystem.exists(path),
+        "\(commentPrefix)File '\(path)' does not exist. \(msgSuffix)",
+        sourceLocation: sourceLocation,
+    )
+}
+
+public func expectFileDoesNotExists(
+    at path: AbsolutePath,
+    _ comment: Comment? = nil,
+    sourceLocation: SourceLocation = #_sourceLocation,
+) {
+    let commentPrefix =
+        if let comment {
+            "\(comment): "
+        } else {
+            ""
+        }
+    let msgSuffix: String
+    do {
+        msgSuffix = try "Directory contents: \(localFileSystem.getDirectoryContents(path.parentDirectory))"
+    } catch {
+        msgSuffix = ""
+    }
+    #expect(
+        !localFileSystem.exists(path),
+        "\(commentPrefix)File: '\(path)' was not expected to exist, but does.\(msgSuffix))",
         sourceLocation: sourceLocation,
     )
 }
@@ -54,7 +72,7 @@ public func expectFileIsExecutable(
         }
     #expect(
         localFileSystem.isExecutableFile(fixturePath),
-        "\(commentPrefix)\(fixturePath) does not exist",
+        "\(commentPrefix)File '\(fixturePath)' expected to be executable, but is not.",
         sourceLocation: sourceLocation,
     )
 }
@@ -63,9 +81,15 @@ public func expectDirectoryExists(
     at path: AbsolutePath,
     sourceLocation: SourceLocation = #_sourceLocation,
 ) {
+let msgSuffix: String
+    do {
+        msgSuffix = try "Directory contents: \(localFileSystem.getDirectoryContents(path))"
+    } catch {
+        msgSuffix = ""
+    }
     #expect(
         localFileSystem.isDirectory(path),
-        "Expected directory doesn't exist: \(path)",
+        "Expected directory doesn't exist: '\(path)'. \(msgSuffix)",
         sourceLocation: sourceLocation,
     )
 }
@@ -74,9 +98,15 @@ public func expectDirectoryDoesNotExist(
     at path: AbsolutePath,
     sourceLocation: SourceLocation = #_sourceLocation,
 ) {
+    let msgSuffix: String
+    do {
+        msgSuffix = try "Directory contents: \(localFileSystem.getDirectoryContents(path))"
+    } catch {
+        msgSuffix = ""
+    }
     #expect(
         !localFileSystem.isDirectory(path),
-        "Directory exists unexpectedly: \(path)",
+        "Directory exists unexpectedly: '\(path)'.\(msgSuffix)",
         sourceLocation: sourceLocation,
     )
 }

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -79,6 +79,13 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
+    /// Enabled if toolsupm suported SDK Dependent Tests
+    public static var requiresSDKDependentTestsSupport: Self {
+        enabled("skipping because test environment doesn't support this test") {
+            (try? UserToolchain.default)!.supportsSDKDependentTests()
+        }
+    }
+
     // Enabled if the toolchain has supported features
     public static var supportsSupportedFeatures: Self {
         enabled("skipping because test environment compiler doesn't support `-print-supported-features`") {

--- a/Tests/BuildTests/BuildSystemDelegateTests.swift
+++ b/Tests/BuildTests/BuildSystemDelegateTests.swift
@@ -2,50 +2,94 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import PackageModel
 import _InternalTestSupport
-import XCTest
+import Testing
 
 import var TSCBasic.localFileSystem
 
-final class BuildSystemDelegateTests: XCTestCase {
-    func testDoNotFilterLinkerDiagnostics() async throws {
-        try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
-        try await fixtureXCTest(name: "Miscellaneous/DoNotFilterLinkerDiagnostics") { fixturePath in
-            #if !os(macOS)
-            // These linker diagnostics are only produced on macOS.
-            try XCTSkipIf(true, "test is only supported on macOS")
-            #endif
-            let (fullLog, _) = try await executeSwiftBuild(fixturePath, buildSystem: .native)
-            XCTAssertTrue(fullLog.contains("ld: warning: search path 'foobar' not found"), "log didn't contain expected linker diagnostics")
+@Suite(
+    .tags(
+        .TestSize.large,
+    )
+)
+struct BuildSystemDelegateTests {
+    @Test(
+        .requiresSDKDependentTestsSupport,
+        .requireHostOS(.macOS),  // These linker diagnostics are only produced on macOS.
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+    )
+    func doNotFilterLinkerDiagnostics(
+        data: BuildData,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/DoNotFilterLinkerDiagnostics") { fixturePath in
+            let (stdout, stderr) = try await executeSwiftBuild(
+                fixturePath,
+                configuration: data.config,
+                // extraArgs: ["--verbose"],
+                buildSystem: data.buildSystem,
+            )
+            switch data.buildSystem {
+            case .native:
+                #expect(
+                    stdout.contains("ld: warning: search path 'foobar' not found"),
+                    "log didn't contain expected linker diagnostics.  stderr: '\(stderr)')",
+                )
+            case .swiftbuild:
+                #expect(
+                    stderr.contains("warning: Search path 'foobar' not found"),
+                    "log didn't contain expected linker diagnostics. stderr: '\(stdout)",
+                )
+                #expect(
+                    !stdout.contains("warning: Search path 'foobar' not found"),
+                    "log didn't contain expected linker diagnostics.  stderr: '\(stderr)')",
+                )
+            case .xcode:
+                Issue.record("Test expectation has not be implemented")
+            }
         }
     }
 
-    func testFilterNonFatalCodesignMessages() async throws {
-        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8540: Package fails to build when the test is being executed")
-
-        try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
-        // Note: we can re-use the `TestableExe` fixture here since we just need an executable.
-        #if os(Windows)
-        let executableExt = ".exe"
-        #else
-        let executableExt = ""
-        #endif
-        try await fixtureXCTest(name: "Miscellaneous/TestableExe") { fixturePath in
-            _ = try await executeSwiftBuild(fixturePath, buildSystem: .native)
-            let execPath = fixturePath.appending(components: ".build", "debug", "TestableExe1\(executableExt)")
-            XCTAssertTrue(localFileSystem.exists(execPath), "executable not found at '\(execPath)'")
-            try localFileSystem.removeFileTree(execPath)
-            let (fullLog, _) = try await executeSwiftBuild(fixturePath, buildSystem: .native)
-            XCTAssertFalse(fullLog.contains("replacing existing signature"), "log contained non-fatal codesigning messages")
+    @Test(
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/8540", relationship: .defect),  // Package fails to build when the test is being executed"
+        .requiresSDKDependentTestsSupport,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+    )
+    func filterNonFatalCodesignMessages(
+        data: BuildData,
+    ) async throws {
+        try await withKnownIssue {
+            // Note: we can re-use the `TestableExe` fixture here since we just need an executable.
+            try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
+                _ = try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: data.config,
+                    buildSystem: data.buildSystem,
+                )
+                let execPath = try fixturePath.appending(
+                    components: data.buildSystem.binPath(for: data.config) + [executableName("TestableExe1")]
+                )
+                expectFileExists(at: execPath)
+                try localFileSystem.removeFileTree(execPath)
+                let (stdout, stderr) = try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: data.config,
+                    buildSystem: data.buildSystem,
+                )
+                #expect(!stdout.contains("replacing existing signature"), "log contained non-fatal codesigning messages stderr: '\(stderr)'")
+                #expect(!stderr.contains("replacing existing signature"), "log contained non-fatal codesigning messages. stdout: '\(stdout)'")
+            }
+        } when: {
+            ProcessInfo.hostOperatingSystem == .windows
         }
     }
 }

--- a/Tests/BuildTests/PluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/PluginsBuildPlanTests.swift
@@ -2,91 +2,181 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-
+import Foundation
 import Basics
-import _InternalTestSupport
-@testable import SPMBuildCore
-import XCTest
 import PackageModel
+import Testing
+import _InternalTestSupport
 
-final class PluginsBuildPlanTests: XCTestCase {
-    func testBuildToolsDatabasePath() async throws {
-        try XCTSkipOnWindows(because: "Fails to build the project to due to incorrect Path handling.  Possibly related to https://github.com/swiftlang/swift-package-manager/issues/8511")
+@testable import SPMBuildCore
 
-        try await fixtureXCTest(name: "Miscellaneous/Plugins/MySourceGenPlugin") { fixturePath in
-            let (stdout, _) = try await executeSwiftBuild(fixturePath, buildSystem: .native)
-            XCTAssertMatch(stdout, .contains("Build complete!"))
+@Suite(
+    .serialized,
+    .tags(
+        .TestSize.large,
+    ),
+)
+struct PluginsBuildPlanTests {
+    @Test(
+        .tags(
+            .Feature.Command.Build,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/8511", relationship: .defect), // Fails to build the project to due to incorrect Path handling
+        arguments: BuildConfiguration.allCases,
+    )
+    func buildToolsDatabasePath(
+        config: BuildConfiguration,
+    ) async throws {
+        try await withKnownIssue(isIntermittent: true) {
+        try await fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                configuration: config,
+                buildSystem: .native
+            )
+            #expect(stdout.contains("Build complete!"))
             // FIXME: This is temporary until build of plugin tools is extracted into its own command.
-            XCTAssertTrue(localFileSystem.exists(fixturePath.appending(RelativePath(".build/plugin-tools.db"))))
-            XCTAssertTrue(localFileSystem.exists(fixturePath.appending(RelativePath(".build/build.db"))))
+            #expect(localFileSystem.exists(fixturePath.appending(RelativePath(".build/plugin-tools.db"))))
+            #expect(localFileSystem.exists(fixturePath.appending(RelativePath(".build/build.db"))))
+        }
+        } when: {
+            ProcessInfo.hostOperatingSystem == .windows
         }
     }
 
-    func testCommandPluginDependenciesWhenCrossCompiling() async throws {
-        // Command Plugin dependencies must be built for the host.
-        // This test is only supported on macOS because that is the only
-        // platform on which we can currently be sure of having a viable
-        // cross-compilation environment (arm64->x86_64 or vice versa).
-        // On Linux it is typically only possible to build for the host
-        // environment unless cross-compilation SDKs are being used.
-        #if !os(macOS)
-        try XCTSkipIf(true, "test is only supported on macOS")
-        #endif
-
-        let hostToolchain = try UserToolchain(swiftSDK: .hostSwiftSDK(environment: [:]), environment: [:])
+    @Test(
+        .serialized,
+        .tags(
+            .Feature.Command.Package.CommandPlugin,
+        ),
+        .requireHostOS(.macOS),
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+    )
+    func commandPluginDependenciesWhenNotCrossCompiling(
+        buildData: BuildData,
+    ) async throws {
+        let hostToolchain = try UserToolchain(
+            swiftSDK: .hostSwiftSDK(environment: [:]),
+            environment: [:]
+        )
         let hostTriple = try! hostToolchain.targetTriple.withoutVersion().tripleString
+
+        let hostBinPathSegments = try buildData.buildSystem.binPath(
+            for: buildData.config,
+            triple: hostTriple,
+        )
+        let hostDebugBinPathSegments = try buildData.buildSystem.binPath(
+            for: .debug,
+            triple: hostTriple,
+        )
+        // By default, plugin dependencies are built for the host platform
+        try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+            let hostBinPath: AbsolutePath = fixturePath.appending(components: hostBinPathSegments)
+            let hostDebugBinPath: AbsolutePath = fixturePath.appending(components: hostDebugBinPathSegments)
+            let (stdout, stderr) = try await executeSwiftPackage(
+                fixturePath,
+                configuration: buildData.config,
+                extraArgs: ["-v", "build-plugin-dependency"],
+                buildSystem: buildData.buildSystem,
+            )
+            #expect(stdout.contains("Hello from dependencies-stub"))
+            if buildData.buildSystem == .native {
+                #expect(stderr.contains("Build of product 'plugintool' complete!"))
+            }
+            let pluginToolName: String
+            switch buildData.buildSystem {
+                case .native:
+                pluginToolName = "plugintool-tool"
+                case .swiftbuild:
+                pluginToolName = "plugintool"
+                case .xcode:
+                pluginToolName = ""
+                Issue.record("Test has not been updated for this build system")
+            }
+            expectFileExists(at: hostBinPath.appending(pluginToolName))
+            expectFileExists(at: hostDebugBinPath.appending("placeholder"))
+        }
+    }
+
+    @Test(
+        .serialized,
+        .tags(
+            .Feature.Command.Package.CommandPlugin,
+        ),
+        .requireHostOS(.macOS),
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+    )
+    func commandPluginDependenciesWhenCrossCompiling(
+        buildData: BuildData,
+    ) async throws {
+        let hostToolchain = try UserToolchain(
+            swiftSDK: .hostSwiftSDK(environment: [:]),
+            environment: [:]
+        )
+        // let hostTriple = try! hostToolchain.targetTriple.withoutVersion().tripleString
 
         let x86Triple = "x86_64-apple-macosx"
         let armTriple = "arm64-apple-macosx"
         let targetTriple = hostToolchain.targetTriple.arch == .aarch64 ? x86Triple : armTriple
 
-        // By default, plugin dependencies are built for the host platform
-        try await fixtureXCTest(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
-            let (stdout, stderr) = try await executeSwiftPackage(
-                fixturePath,
-                extraArgs: ["-v", "build-plugin-dependency"],
-                buildSystem: .native,
-            )
-            XCTAssertMatch(stdout, .contains("Hello from dependencies-stub"))
-            XCTAssertMatch(stderr, .contains("Build of product 'plugintool' complete!"))
-            XCTAssertTrue(
-                localFileSystem.exists(
-                    fixturePath.appending(RelativePath(".build/\(hostTriple)/debug/plugintool-tool"))
-                )
-            )
-            XCTAssertTrue(
-                localFileSystem.exists(
-                    fixturePath.appending(RelativePath(".build/\(hostTriple)/debug/placeholder"))
-                )
-            )
-        }
+        let hostBinPathSegments = try buildData.buildSystem.binPath(
+            for: buildData.config,
+        )
+        let targetDebugBinPathSegments = try buildData.buildSystem.binPath(
+            for: .debug,
+            triple: targetTriple,
+        )
 
         // When cross compiling the final product, plugin dependencies should still be built for the host
-        try await fixtureXCTest(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+        try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+            // let hostBinPath: AbsolutePath = fixturePath.appending(components: hostBinPathSegments)
+            let targetDebugBinPath: AbsolutePath = fixturePath.appending(components: targetDebugBinPathSegments)
+            let hostBinPath = try fixturePath.appending(
+                components: buildData.buildSystem.binPath(
+                    for: buildData.config,
+                )
+            )
+            let targetBinPath = try fixturePath.appending(
+                components: buildData.buildSystem.binPath(
+                    for: buildData.config,
+                    triple: targetTriple,
+                )
+            )
             let (stdout, stderr) = try await executeSwiftPackage(
                 fixturePath,
-                extraArgs: ["--triple", targetTriple, "-v", "build-plugin-dependency"],
-                buildSystem: .native,
+                configuration: buildData.config,
+                extraArgs: ["-v", "--triple", targetTriple, "build-plugin-dependency"],
+                buildSystem: buildData.buildSystem,
             )
-            XCTAssertMatch(stdout, .contains("Hello from dependencies-stub"))
-            XCTAssertMatch(stderr, .contains("Build of product 'plugintool' complete!"))
-            XCTAssertTrue(
-                localFileSystem.exists(
-                    fixturePath.appending(RelativePath(".build/\(hostTriple)/debug/plugintool-tool"))
-                )
-            )
-            XCTAssertTrue(
-                localFileSystem.exists(
-                    fixturePath.appending(RelativePath(".build/\(targetTriple)/debug/placeholder"))
-                )
-            )
+            #expect(stdout.contains("Hello from dependencies-stub"))
+            if buildData.buildSystem == .native {
+                #expect(stderr.contains("Build of product 'plugintool' complete!"))
+            }
+            let pluginToolName: String
+            let pluginToolBinPath: AbsolutePath
+            switch buildData.buildSystem {
+                case .native:
+                pluginToolName = "plugintool-tool"
+                pluginToolBinPath = hostBinPath
+                case .swiftbuild:
+                pluginToolName = "plugintool"
+                pluginToolBinPath = targetBinPath
+                case .xcode:
+                pluginToolName = ""
+                pluginToolBinPath = AbsolutePath("/")
+                Issue.record("Test has not been updated for this build system")
+            }
+
+            expectFileExists(at: targetDebugBinPath.appending("placeholder"))
+            expectFileExists(at: pluginToolBinPath.appending(pluginToolName))
         }
     }
+
 }

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -52,7 +52,6 @@ struct SanitierTests {
 }
 
 @Suite(
-    .serialized, // to limit the number of swift executable running.
     .tags(
         Tag.TestSize.large,
         Tag.Feature.Command.Build,
@@ -165,18 +164,11 @@ struct BuildCommandTestCases {
         // Test is not implemented for Xcode build system
         try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
             let fullPath = try resolveSymlinks(fixturePath)
-            
-            let rootScrathPath = fullPath.appending(component: ".build")
-            let targetPath: AbsolutePath
-            if buildSystem == .xcode {
-                targetPath =  rootScrathPath
-            } else {
-                targetPath = try rootScrathPath.appending(component: UserToolchain.default.targetTriple.platformBuildPathComponent)
-            }
+
+            let targetPath = try fullPath.appending(components: buildSystem.binPath(for: configuration))
             let path = try await self.execute(["--show-bin-path"], packagePath: fullPath, configuration: configuration, buildSystem: buildSystem).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(
-                AbsolutePath(path).pathString == targetPath
-                .appending(components: buildSystem.binPathSuffixes(for: configuration)).pathString
+                AbsolutePath(path).pathString == targetPath.pathString
             )
         }
     }
@@ -288,29 +280,19 @@ struct BuildCommandTestCases {
     }
 
     @Test(
-        .SWBINTTODO("Test fails because of a difference in the build layout. This needs to be updated to the expected path"),
         arguments: SupportedBuildSystemOnPlatform, BuildConfiguration.allCases
     )
     func symlink(
         buildSystem: BuildSystemProvider.Kind,
         configuration: BuildConfiguration,
     ) async throws {
-        try await withKnownIssue {
-            try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
-                let fullPath = try resolveSymlinks(fixturePath)
-                let targetPath = try fullPath.appending(components:
-                                                            ".build",
-                                                        UserToolchain.default.targetTriple.platformBuildPathComponent
-                )
-                // Test symlink.
-                let buildDir = fullPath.appending(components: ".build")
-                try await self.execute(packagePath: fullPath, configuration: configuration, buildSystem: buildSystem)
-                let actualDebug = try resolveSymlinks(buildDir.appending(components: buildSystem.binPathSuffixes(for: configuration)))
-                let expectedDebug = targetPath.appending(components: buildSystem.binPathSuffixes(for: configuration))
-                #expect(actualDebug == expectedDebug)
-            }
-        } when: {
-            buildSystem != .native
+        try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
+            let fullPath = try resolveSymlinks(fixturePath)
+            // Test symlink.
+            try await self.execute(packagePath: fullPath, configuration: configuration, buildSystem: buildSystem)
+            let actualDebug = try resolveSymlinks(fullPath.appending(components: buildSystem.binPath(for: configuration)))
+            let expectedDebug = try fullPath.appending(components: buildSystem.binPath(for: configuration))
+            #expect(actualDebug == expectedDebug)
         }
     }
 
@@ -1125,10 +1107,9 @@ struct BuildCommandTestCases {
         return try SupportedBuildSystemOnPlatform.map { buildSystem in
             let triple = try UserToolchain.default.targetTriple.withoutVersion()
             let base = try RelativePath(validating: ".build")
-            let debugFolderComponents = buildSystem.binPathSuffixes(for: .debug)
+            let path = try base.appending(components: buildSystem.binPath(for: .debug, scratchPath: []))
             switch buildSystem {
                 case .xcode:
-                    let path = base.appending(components: debugFolderComponents)
                     return (
                         buildSystem,
                         triple.platformName() == "macosx" ? path.appending("ExecutableNew") : path
@@ -1137,8 +1118,6 @@ struct BuildCommandTestCases {
                             .appending("\(triple).swiftsourceinfo")
                     )
                 case .swiftbuild:
-                    let path = base.appending(triple.tripleString)
-                        .appending(components: debugFolderComponents)
                     return (
                         buildSystem,
                         triple.platformName() == "macosx" ? path.appending("ExecutableNew") : path
@@ -1149,8 +1128,7 @@ struct BuildCommandTestCases {
                 case .native:
                     return (
                         buildSystem,
-                        base.appending(components: debugFolderComponents)
-                            .appending("ExecutableNew.build")
+                        path.appending("ExecutableNew.build")
                             .appending("main.swift.o")
                     )
             }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2348,12 +2348,9 @@ struct PackageCommandTests {
                 )
 
                 // Path to the executable.
+                let binPath = try fooPath.appending(components: data.buildSystem.binPath(for: data.config))
                 let exec = [
-                    fooPath.appending(
-                        components: [
-                            ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent,
-                        ] + data.buildSystem.binPathSuffixes(for: data.config) + ["foo"]
-                    ).pathString
+                    binPath.appending("foo").pathString
                 ]
 
                 // We should see it now in packages directory.
@@ -2489,10 +2486,8 @@ struct PackageCommandTests {
                     buildSystem: data.buildSystem,
                 )
                 let buildPath = packageRoot.appending(".build")
-                let binFile = buildPath.appending(
-                    components: [try UserToolchain.default.targetTriple.platformBuildPathComponent]
-                        + data.buildSystem.binPathSuffixes(for: data.config) + [executableName("Bar")]
-                )
+                let binPath = try buildPath.appending(components: data.buildSystem.binPath(for: data.config, scratchPath: []))
+                let binFile = binPath.appending(executableName("Bar"))
                 expectFileExists(at: binFile)
                 #expect(localFileSystem.isDirectory(buildPath))
 
@@ -2540,10 +2535,8 @@ struct PackageCommandTests {
                     buildSystem: data.buildSystem
                 )
                 let buildPath = packageRoot.appending(".build")
-                let binFile = buildPath.appending(
-                    components: [try UserToolchain.default.targetTriple.platformBuildPathComponent]
-                        + data.buildSystem.binPathSuffixes(for: data.config) + [executableName("Bar")]
-                )
+                let binPath = try buildPath.appending(components: data.buildSystem.binPath(for: data.config, scratchPath: [], ))
+                let binFile = binPath.appending(executableName("Bar"))
                 expectFileExists(at: binFile)
                 #expect(localFileSystem.isDirectory(buildPath))
                 // Clean, and check for removal of the build directory but not Packages.
@@ -2669,15 +2662,9 @@ struct PackageCommandTests {
         try await withKnownIssue(isIntermittent: (ProcessInfo.hostOperatingSystem == .linux)) {
             try await fixture(name: "Miscellaneous/PackageEdit") { fixturePath in
                 let fooPath = fixturePath.appending("foo")
+                let binPath = try fooPath.appending(components: data.buildSystem.binPath(for: data.config))
                 let exec = [
-                    fooPath.appending(
-                        components: [
-                            ".build",
-                            try UserToolchain.default.targetTriple.platformBuildPathComponent,
-                        ] + data.buildSystem.binPathSuffixes(for: data.config) + [
-                            "foo"
-                        ]
-                    ).pathString
+                    binPath.appending("foo").pathString
                 ]
 
                 // Build and check.
@@ -4902,15 +4889,8 @@ struct PackageCommandTests {
         func commandPluginTargetBuilds_BinaryIsBuildinDebugByDefault(
             buildData: BuildData,
         ) async throws {
-            let tripleString = try UserToolchain.default.targetTriple.platformBuildPathComponent
-            let debugTarget =
-                [".build", tripleString] + buildData.buildSystem.binPathSuffixes(for: .debug) + [
-                    executableName("placeholder")
-                ]
-            let releaseTarget =
-                [".build", tripleString] + buildData.buildSystem.binPathSuffixes(for: .release) + [
-                    executableName("placeholder")
-                ]
+            let debugTarget = try buildData.buildSystem.binPath(for: .debug) + [executableName("placeholder")]
+            let releaseTarget = try buildData.buildSystem.binPath(for: .release) + [executableName("placeholder")]
             try await withKnownIssue {
                 // By default, a plugin-requested build produces a debug binary
                 try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
@@ -4940,15 +4920,8 @@ struct PackageCommandTests {
         func commandPluginTargetBuilds_BinaryWillBeBuiltInDebugIfPluginSpecifiesDebugBuild(
             buildData: BuildData,
         ) async throws {
-            let tripleString = try UserToolchain.default.targetTriple.platformBuildPathComponent
-            let debugTarget =
-                [".build", tripleString] + buildData.buildSystem.binPathSuffixes(for: .debug) + [
-                    executableName("placeholder")
-                ]
-            let releaseTarget =
-                [".build", tripleString] + buildData.buildSystem.binPathSuffixes(for: .release) + [
-                    executableName("placeholder")
-                ]
+            let debugTarget = try buildData.buildSystem.binPath(for: .debug) + [executableName("placeholder")]
+            let releaseTarget = try buildData.buildSystem.binPath(for: .release) + [executableName("placeholder")]
             try await withKnownIssue {
                 // If the plugin specifies a debug binary, that is what will be built, regardless of overall configuration
                 try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
@@ -4982,17 +4955,9 @@ struct PackageCommandTests {
         func commandPluginTargetBuilds_BinaryWillBeBuiltInReleaseIfPluginSpecifiesReleaseBuild(
             buildData: BuildData,
         ) async throws {
-            let tripleString = try UserToolchain.default.targetTriple.platformBuildPathComponent
-            let debugTarget =
-                [".build", tripleString] + buildData.buildSystem.binPathSuffixes(for: .debug) + [
-                    executableName("placeholder")
-                ]
-            let releaseTarget =
-                [".build", tripleString] + buildData.buildSystem.binPathSuffixes(for: .release) + [
-                    executableName("placeholder")
-                ]
+            let debugTarget = try buildData.buildSystem.binPath(for: .debug) + [executableName("placeholder")]
+            let releaseTarget = try buildData.buildSystem.binPath(for: .release) + [executableName("placeholder")]
             try await withKnownIssue {
-
                 // If the plugin requests a release binary, that is what will be built, regardless of overall configuration
                 try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
                     let _ = try await execute(
@@ -5024,15 +4989,8 @@ struct PackageCommandTests {
         func commandPluginTargetBuilds_BinaryWillBeBuiltCorrectlyIfPluginSpecifiesInheritBuild(
             buildData: BuildData,
         ) async throws {
-            let tripleString = try UserToolchain.default.targetTriple.platformBuildPathComponent
-            let debugTarget =
-                [".build", tripleString] + buildData.buildSystem.binPathSuffixes(for: .debug) + [
-                    executableName("placeholder")
-                ]
-            let releaseTarget =
-                [".build", tripleString] + buildData.buildSystem.binPathSuffixes(for: .release) + [
-                    executableName("placeholder")
-                ]
+            let debugTarget = try buildData.buildSystem.binPath(for: .debug) + [executableName("placeholder")]
+            let releaseTarget = try buildData.buildSystem.binPath(for: .release) + [executableName("placeholder")]
             try await withKnownIssue {
                 // If the plugin inherits the overall build configuration, that is what will be built
                 try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
@@ -5133,7 +5091,7 @@ struct PackageCommandTests {
                 }
             } when: {
                 ProcessInfo.hostOperatingSystem == .windows
-                || (ProcessInfo.hostOperatingSystem == .linux && data.buildSystem == .swiftbuild)
+                    || (ProcessInfo.hostOperatingSystem == .linux && data.buildSystem == .swiftbuild)
             }
         }
 
@@ -6689,7 +6647,7 @@ struct PackageCommandTests {
                         }
                         #expect(stdout.contains("Building for \(data.config.buildFor)..."))
                     }
-                } when : {
+                } when: {
                     ProcessInfo.hostOperatingSystem == .windows && data.buildSystem == .swiftbuild
                 }
 
@@ -6781,7 +6739,7 @@ struct PackageCommandTests {
         func commandPluginCompilationErrorSwiftBuild(
             data: BuildData,
         ) async throws {
-            // Once this is fix, merge data iunto commandPluginCompilationError 
+            // Once this is fix, merge data iunto commandPluginCompilationError
             await withKnownIssue {
                 try await Self.commandPluginCompilationErrorImplementation(data: data)
             }

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -50,10 +50,8 @@ struct DependencyResolutionTests {
                     buildSystem: buildSystem,
                 )
 
-                let executablePath = try fixturePath.appending(
-                    components: [".build", UserToolchain.default.targetTriple.platformBuildPathComponent]
-                        + buildSystem.binPathSuffixes(for: configuration) + ["Foo"]
-                )
+                let binPath = try fixturePath.appending(components: buildSystem.binPath(for: configuration))
+                let executablePath = binPath.appending(components: "Foo")
                 let output = try await AsyncProcess.checkNonZeroExit(args: executablePath.pathString).withSwiftLineEnding
                 #expect(output == "Foo\nBar\n")
             }
@@ -111,10 +109,8 @@ struct DependencyResolutionTests {
                     buildSystem: buildSystem,
                 )
 
-                let executablePath = try fixturePath.appending(
-                    components: [".build", UserToolchain.default.targetTriple.platformBuildPathComponent]
-                        + buildSystem.binPathSuffixes(for: configuration) + ["Foo"]
-                )
+                let binPath = try fixturePath.appending(components: buildSystem.binPath(for: configuration))
+                let executablePath = binPath.appending(components: "Foo")
                 let output = try await AsyncProcess.checkNonZeroExit(args: executablePath.pathString)
                     .withSwiftLineEnding
                 #expect(output == "meiow Baz\n")
@@ -152,12 +148,8 @@ struct DependencyResolutionTests {
                     configuration: configuration,
                     buildSystem: buildSystem,
                 )
-                let executablePath = packageRoot.appending(
-                    components: [
-                        ".build",
-                        try UserToolchain.default.targetTriple.platformBuildPathComponent,
-                    ] + buildSystem.binPathSuffixes(for: configuration) + [executableName("Bar")]
-                )
+                let binPath = try packageRoot.appending(components: buildSystem.binPath(for: configuration))
+                let executablePath = binPath.appending(components: executableName("Bar"))
                 #expect(
                     localFileSystem.exists(executablePath),
                     "Path \(executablePath) does not exist",
@@ -185,16 +177,15 @@ struct DependencyResolutionTests {
     ) async throws {
         try await withKnownIssue(isIntermittent: ProcessInfo.hostOperatingSystem == .windows){
             try await fixture(name: "DependencyResolution/External/Complex") { fixturePath in
+                let packageRoot = fixturePath.appending("app")
                 try await executeSwiftBuild(
-                    fixturePath.appending("app"),
+                    packageRoot,
                     configuration: configuration,
                     buildSystem: buildSystem,
                 )
-                let executablePath = try fixturePath.appending(
-                    components: [
-                        "app", ".build", UserToolchain.default.targetTriple.platformBuildPathComponent,
-                    ] + buildSystem.binPathSuffixes(for: configuration) + ["Dealer"]
-                )
+                let binPath = try packageRoot.appending(components: buildSystem.binPath(for: configuration))
+                let executablePath = binPath.appending(components: "Dealer")
+                expectFileExists(at: executablePath)
                 let output = try await AsyncProcess.checkNonZeroExit(args: executablePath.pathString)
                     .withSwiftLineEnding
                 #expect(output == "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -39,7 +39,7 @@ struct ModuleAliasingFixtureTests {
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "ModuleAliasing/DirectDeps1") { fixturePath in
                 let pkgPath = fixturePath.appending(components: "AppPkg")
-                let buildPath = pkgPath.appending(components: [".build", try UserToolchain.default.targetTriple.platformBuildPathComponent] + buildSystem.binPathSuffixes(for: configuration))
+                let buildPath = try pkgPath.appending(components: buildSystem.binPath(for: configuration))
                 try await executeSwiftBuild(
                     pkgPath,
                     configuration: configuration,
@@ -82,7 +82,7 @@ struct ModuleAliasingFixtureTests {
         try await withKnownIssue {
         try await fixture(name: "ModuleAliasing/DirectDeps2") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
-            let buildPath = pkgPath.appending(components: [".build", try UserToolchain.default.targetTriple.platformBuildPathComponent] + buildSystem.binPathSuffixes(for: configuration))
+            let buildPath = try pkgPath.appending(components: buildSystem.binPath(for: configuration))
             try await executeSwiftBuild(
                 pkgPath,
                 configuration: configuration,
@@ -117,7 +117,7 @@ struct ModuleAliasingFixtureTests {
         try await withKnownIssue {
         try await fixture(name: "ModuleAliasing/NestedDeps1") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
-            let buildPath = pkgPath.appending(components: [".build", try UserToolchain.default.targetTriple.platformBuildPathComponent] + buildSystem.binPathSuffixes(for: configuration))
+            let buildPath = try pkgPath.appending(components: buildSystem.binPath(for: configuration))
             try await executeSwiftBuild(
                 pkgPath,
                 configuration: configuration,
@@ -156,7 +156,7 @@ struct ModuleAliasingFixtureTests {
         try await withKnownIssue {
         try await fixture(name: "ModuleAliasing/NestedDeps2") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
-            let buildPath = pkgPath.appending(components: [".build", try UserToolchain.default.targetTriple.platformBuildPathComponent] + buildSystem.binPathSuffixes(for: configuration))
+            let buildPath = try pkgPath.appending(components: buildSystem.binPath(for: configuration))
             try await executeSwiftBuild(
                 pkgPath,
                 configuration: configuration,

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -124,7 +124,8 @@ struct ToolsVersionTests {
                     configuration: configuration,
                     buildSystem: buildSystem,
                 )
-                let exe: String = primaryPath.appending(components: [".build", try UserToolchain.default.targetTriple.platformBuildPathComponent] + buildSystem.binPathSuffixes(for: configuration) + ["Primary"]).pathString
+                let binPath = try primaryPath.appending(components: buildSystem.binPath(for: configuration))
+                let exe: String = binPath.appending(components: "Primary").pathString
                 // v1 should get selected because v1.0.1 depends on a (way) higher set of tools.
                 try await withKnownIssue {
                     let executableActualOutput = try await AsyncProcess.checkNonZeroExit(args: exe).spm_chomp()


### PR DESCRIPTION
Migrate the `PluginsBuildPlanTests` suite to Swift Testing and, where applicable, augment the test to run against both the Native and SwiftBuild build system, in addition to the `debug` and `release` build configurations.

Depends on: #9013
Relates to: #8997
issue: rdar://157669245