### PR TITLE
Compile all of the plugins at the start of a build with swiftbuild

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -384,7 +384,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         /// But because the modules graph and build plan are not loaded for incremental
         /// builds, this information is included in the BuildDescription, and the plugin
         /// modules are compiled directly.
-        class PluginBuildDescription: Codable {
+        struct PluginBuildDescription: Codable {
             /// The identity of the package in which the plugin is defined.
             public let package: PackageIdentity
 
@@ -472,6 +472,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             }
 
             func willCompilePlugin(commandLine: [String], environment: [String: String]) { }
+
             func didCompilePlugin(result: PluginCompilationResult) {
                 if !result.compilerOutput.isEmpty && !result.succeeded {
                     print(result.compilerOutput, to: &stdoutStream)

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -6831,10 +6831,6 @@ struct PackageCommandTests {
         }
 
         @Test(
-            .issue(
-                "https://github.com/swiftlang/swift-package-manager/issues/8977",
-                relationship: .defect
-            ),
             .requiresSwiftConcurrencySupport,
             .IssueWindowsLongPath,
             .tags(
@@ -6961,37 +6957,29 @@ struct PackageCommandTests {
                     ProcessInfo.hostOperatingSystem == .windows && data.buildSystem == .swiftbuild
                 }
 
-                try await withKnownIssue {
-                    // Check that building just one of them just compiles that plugin and doesn't build anything else.
-                    do {
-                        let (stdout, stderr) = try await executeSwiftBuild(
-                            packageDir,
-                            configuration: data.config,
-                            extraArgs: ["--target", "MyCommandPlugin"],
-                            buildSystem: data.buildSystem,
-                        )
-                        if data.buildSystem == .native {
-                            #expect(!stdout.contains("Compiling plugin MyBuildToolPlugin"), "stderr: \(stderr)")
-                            #expect(stdout.contains("Compiling plugin MyCommandPlugin"), "stderr: \(stderr)")
-                        }
-                        #expect(!stdout.contains("Building for \(data.config.buildFor)..."), "stderr: \(stderr)")
+                // Check that building just one of them just compiles that plugin and doesn't build anything else.
+                do {
+                    let (stdout, stderr) = try await executeSwiftBuild(
+                        packageDir,
+                        configuration: data.config,
+                        extraArgs: ["--target", "MyCommandPlugin"],
+                        buildSystem: data.buildSystem,
+                    )
+                    if data.buildSystem == .native {
+                        #expect(!stdout.contains("Compiling plugin MyBuildToolPlugin"), "stderr: \(stderr)")
+                        #expect(stdout.contains("Compiling plugin MyCommandPlugin"), "stderr: \(stderr)")
                     }
-                } when: {
-                    data.buildSystem == .swiftbuild
+                    #expect(!stdout.contains("Building for \(data.config.buildFor)..."), "stderr: \(stderr)")
                 }
             }
         }
 
         @Test(
-            .issue(
-                "https://github.com/swiftlang/swift-package-manager/issues/8977",
-                relationship: .defect,
-            ),
             .requiresSwiftConcurrencySupport,
             .tags(
                 .Feature.Command.Package.CommandPlugin,
             ),
-            arguments: getBuildData(for: [.swiftbuild]),
+            arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
         )
         func commandPluginCompilationErrorImplementation(
             data: BuildData,

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -6965,9 +6965,15 @@ struct PackageCommandTests {
                         extraArgs: ["--target", "MyCommandPlugin"],
                         buildSystem: data.buildSystem,
                     )
-                    if data.buildSystem == .native {
-                        #expect(!stdout.contains("Compiling plugin MyBuildToolPlugin"), "stderr: \(stderr)")
-                        #expect(stdout.contains("Compiling plugin MyCommandPlugin"), "stderr: \(stderr)")
+                    switch data.buildSystem {
+                    case .native:
+                            #expect(!stdout.contains("Compiling plugin MyBuildToolPlugin"), "stderr: \(stderr)")
+                            #expect(stdout.contains("Compiling plugin MyCommandPlugin"), "stderr: \(stderr)")
+                        case .swiftbuild:
+                        // nothing specific
+                        break
+                        case .xcode:
+                            Issue.record("Test expected have not been considered")
                     }
                     #expect(!stdout.contains("Building for \(data.config.buildFor)..."), "stderr: \(stderr)")
                 }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -6982,7 +6982,18 @@ struct PackageCommandTests {
             }
         }
 
-        private static func commandPluginCompilationErrorImplementation(
+        @Test(
+            .issue(
+                "https://github.com/swiftlang/swift-package-manager/issues/8977",
+                relationship: .defect,
+            ),
+            .requiresSwiftConcurrencySupport,
+            .tags(
+                .Feature.Command.Package.CommandPlugin,
+            ),
+            arguments: getBuildData(for: [.swiftbuild]),
+        )
+        func commandPluginCompilationErrorImplementation(
             data: BuildData,
         ) async throws {
             try await fixture(name: "Miscellaneous/Plugins/CommandPluginCompilationError") { packageDir in
@@ -7014,44 +7025,6 @@ struct PackageCommandTests {
                         )
                     }
                 }
-            }
-        }
-
-        @Test(
-            .requiresSwiftConcurrencySupport,
-            .tags(
-                .Feature.Command.Package.CommandPlugin,
-            ),
-            // arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
-            arguments: getBuildData(for: [.native]),
-        )
-        func commandPluginCompilationError(
-            data: BuildData,
-        ) async throws {
-            try await Self.commandPluginCompilationErrorImplementation(data: data)
-        }
-
-        @Test(
-            .disabled("the swift-build process currently has a fatal error"),
-            .issue(
-                "https://github.com/swiftlang/swift-package-manager/issues/8977",
-                relationship: .defect
-            ),
-            .SWBINTTODO("Building sample package causes a backtrace on linux"),
-            .requireSwift6_2,
-            .requiresSwiftConcurrencySupport,
-            .tags(
-                .Feature.Command.Package.CommandPlugin,
-            ),
-            // arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
-            arguments: getBuildData(for: [.swiftbuild]),
-        )
-        func commandPluginCompilationErrorSwiftBuild(
-            data: BuildData,
-        ) async throws {
-            // Once this is fix, merge data iunto commandPluginCompilationError
-            await withKnownIssue {
-                try await Self.commandPluginCompilationErrorImplementation(data: data)
             }
         }
 


### PR DESCRIPTION
When building with the swiftbuild build system there can be a compilation problem with the
plugin.swift with one of the plugins. However, you won't discover that unless you run the
command plugin specifically. This is not the behaviour of the existing native build system
that does a plugin pass at the start of a build.

Implement a similar plugin pass with the swiftbuild system to catch problems with the plugin
code when building the packages.

Fixes #8977