### PR TITLE
Use SwiftBuild API to reliably compute built artifacts

### DIFF
--- a/Fixtures/PartiallyUnusedDependency/Dep/Package.swift
+++ b/Fixtures/PartiallyUnusedDependency/Dep/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "Dep",
+    products: [
+        .library(
+            name: "MyDynamicLibrary",
+            type: .dynamic,
+            targets: ["MyDynamicLibrary"]
+        ),
+        .executable(
+            name: "MySupportExecutable",
+            targets: ["MySupportExecutable"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "MyDynamicLibrary"
+        ),
+        .executableTarget(
+            name: "MySupportExecutable",
+            dependencies: ["MyDynamicLibrary"]
+        )
+    ]
+)

--- a/Fixtures/PartiallyUnusedDependency/Dep/Sources/MyDynamicLibrary/Dep.swift
+++ b/Fixtures/PartiallyUnusedDependency/Dep/Sources/MyDynamicLibrary/Dep.swift
@@ -1,0 +1,3 @@
+public func sayHello() {
+    print("hello!")
+}

--- a/Fixtures/PartiallyUnusedDependency/Dep/Sources/MySupportExecutable/exe.swift
+++ b/Fixtures/PartiallyUnusedDependency/Dep/Sources/MySupportExecutable/exe.swift
@@ -1,0 +1,8 @@
+import MyDynamicLibrary
+
+@main struct Entry {
+    static func main() {
+        print("running support tool")
+        sayHello()
+    }
+}

--- a/Fixtures/PartiallyUnusedDependency/Package.swift
+++ b/Fixtures/PartiallyUnusedDependency/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "PartiallyUnusedDependency",
+    products: [
+        .executable(
+            name: "MyExecutable",
+            targets: ["MyExecutable"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "Dep")
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyExecutable",
+            dependencies: [.product(name: "MyDynamicLibrary", package: "Dep")]
+        ),
+        .plugin(
+            name: "dump-artifacts-plugin",
+            capability: .command(
+                intent: .custom(verb: "dump-artifacts-plugin", description: "Dump Artifacts"),
+                permissions: []
+            )
+        )
+    ]
+)

--- a/Fixtures/PartiallyUnusedDependency/Plugins/dump-artifacts-plugin.swift
+++ b/Fixtures/PartiallyUnusedDependency/Plugins/dump-artifacts-plugin.swift
@@ -1,0 +1,24 @@
+import PackagePlugin
+
+@main
+struct DumpArtifactsPlugin: CommandPlugin {
+    func performCommand(
+        context: PluginContext,
+        arguments: [String]
+    ) throws {
+        do {
+            var parameters = PackageManager.BuildParameters()
+            parameters.configuration = .debug
+            parameters.logging = .concise
+            let result = try packageManager.build(.all(includingTests: false), parameters: parameters)
+            print("succeeded: \(result.succeeded)")
+            for artifact in result.builtArtifacts {
+                print("artifact-path: \(artifact.path.string)")
+                print("artifact-kind: \(artifact.kind)")
+            }
+        }
+        catch {
+            print("error from the plugin host: \\(error)")
+        }
+    }
+}

--- a/Fixtures/PartiallyUnusedDependency/Sources/MyExecutable/PartiallyUnusedDependency.swift
+++ b/Fixtures/PartiallyUnusedDependency/Sources/MyExecutable/PartiallyUnusedDependency.swift
@@ -1,0 +1,8 @@
+import MyDynamicLibrary
+
+@main struct Entry {
+    static func main() {
+        print("Hello, world!")
+        sayHello()
+    }
+}

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -39,32 +39,6 @@ public enum BuildSubset {
 /// build systems can produce all possible build outputs. Check the build
 /// result for indication that the output was produced.
 public enum BuildOutput: Equatable {
-    public static func == (lhs: BuildOutput, rhs: BuildOutput) -> Bool {
-        switch lhs {    
-        case .symbolGraph(let leftOptions):
-            switch rhs {
-                case .symbolGraph(let rightOptions):
-                    return leftOptions == rightOptions
-                default:
-                    return false
-            }
-        case .buildPlan:
-            switch rhs {
-                case .buildPlan:
-                    return true
-                default:
-                    return false
-            }
-        case .replArguments:
-            switch rhs {
-                case .replArguments:
-                    return true
-                default:
-                    return false
-            }
-        }
-    }
-
     public enum SymbolGraphAccessLevel: String {
         case `private`, `fileprivate`, `internal`, `package`, `public`, `open`
     }
@@ -93,6 +67,7 @@ public enum BuildOutput: Equatable {
     case symbolGraph(SymbolGraphOptions)
     case buildPlan
     case replArguments
+    case builtArtifacts
 }
 
 /// A protocol that represents a build system used by SwiftPM for all build operations. This allows factoring out the
@@ -144,12 +119,14 @@ public struct BuildResult {
         serializedDiagnosticPathsByTargetName: Result<[String: [AbsolutePath]], Error>,
         symbolGraph: SymbolGraphResult? = nil,
         buildPlan: BuildPlan? = nil,
-        replArguments: CLIArguments?
+        replArguments: CLIArguments?,
+        builtArtifacts: [(String, PluginInvocationBuildResult.BuiltArtifact)]? = nil
     ) {
         self.serializedDiagnosticPathsByTargetName = serializedDiagnosticPathsByTargetName
         self.symbolGraph = symbolGraph
         self.buildPlan = buildPlan
         self.replArguments = replArguments
+        self.builtArtifacts = builtArtifacts
     }
     
     public let replArguments: CLIArguments?
@@ -157,6 +134,7 @@ public struct BuildResult {
     public let buildPlan: BuildPlan?
 
     public var serializedDiagnosticPathsByTargetName: Result<[String: [AbsolutePath]], Error>
+    public var builtArtifacts: [(String, PluginInvocationBuildResult.BuiltArtifact)]?
 }
 
 public protocol ProductBuildDescription {


### PR DESCRIPTION
Depends on https://github.com/swiftlang/swift-build/pull/801

By querying the build system for the artifacts, we ensure we only report any we will actually produce in the current build. At the same time, pull in an alternative fix for https://github.com/swiftlang/swift-package-manager/pull/9121 which restores the original behavior of the native build system when considering products in dependency packages.