### PR TITLE
Tests: Run some test serially on Windows

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+Traits.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Traits.swift
@@ -1,0 +1,25 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Testing
+
+#if os(Windows)
+    extension Trait where Self == ParallelizationTrait {
+        public static var serializedIfOnWindows: Self {
+            .serialized
+        }
+    }
+#else
+    extension Trait where Self == ConditionTrait {
+        public static var serializedIfOnWindows: Self {
+            .enabled(if: true)
+        }
+    }
+#endif

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -33,7 +33,9 @@ extension Trait where Self == Testing.ConditionTrait {
     }
 }
 
-@Suite
+@Suite(
+    .serializedIfOnWindows,
+)
 struct APIDiffTests {
     @discardableResult
     private func execute(

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -119,6 +119,7 @@ fileprivate func build(
 }
 
 @Suite(
+    .serializedIfOnWindows,
     .tags(
         Tag.TestSize.large,
         Tag.Feature.Command.Build,

--- a/Tests/CommandsTests/CoverageTests.swift
+++ b/Tests/CommandsTests/CoverageTests.swift
@@ -20,6 +20,7 @@ import struct SPMBuildCore.BuildSystemProvider
 import Testing
 
 @Suite(
+    .serializedIfOnWindows,
     .tags(
         .TestSize.large,
         .Feature.CodeCoverage,

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -90,7 +90,7 @@ private func executeAddURLDependencyAndAssert(
 }
 
 @Suite(
-    // .serialized,
+    .serializedIfOnWindows,
     .tags(
         .TestSize.large,
         .Feature.Command.Package.General,

--- a/Tests/CommandsTests/PackageRegistryCommandTests.swift
+++ b/Tests/CommandsTests/PackageRegistryCommandTests.swift
@@ -31,6 +31,7 @@ let defaultRegistryBaseURL = URL("https://packages.example.com")
 let customRegistryBaseURL = URL("https://custom.packages.example.com")
 
 @Suite(
+    .serializedIfOnWindows,
     .tags(
         .Feature.Command.PackageRegistry.General,
     ),

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -40,6 +40,7 @@ fileprivate func expectDirectoryContainsFile(
 }
 
 @Suite(
+    .serializedIfOnWindows,
     .tags(
         .TestSize.large,
     ),

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -23,6 +23,7 @@ import struct SPMBuildCore.BuildSystemProvider
 import enum TSCUtility.Git
 
 @Suite(
+    .serializedIfOnWindows,
     .tags(
         Tag.TestSize.large,
     ),

--- a/Tests/FunctionalTests/MacroTests.swift
+++ b/Tests/FunctionalTests/MacroTests.swift
@@ -19,6 +19,7 @@ import PackageModel
 import Testing
 
 @Suite(
+    .serializedIfOnWindows,
     .tags(
         Tag.TestSize.large
     ),

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -20,6 +20,7 @@ import Workspace
 import Testing
 
 @Suite(
+    .serializedIfOnWindows,
     .tags(
         Tag.TestSize.large,
     ),

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -24,8 +24,10 @@ import Testing
 import Foundation
 
 @Suite(
+    .serializedIfOnWindows,
     .tags(
         .Feature.Command.Package.Plugin,
+        .TestSize.large,
     )
 )
 final class PluginTests {

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -18,7 +18,9 @@ import Testing
 import struct Foundation.UUID
 import class Foundation.ProcessInfo
 
-@Suite
+@Suite(
+    .serializedIfOnWindows,
+)
 struct TestDiscoveryTests {
     static var buildSystems: [BuildSystemProvider.Kind] = [BuildSystemProvider.Kind.native, .swiftbuild]
 

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -20,6 +20,7 @@ import Testing
 import _InternalTestSupport
 
 @Suite(
+    .serializedIfOnWindows,
     .tags(
         Tag.TestSize.large,
         Tag.Feature.Traits,

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -19,6 +19,7 @@ import struct SPMBuildCore.BuildSystemProvider
 import enum PackageModel.BuildConfiguration
 
 @Suite(
+    .serializedIfOnWindows,
     .tags(
         .TestSize.large,
     ),


### PR DESCRIPTION
The Windows self hosted pipeline occassionally has a test hanging.  In order to prevent this from occurring, run some `large` (ie: end-to-end) tests serially on Windows.
