### PR TITLE
Use local dependencies in `build-using-self`

### DIFF
--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -141,6 +141,7 @@ def set_environment(
     swiftpm_bin_dir: pathlib.Path,
 ) -> None:
     os.environ["SWIFTCI_IS_SELF_HOSTED"] = "1"
+    os.environ["SWIFTCI_USE_LOCAL_DEPS"] = "1"
 
     # Ensure SDKROOT is configure
     if is_on_darwin():


### PR DESCRIPTION
Cross PR testing only works when using update-checkout and local dependencies. Update `build-using-self` to pass `SWIFTCI_USE_LOCAL_DEPS` so that we're not re-fetching (possibly incorrect) dependencies.