### PR TITLE
[6.2] Cherry Pick - Use only enabled traits when loading package (#8970)

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1255,8 +1255,7 @@ extension Workspace {
                     prebuilts: [:],
                     fileSystem: self.fileSystem,
                     observabilityScope: observabilityScope,
-                    // For now we enable all traits
-                    enabledTraits: Set(manifest.traits.map(\.name))
+                    enabledTraits: try manifest.enabledTraits(using: .default)
                 )
                 return try builder.construct()
             }
@@ -1323,8 +1322,7 @@ extension Workspace {
             createREPLProduct: self.configuration.createREPLProduct,
             fileSystem: self.fileSystem,
             observabilityScope: observabilityScope,
-            // For now we enable all traits
-            enabledTraits: Set(manifest.traits.map(\.name))
+            enabledTraits: try manifest.enabledTraits(using: .default)
         )
         return try builder.construct()
     }


### PR DESCRIPTION
Both `loadPackage` and `loadRootPackage` specified all traits as enabled when loading a package. Narrow this to only the enabled traits so that the returned `Package` accurately reflects the enabled traits.
