### PR TITLE
Use `custom` notation for platform conditions where necessary in manifest code generation

### DIFF
--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -407,7 +407,19 @@ fileprivate extension SourceCodeFragment {
             case "watchos": return SourceCodeFragment(enum: "watchOS")
             case "visionos": return SourceCodeFragment(enum: "visionOS")
             case "driverkit": return SourceCodeFragment(enum: "driverKit")
-            default: return SourceCodeFragment(enum: platformName)
+
+            // Among known cases, those not requiring capitalization changes
+            case "linux", "windows", "android", "wasi", "openbsd":
+                return SourceCodeFragment(enum: platformName)
+
+            // Known cases but not yet available
+            case "freebsd": fallthrough
+            default:
+                // For unknown cases, output using custom notation
+                return SourceCodeFragment(
+                    enum: "custom",
+                    subnodes: [.init(string: platformName)]
+                )
             }
         }
         if !platformNodes.isEmpty {

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -503,7 +503,8 @@ final class ManifestSourceGenerationTests: XCTestCase {
                         dependencies: [
                             .target(name: "MyLib", condition: .when(platforms: [
                                 .macOS, .macCatalyst, .iOS, .tvOS, .watchOS, .visionOS,
-                                .driverKit, .linux, .windows, .android, .wasi, .openbsd
+                                .driverKit, .linux, .windows, .android, .wasi, .openbsd,
+                                .custom("freebsd"), .custom("toasterOS")
                             ]))
                         ]
                     ),


### PR DESCRIPTION
Use `custom` notation for platform conditions where necessary in manifest code generation

### Motivation:

Currently, for platform cases that are known but not yet available, or entirely unknown, the generated code becomes invalid.

### Modifications:

Change the implementation so that such cases are expressed using `custom` notation.

### Result:

Manifest code generation will correctly handle known-but-unavailable and unknown platform conditions by outputting them with `custom` notation.

### Additional Context:

In practice, `swift-subprocess` includes `.custom("freebsd")` in its manifest.
When this is imported, source code is generated, and then reloaded with SwiftPM, the following error occurs:

```
PackageDescription.Platform.freebsd:3:21: note: 'freebsd' was introduced in PackageDescription 999.0
```

This change prevents such errors by ensuring unsupported or future platforms are represented as `custom`.