### PR TITLE
swift test: Fix incorrect `wasmkit` arguments

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -966,6 +966,9 @@ final class TestRunner {
             args.append(runnerPath.pathString)
             args.append(contentsOf: runner.extraCLIOptions)
             args.append(testPath.relative(to: localFileSystem.currentWorkingDirectory!).pathString)
+            if runner.path?.components.last == "wasmkit" {
+                args.append("--")
+            }
             args.append(contentsOf: self.additionalArguments)
         } else {
 #if os(macOS)

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -966,9 +966,6 @@ final class TestRunner {
             args.append(runnerPath.pathString)
             args.append(contentsOf: runner.extraCLIOptions)
             args.append(testPath.relative(to: localFileSystem.currentWorkingDirectory!).pathString)
-            if runner.path?.components.last == "wasmkit" {
-                args.append("--")
-            }
             args.append(contentsOf: self.additionalArguments)
         } else {
 #if os(macOS)

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -896,7 +896,7 @@ extension SwiftSDK {
     ) throws -> [SwiftSDK] {
         let wasmKitProperties = Toolset.ToolProperties(
             path: hostToolchainBinDir.appending("wasmkit"),
-            extraCLIOptions: ["run"]
+            extraCLIOptions: ["run", "--dir", "."]
         )
 
         switch semanticVersion.schemaVersion {

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -578,7 +578,7 @@ final class SwiftSDKTests: XCTestCase {
 
         let wasmKitProperties = Toolset.ToolProperties(
             path: toolchainBinAbsolutePath.appending("wasmkit"),
-            extraCLIOptions: ["run"]
+            extraCLIOptions: ["run", "--dir", "."]
         )
         XCTAssertEqual(wasiWithoutToolsetsDecoded[0].toolset.knownTools[.debugger], wasmKitProperties)
 


### PR DESCRIPTION
`wasmkit` expects executable arguments to be passed after `--` delimiter. Additionally, we need to bridge current directory to the host with the additional `--dir .` option.

Fixed https://github.com/swiftlang/swift-package-manager/issues/9113

rdar://160218251