### PR TITLE
Enable commandPluginCompilationErrorImplementation tests for SwiftBuild

### DIFF
--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -6982,13 +6982,25 @@ struct PackageCommandTests {
             }
         }
 
-        private static func commandPluginCompilationErrorImplementation(
+        @Test(
+            .issue(
+                "https://github.com/swiftlang/swift-package-manager/issues/8977",
+                relationship: .defect,
+            ),
+            .requiresSwiftConcurrencySupport,
+            .tags(
+                .Feature.Command.Package.CommandPlugin,
+            ),
+            arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+        )
+        func commandPluginCompilationErrorImplementation(
             data: BuildData,
         ) async throws {
             try await fixture(name: "Miscellaneous/Plugins/CommandPluginCompilationError") { packageDir in
                 // Check that building stops after compiling the plugin and doesn't proceed.
                 // Run this test a number of times to try to catch any race conditions.
                 for num in 1...5 {
+                    try await withKnownIssue {
                     await expectThrowsCommandExecutionError(
                         try await executeSwiftBuild(
                             packageDir,
@@ -7013,45 +7025,10 @@ struct PackageCommandTests {
                             "iteration \(num) failed.   stderr: \(stderr)",
                         )
                     }
+                    } when: {
+                        data.buildSystem == .swiftbuild
+                    }
                 }
-            }
-        }
-
-        @Test(
-            .requiresSwiftConcurrencySupport,
-            .tags(
-                .Feature.Command.Package.CommandPlugin,
-            ),
-            // arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
-            arguments: getBuildData(for: [.native]),
-        )
-        func commandPluginCompilationError(
-            data: BuildData,
-        ) async throws {
-            try await Self.commandPluginCompilationErrorImplementation(data: data)
-        }
-
-        @Test(
-            .disabled("the swift-build process currently has a fatal error"),
-            .issue(
-                "https://github.com/swiftlang/swift-package-manager/issues/8977",
-                relationship: .defect
-            ),
-            .SWBINTTODO("Building sample package causes a backtrace on linux"),
-            .requireSwift6_2,
-            .requiresSwiftConcurrencySupport,
-            .tags(
-                .Feature.Command.Package.CommandPlugin,
-            ),
-            // arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
-            arguments: getBuildData(for: [.swiftbuild]),
-        )
-        func commandPluginCompilationErrorSwiftBuild(
-            data: BuildData,
-        ) async throws {
-            // Once this is fix, merge data iunto commandPluginCompilationError
-            await withKnownIssue {
-                try await Self.commandPluginCompilationErrorImplementation(data: data)
             }
         }
 


### PR DESCRIPTION
Re-enable the commandPluginCompilationErrorImplementation tests for SwiftBuild as a fatalError no longer occurs.  However, the tests still fails pending command plugin feature parity support, so mark the test withKnownIssue.

Relates to: #8977 