### PR TITLE
Fix macros that depend on libraries that also depend on swift-syntax

### DIFF
--- a/Sources/PackageGraph/Resolution/ResolvedModule.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedModule.swift
@@ -288,7 +288,12 @@ extension ResolvedModule: Identifiable {
         public var targetName: String { self.moduleName }
 
         public let moduleName: String
-        let packageIdentity: PackageIdentity
+        public let packageIdentity: PackageIdentity
+
+        public init(moduleName: String, packageIdentity: PackageIdentity) {
+            self.moduleName = moduleName
+            self.packageIdentity = packageIdentity
+        }
     }
 
     public var id: ID {

--- a/Sources/PackageModel/BuildEnvironment.swift
+++ b/Sources/PackageModel/BuildEnvironment.swift
@@ -13,10 +13,12 @@
 /// A build environment with which to evaluate conditions.
 public struct BuildEnvironment {
     public let platform: Platform
+    public let isHost: Bool
     public let configuration: BuildConfiguration?
 
-    public init(platform: Platform, configuration: BuildConfiguration? = nil) {
+    public init(platform: Platform, isHost: Bool, configuration: BuildConfiguration? = nil) {
         self.platform = platform
         self.configuration = configuration
+        self.isHost = isHost
     }
 }

--- a/Sources/PackageModel/Manifest/PackageConditionDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageConditionDescription.swift
@@ -30,6 +30,7 @@ public enum PackageCondition: Hashable, Sendable {
     case platforms(PlatformsCondition)
     case configuration(ConfigurationCondition)
     case traits(TraitCondition)
+    case host(HostCondition)
 
     public func satisfies(_ environment: BuildEnvironment) -> Bool {
         switch self {
@@ -39,6 +40,8 @@ public enum PackageCondition: Hashable, Sendable {
             return platforms.satisfies(environment)
         case .traits(let traits):
             return traits.satisfies(environment)
+        case .host(let host):
+            return host.satisfies(environment)
         }
     }
 
@@ -107,9 +110,7 @@ public struct ConfigurationCondition: Hashable, Sendable {
     }
 }
 
-
-/// A configuration condition implies that an assignment is valid on
-/// a particular build configuration.
+/// A traits condition implies that an assignment is valid in the given build environment
 public struct TraitCondition: Hashable, Sendable {
     public let traits: Set<String>
 
@@ -122,3 +123,15 @@ public struct TraitCondition: Hashable, Sendable {
     }
 }
 
+/// A host condition determines whether the build environment is for host
+public struct HostCondition: Hashable, Sendable {
+    public let isHost: Bool
+
+    public init(isHost: Bool) {
+        self.isHost = isHost
+    }
+
+    public func satisfies(_ environment: BuildEnvironment) -> Bool {
+        environment.isHost == isHost
+    }
+}

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -90,7 +90,7 @@ public struct BuildParameters: Encodable {
 
     /// The current build environment.
     public var buildEnvironment: BuildEnvironment {
-        BuildEnvironment(platform: currentPlatform, configuration: configuration)
+        BuildEnvironment(platform: currentPlatform, isHost: destination == .host, configuration: configuration)
     }
 
     /// The current platform we're building for.

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -28,6 +28,7 @@ import enum PackageModel.BuildConfiguration
 import enum PackageModel.BuildSettings
 import class PackageModel.ClangModule
 import struct PackageModel.ConfigurationCondition
+import struct PackageModel.HostCondition
 import class PackageModel.Manifest
 import class PackageModel.Module
 import enum PackageModel.ModuleMapType
@@ -255,12 +256,14 @@ extension Sequence<PackageModel.PackageCondition> {
         var platformConditions: [PackageModel.PlatformsCondition] = []
         var configurationConditions: [PackageModel.ConfigurationCondition] = []
         var traitConditions: [PackageModel.TraitCondition] = []
+        var hostConditions: [PackageModel.HostCondition] = []
 
         for packageCondition in self {
             switch packageCondition {
             case .platforms(let condition): platformConditions.append(condition)
             case .configuration(let condition): configurationConditions.append(condition)
             case .traits(let condition): traitConditions.append(condition)
+            case .host(let condition): hostConditions.append(condition)
             }
         }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -957,6 +957,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             let plan = try await mockBuildPlan(
                 environment: BuildEnvironment(
                     platform: .linux,
+                    isHost: true,
                     configuration: .release
                 ),
                 graph: graph,
@@ -999,6 +1000,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             let plan = try await mockBuildPlan(
                 environment: BuildEnvironment(
                     platform: .macOS,
+                    isHost: true,
                     configuration: .debug
                 ),
                 graph: graph,
@@ -1507,6 +1509,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             let result = try await BuildPlanResult(plan: mockBuildPlan(
                 environment: BuildEnvironment(
                     platform: .linux,
+                    isHost: true,
                     configuration: .release
                 ),
                 graph: graph,
@@ -1526,6 +1529,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             let result = try await BuildPlanResult(plan: mockBuildPlan(
                 environment: BuildEnvironment(
                     platform: .macOS,
+                    isHost: true,
                     configuration: .debug
                 ),
                 graph: graph,
@@ -2106,6 +2110,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             let plan = try await mockBuildPlan(
                 environment: BuildEnvironment(
                     platform: .linux,
+                    isHost: true,
                     configuration: .release
                 ),
                 graph: graph,
@@ -3568,7 +3573,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         let graphResult = PackageGraphResultXCTest(graph)
 
         do {
-            let linuxDebug = BuildEnvironment(platform: .linux, configuration: .debug)
+            let linuxDebug = BuildEnvironment(platform: .linux, isHost: true, configuration: .debug)
             try graphResult.check(reachableBuildProducts: "aexec", "BLibrary1", "BLibrary2", in: linuxDebug)
             try graphResult.check(reachableBuildTargets: "ATarget", "BTarget1", "BTarget2", in: linuxDebug)
 
@@ -3583,7 +3588,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         }
 
         do {
-            let macosDebug = BuildEnvironment(platform: .macOS, configuration: .debug)
+            let macosDebug = BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
             try graphResult.check(reachableBuildProducts: "aexec", "BLibrary2", in: macosDebug)
             try graphResult.check(reachableBuildTargets: "ATarget", "BTarget2", "BTarget3", in: macosDebug)
 
@@ -3598,7 +3603,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         }
 
         do {
-            let androidRelease = BuildEnvironment(platform: .android, configuration: .release)
+            let androidRelease = BuildEnvironment(platform: .android, isHost: false, configuration: .release)
             try graphResult.check(reachableBuildProducts: "aexec", "CLibrary", in: androidRelease)
             try graphResult.check(reachableBuildTargets: "ATarget", "CTarget", in: androidRelease)
 
@@ -4905,7 +4910,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         // Test debug configuration
         do {
             let result = try await BuildPlanResult(plan: mockBuildPlan(
-                environment: BuildEnvironment(platform: .macOS, configuration: .debug),
+                environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug),
                 graph: graph,
                 fileSystem: fs,
                 observabilityScope: observability.topScope
@@ -4927,7 +4932,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         // Test release configuration
         do {
             let result = try await BuildPlanResult(plan: mockBuildPlan(
-                environment: BuildEnvironment(platform: .macOS, configuration: .release),
+                environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release),
                 graph: graph,
                 fileSystem: fs,
                 observabilityScope: observability.topScope
@@ -4993,7 +4998,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         // Test debug configuration
         do {
             let result = try await BuildPlanResult(plan: mockBuildPlan(
-                environment: BuildEnvironment(platform: .macOS, configuration: .debug),
+                environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug),
                 graph: graph,
                 fileSystem: fs,
                 observabilityScope: observability.topScope
@@ -5011,7 +5016,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         // Test release configuration
         do {
             let result = try await BuildPlanResult(plan: mockBuildPlan(
-                environment: BuildEnvironment(platform: .macOS, configuration: .release),
+                environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release),
                 graph: graph,
                 fileSystem: fs,
                 observabilityScope: observability.topScope
@@ -5131,7 +5136,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         // Test debug configuration
         do {
             let result = try await BuildPlanResult(plan: mockBuildPlan(
-                environment: BuildEnvironment(platform: .macOS, configuration: .debug),
+                environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug),
                 graph: graph,
                 fileSystem: fs,
                 observabilityScope: observability.topScope
@@ -5162,7 +5167,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         // Test release configuration
         do {
             let result = try await BuildPlanResult(plan: mockBuildPlan(
-                environment: BuildEnvironment(platform: .macOS, configuration: .release),
+                environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release),
                 graph: graph,
                 fileSystem: fs,
                 observabilityScope: observability.topScope
@@ -7235,6 +7240,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         let result = try await BuildPlanResult(plan: mockBuildPlan(
             environment: BuildEnvironment(
                 platform: .linux,
+                isHost: true,
                 configuration: .release
             ),
             graph: graph,

--- a/Tests/BuildTests/LLBuildManifestBuilderTests.swift
+++ b/Tests/BuildTests/LLBuildManifestBuilderTests.swift
@@ -56,6 +56,7 @@ struct LLBuildManifestBuilderTests {
         var plan = try await mockBuildPlan(
             environment: BuildEnvironment(
                 platform: .macOS,
+                isHost: true,
                 configuration: .release
             ),
             graph: graph,
@@ -86,6 +87,7 @@ struct LLBuildManifestBuilderTests {
         plan = try await mockBuildPlan(
             environment: BuildEnvironment(
                 platform: .macOS,
+                isHost: true,
                 configuration: .debug
             ),
             graph: graph,
@@ -129,6 +131,7 @@ struct LLBuildManifestBuilderTests {
         plan = try await mockBuildPlan(
             environment: BuildEnvironment(
                 platform: .linux,
+                isHost: true,
                 configuration: .release
             ),
             graph: graph,
@@ -155,6 +158,7 @@ struct LLBuildManifestBuilderTests {
         plan = try await mockBuildPlan(
             environment: BuildEnvironment(
                 platform: .linux,
+                isHost: true,
                 configuration: .debug
             ),
             graph: graph,

--- a/Tests/BuildTests/PluginInvocationTests.swift
+++ b/Tests/BuildTests/PluginInvocationTests.swift
@@ -233,7 +233,7 @@ final class PluginInvocationTests: XCTestCase {
         let pluginRunner = MockPluginScriptRunner()
         let buildParameters = mockBuildParameters(
             destination: .host,
-            environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+            environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
         )
 
         let results = try await invokeBuildToolPlugins(
@@ -960,7 +960,7 @@ final class PluginInvocationTests: XCTestCase {
                 let outputDir = packageDir.appending(".build")
                 let buildParameters = mockBuildParameters(
                     destination: .host,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
 
                 let result = try await invokeBuildToolPlugins(
@@ -1102,7 +1102,7 @@ final class PluginInvocationTests: XCTestCase {
                 let outputDir = packageDir.appending(".build")
                 let buildParameters = mockBuildParameters(
                     destination: .host,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
 
                 let result = try await invokeBuildToolPlugins(
@@ -1456,7 +1456,7 @@ final class PluginInvocationTests: XCTestCase {
             let outputDir = packageDir.appending(".build")
             let buildParameters = mockBuildParameters(
                 destination: .host,
-                environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
             )
 
             return try await invokeBuildToolPlugins(

--- a/Tests/BuildTests/ProductBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ProductBuildDescriptionTests.swift
@@ -63,7 +63,7 @@ final class ProductBuildDescriptionTests: XCTestCase {
             package: package,
             product: product,
             toolsVersion: .v5_9,
-            buildParameters: mockBuildParameters(destination: .target, environment: .init(platform: .macOS)),
+            buildParameters: mockBuildParameters(destination: .target, environment: .init(platform: .macOS, isHost: true)),
             fileSystem: fs,
             observabilityScope: observability.topScope
         )

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -806,7 +806,7 @@ final class PluginTests {
                     let success = try await withCheckedThrowingContinuation { continuation in
                       plugin.invoke(
                         action: .performCommand(package: package, arguments: arguments),
-                        buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
+                        buildEnvironment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug),
                         scriptRunner: scriptRunner,
                         workingDirectory: package.path,
                         outputDirectory: pluginDir.appending("output"),
@@ -1101,7 +1101,7 @@ final class PluginTests {
                 try await withTaskCancellationHandler {
                     _ = try await plugin.invoke(
                         action: .performCommand(package: package, arguments: []),
-                        buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
+                        buildEnvironment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug),
                         scriptRunner: scriptRunner,
                         workingDirectory: package.path,
                         outputDirectory: pluginDir.appending("output"),

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -2369,20 +2369,20 @@ struct ModulesGraphTests {
             try result.checkTarget("Foo") { result in
                 result.check(dependencies: "Bar", "Baz", "Biz")
                 try result.checkDependency("Bar") { result in
-                    result.checkConditions(satisfy: .init(platform: .linux, configuration: .debug))
-                    result.checkConditions(satisfy: .init(platform: .linux, configuration: .release))
-                    result.checkConditions(dontSatisfy: .init(platform: .macOS, configuration: .release))
+                    result.checkConditions(satisfy: .init(platform: .linux, isHost: true, configuration: .debug))
+                    result.checkConditions(satisfy: .init(platform: .linux, isHost: true, configuration: .release))
+                    result.checkConditions(dontSatisfy: .init(platform: .macOS, isHost: true, configuration: .release))
                 }
                 try result.checkDependency("Baz") { result in
-                    result.checkConditions(satisfy: .init(platform: .watchOS, configuration: .debug))
-                    result.checkConditions(satisfy: .init(platform: .tvOS, configuration: .debug))
-                    result.checkConditions(dontSatisfy: .init(platform: .tvOS, configuration: .release))
+                    result.checkConditions(satisfy: .init(platform: .watchOS, isHost: true, configuration: .debug))
+                    result.checkConditions(satisfy: .init(platform: .tvOS, isHost: true, configuration: .debug))
+                    result.checkConditions(dontSatisfy: .init(platform: .tvOS, isHost: true, configuration: .release))
                 }
                 try result.checkDependency("Biz") { result in
-                    result.checkConditions(satisfy: .init(platform: .watchOS, configuration: .release))
-                    result.checkConditions(satisfy: .init(platform: .iOS, configuration: .release))
-                    result.checkConditions(dontSatisfy: .init(platform: .iOS, configuration: .debug))
-                    result.checkConditions(dontSatisfy: .init(platform: .macOS, configuration: .release))
+                    result.checkConditions(satisfy: .init(platform: .watchOS, isHost: true, configuration: .release))
+                    result.checkConditions(satisfy: .init(platform: .iOS, isHost: true, configuration: .release))
+                    result.checkConditions(dontSatisfy: .init(platform: .iOS, isHost: true, configuration: .debug))
+                    result.checkConditions(dontSatisfy: .init(platform: .macOS, isHost: true, configuration: .release))
                 }
             }
         }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2631,7 +2631,7 @@ struct PackageBuilderTests {
             try package.checkModule("cbar") { package in
                 let scope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(scope.evaluate(.GCC_PREPROCESSOR_DEFINITIONS) == ["CCC=2", "CXX"])
                 #expect(scope.evaluate(.HEADER_SEARCH_PATHS) == ["Sources/headers", "Sources/cppheaders"])
@@ -2640,7 +2640,7 @@ struct PackageBuilderTests {
 
                 let releaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release)
                 )
                 #expect(releaseScope.evaluate(.GCC_PREPROCESSOR_DEFINITIONS) == ["CCC=2", "CXX", "RCXX"])
             }
@@ -2648,20 +2648,20 @@ struct PackageBuilderTests {
             try package.checkModule("bar") { package in
                 let scope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .linux, configuration: .debug)
+                    environment: BuildEnvironment(platform: .linux, isHost: true, configuration: .debug)
                 )
                 #expect(scope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS) == ["SOMETHING", "LINUX"])
                 #expect(scope.evaluate(.OTHER_SWIFT_FLAGS) == ["-Isfoo", "-L", "sbar"])
 
                 let rscope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .linux, configuration: .release)
+                    environment: BuildEnvironment(platform: .linux, isHost: true, configuration: .release)
                 )
                 #expect(rscope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS) == ["SOMETHING", "LINUX", "RLINUX"])
 
                 let mscope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(mscope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS) == ["SOMETHING", "DMACOS"])
             }
@@ -2669,7 +2669,7 @@ struct PackageBuilderTests {
             try package.checkModule("exe") { package in
                 let scope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .linux, configuration: .debug)
+                    environment: BuildEnvironment(platform: .linux, isHost: true, configuration: .debug)
                 )
                 #expect(scope.evaluate(.LINK_LIBRARIES) == ["sqlite3"])
                 #expect(scope.evaluate(.OTHER_LDFLAGS) == ["-Ilfoo", "-L", "lbar"])
@@ -2680,7 +2680,7 @@ struct PackageBuilderTests {
 
                 let mscope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .iOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .iOS, isHost: false, configuration: .debug)
                 )
                 #expect(mscope.evaluate(.LINK_LIBRARIES) == ["sqlite3"])
                 #expect(mscope.evaluate(.LINK_FRAMEWORKS) == ["CoreData"])
@@ -2728,7 +2728,7 @@ struct PackageBuilderTests {
             try package.checkModule("foo") { package in
                 let macosDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(macosDebugScope.evaluate(.OTHER_CFLAGS) == [])
                 #expect(macosDebugScope.evaluate(.OTHER_CPLUSPLUSFLAGS) == [])
@@ -2736,7 +2736,7 @@ struct PackageBuilderTests {
 
                 let macosReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release)
                 )
                 #expect(macosReleaseScope.evaluate(.OTHER_CFLAGS) == [])
                 #expect(macosReleaseScope.evaluate(.OTHER_CPLUSPLUSFLAGS) == [])
@@ -2746,21 +2746,21 @@ struct PackageBuilderTests {
             try package.checkModule("bar") { package in
                 let linuxDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .linux, configuration: .debug)
+                    environment: BuildEnvironment(platform: .linux, isHost: true, configuration: .debug)
                 )
                 #expect(linuxDebugScope.evaluate(.OTHER_SWIFT_FLAGS) == [])
                 #expect(linuxDebugScope.evaluate(.OTHER_LDFLAGS) == [])
 
                 let linuxReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .linux, configuration: .release)
+                    environment: BuildEnvironment(platform: .linux, isHost: true, configuration: .release)
                 )
                 #expect(linuxReleaseScope.evaluate(.OTHER_SWIFT_FLAGS) == [])
                 #expect(linuxReleaseScope.evaluate(.OTHER_LDFLAGS) == [])
 
                 let macosDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(macosDebugScope.evaluate(.OTHER_SWIFT_FLAGS) == [])
                 #expect(macosDebugScope.evaluate(.OTHER_LDFLAGS) == [])
@@ -2928,22 +2928,22 @@ struct PackageBuilderTests {
                 target.check(dependencies: ["Bar", "Baz", "Biz"])
 
                 target.checkDependency("Bar") { result in
-                    result.checkConditions(satisfy: .init(platform: .macOS, configuration: .debug))
-                    result.checkConditions(satisfy: .init(platform: .macOS, configuration: .release))
-                    result.checkConditions(dontSatisfy: .init(platform: .watchOS, configuration: .release))
+                    result.checkConditions(satisfy: .init(platform: .macOS, isHost: true, configuration: .debug))
+                    result.checkConditions(satisfy: .init(platform: .macOS, isHost: true, configuration: .release))
+                    result.checkConditions(dontSatisfy: .init(platform: .watchOS, isHost: false, configuration: .release))
                 }
 
                 target.checkDependency("Baz") { result in
-                    result.checkConditions(satisfy: .init(platform: .macOS, configuration: .debug))
-                    result.checkConditions(satisfy: .init(platform: .linux, configuration: .debug))
-                    result.checkConditions(dontSatisfy: .init(platform: .linux, configuration: .release))
+                    result.checkConditions(satisfy: .init(platform: .macOS, isHost: true, configuration: .debug))
+                    result.checkConditions(satisfy: .init(platform: .linux, isHost: true, configuration: .debug))
+                    result.checkConditions(dontSatisfy: .init(platform: .linux, isHost: true, configuration: .release))
                 }
 
                 target.checkDependency("Biz") { result in
-                    result.checkConditions(satisfy: .init(platform: .watchOS, configuration: .release))
-                    result.checkConditions(satisfy: .init(platform: .iOS, configuration: .release))
-                    result.checkConditions(dontSatisfy: .init(platform: .linux, configuration: .release))
-                    result.checkConditions(dontSatisfy: .init(platform: .iOS, configuration: .debug))
+                    result.checkConditions(satisfy: .init(platform: .watchOS, isHost: false, configuration: .release))
+                    result.checkConditions(satisfy: .init(platform: .iOS, isHost: false, configuration: .release))
+                    result.checkConditions(dontSatisfy: .init(platform: .linux, isHost: false, configuration: .release))
+                    result.checkConditions(dontSatisfy: .init(platform: .iOS, isHost: false, configuration: .debug))
                 }
             }
         }
@@ -3234,13 +3234,13 @@ struct PackageBuilderTests {
             try package.checkModule("foo") { package in
                 let macosDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(macosDebugScope.evaluate(.SWIFT_VERSION) == ["5"])
 
                 let macosReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release)
                 )
                 #expect(macosReleaseScope.evaluate(.SWIFT_VERSION) == ["5"])
             }
@@ -3248,19 +3248,19 @@ struct PackageBuilderTests {
             try package.checkModule("bar") { package in
                 let linuxDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .linux, configuration: .debug)
+                    environment: BuildEnvironment(platform: .linux, isHost: true, configuration: .debug)
                 )
                 #expect(linuxDebugScope.evaluate(.SWIFT_VERSION) == ["3"])
 
                 let macosDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(macosDebugScope.evaluate(.SWIFT_VERSION) == ["4"])
 
                 let macosReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release)
                 )
                 #expect(macosReleaseScope.evaluate(.SWIFT_VERSION) == ["5"])
             }
@@ -3293,7 +3293,7 @@ struct PackageBuilderTests {
             try package.checkModule("foo") { package in
                 let macosDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(
                     macosDebugScope.evaluate(.OTHER_SWIFT_FLAGS) ==
@@ -3302,7 +3302,7 @@ struct PackageBuilderTests {
 
                 let macosReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release)
                 )
                 #expect(
                     macosReleaseScope.evaluate(.OTHER_SWIFT_FLAGS) ==
@@ -3339,7 +3339,7 @@ struct PackageBuilderTests {
             try package.checkModule("cfoo") { package in
                 let macosDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(
                     macosDebugScope.evaluate(.OTHER_CFLAGS) ==
@@ -3348,7 +3348,7 @@ struct PackageBuilderTests {
 
                 let macosReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release)
                 )
                 #expect(
                     macosReleaseScope.evaluate(.OTHER_CFLAGS) ==
@@ -3385,7 +3385,7 @@ struct PackageBuilderTests {
             try package.checkModule("cxxfoo") { package in
                 let macosDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(
                     macosDebugScope.evaluate(.OTHER_CPLUSPLUSFLAGS) ==
@@ -3394,7 +3394,7 @@ struct PackageBuilderTests {
 
                 let macosReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release)
                 )
                 #expect(
                     macosReleaseScope.evaluate(.OTHER_CPLUSPLUSFLAGS) ==
@@ -3429,7 +3429,7 @@ struct PackageBuilderTests {
             try package.checkModule("cfoo") { package in
                 let macosDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(
                     macosDebugScope.evaluate(.OTHER_CFLAGS) ==
@@ -3438,7 +3438,7 @@ struct PackageBuilderTests {
 
                 let macosReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release)
                 )
                 #expect(
                     macosReleaseScope.evaluate(.OTHER_CFLAGS) ==
@@ -3473,7 +3473,7 @@ struct PackageBuilderTests {
             try package.checkModule("cxxfoo") { package in
                 let macosDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(
                     macosDebugScope.evaluate(.OTHER_CPLUSPLUSFLAGS) ==
@@ -3482,7 +3482,7 @@ struct PackageBuilderTests {
 
                 let macosReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release)
                 )
                 #expect(
                     macosReleaseScope.evaluate(.OTHER_CPLUSPLUSFLAGS) ==
@@ -3523,14 +3523,14 @@ struct PackageBuilderTests {
             try package.checkModule("A") { package in
                 let macosDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(macosDebugScope.evaluate(.OTHER_SWIFT_FLAGS).contains("-default-isolation"))
                 #expect(macosDebugScope.evaluate(.OTHER_SWIFT_FLAGS).contains("MainActor"))
 
                 let macosReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release)
                 )
                 #expect(macosReleaseScope.evaluate(.OTHER_SWIFT_FLAGS).contains("-default-isolation"))
                 #expect(macosReleaseScope.evaluate(.OTHER_SWIFT_FLAGS).contains("MainActor"))
@@ -3540,21 +3540,21 @@ struct PackageBuilderTests {
             try package.checkModule("B") { package in
                 let linuxDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .linux, configuration: .debug)
+                    environment: BuildEnvironment(platform: .linux, isHost: true, configuration: .debug)
                 )
                 #expect(linuxDebugScope.evaluate(.OTHER_SWIFT_FLAGS).contains("-default-isolation"))
                 #expect(linuxDebugScope.evaluate(.OTHER_SWIFT_FLAGS).contains("nonisolated"))
 
                 let macosDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .debug)
                 )
                 #expect(macosDebugScope.evaluate(.OTHER_SWIFT_FLAGS).contains("-default-isolation"))
                 #expect(macosDebugScope.evaluate(.OTHER_SWIFT_FLAGS).contains("MainActor"))
 
                 let macosReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
-                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                    environment: BuildEnvironment(platform: .macOS, isHost: true, configuration: .release)
                 )
                 #expect(!macosReleaseScope.evaluate(.OTHER_SWIFT_FLAGS).contains("-default-isolation") ||
                         !macosReleaseScope.evaluate(.OTHER_SWIFT_FLAGS).contains("MainActor"))

--- a/Tests/SPMBuildCoreTests/BuildParametersTests.swift
+++ b/Tests/SPMBuildCoreTests/BuildParametersTests.swift
@@ -21,7 +21,7 @@ struct BuildParametersTests {
     func configurationDependentProperties() throws {
         var parameters = mockBuildParameters(
             destination: .host,
-            environment: BuildEnvironment(platform: .linux, configuration: .debug)
+            environment: BuildEnvironment(platform: .linux, isHost: true, configuration: .debug)
         )
         #expect(parameters.enableTestability)
         parameters.configuration = .release


### PR DESCRIPTION
Previously the library would be built from source and then link together with the prebuilt to create the macro executable. That causes a crash in the macro.

This change extends what we build using the prebuilt to all targets when built for host. It will continue to build from source when targets are built for destination. This will include plugin tools as well. The separation of build output between host and destination (which is potentially a different platform) makes this work.

This is accomplished by recording in the BuildEnvironment whether the destination was host and the adding in an internal HostCondition that checks it in it's satisfy method.
