### PR TITLE
SwiftBuild: Support Module aliasing

### DIFF
--- a/Fixtures/ModuleAliasing/DirectDeps2/AppPkg/Package.swift
+++ b/Fixtures/ModuleAliasing/DirectDeps2/AppPkg/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
                          package: "Bpkg",
                          moduleAliases: ["Utils": "BUtils"]
                         )
-            ]),
+            ]
+        ),
     ]
 )
 

--- a/Sources/PackageGraph/Resolution/ResolvedProduct.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedProduct.swift
@@ -179,7 +179,7 @@ public struct ResolvedProduct {
 
 extension ResolvedProduct: CustomStringConvertible {
     public var description: String {
-        "<ResolvedProduct: \(self.name), \(self.type)>"
+        "<ResolvedProduct: \(self.packageIdentity), \(self.name), \(self.type)>"
     }
 }
 

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -30,32 +30,39 @@ struct ModuleAliasingFixtureTests {
         .tags(
             Tag.Feature.Command.Build,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
     func moduleDirectDeps1(
-        buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
+        data: BuildData,
     ) async throws {
+        let buildSystem = data.buildSystem
+        let configuration = data.config
+
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "ModuleAliasing/DirectDeps1") { fixturePath in
                 let pkgPath = fixturePath.appending(components: "AppPkg")
                 let buildPath = try pkgPath.appending(components: buildSystem.binPath(for: configuration))
+                let expectedModules = [
+                    "GameUtils.swiftmodule",
+                    "Utils.swiftmodule",
+                ]
                 try await executeSwiftBuild(
                     pkgPath,
                     configuration: configuration,
                     extraArgs: ["--vv"],
                     buildSystem: buildSystem,
                 )
+
                 expectFileExists(at: buildPath.appending(components: executableName("App")))
-                switch buildSystem {
+                for file in expectedModules {
+                    switch buildSystem {
                     case .native:
-                        expectFileExists(at: buildPath.appending(components: "Modules", "GameUtils.swiftmodule"))
-                        expectFileExists(at: buildPath.appending(components: "Modules", "Utils.swiftmodule"))
+                        expectFileExists(at: buildPath.appending(components: "Modules", file))
                     case .swiftbuild:
-                        expectFileExists(at: buildPath.appending(components: "GameUtils.swiftmodule"))
-                        expectFileExists(at: buildPath.appending(components: "Utils.swiftmodule"))
+                        expectFileExists(at: buildPath.appending(components: file))
                     case .xcode:
-                        #expect(Bool(false), "expectations are not implemented")
+                        Issue.record("expectations are not implemented")
+                    }
                 }
                 _ = try await executeSwiftBuild(
                     pkgPath,
@@ -67,22 +74,30 @@ struct ModuleAliasingFixtureTests {
             ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
         }
     }
-    
+
     @Test(
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8987", relationship: .defect),
+        .issue("https://github.com/swiftlang/swift-package-manager/pull/9130", relationship: .fixedBy),
+        .IssueWindowsLongPath,
+        .IssueWindowsCannotSaveAttachment,
         .tags(
             Tag.Feature.Command.Build,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
     func moduleDirectDeps2(
-        buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
+        data: BuildData
     ) async throws {
-        try await withKnownIssue {
+        let buildSystem = data.buildSystem
+        let configuration = data.config
+        try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "ModuleAliasing/DirectDeps2") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
             let buildPath = try pkgPath.appending(components: buildSystem.binPath(for: configuration))
+            let expectedModules = [
+                "AUtils.swiftmodule",
+                "BUtils.swiftmodule",
+            ]
             try await executeSwiftBuild(
                 pkgPath,
                 configuration: configuration,
@@ -90,8 +105,16 @@ struct ModuleAliasingFixtureTests {
                 buildSystem: buildSystem,
             )
             expectFileExists(at: buildPath.appending(components: executableName("App")))
-            expectFileExists(at: buildPath.appending(components: "Modules", "AUtils.swiftmodule"))
-            expectFileExists(at: buildPath.appending(components: "Modules", "BUtils.swiftmodule"))
+            for file in expectedModules {
+                switch buildSystem {
+                case .native:
+                    expectFileExists(at: buildPath.appending(components: "Modules", file))
+                case .swiftbuild:
+                    expectFileExists(at: buildPath.appending(components: file))
+                case .xcode:
+                    Issue.record("expectations are not implemented")
+                }
+            }
             _ = try await executeSwiftBuild(
                 pkgPath,
                 configuration: configuration,
@@ -99,25 +122,37 @@ struct ModuleAliasingFixtureTests {
             )
         }
         } when: {
-            buildSystem == .swiftbuild
+            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
         }
     }
-    
+
     @Test(
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8987", relationship: .defect),
+        .issue("https://github.com/swiftlang/swift-package-manager/pull/9130", relationship: .fixedBy),
+        .IssueWindowsLongPath,
+        .IssueWindowsCannotSaveAttachment,
         .tags(
             Tag.Feature.Command.Build,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
     func moduleNestedDeps1(
-        buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
+        data: BuildData,
     ) async throws {
-        try await withKnownIssue {
+        let buildSystem = data.buildSystem
+        let configuration = data.config
+        try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "ModuleAliasing/NestedDeps1") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
             let buildPath = try pkgPath.appending(components: buildSystem.binPath(for: configuration))
+            let expectedModules = [
+                "A.swiftmodule",
+                "AFooUtils.swiftmodule",
+                "CarUtils.swiftmodule",
+                "X.swiftmodule",
+                "XFooUtils.swiftmodule",
+                "XUtils.swiftmodule",
+            ]
             try await executeSwiftBuild(
                 pkgPath,
                 configuration: configuration,
@@ -125,12 +160,17 @@ struct ModuleAliasingFixtureTests {
                 buildSystem: buildSystem,
             )
             expectFileExists(at: buildPath.appending(components: executableName("App")))
-            expectFileExists(at: buildPath.appending(components: "Modules", "A.swiftmodule"))
-            expectFileExists(at: buildPath.appending(components: "Modules", "AFooUtils.swiftmodule"))
-            expectFileExists(at: buildPath.appending(components: "Modules", "CarUtils.swiftmodule"))
-            expectFileExists(at: buildPath.appending(components: "Modules", "X.swiftmodule"))
-            expectFileExists(at: buildPath.appending(components: "Modules", "XFooUtils.swiftmodule"))
-            expectFileExists(at: buildPath.appending(components: "Modules", "XUtils.swiftmodule"))
+            for file in expectedModules {
+                switch buildSystem {
+                case .native:
+                    expectFileExists(at: buildPath.appending(components: "Modules", file))
+                case .swiftbuild:
+                    expectFileExists(at: buildPath.appending(components: file))
+                case .xcode:
+                    Issue.record("expectations are not implemented")
+                }
+            }
+
             _ = try await executeSwiftBuild(
                 pkgPath,
                 configuration: configuration,
@@ -138,22 +178,26 @@ struct ModuleAliasingFixtureTests {
             )
         }
         } when: {
-            buildSystem == .swiftbuild
+            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
         }
     }
-    
+
     @Test(
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8987", relationship: .defect),
+        .issue("https://github.com/swiftlang/swift-package-manager/pull/9130", relationship: .fixedBy),
+        .IssueWindowsLongPath,
+        .IssueWindowsCannotSaveAttachment,
         .tags(
             Tag.Feature.Command.Build,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
     func moduleNestedDeps2(
-        buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
+        data: BuildData,
     ) async throws {
-        try await withKnownIssue {
+        let buildSystem = data.buildSystem
+        let configuration = data.config
+        try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "ModuleAliasing/NestedDeps2") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
             let buildPath = try pkgPath.appending(components: buildSystem.binPath(for: configuration))
@@ -163,11 +207,23 @@ struct ModuleAliasingFixtureTests {
                 extraArgs: ["--vv"],
                 buildSystem: buildSystem,
             )
+            let expectedModules = [
+                "A.swiftmodule",
+                "BUtils.swiftmodule",
+                "CUtils.swiftmodule",
+                "XUtils.swiftmodule",
+            ]
             expectFileExists(at: buildPath.appending(components: executableName("App")))
-            expectFileExists(at: buildPath.appending(components: "Modules", "A.swiftmodule"))
-            expectFileExists(at: buildPath.appending(components: "Modules", "BUtils.swiftmodule"))
-            expectFileExists(at: buildPath.appending(components: "Modules", "CUtils.swiftmodule"))
-            expectFileExists(at: buildPath.appending(components: "Modules", "XUtils.swiftmodule"))
+            for file in expectedModules {
+                switch buildSystem {
+                case .native:
+                    expectFileExists(at: buildPath.appending(components: "Modules", file))
+                case .swiftbuild:
+                    expectFileExists(at: buildPath.appending(components: file))
+                case .xcode:
+                    Issue.record("expectations are not implemented")
+                }
+            }
             _ = try await executeSwiftBuild(
                 pkgPath,
                 configuration: configuration,
@@ -175,7 +231,7 @@ struct ModuleAliasingFixtureTests {
             )
         }
         } when: {
-            buildSystem == .swiftbuild
+            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
         }
     }
 }


### PR DESCRIPTION
Ensure the SwiftBuild integratation support the same Module Aliasing feature set as the native build system.

Fixes: #8987
Issue: rdar://157315793