### PR TITLE
Test: Update test expectation to be more flexible

### DIFF
--- a/Tests/BuildTests/BuildSystemDelegateTests.swift
+++ b/Tests/BuildTests/BuildSystemDelegateTests.swift
@@ -45,12 +45,13 @@ struct BuildSystemDelegateTests {
                     "log didn't contain expected linker diagnostics.  stderr: '\(stderr)')",
                 )
             case .swiftbuild:
+                let searchPathRegex = try Regex("warning:(.*)Search path 'foobar' not found")
                 #expect(
-                    stderr.contains("warning: Search path 'foobar' not found"),
+                    stderr.contains(searchPathRegex),
                     "log didn't contain expected linker diagnostics. stderr: '\(stdout)",
                 )
                 #expect(
-                    !stdout.contains("warning: Search path 'foobar' not found"),
+                    !stdout.contains(searchPathRegex),
                     "log didn't contain expected linker diagnostics.  stderr: '\(stderr)')",
                 )
             case .xcode:


### PR DESCRIPTION
A test recently started failing as the expected output now contains a file path.  Update the impacted test to be more robust to such a change as SwiftPM does not generate this output.
