### PR TITLE
[Bootstrap] Add an extra argument to set a library path.

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -168,6 +168,9 @@ def add_build_args(parser):
         action="store_true",
         help="whether to link to the llbuild framework")
     parser.add_argument(
+        "--extra-dynamic-library-path",
+        help="path to add to DYLD/LD_LIBRARY_PATH",
+    parser.add_argument(
         "--release",
         action="store_true",
         help="enables building SwiftPM in release mode")
@@ -890,6 +893,9 @@ def get_swiftpm_env_cmd(args):
             os.path.join(args.build_dirs["swift-certificates"],    "lib"),
             os.path.join(args.build_dirs["swift-build"],           "lib"),
         ]
+
+        if args.extra_dynamic_library_path:
+            libs.append(args.extra_dynamic_library_path)
 
         if platform.system() == 'Darwin':
             env_cmd.append("DYLD_LIBRARY_PATH=%s" % ":".join(libs))


### PR DESCRIPTION
During Swift PR testing, we run the SwiftPM tests.  Unfortunately, the SwiftPM tests always try to link with the system version of the Swift runtime libraries.  This would be fine, except that Swift Testing has been built against the *new* runtimes and as a result has ended up referencing symbols from them that might not be present in the system runtime libraries.

To fix this, add an extra argument to allow us to add to the `DYLD_LIBRARY_PATH` setting SwiftPM uses to run its tests.

rdar://160273124
