### PR TITLE
Mirror what native build system does for enabling clang modules

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -412,7 +412,8 @@ public final class PIFBuilder {
                 }
 
                 let packagePIFBuilderDelegate = PackagePIFBuilderDelegate(
-                    package: package
+                    package: package,
+                    buildParameters: buildParameters,
                 )
                 let packagePIFBuilder = PackagePIFBuilder(
                     modulesGraph: self.graph,
@@ -484,9 +485,11 @@ public final class PIFBuilder {
 
 fileprivate final class PackagePIFBuilderDelegate: PackagePIFBuilder.BuildDelegate {
     let package: ResolvedPackage
+    let buildParameters: BuildParameters
     
-    init(package: ResolvedPackage) {
+    init(package: ResolvedPackage, buildParameters: BuildParameters) {
         self.package = package
+        self.buildParameters = buildParameters
     }
     
     var isRootPackage: Bool {
@@ -522,7 +525,8 @@ fileprivate final class PackagePIFBuilderDelegate: PackagePIFBuilder.BuildDelega
     }
     
     func configureProjectBuildSettings(_ buildSettings: inout ProjectModel.BuildSettings) {
-        /* empty */
+        // This is parity to the native build, But we should investigate what it would take to get this working on platforms.
+        buildSettings[.CLANG_ENABLE_MODULES] = self.buildParameters.triple.isDarwin() ? "YES" : "NO"
     }
     
     func configureSourceModuleBuildSettings(sourceModule: ResolvedModule, settings: inout ProjectModel.BuildSettings) {

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -1034,7 +1034,6 @@ extension ProjectModel.BuildSettings {
         self[.PRODUCT_NAME] = productName
         self[.PRODUCT_MODULE_NAME] = productName
         self[.PRODUCT_BUNDLE_IDENTIFIER] = "\(packageIdentity).\(productName)".spm_mangledToBundleIdentifier()
-        self[.CLANG_ENABLE_MODULES] = "YES"
         self[.SWIFT_PACKAGE_NAME] = packageName ?? nil
 
         if !createDylibForDynamicProducts {

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -529,11 +529,6 @@ public final class PackagePIFBuilder {
         }
 
         settings[.USE_HEADERMAP] = "NO"
-        settings[.OTHER_SWIFT_FLAGS].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) { $0.append("-DXcode") }
-
-        // TODO: Might be relevant to make customizable —— Paulo
-        // (If we want to be extra careful with differences to the existing PIF in the SwiftPM.)
-        settings[.OTHER_CFLAGS] = ["$(inherited)", "-DXcode"]
 
         if !self.delegate.isRootPackage {
             if self.suppressWarningsForPackageDependencies {

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -115,7 +115,6 @@ extension PackagePIFProjectBuilder {
         settings[.PRODUCT_MODULE_NAME] = product.c99name
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = "\(self.package.identity).\(product.name)"
             .spm_mangledToBundleIdentifier()
-        settings[.CLANG_ENABLE_MODULES] = "YES"
         settings[.SWIFT_PACKAGE_NAME] = mainModule.packageName
 
         if mainModule.type == .test {

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -34,31 +34,28 @@ extension Trait where Self == Testing.ConditionTrait {
     /// Enabled only if toolchain support swift concurrency
     public static var requiresSwiftConcurrencySupport: Self {
         enabled("skipping because test environment doesn't support concurrency") {
-            (try? UserToolchain.default)!.supportsSwiftConcurrency()
+            (try? UserToolchain.default)?.supportsSwiftConcurrency() != nil
         }
     }
 
     /// Enabled only if 'llvm-profdata' is available
     public static var requiresLLVMProfData: Self {
         disabled("skipping test because the `llvm-profdata` tool isn't available") {
-            let toolPath = try (try? UserToolchain.default)!.getLLVMProf()
-            return toolPath == nil
+            try (try? UserToolchain.default)?.getLLVMProf() == nil
         }
     }
 
     /// Enabled only if 'llvm-cov' is available
     public static var requiresLLVMCov: Self {
         disabled("skipping test because the `llvm-cov` tool isn't available") {
-            let toolPath = try (try? UserToolchain.default)!.getLLVMCov()
-            return toolPath == nil
+            try (try? UserToolchain.default)?.getLLVMCov() == nil
         }
     }
 
     /// Enabled only if 'swift-symbolgraph-extract' is available
     public static var requiresSymbolgraphExtract: Self {
         disabled("skipping test because the `swift-symbolgraph-extract` tools isn't available") {
-            let toolPath = try (try? UserToolchain.default)!.getSymbolGraphExtract()
-            return toolPath == nil
+            try (try? UserToolchain.default)?.getSymbolGraphExtract() == nil
         }
     }
 


### PR DESCRIPTION
- the native builder only enables clang modules on Darwin, so we will need to do the same with swift-build.

