### PR TITLE
fix builtArtifacts for products from dependencies

### DIFF
--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -184,7 +184,7 @@ final class PluginDelegate: PluginInvocationDelegate {
 
         var builtArtifacts: [PluginInvocationBuildResult.BuiltArtifact] = []
 
-        for rootPkg in packageGraph.rootPackages {
+        for rootPkg in packageGraph.packages {
             let builtProducts = rootPkg.products.filter {
                 switch subset {
                 case .all(let includingTests):


### PR DESCRIPTION
Traverse all `packages` in package graph.

### Motivation:

As described in this [issue](https://github.com/swiftlang/swift-package-manager/issues/9119) this is an attempt to fix the regression.

### Modifications:

Traverse all `packages` instead of only `root packages` to be able to populate `builtArfifacts` from products from dependencies.

### Result:

Building products from dependencies inside command plugin works again.
