### PR TITLE
[Commands] Adopt changes to package manifest refactoring actions

### DIFF
--- a/Sources/Commands/PackageCommands/AddDependency.swift
+++ b/Sources/Commands/PackageCommands/AddDependency.swift
@@ -255,7 +255,7 @@ extension SwiftPackageCommand {
                 }
             }
 
-            let editResult = try AddPackageDependency.manifestRefactor(
+            let editResult = try AddPackageDependency.textRefactor(
                 syntax: manifestSyntax,
                 in: .init(dependency: packageDependency)
             )

--- a/Sources/Commands/PackageCommands/AddProduct.swift
+++ b/Sources/Commands/PackageCommands/AddProduct.swift
@@ -93,7 +93,7 @@ extension SwiftPackageCommand {
                 targets: targets
             )
 
-            let editResult = try SwiftRefactor.AddProduct.manifestRefactor(
+            let editResult = try SwiftRefactor.AddProduct.textRefactor(
                 syntax: manifestSyntax,
                 in: .init(product: product)
             )

--- a/Sources/Commands/PackageCommands/AddSetting.swift
+++ b/Sources/Commands/PackageCommands/AddSetting.swift
@@ -126,7 +126,7 @@ extension SwiftPackageCommand {
                     }
                 }
 
-                let editResult: PackageEdit
+                let editResult: [SourceEdit]
 
                 switch setting {
                 case .experimentalFeature:

--- a/Sources/Commands/PackageCommands/AddTarget.swift
+++ b/Sources/Commands/PackageCommands/AddTarget.swift
@@ -129,7 +129,8 @@ extension SwiftPackageCommand {
                 url: url,
                 checksum: checksum
             )
-            let editResult = try AddPackageTarget.manifestRefactor(
+
+            let editResult = try AddPackageTarget.textRefactor(
                 syntax: manifestSyntax,
                 in: .init(
                     target: target,

--- a/Sources/Commands/PackageCommands/AddTargetDependency.swift
+++ b/Sources/Commands/PackageCommands/AddTargetDependency.swift
@@ -73,7 +73,7 @@ extension SwiftPackageCommand {
                 dependency = .target(name: dependencyName)
             }
 
-            let editResult = try SwiftRefactor.AddTargetDependency.manifestRefactor(
+            let editResult = try SwiftRefactor.AddTargetDependency.textRefactor(
                 syntax: manifestSyntax,
                 in: .init(
                     dependency: dependency,

--- a/Sources/Commands/Utilities/RefactoringSupport.swift
+++ b/Sources/Commands/Utilities/RefactoringSupport.swift
@@ -15,7 +15,7 @@ import Basics
 @_spi(PackageRefactor) import SwiftRefactor
 import SwiftSyntax
 
-package extension PackageEdit {
+package extension [SourceEdit] {
     /// Apply the edits for the given manifest to the specified file system,
     /// updating the manifest to the given manifest
     func applyEdits(
@@ -32,7 +32,7 @@ package extension PackageEdit {
         }
 
         let updatedManifestSource = FixItApplier.apply(
-            edits: manifestEdits,
+            edits: self,
             to: manifest
         )
         try filesystem.writeFileContents(


### PR DESCRIPTION
### Motivation:

Previously package manifest refactoring actions conformed to a custom refactoring provider and produced a `PackageEdit` that, in addition to manifest file changes, included a list of auxiliary files. This is no longer the case and all package manifest refactoring actions are now responsible only for manifest file transformations, the rest is handled by the commands themselves.

### Modifications:

- Updates package refactoring commands to use `textRefactor` instead of (now removed) `manifestRefactor.
- Switches `applyEdits` to be on `[SourceEdit]` instead of a custom type.
