### PR TITLE
Make the `dump-package` command output defaultLocalization

### DIFF
--- a/Fixtures/DependencyResolution/External/Complex/app/Package.swift
+++ b/Fixtures/DependencyResolution/External/Complex/app/Package.swift
@@ -1,8 +1,9 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
     name: "Dealer",
+    defaultLocalization: "en",
     platforms: [
         .macOS(.v10_12),
         .iOS(.v10),

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -655,6 +655,7 @@ extension Manifest: Encodable {
         }
 
         try container.encode(self.toolsVersion, forKey: .toolsVersion)
+        try container.encode(self.defaultLocalization, forKey: .defaultLocalization)
         try container.encode(self.pkgConfig, forKey: .pkgConfig)
         try container.encode(self.providers, forKey: .providers)
         try container.encode(self.cLanguageStandard, forKey: .cLanguageStandard)

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -1003,11 +1003,16 @@ struct PackageCommandTests {
                 Issue.record("unexpected result")
                 return
             }
+            guard case .string(let defaultLocalization)? = contents["defaultLocalization"] else {
+                Issue.record("unexpected result")
+                return
+            }
             guard case .array(let platforms)? = contents["platforms"] else {
                 Issue.record("unexpected result")
                 return
             }
             #expect(name == "Dealer")
+            #expect(defaultLocalization == "en")
             #expect(
                 platforms == [
                     .dictionary([


### PR DESCRIPTION
Make the `dump-package` command output defaultLocalization

### Motivation:

The `dump-package` command did not output `defaultLocalization`, which meant that manifests containing this information could not be fully represented in the dumped JSON.


### Modifications:

Fixed the implementation so that `defaultLocalization` is now included in the output of the `dump-package` command.

### Result:

Running `swift package dump-package` will now correctly include the `defaultLocalization` field in its JSON output.

