### PR TITLE
[Tests] Consolidate expectThrowsCommandExecutionError usage

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
@@ -123,7 +123,7 @@ private func runCommandExpectingError<T>(
     _ message: @autoclosure () -> Comment = "",
     sourceLocation: SourceLocation
 ) async -> CommandExecutionError? {
-    let error = await #expect(throws: SwiftPMError.self, sourceLocation: sourceLocation) {
+    let error: SwiftPMError? = await #expect(throws: SwiftPMError.self, sourceLocation: sourceLocation) {
         try await expression()
     }
 

--- a/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
@@ -134,7 +134,8 @@ private func _expectThrowsCommandExecutionError<R>(
         try await expressionClosure()
     }
 
-    guard case .executionFailure(let processError, let stdout, let stderr) = error,
+    guard let error = error,
+          case .executionFailure(let processError, let stdout, let stderr) = error,
           case AsyncProcessResult.Error.nonZeroExit(let processResult) = processError,
           processResult.exitStatus != .terminated(code: 0) else {
         Issue.record("Unexpected error type: \(error?.interpolationDescription ?? "<unknown>")", sourceLocation: sourceLocation)

--- a/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
@@ -124,21 +124,21 @@ public func expectThrowsCommandExecutionError<T>(
     }
 }
 
-private func _expectThrowsCommandExecutionError<R>(
-    _ expressionClosure: () async throws -> Any,
+private func _expectThrowsCommandExecutionError<R, T>(
+    _ expressionClosure: () async throws -> T,
     _ message: () -> Comment,
     sourceLocation: SourceLocation,
     _ errorHandler: (_ error: CommandExecutionError) throws -> R
 ) async rethrows -> R? {
-    let error = await #expect(throws: SwiftPMError.self, message(), sourceLocation: sourceLocation) {
+    let err = await #expect(throws: SwiftPMError.self, message(), sourceLocation: sourceLocation) {
         try await expressionClosure()
     }
 
-    guard let error = error,
+    guard let error = err,
           case .executionFailure(let processError, let stdout, let stderr) = error,
           case AsyncProcessResult.Error.nonZeroExit(let processResult) = processError,
           processResult.exitStatus != .terminated(code: 0) else {
-        Issue.record("Unexpected error type: \(error?.interpolationDescription ?? "<unknown>")", sourceLocation: sourceLocation)
+        Issue.record("Unexpected error type: \(err?.interpolationDescription ?? "<unknown>")", sourceLocation: sourceLocation)
         return nil
     }
     return try errorHandler(CommandExecutionError(result: processResult, stdout: stdout, stderr: stderr))

--- a/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
@@ -121,11 +121,6 @@ private func _expectThrowsCommandExecutionError<R, T>(
     _ sourceLocation: SourceLocation,
     _ errorHandler: (_ error: CommandExecutionError) throws -> R
 ) async rethrows -> R? {
-    #if compiler(>=6.1)
-    let err = await #expect(throws: SwiftPMError.self, message(), sourceLocation: sourceLocation) {
-        try await expressionClosure()
-    }
-    #else
     // Older toolchains don't have https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0006-return-errors-from-expect-throws.md
     // This can be removed once the CI smoke jobs build with 6.2.
     var err: SwiftPMError?
@@ -137,7 +132,6 @@ private func _expectThrowsCommandExecutionError<R, T>(
             throw error
         }
     }
-    #endif
 
     guard let error = err,
           case .executionFailure(let processError, let stdout, let stderr) = error,


### PR DESCRIPTION
- Add throwing and non-throwing overloads for expectThrowsCommandExecutionError in SwiftTesting+Helpers
- Remove duplicate implementation from APIDiffTests
- Simplify call sites by using appropriate overload without unnecessary `try`s where appropriate
