### PR TITLE
[6.2][native] Add toolchain span back deployment rpaths when required (#9164)

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -318,12 +318,12 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
                 throw InternalError("unexpectedly asked to generate linker arguments for a plugin product")
             }
 
-            // When deploying to macOS prior to macOS 12, add an rpath to the
-            // back-deployed concurrency libraries.
             if useStdlibRpath, triple.isMacOSX {
                 let macOSSupportedPlatform = self.package.getSupportedPlatform(for: .macOS, usingXCTest: product.isLinkingXCTest)
 
                 if macOSSupportedPlatform.version.major < 12 {
+                    // When deploying to macOS prior to macOS 12, add an rpath to the
+                    // back-deployed concurrency libraries.
                     let backDeployedStdlib = try buildParameters.toolchain.macosSwiftStdlib
                         .parentDirectory
                         .parentDirectory
@@ -331,6 +331,21 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
                         .appending("macosx")
                     args += ["-Xlinker", "-rpath", "-Xlinker", backDeployedStdlib.pathString]
                 }
+
+                if macOSSupportedPlatform.version.major < 26 {
+                    // When deploying to macOS prior to macOS 26, add an rpath to the
+                    // back-deployed Span library.
+                    let backDeployedStdlib = try buildParameters.toolchain.macosSwiftStdlib
+                        .parentDirectory
+                        .parentDirectory
+                        .appending("swift-6.2")
+                        .appending("macosx")
+                    args += ["-Xlinker", "-rpath", "-Xlinker", backDeployedStdlib.pathString]
+                }
+
+                // If either back deployment library is used, the driver is responsible for injecting
+                // a /usr/lib/swift -rpath at the front to ensure OS content is preferred when
+                // available.
             }
         } else {
             // Don't link runtime compatibility patch libraries if there are no

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -834,6 +834,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path", "-Xlinker",
             buildPath.appending(components: "Modules", "lib.swiftmodule").pathString,
@@ -1149,6 +1150,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-g",
         ])
@@ -1243,6 +1245,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-g",
         ])
@@ -1793,6 +1796,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/exe.build/exe.swiftmodule",
             "-g",
@@ -2352,11 +2356,12 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
 
         #if os(macOS)
         let version = MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString
-        let rpathsForBackdeployment: [String]
+        var rpathsForBackdeployment: [String] = []
         if let version = try? Version(string: version, lenient: true), version.major < 12 {
-            rpathsForBackdeployment = ["-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx"]
-        } else {
-            rpathsForBackdeployment = []
+            rpathsForBackdeployment += ["-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx"]
+        }
+        if let version = try? Version(string: version, lenient: true), version.major < 26 {
+            rpathsForBackdeployment += ["-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx"]
         }
         XCTAssertEqual(
             try result.buildProduct(for: "PkgPackageTests").linkArguments(),
@@ -2474,6 +2479,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-dead_strip",
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", hostTriple.tripleString(forPlatformVersion: "12.0"),
             "-g",
         ])
@@ -2845,6 +2851,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path",
             "-Xlinker", buildPath.appending(components: "exe.build", "exe.swiftmodule").pathString,
@@ -2991,6 +2998,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "Foo.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path",
             "-Xlinker", buildPath.appending(components: "Foo.build", "Foo.swiftmodule").pathString,
@@ -3008,6 +3016,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "Bar-Baz.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path",
             "-Xlinker", buildPath.appending(components: "Modules", "Bar.swiftmodule").pathString,
@@ -3164,6 +3173,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "lib.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path", "-Xlinker",
             buildPath.appending(components: "Modules", "lib.swiftmodule").pathString,
@@ -7294,6 +7304,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-emit-executable",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path",
             "-Xlinker", buildPath.appending(components: "Modules", "lib.swiftmodule").pathString,


### PR DESCRIPTION
**Explanation**: SwiftPM's native build system does not have the concept of embedding the compatibility libraries for distribution, so add rpaths to the span back deploy library in the toolchain when targeting macOS < 26. 
- **Scope**: Default package rpaths
- **Issues**: https://github.com/swiftlang/swift-package-manager/issues/9163
- **Original PRs**: https://github.com/swiftlang/swift-package-manager/pull/9164
- **Risk**: Low, this change follows an established pattern used by the concurrency back deployment library
- **Testing**: Updated unit tests, manual testing on older macOS versions
- **Reviewers**: @jakepetroules 
---
Original:
SwiftPM's native build system does not have the concept of embedding the compatibility libraries for distribution, so add rpaths to the span back deploy library in the toolchain when targeting macOS < 26. Ensure we always insert /usr/lib/swift ahead of the added rpaths to prefer the OS content when available. this mirrors the handling of the concurrency compat lib

Closes https://github.com/swiftlang/swift-package-manager/issues/9163
