### PR TITLE
[6.2] Cherry-pick: Fix pre-computation of traits when loading dependency manifests

### DIFF
--- a/Fixtures/Traits/PackageConditionalDeps/Package.swift
+++ b/Fixtures/Traits/PackageConditionalDeps/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "PackageConditionalDeps",
+    products: [
+        .library(
+            name: "PackageConditionalDeps",
+            targets: ["PackageConditionalDeps"]
+        ),
+    ],
+    traits: [
+        .default(enabledTraits: ["EnablePackage1Dep"]),
+        "EnablePackage1Dep",
+        "EnablePackage2Dep"
+    ],
+    dependencies: [
+        .package(path: "../Package1"),
+        .package(path: "../Package2"),
+    ],
+    targets: [
+        .target(
+            name: "PackageConditionalDeps",
+            dependencies: [ 
+                .product(
+                    name: "Package1Library1",
+                    package: "Package1",
+                    condition: .when(traits: ["EnablePackage1Dep"])
+                ),
+                .product(
+                    name: "Package2Library1",
+                    package: "Package2",
+                    condition: .when(traits: ["EnablePackage2Dep"])
+                )
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Traits/PackageConditionalDeps/Sources/PackageConditionalDeps/PackageConditionalDeps.swift
+++ b/Fixtures/Traits/PackageConditionalDeps/Sources/PackageConditionalDeps/PackageConditionalDeps.swift
@@ -1,0 +1,3 @@
+public func nothingHappens() {
+    // Do nothing.
+}

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -497,26 +497,14 @@ public func loadModulesGraph(
                         return condition.isSatisfied(by: parentTraits)
                     }.map(\.name)
 
-                    var enabledTraitsSet = explicitlyEnabledTraits.flatMap { Set($0) }
-                    let precomputedTraits = enabledTraitsMap[dependency.identity]
-
-                    if precomputedTraits == ["default"],
-                       let enabledTraitsSet {
-                        enabledTraitsMap[dependency.identity] = enabledTraitsSet
-                    } else {
-                        // unify traits
-                        enabledTraitsSet?.formUnion(precomputedTraits)
-                        if let enabledTraitsSet {
-                            enabledTraitsMap[dependency.identity] = enabledTraitsSet
-                        }
+                    if let enabledTraitsSet = explicitlyEnabledTraits.flatMap({ Set($0) }) {
+                        let calculatedTraits = try manifest.enabledTraits(
+                            using: enabledTraitsSet,
+                            .init(parent)
+                        )
+                        enabledTraitsMap[dependency.identity] = calculatedTraits
                     }
 
-                    let calculatedTraits = try manifest.enabledTraits(
-                        using: enabledTraitsSet ?? ["default"],
-                        .init(parent)
-                    )
-
-                    enabledTraitsMap[dependency.identity] = calculatedTraits
                     let result = visited.insert(dependency.identity)
                     if result.inserted {
                         try dependencies(of: manifest, dependency.productFilter)

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -164,8 +164,8 @@ public struct PackageGraphRoot {
                     return condition.isSatisfied(by: rootEnabledTraits)
                 }.map(\.name)
 
-                var enabledTraitsSet = enabledTraits.flatMap { Set($0) } ?? ["default"]
-                enabledTraitsSet.formUnion(enabledTraitsMap[dep.identity])
+                var enabledTraitsSet = enabledTraitsMap[dep.identity]
+                enabledTraitsSet.formUnion(enabledTraits.flatMap({ Set($0) }) ?? [])
 
                 return PackageContainerConstraint(
                     package: dep.packageRef,

--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -42,7 +42,7 @@ extension Manifest {
                 return condition.isSatisfied(by: enabledTraits)
             }.map(\.name)
 
-            var enabledTraitsSet = explicitlyEnabledTraits.flatMap({ Set($0) }) ?? ["default"]
+            let enabledTraitsSet = explicitlyEnabledTraits.flatMap({ Set($0) }) ?? ["default"]
 
             return PackageContainerConstraint(
                 package: $0.packageRef,

--- a/Sources/PackageModel/EnabledTraitsMap.swift
+++ b/Sources/PackageModel/EnabledTraitsMap.swift
@@ -31,7 +31,22 @@ public struct EnabledTraitsMap: ExpressibleByDictionaryLiteral {
 
     public subscript(key: PackageIdentity) -> Set<String> {
         get { storage[key] ?? ["default"] }
-        set { storage[key] = newValue }
+        set {
+            // Omit adding "default" explicitly, since the map returns "default"
+            // if there is no explicit traits declared. This will allow us to check
+            // for nil entries in the stored dictionary, which tells us whether
+            // traits have been explicitly declared.
+            guard newValue != ["default"] else { return }
+            if storage[key] == nil {
+                storage[key] = newValue
+            } else {
+                storage[key]?.formUnion(newValue)
+            }
+        }
+    }
+
+    public subscript(explicitlyEnabledTraitsFor key: PackageIdentity) -> Set<String>? {
+        get { storage[key] }
     }
 
     public var dictionaryLiteral: [PackageIdentity: Set<String>] {

--- a/Sources/PackageModel/Manifest/Manifest+Traits.swift
+++ b/Sources/PackageModel/Manifest/Manifest+Traits.swift
@@ -313,7 +313,7 @@ extension Manifest {
         let areDefaultsEnabled = enabledTraits.remove("default") != nil
 
         // We have to enable all default traits if no traits are enabled or the defaults are explicitly enabled
-        if /*explictlyEnabledTraits == nil*//*enabledTraits.isEmpty && */explictlyEnabledTraits == ["default"] || areDefaultsEnabled {
+        if explictlyEnabledTraits == ["default"] || areDefaultsEnabled {
             if let defaultTraits {
                 enabledTraits.formUnion(defaultTraits.flatMap(\.enabledTraits))
             }

--- a/Sources/_InternalTestSupport/MockPackage.swift
+++ b/Sources/_InternalTestSupport/MockPackage.swift
@@ -35,7 +35,7 @@ public struct MockPackage {
         targets: [MockTarget],
         products: [MockProduct] = [],
         dependencies: [MockDependency] = [],
-        traits: Set<TraitDescription> = [.init(name: "default")],
+        traits: Set<TraitDescription> = [],
         versions: [String?] = [],
         revisionProvider: ((String) -> String)? = nil,
         toolsVersion: ToolsVersion? = nil

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -4463,6 +4463,164 @@ final class ModulesGraphTests: XCTestCase {
             }
         }
     }
+
+    func testTraits_whenConditionalDependencies() throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Lunch/Sources/Drink/source.swift",
+            "/Caffeine/Sources/CoffeeTarget/source.swift",
+            "/Juice/Sources/AppleJuiceTarget/source.swift",
+        )
+
+        let manifests = try [
+            Manifest.createRootManifest(
+                displayName: "Lunch",
+                path: "/Lunch",
+                toolsVersion: .v5_9,
+                dependencies: [
+                    .localSourceControl(
+                        path: "/Caffeine",
+                        requirement: .upToNextMajor(from: "1.0.0"),
+                    ),
+                    .localSourceControl(
+                        path: "/Juice",
+                        requirement: .upToNextMajor(from: "1.0.0")
+                    )
+                ],
+                targets: [
+                    TargetDescription(
+                        name: "Drink",
+                        dependencies: [
+                            .product(
+                                name: "Coffee",
+                                package: "Caffeine",
+                                condition: .init(traits: ["EnableCoffeeDep"])
+                            ),
+                            .product(
+                                name: "AppleJuice",
+                                package: "Juice",
+                                condition: .init(traits: ["EnableAppleJuiceDep"])
+                            )
+                        ],
+                    ),
+                ],
+                traits: [
+                    .init(name: "default", enabledTraits: ["EnableCoffeeDep"]),
+                    .init(name: "EnableCoffeeDep"),
+                    .init(name: "EnableAppleJuiceDep"),
+                ],
+            ),
+            Manifest.createFileSystemManifest(
+                displayName: "Caffeine",
+                path: "/Caffeine",
+                toolsVersion: .v5_9,
+                products: [
+                    .init(
+                        name: "Coffee",
+                        type: .library(.automatic),
+                        targets: ["CoffeeTarget"]
+                    ),
+                ],
+                targets: [
+                    TargetDescription(
+                        name: "CoffeeTarget",
+                    ),
+                ],
+            ),
+            Manifest.createFileSystemManifest(
+                displayName: "Juice",
+                path: "/Juice",
+                toolsVersion: .v5_9,
+                products: [
+                    .init(
+                        name: "AppleJuice",
+                        type: .library(.automatic),
+                        targets: ["AppleJuiceTarget"]
+                    ),
+                ],
+                targets: [
+                    TargetDescription(
+                        name: "AppleJuiceTarget",
+                    ),
+                ],
+            )
+        ]
+
+        // Test graph with default trait configuration
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: manifests,
+            observabilityScope: observability.topScope
+        )
+
+        XCTAssertEqual(observability.diagnostics.count, 0)
+        PackageGraphTester(graph) { result in
+            result.checkPackage("Lunch") { package in
+                XCTAssertEqual(package.enabledTraits, ["EnableCoffeeDep"])
+                XCTAssertEqual(package.dependencies.count, 1)
+            }
+            result.checkTarget("Drink") { target in
+                target.check(dependencies: "Coffee")
+            }
+            result.checkPackage("Caffeine") { package in
+                XCTAssertEqual(package.enabledTraits, ["default"])
+            }
+            result.checkPackage("Juice") { package in
+                XCTAssertEqual(package.enabledTraits, ["default"])
+            }
+        }
+
+        // Test graph when disabling all traits
+        let graphWithTraitsDisabled = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: manifests,
+            observabilityScope: observability.topScope,
+            traitConfiguration: .disableAllTraits
+        )
+        XCTAssertEqual(observability.diagnostics.count, 0)
+
+        PackageGraphTester(graphWithTraitsDisabled) { result in
+            result.checkPackage("Lunch") { package in
+                XCTAssertEqual(package.enabledTraits, [])
+                XCTAssertEqual(package.dependencies.count, 0)
+            }
+            result.checkTarget("Drink") { target in
+                XCTAssertTrue(target.target.dependencies.isEmpty)
+            }
+            result.checkPackage("Caffeine") { package in
+                XCTAssertEqual(package.enabledTraits, ["default"])
+            }
+            result.checkPackage("Juice") { package in
+                XCTAssertEqual(package.enabledTraits, ["default"])
+            }
+        }
+
+        // Test graph when we set a trait configuration that enables different traits than the defaults
+        let graphWithDifferentEnabledTraits = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: manifests,
+            observabilityScope: observability.topScope,
+            traitConfiguration: .enabledTraits(["EnableAppleJuiceDep"])
+        )
+        XCTAssertEqual(observability.diagnostics.count, 0)
+
+        PackageGraphTester(graphWithDifferentEnabledTraits) { result in
+            result.checkPackage("Lunch") { package in
+                XCTAssertEqual(package.enabledTraits, ["EnableAppleJuiceDep"])
+                XCTAssertEqual(package.dependencies.count, 1)
+            }
+            result.checkTarget("Drink") { target in
+                target.check(dependencies: "AppleJuice")
+            }
+            result.checkPackage("Caffeine") { package in
+                XCTAssertEqual(package.enabledTraits,["default"])
+            }
+            result.checkPackage("Juice") { package in
+                XCTAssertEqual(package.enabledTraits, ["default"])
+            }
+        }
+    }
 }
 
 extension Manifest {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -16408,6 +16408,129 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    func testTraitsConditionalDependencies() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        func createMockWorkspace(_ traitConfiguration: TraitConfiguration) async throws -> MockWorkspace {
+            try await MockWorkspace(
+                sandbox: sandbox,
+                fileSystem: fs,
+                roots: [
+                    MockPackage(
+                        name: "Cereal",
+                        targets: [
+                            MockTarget(
+                                name: "Wheat",
+                                dependencies: [
+                                    .product(
+                                        name: "Icing",
+                                        package: "Sugar",
+                                        condition: .init(traits: ["BreakfastOfChampions"])
+                                    ),
+                                    .product(
+                                        name: "Raisin",
+                                        package: "Fruit",
+                                        condition: .init(traits: ["Healthy"])
+                                    )
+                                ]
+                            ),
+                        ],
+                        products: [
+                            MockProduct(name: "YummyBreakfast", modules: ["Wheat"])
+                        ],
+                        dependencies: [
+                            .sourceControl(path: "./Sugar", requirement: .upToNextMajor(from: "1.0.0")),
+                            .sourceControl(path: "./Fruit", requirement: .upToNextMajor(from: "1.0.0")),
+                        ],
+                        traits: ["Healthy", "BreakfastOfChampions"]
+                    ),
+                ],
+                packages: [
+                    MockPackage(
+                        name: "Sugar",
+                        targets: [
+                            MockTarget(name: "Icing"),
+                        ],
+                        products: [
+                            MockProduct(name: "Icing", modules: ["Icing"]),
+                        ],
+                        versions: ["1.0.0", "1.5.0"]
+                    ),
+                    MockPackage(
+                        name: "Fruit",
+                        targets: [
+                            MockTarget(name: "Raisin"),
+                        ],
+                        products: [
+                            MockProduct(name: "Raisin", modules: ["Raisin"]),
+                        ],
+                        versions: ["1.0.0", "1.2.0"]
+                    ),
+                ],
+                traitConfiguration: traitConfiguration
+            )
+        }
+
+
+        let deps: [MockDependency] = [
+            .sourceControl(path: "./Sugar", requirement: .exact("1.0.0"), products: .specific(["Icing"])),
+            .sourceControl(path: "./Fruit", requirement: .exact("1.0.0"), products: .specific(["Raisin"])),
+        ]
+
+        let workspaceOfChampions = try await createMockWorkspace(.enabledTraits(["BreakfastOfChampions"]))
+        try await workspaceOfChampions.checkPackageGraph(roots: ["Cereal"], deps: deps) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTester(graph) { result in
+                result.check(roots: "Cereal")
+                result.check(packages: "cereal", "sugar")
+                result.check(modules: "Wheat", "Icing")
+                result.checkTarget("Wheat") { result in
+                    result.check(dependencies: "Icing")
+                }
+            }
+        }
+
+        let healthyWorkspace = try await createMockWorkspace(.enabledTraits(["Healthy"]))
+        try await healthyWorkspace.checkPackageGraph(roots: ["Cereal"], deps: deps) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTester(graph) { result in
+                result.check(roots: "Cereal")
+                result.check(packages: "cereal", "fruit")
+                result.check(modules: "Wheat", "Raisin")
+                result.check(products: "YummyBreakfast", "Raisin")
+                result.checkTarget("Wheat") { result in
+                    result.check(dependencies: "Raisin")
+                }
+            }
+        }
+
+        let allEnabledTraitsWorkspace = try await createMockWorkspace(.enableAllTraits)
+        try await allEnabledTraitsWorkspace.checkPackageGraph(roots: ["Cereal"], deps: deps) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTester(graph) { result in
+                result.check(roots: "Cereal")
+                result.check(packages: "cereal", "sugar", "fruit")
+                result.check(modules: "Wheat", "Icing", "Raisin")
+                result.check(products: "YummyBreakfast", "Icing", "Raisin")
+                result.checkTarget("Wheat") { result in
+                    result.check(dependencies: "Icing", "Raisin")
+                }
+            }
+        }
+
+        let boringBreakfastWorkspace = try await createMockWorkspace(.disableAllTraits)
+        try await boringBreakfastWorkspace.checkPackageGraph(roots: ["Cereal"], deps: deps) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTester(graph) { result in
+                result.check(roots: "Cereal")
+                result.check(packages: "cereal")
+                result.check(modules: "Wheat")
+                result.check(products: "YummyBreakfast")
+            }
+        }
+    }
+
     func makeRegistryClient(
         packageIdentity: PackageIdentity,
         packageVersion: Version,


### PR DESCRIPTION
- **Explanation**:
Fixes some errors in trait computation that hadn't considered when default traits `["default"]` were being appended to the `EnabledTraitsMap`, which should only consider a list of flattened traits + *explicitly enabled traits* by a user/parent package. The inclusion of `default` in this dictionary was resulting in an inaccurate computation of which traits were enabled, since pre-computation serves to flatten the list of transitively enabled traits for future reference.
There were also cases where we were re-computing transitively enabled traits in areas where we had already filled out the `enabledTraitsMap`, so we now default to simply fetching the entry from the dictionary instead of computing the traits all over again.

- **Scope**:
Fixes trait-related computation in dependency resolution

- **Issues**:

- **Original PRs**:
#9057 
- **Risk**:
Low risk
- **Testing**:
Added new fixtures + unit tests to address the behaviour that was previously incorrect.
- **Reviewers**:
@dschaefer2 