### PR TITLE
[test] Fix testExamplePackageDealer

### DIFF
--- a/Tests/IntegrationTests/BasicTests.swift
+++ b/Tests/IntegrationTests/BasicTests.swift
@@ -40,6 +40,12 @@ private struct BasicTests {
                     try sh("git\(ProcessInfo.exeSuffix)", "clone", "https://github.com/apple/example-package-dealer", packagePath)
                 #endif
             }
+
+            // Do not run the test when the git clone operation failed
+            if !FileManager.default.fileExists(atPath: packagePath.pathString) {
+                return
+            }
+
             let build1Output = try await executeSwiftBuild(
                 packagePath,
                 buildSystem: .native,

--- a/Tests/IntegrationTests/BasicTests.swift
+++ b/Tests/IntegrationTests/BasicTests.swift
@@ -32,7 +32,7 @@ private struct BasicTests {
             let packagePath = tempDir.appending(component: "dealer")
             withKnownIssue(isIntermittent: true) {
                 // marking as withKnownIssue(intermittent: trye) as git operation can fail.
-                try sh("git\(ProcessInfo.exeSuffix)", "clone", "https://github.com/apple/example-package-dealer", packagePath, env: ["HOME": tempDir.dirname])
+                try sh("git\(ProcessInfo.exeSuffix)", "clone", "https://github.com/apple/example-package-dealer", packagePath)
             }
             let build1Output = try await executeSwiftBuild(
                 packagePath,

--- a/Tests/IntegrationTests/BasicTests.swift
+++ b/Tests/IntegrationTests/BasicTests.swift
@@ -31,8 +31,14 @@ private struct BasicTests {
         try await withTemporaryDirectory { tempDir in
             let packagePath = tempDir.appending(component: "dealer")
             withKnownIssue(isIntermittent: true) {
-                // marking as withKnownIssue(intermittent: trye) as git operation can fail.
-                try sh("git\(ProcessInfo.exeSuffix)", "clone", "https://github.com/apple/example-package-dealer", packagePath)
+                // marking as withKnownIssue(intermittent: true) as git operation can fail.
+
+                #if os(macOS)
+                    // On macOS, we add the HOME variable to avoid git errors.                
+                    try sh("git\(ProcessInfo.exeSuffix)", "clone", "https://github.com/apple/example-package-dealer", packagePath, env: ["HOME": tempDir.pathString])
+                #else
+                    try sh("git\(ProcessInfo.exeSuffix)", "clone", "https://github.com/apple/example-package-dealer", packagePath)
+                #endif
             }
             let build1Output = try await executeSwiftBuild(
                 packagePath,

--- a/Tests/IntegrationTests/BasicTests.swift
+++ b/Tests/IntegrationTests/BasicTests.swift
@@ -30,19 +30,23 @@ private struct BasicTests {
     func testExamplePackageDealer() async throws {
         try await withTemporaryDirectory { tempDir in
             let packagePath = tempDir.appending(component: "dealer")
+            let repoToClone = "https://github.com/swiftlang/example-package-dealer"
             withKnownIssue(isIntermittent: true) {
                 // marking as withKnownIssue(intermittent: true) as git operation can fail.
 
                 #if os(macOS)
-                    // On macOS, we add the HOME variable to avoid git errors.                
-                    try sh("git\(ProcessInfo.exeSuffix)", "clone", "https://github.com/apple/example-package-dealer", packagePath, env: ["HOME": tempDir.pathString])
+                    // On macOS, we add the HOME variable to avoid git errors.
+                    try sh("git\(ProcessInfo.exeSuffix)", "clone", repoToClone, packagePath, env: ["HOME": tempDir.pathString])
                 #else
-                    try sh("git\(ProcessInfo.exeSuffix)", "clone", "https://github.com/apple/example-package-dealer", packagePath)
+                    try sh("git\(ProcessInfo.exeSuffix)", "clone", repoToClone, packagePath)
                 #endif
             }
 
             // Do not run the test when the git clone operation failed
             if !FileManager.default.fileExists(atPath: packagePath.pathString) {
+                #if compiler(>=6.3)
+                    Issue.record("Can't clone the repository \(repoToClone), abording the test.", severity: .warning)
+                #endif
                 return
             }
 

--- a/Tests/IntegrationTests/BasicTests.swift
+++ b/Tests/IntegrationTests/BasicTests.swift
@@ -44,6 +44,8 @@ private struct BasicTests {
 
             // Do not run the test when the git clone operation failed
             if !FileManager.default.fileExists(atPath: packagePath.pathString) {
+                //TODO: use Test Cancellation when available
+                //https://forums.swift.org/t/pitch-test-cancellation/81847/18
                 #if compiler(>=6.3)
                     Issue.record("Can't clone the repository \(repoToClone), abording the test.", severity: .warning)
                 #endif


### PR DESCRIPTION
The test `testExamplePackageDealer` was failing on Amazon Linux and not in Swift.org's CI 
See https://github.com/swiftlang/swift-package-manager/issues/9126

### Motivation:

The reason why the test is working on Swift.org's CI is because it silently ignores outbound connection issues.  The test fails to clone the project on github.com and silently stops.

When the clone operation succeed, the test fails. This is the case on macOS and Amazon Linux 2023, probably others OSes too.

### Modifications:

I observed multiple problems in this test.

1. the test was not marked `async` and the `withTemporaryDirectory` was not await. The test completed execution before the `git clone` operation finished.

2. The `git clone` operation requires an environment variable `HOME` to be defined

3. On Swift 6.1 and later, the second build recompiles the plugins. There are some lines `Compiling plugin` that are valid and should not fail the test.

Here is an example of a valid output. It contains `Compiling plugin`
```
➜  example-package-dealer git:(main) ✗ swift build > output.txt 2>&1
➜  example-package-dealer git:(main) ✗ cat output.txt 
[0/1] Planning build
[1/1] Compiling plugin GenerateManual
[2/2] Compiling plugin GenerateDoccReference
Building for debugging...
[2/5] Write swift-version-1FA6DEBB9BBC2F77.txt
Build complete! (1.01s)
➜  example-package-dealer git:(main) ✗ swift --version 
Apple Swift version 6.1.2 (swift-6.1.2-RELEASE)
Target: arm64-apple-macosx15.0
```

### Result:

The test passes on macOS and Amazon Linux 2023

```
✗ swift test --filter testExamplePackageDealer
Building for debugging...
[9/9] Linking SwiftPMPackageTests
Build complete! (12.99s)
Test Suite 'Selected tests' started at 2025-09-12 21:04:15.723.
Test Suite 'SwiftPMPackageTests.xctest' started at 2025-09-12 21:04:15.727.
Test Suite 'SwiftPMPackageTests.xctest' passed at 2025-09-12 21:04:15.727.
         Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'Selected tests' passed at 2025-09-12 21:04:15.727.
         Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.004) seconds
􀟈  Test run started.
􀄵  Testing Library Version: 6.1.2 (d6b70f9ef9eb207)
􀄵  Target Platform: arm64-apple-macosx
􀟈  Suite BasicTests started.
􀟈  Test testExamplePackageDealer() started.
􁁛  Test testExamplePackageDealer() passed after 17.278 seconds.
􁁛  Suite BasicTests passed after 17.279 seconds.
􁁛  Test run with 1 test passed after 17.279 seconds.
```
