### PR TITLE
Clean up test traits

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift
@@ -75,19 +75,4 @@ extension Trait where Self == Testing.Bug {
             relationship: .defect,
         )
     }
-
-    public static var IssueSwiftBuildLinuxRunnable: Self {
-        .issue(
-            "https://github.com/swiftlang/swift-package-manager/issues/8416",
-            relationship: .defect,
-        )
-    }
-
-    public static var IssueCannnotOpenSharedObjectFileLibSwiftCore : Self {
-        // /tmp/Miscellaneous_PackageEdit.H5ku8Q/foo/.build/aarch64-unknown-linux-gnu/Products/Debug-linux/foo: error while loading shared libraries: libswiftCore.so: cannot open shared object file: No such file or directory
-        .issue(
-            "https://github.com/swiftlang/swift-package-manager/issues/8416",
-            relationship: .defect,
-        )
-    }
 }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2581,7 +2581,6 @@ struct PackageCommandTests {
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8774", relationship: .defect),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8380", relationship: .defect),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8416", relationship: .defect),  // swift run linux issue with swift build,
-        .IssueCannnotOpenSharedObjectFileLibSwiftCore,
         .tags(
             .Feature.Command.Package.Edit,
             .Feature.Command.Package.Unedit,
@@ -2902,7 +2901,6 @@ struct PackageCommandTests {
         // windows long path issue
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8774", relationship: .defect),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8380", relationship: .defect),
-        .IssueCannnotOpenSharedObjectFileLibSwiftCore,
         .tags(
             .Feature.Command.Build,
             .Feature.Command.Package.Resolve,

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -29,7 +29,6 @@ import enum TSCUtility.Git
 )
 struct DependencyResolutionTests {
     @Test(
-        .IssueSwiftBuildLinuxRunnable,
         .IssueWindowsLongPath,
         .IssueProductTypeForObjectLibraries,
         .tags(
@@ -161,7 +160,6 @@ struct DependencyResolutionTests {
     }
 
     @Test(
-        .IssueSwiftBuildLinuxRunnable,
         .IssueWindowsLongPath,
         .tags(
             Tag.Feature.Command.Build,

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -1445,7 +1445,6 @@ final class PluginTests {
             .issue("https://github.com/swiftlang/swift-package-manager/issues/9040", relationship: .verifies),
             .IssueWindowsCannotSaveAttachment,
             .requiresSwiftConcurrencySupport,
-            .IssueSwiftBuildLinuxRunnable,
             arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms), try getFiles(in: RelativePath(validating: "Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Snippets"), matchingExtension: "swift",),
         )
         func testBasicRunSnippets(
@@ -1465,7 +1464,7 @@ final class PluginTests {
                 #expect(stdout.contains("hello, snippets"), "stderr: \(stderr)")
             }
             } when: {
-                [.windows, .linux].contains(ProcessInfo.hostOperatingSystem) && data.buildSystem == .swiftbuild
+                [.windows].contains(ProcessInfo.hostOperatingSystem) && data.buildSystem == .swiftbuild
             }
         }
     }

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -29,7 +29,6 @@ struct TraitTests {
     @Test(
         .IssueWindowsPathTestsFailures,
         .IssueWindowsRelativePathAssert,
-        .IssueSwiftBuildLinuxRunnable,
         .IssueProductTypeForObjectLibraries,
         .tags(
             Tag.Feature.Command.Run,
@@ -40,9 +39,7 @@ struct TraitTests {
         buildSystem: BuildSystemProvider.Kind,
         configuration: BuildConfiguration,
     ) async throws {
-        try await withKnownIssue("""
-        Linux: https://github.com/swiftlang/swift-package-manager/issues/8416
-        """, isIntermittent: (ProcessInfo.hostOperatingSystem == .linux) || (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild)) {
+        try await withKnownIssue(isIntermittent: (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild)) {
         try await fixture(name: "Traits") { fixturePath in
             let (stdout, stderr) = try await executeSwiftRun(
                 fixturePath.appending("Example"),
@@ -66,14 +63,13 @@ struct TraitTests {
         }
         } when: {
             (ProcessInfo.hostOperatingSystem == .windows && (CiEnvironment.runningInSmokeTestPipeline || buildSystem == .swiftbuild))
-            || (buildSystem == .swiftbuild && [.linux, .windows].contains(ProcessInfo.hostOperatingSystem))
+            || (buildSystem == .swiftbuild && [.windows].contains(ProcessInfo.hostOperatingSystem))
         }
     }
 
     @Test(
         .IssueWindowsPathTestsFailures,
         .IssueWindowsRelativePathAssert,
-        .IssueSwiftBuildLinuxRunnable,
         .IssueProductTypeForObjectLibraries,
         .tags(
             Tag.Feature.Command.Run,
@@ -86,7 +82,6 @@ struct TraitTests {
     ) async throws {
         try await withKnownIssue(
             """
-            Linux: https://github.com/swiftlang/swift-package-manager/issues/8416
             Windows: "https://github.com/swiftlang/swift-build/issues/609"
             """,
             isIntermittent: (ProcessInfo.hostOperatingSystem == .windows),
@@ -126,7 +121,6 @@ struct TraitTests {
     @Test(
         .IssueWindowsPathTestsFailures,
         .IssueWindowsRelativePathAssert,
-        .IssueSwiftBuildLinuxRunnable,
         .IssueProductTypeForObjectLibraries,
         .tags(
             Tag.Feature.Command.Run,
@@ -139,7 +133,6 @@ struct TraitTests {
     ) async throws {
         try await withKnownIssue(
             """
-            Linux: https://github.com/swiftlang/swift-package-manager/issues/8416,
             Windows: https://github.com/swiftlang/swift-build/issues/609
             """,
             isIntermittent: (ProcessInfo.hostOperatingSystem == .windows),
@@ -176,7 +169,6 @@ struct TraitTests {
     @Test(
         .IssueWindowsPathTestsFailures,
         .IssueWindowsRelativePathAssert,
-        .IssueSwiftBuildLinuxRunnable,
         .IssueProductTypeForObjectLibraries,
         .tags(
             Tag.Feature.Command.Run,
@@ -189,7 +181,6 @@ struct TraitTests {
     ) async throws {
         try await withKnownIssue(
             """
-            Linux: https://github.com/swiftlang/swift-package-manager/issues/8416,
             Windows: https://github.com/swiftlang/swift-build/issues/609
             """,
             isIntermittent: (ProcessInfo.hostOperatingSystem == .windows),
@@ -230,7 +221,6 @@ struct TraitTests {
     @Test(
         .IssueWindowsPathTestsFailures,
         .IssueWindowsRelativePathAssert,
-        .IssueSwiftBuildLinuxRunnable,
         .IssueProductTypeForObjectLibraries,
         .tags(
             Tag.Feature.Command.Run,
@@ -241,10 +231,7 @@ struct TraitTests {
         buildSystem: BuildSystemProvider.Kind,
         configuration: BuildConfiguration,
     ) async throws {
-        try await withKnownIssue("""
-        Linux: https://github.com/swiftlang/swift-package-manager/issues/8416,
-        """,
-        isIntermittent: (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild)) {
+        try await withKnownIssue(isIntermittent: (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild)) {
         try await fixture(name: "Traits") { fixturePath in
             let (stdout, stderr) = try await executeSwiftRun(
                 fixturePath.appending("Example"),
@@ -271,7 +258,6 @@ struct TraitTests {
     @Test(
         .IssueWindowsPathTestsFailures,
         .IssueWindowsRelativePathAssert,
-        .IssueSwiftBuildLinuxRunnable,
         .IssueProductTypeForObjectLibraries,
         .tags(
             Tag.Feature.Command.Run,
@@ -283,7 +269,6 @@ struct TraitTests {
         configuration: BuildConfiguration,
     ) async throws {
         try await withKnownIssue("""
-            Linux: https://github.com/swiftlang/swift-package-manager/issues/8416,
             Windows: https://github.com/swiftlang/swift-build/issues/609
             """,
             isIntermittent: (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild),
@@ -317,7 +302,6 @@ struct TraitTests {
     @Test(
         .IssueWindowsPathTestsFailures,
         .IssueWindowsRelativePathAssert,
-        .IssueSwiftBuildLinuxRunnable,
         .IssueProductTypeForObjectLibraries,
         .tags(
             Tag.Feature.Command.Run,
@@ -330,7 +314,6 @@ struct TraitTests {
     ) async throws {
         try await withKnownIssue(
             """
-            Linux: https://github.com/swiftlang/swift-package-manager/issues/8416,
             Windows: https://github.com/swiftlang/swift-build/issues/609
             """,
             isIntermittent: (ProcessInfo.hostOperatingSystem == .windows),
@@ -374,7 +357,6 @@ struct TraitTests {
     @Test(
         .IssueWindowsPathTestsFailures,
         .IssueWindowsRelativePathAssert,
-        .IssueSwiftBuildLinuxRunnable,
         .IssueProductTypeForObjectLibraries,
         .tags(
             Tag.Feature.Command.Run,
@@ -387,7 +369,6 @@ struct TraitTests {
     ) async throws {
         try await withKnownIssue(
             """
-            Linux: https://github.com/swiftlang/swift-package-manager/issues/8416,
             Windows: https://github.com/swiftlang/swift-build/issues/609
             """,
             isIntermittent: (ProcessInfo.hostOperatingSystem == .windows)
@@ -615,7 +596,6 @@ struct TraitTests {
     }
 
     @Test(
-        .IssueSwiftBuildLinuxRunnable,
         .tags(
             Tag.Feature.Command.Run,
         ),
@@ -626,38 +606,29 @@ struct TraitTests {
         configuration: BuildConfiguration,
     ) async throws {
         try await fixture(name: "Traits") { fixturePath in
-            try await withKnownIssue("""
-            Linux: https://github.com/swiftlang/swift-package-manager/issues/8416,
-            """,
-            isIntermittent: true,
-            ) {
-                let error = await #expect(throws: SwiftPMError.self) {
-                    try await executeSwiftRun(
-                    fixturePath.appending("DisablingEmptyDefaultsExample"),
-                        "DisablingEmptyDefaultsExample",
-                        configuration: configuration,
-                        buildSystem: buildSystem,
-                    )
-                }
-
-                guard case SwiftPMError.executionFailure(_, _, let stderr) = try #require(error) else {
-                    Issue.record("Incorrect error was raised.")
-                    return
-                }
-
-                let expectedErr = """
-                    error: Disabled default traits by package 'disablingemptydefaultsexample' (DisablingEmptyDefaultsExample) on package 'package11' (Package11) that declares no traits. This is prohibited to allow packages to adopt traits initially without causing an API break.
-
-                    """
-                #expect(stderr.contains(expectedErr))
-            } when: {
-                buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .linux
+            let error = await #expect(throws: SwiftPMError.self) {
+                try await executeSwiftRun(
+                fixturePath.appending("DisablingEmptyDefaultsExample"),
+                    "DisablingEmptyDefaultsExample",
+                    configuration: configuration,
+                    buildSystem: buildSystem,
+                )
             }
+
+            guard case SwiftPMError.executionFailure(_, _, let stderr) = try #require(error) else {
+                Issue.record("Incorrect error was raised.")
+                return
+            }
+
+            let expectedErr = """
+                error: Disabled default traits by package 'disablingemptydefaultsexample' (DisablingEmptyDefaultsExample) on package 'package11' (Package11) that declares no traits. This is prohibited to allow packages to adopt traits initially without causing an API break.
+
+                """
+            #expect(stderr.contains(expectedErr))
         }
     }
 
     @Test(
-        .IssueSwiftBuildLinuxRunnable,
         .IssueProductTypeForObjectLibraries,
         .tags(
             Tag.Feature.Command.Run,
@@ -705,7 +676,6 @@ struct TraitTests {
     ) async throws {
         try await withKnownIssue(
             """
-            Linux: https://github.com/swiftlang/swift-package-manager/issues/8416,
             Windows: https://github.com/swiftlang/swift-build/issues/609
             """,
             isIntermittent: (ProcessInfo.hostOperatingSystem == .windows),

--- a/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/Tests/IntegrationTests/SwiftPMTests.swift
@@ -84,11 +84,6 @@ private struct SwiftPMTests {
     }
 
     @Test(
-        .IssueSwiftBuildLinuxRunnable,
-        .bug(
-            "https://github.com/swiftlang/swift-package-manager/issues/8514",
-            "[Windows] Integration test SwiftPMTests.packageInitExecutable with --build-system swiftbuild is skipped"
-        ),
         .tags(
             Tag.Feature.Command.Package.Init,
             Tag.Feature.PackageType.Executable,


### PR DESCRIPTION
The change in #8884 fixed the root cause, but did not update all the tests accordingly as some tests unnecessarily contained a `withKnownIssue` block.

Remove the remaining `withKnownIssues` and the defect trait from the test.

Closes: #8416