### PR TITLE
Prebuild plugin support for swiftbuild build system

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
@@ -7,6 +7,8 @@ struct MyPlugin: BuildToolPlugin {
         print("Hello from the Build Tool Plugin!")
         guard let target = target as? SourceModuleTarget else { return [] }
         let inputFiles = target.sourceFiles.filter({ $0.path.extension == "dat" })
+        let workDir = context.pluginWorkDirectoryURL
+
         return try inputFiles.map {
             let inputFile = $0
             let inputPath = inputFile.path
@@ -29,6 +31,16 @@ struct MyPlugin: BuildToolPlugin {
                     outputPath
                 ]
             )
-        }
+        } + [
+            .prebuildCommand(
+                displayName:
+                    "Generating files in \(workDir.path)",
+                executable:
+                    try context.tool(named: "mytool").url,
+                arguments:
+                    ["--verbose", "\(target.directoryURL.appendingPathComponent("bar.in").path)", "\(workDir.appendingPathComponent("bar.swift").path)"],
+                outputFilesDirectory: workDir
+            )
+        ]
     }
 }

--- a/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Sources/MyLocalTool/bar.in
+++ b/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Sources/MyLocalTool/bar.in
@@ -1,0 +1,1 @@
+let bar = "I am Bar!"

--- a/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Sources/MyLocalTool/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Sources/MyLocalTool/main.swift
@@ -1,1 +1,2 @@
 print("Generated string Foo: '\(foo)'")
+print("Generated string Bar: '\(bar)'")

--- a/Fixtures/Miscellaneous/Plugins/PrebuildDependsExecutableTarget/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/PrebuildDependsExecutableTarget/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.3
+
+import PackageDescription
+
+let package = Package(
+    name: "PrebuildDependsExecutableTarget",
+    platforms: [ .macOS(.v13) ],
+    dependencies: [
+    ],
+    targets: [
+        .executableTarget(name: "MyExecutable"),
+
+        .plugin(
+            name: "MyPlugin",
+            capability: .buildTool(),
+            dependencies: [
+                "MyExecutable"
+            ]
+        ),
+
+        .executableTarget(
+            name: "MyClient",
+            plugins: [
+                "MyPlugin",
+            ]
+        ),
+    ],
+    swiftLanguageModes: [.v5]
+)

--- a/Fixtures/Miscellaneous/Plugins/PrebuildDependsExecutableTarget/Plugins/MyPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/PrebuildDependsExecutableTarget/Plugins/MyPlugin/plugin.swift
@@ -1,0 +1,22 @@
+import PackagePlugin
+import Foundation
+
+@main
+struct MyPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        let outputFilePath = context.pluginWorkDirectoryURL.appendingPathComponent("MyGeneratedFile.swift")
+
+        // We are attempting to assemble a prebuild command that relies on an executable that hasn't
+        // been built yet. This should result in an error in prebuild.
+        let myExecutable = try context.tool(named: "MyExecutable")
+
+        return [
+            .prebuildCommand(
+                displayName: "Prebuild that runs MyExecutable",
+                executable: myExecutable.url,
+                arguments: ["--output-file-path", outputFilePath.path],
+                outputFilesDirectory: context.pluginWorkDirectoryURL
+            )
+        ]
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/PrebuildDependsExecutableTarget/Sources/MyClient/client.swift
+++ b/Fixtures/Miscellaneous/Plugins/PrebuildDependsExecutableTarget/Sources/MyClient/client.swift
@@ -1,0 +1,6 @@
+@main
+struct Client {
+    static func main() throws {
+        print(MyGeneratedStruct.message)
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/PrebuildDependsExecutableTarget/Sources/MyExecutable/tool.swift
+++ b/Fixtures/Miscellaneous/Plugins/PrebuildDependsExecutableTarget/Sources/MyExecutable/tool.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+@main
+struct Tool {
+    static func main() async throws {
+        print("warning: Whoops! Coming from the executable", to: &StdErr.shared)
+        
+        let path = CommandLine.arguments[2]
+        print("Writing a file to \(path)")
+        
+        try #"""
+        public struct MyGeneratedStruct {
+            public static var message: String = "You got struct'd"
+        }
+        """#.write(to: URL(fileURLWithPath: path), atomically: true, encoding: .utf8)
+    }
+}
+
+struct StdErr: TextOutputStream {
+    static var shared: Self = .init()
+    mutating func write(_ string: String) {
+        string.withCString { ptr in
+            _ = fputs(ptr, stderr)
+        }
+    }
+}

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -1500,7 +1500,7 @@ final class PluginTests {
     @Test(
         .enabled(if: ProcessInfo.hostOperatingSystem == .macOS, "sandboxing tests are only supported on macOS"),
         .requiresSwiftConcurrencySupport,
-        arguments: [BuildSystemProvider.Kind.native], // FIXME: enable swiftbuild testing once pre-build plugins are working
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testSandboxViolatingBuildToolPluginCommands(
         buildSystem: BuildSystemProvider.Kind,
@@ -1515,7 +1515,14 @@ final class PluginTests {
                 )
             }
 
-            #expect("\(error)".contains("You don’t have permission to save the file “generated” in the folder “MyLibrary”."))
+            switch buildSystem {
+            case .native:
+                #expect("\(error)".contains("You don’t have permission to save the file “generated” in the folder “MyLibrary”."))
+            case .swiftbuild:
+                #expect("\(error)".contains("Operation not permitted"))
+            case .xcode:
+                Issue.record("Test expected have not been considered")
+            }
         }
 
         // Check that the build succeeds if we disable the sandbox.
@@ -1526,7 +1533,7 @@ final class PluginTests {
                 extraArgs: ["--disable-sandbox"],
                 buildSystem: buildSystem,
             )
-            #expect(stdout.contains("Compiling MyLibrary foo.swift"), "[STDOUT]\n\(stdout)\n[STDERR]\n\(stderr)\n")
+            #expect(stdout.contains("Build complete!"), "[STDOUT]\n\(stdout)\n[STDERR]\n\(stderr)\n")
         }
     }
 

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -387,7 +387,6 @@ final class PluginTests {
 
     @Test(
         .requiresSwiftConcurrencySupport,
-        .enabled(if: ProcessInfo.hostOperatingSystem == .macOS, "Test is only supported on macOS"),
         arguments: [BuildSystemProvider.Kind.native, .swiftbuild]
     )
     func testUseOfVendedBinaryTool(buildSystem: BuildSystemProvider.Kind) async throws {


### PR DESCRIPTION
Add prebuild command support for build tool plugins with the swiftbuild build system.
Include a test case that verifies that referring to a tool through context fails in both
major build systems. Test that tools made available through binary artifact dependencies
with an artifact bundle work with both build systems.