### PR TITLE
Rename runCommandPlugins methods to a more accurate name

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -337,7 +337,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                     }
 
                     buildToolPluginInvocationResults[module.id] = pluginInvocationResults
-                    prebuildCommandResults[module.id] = try Self.runCommandPlugins(
+                    prebuildCommandResults[module.id] = try Self.runPluginCommands(
                         using: pluginConfiguration,
                         for: pluginInvocationResults,
                         fileSystem: fileSystem,
@@ -854,9 +854,9 @@ extension BuildPlan {
         return buildToolPluginResults
     }
 
-    /// Runs any command plugins associated with the given list of plugin invocation results,
+    /// Runs any commands associated with the given list of plugin invocation results,
     /// in order, and returns the results of running those prebuild commands.
-    fileprivate static func runCommandPlugins(
+    fileprivate static func runPluginCommands(
         using pluginConfiguration: PluginConfiguration,
         for pluginResults: [BuildToolPluginInvocationResult],
         fileSystem: any FileSystem,

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -369,7 +369,7 @@ public final class PIFBuilder {
 
                     // Run the prebuild commands generated from the plugin invocation now for this module. This will
                     // also give use the derived source code files needed for PIF generation.
-                    let runResults = try Self.runCommandPlugins(
+                    let runResults = try Self.runPluginCommands(
                         using: self.pluginConfiguration,
                         for: buildToolPluginResults,
                         fileSystem: fileSystem,
@@ -429,9 +429,9 @@ public final class PIFBuilder {
         }
     }
 
-    /// Runs any command plugins associated with the given list of plugin invocation results,
+    /// Runs any commands associated with the given list of plugin invocation results,
     /// in order, and returns the results of running those prebuild commands.
-    fileprivate static func runCommandPlugins(
+    fileprivate static func runPluginCommands(
         using pluginConfiguration: PluginConfiguration,
         for pluginResults: [BuildToolPluginInvocationResult],
         fileSystem: any FileSystem,


### PR DESCRIPTION
_[One line description of your change]_

### Motivation:

This method is very confusing because it suggests that command plugins will be run during build, which is not the case. Command plugins always run at the user's request using `swift package plugin <name>` outside of a build.

Instead, this method should be renamed to reflect that it is running commands that the plugin has generated when it was invoked from a collection of results.

Rename the methods in both the SwiftBuildSupport and Build components and update the documentation.