### PR TITLE
[WIP] Emit output from SwiftBuild tasks

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -533,13 +533,20 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                         case .targetStarted(let info):
                             try buildState.started(target: info)
                         case .planningOperationStarted, .planningOperationCompleted, .reportBuildDescription, .reportPathMap, .preparedForIndex, .backtraceFrame, .buildStarted, .preparationComplete, .targetUpToDate, .targetComplete, .taskUpToDate:
+                            // TODO bp print out every message here for investigation (--vv)
+                            self.observabilityScope.emit(error: "Unhandled message: \(message)")
                             break
                         case .buildDiagnostic, .targetDiagnostic, .taskDiagnostic:
                             break // deprecated
                         case .buildOutput, .targetOutput, .taskOutput:
                             break // deprecated
-                        @unknown default:
-                            break
+
+//                        default:
+//                            self.outputStream.send(<#T##value: ArraySlice<UInt8>##ArraySlice<UInt8>#>)
+//                            self.observabilityScope.emit(info: "\(message)")
+//                        @unknown default:
+//                            break
+                            // TODO bp print(message) instead of switch
                         }
                     }
 


### PR DESCRIPTION
WIP: an investigation into what logs/diagnostics are being emitted currently for SwiftBuild, and what it may be missing.

**TODO:**
- Determine which tasks should emit output
- Formalize verbosity levels for each type of task output, if necessary
- Investigate progress animation and the text output compared to native build system