### PR TITLE
Show traits package subcommand

### DIFF
--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(Commands
   PackageCommands/Resolve.swift
   PackageCommands/ShowDependencies.swift
   PackageCommands/ShowExecutables.swift
+  PackageCommands/ShowTraits.swift
   PackageCommands/SwiftPackageCommand.swift
   PackageCommands/ToolsVersionCommand.swift
   PackageCommands/Update.swift

--- a/Sources/Commands/PackageCommands/ShowTraits.swift
+++ b/Sources/Commands/PackageCommands/ShowTraits.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Basics
+import CoreCommands
+import Foundation
+import PackageModel
+import PackageGraph
+import Workspace
+
+struct ShowTraits: AsyncSwiftCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "List the available traits for a package.")
+
+    @OptionGroup(visibility: .hidden)
+    var globalOptions: GlobalOptions
+
+    @Option(help: "Show traits for the package id")
+    var packageId: String?
+
+    @Option(help: "Set the output format.")
+    var format: ShowTraitsMode = .flatlist
+
+    func run(_ swiftCommandState: SwiftCommandState) async throws {
+        let packageGraph = try await swiftCommandState.loadPackageGraph()
+
+        let traits = if let packageId {
+            packageGraph.packages.filter({ $0.identity.description == packageId }).flatMap( { $0.manifest.traits } ).sorted(by: {$0.name < $1.name} )
+        } else {
+            packageGraph.rootPackages.flatMap( { $0.manifest.traits } ).sorted(by: {$0.name < $1.name} )
+        }
+
+        switch self.format {
+        case .flatlist:
+            let defaultTraits = traits.filter( { $0.isDefault } ).flatMap( { $0.enabledTraits })
+
+            for trait in traits {
+                guard !trait.isDefault else {
+                    continue
+                }
+
+                print("\(trait.name)\(trait.description ?? "" != "" ? " - " + trait.description! : "")\(defaultTraits.contains(trait.name) ? " (default)" : "")")
+            }
+
+        case .json:
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(traits)
+            if let output = String(data: data, encoding: .utf8) {
+                print(output)
+            }
+        }
+    }
+
+    enum ShowTraitsMode: String, RawRepresentable, CustomStringConvertible, ExpressibleByArgument, CaseIterable {
+        case flatlist, json
+
+        public init?(rawValue: String) {
+            switch rawValue.lowercased() {
+            case "flatlist":
+                self = .flatlist
+            case "json":
+                self = .json
+            default:
+                return nil
+            }
+        }
+
+        public var description: String {
+            switch self {
+            case .flatlist: return "flatlist"
+            case .json: return "json"
+            }
+        }
+    }
+}

--- a/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
+++ b/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
@@ -66,6 +66,7 @@ public struct SwiftPackageCommand: AsyncParsableCommand {
 
             ShowDependencies.self,
             ShowExecutables.self,
+            ShowTraits.self,
             ToolsVersionCommand.self,
             ComputeChecksum.self,
             ArchiveSource.self,

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageCommands.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageCommands.md
@@ -41,6 +41,7 @@ Overview of package manager commands here...
 - <doc:PackageDescribe>
 - <doc:PackageShowDependencies>
 - <doc:PackageShowExecutables>
+- <doc:PackageShowTraits>
 - <doc:PackageToolsVersion>
 - <doc:PackageDumpPackage>
 - <doc:PackageDumpSymbolGraph>

--- a/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
@@ -71,6 +71,7 @@ extension Tag.Feature.Command.Package {
     @Tag public static var Resolve: Tag
     @Tag public static var ShowDependencies: Tag
     @Tag public static var ShowExecutables: Tag
+    @Tag public static var ShowTraits: Tag
     @Tag public static var ToolsVersion: Tag
     @Tag public static var Unedit: Tag
     @Tag public static var Update: Tag


### PR DESCRIPTION
One of the benefits of traits comes from their declarative nature with a
description that helps to explain their purpose. Users should be able to
discover, and understand them so that they can enable them for the
current package, and also dependencies too so that they can enable them
through the package dependencies.

Add a new show-traits package subcommand that defaults to listing
the traits for the current package, and optionally for other packages
with an option.

    swift package show-traits [--package-id=<packageId>]

Add a format option to set either a flat list, or JSON output format.