### PR TITLE
[6.2.1][cherrypick]Add bootstrap option to install without building.

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -121,6 +121,10 @@ def add_global_args(parser):
         "--reconfigure",
         action="store_true",
         help="whether to always reconfigure cmake")
+    parser.add_argument(
+        "--install-only",
+        action="store_true",
+        default=False)
 
 @log_entry_exit
 def add_build_args(parser):
@@ -494,7 +498,10 @@ def test(args):
 @log_entry_exit
 def install(args):
     """Builds SwiftPM, then installs its build products."""
-    build(args)
+    if args.install_only:
+        parse_build_args(args)
+    else:
+        build(args)
 
     # Install swiftpm content in all of the passed prefixes.
     for prefix in args.install_prefixes:


### PR DESCRIPTION
- **Explanation**:

This allows the build action to be decoupled from the install action, so packaging systems that expect to be able to do discrete installation steps post-build can do so cheaply, without having to effectively start the build over from scratch.

This is only intended solely for that use-case, so this is not wired up to other part of the swiftpm build process and defaults to being disabled.

- **Scope**:

Makes a change to the bootstrap wrapper, so no behavioral changes by default.

- **Issues**:

Relevant to OpenBSD port in swiftlang/swift#78437

- **Original PRs**:

#9050 

- **Risk**:

Minimal, since there are no behavioral changes by default.

- **Testing**:

Passed CI.

- **Reviewers**:

@jakepetroules 