### PR TITLE
Exclude PWD and OLDPWD from manifest cache key

### DIFF
--- a/Sources/Basics/Environment/EnvironmentKey.swift
+++ b/Sources/Basics/Environment/EnvironmentKey.swift
@@ -51,6 +51,13 @@ extension EnvironmentKey {
         "VSCODE_IPC_HOOK_CLI",
         "HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET",
         "SSH_AUTH_SOCK",
+        // Shell-maintained working directory variables. These reflect the
+        // invoking shell's state and do not affect manifest compilation, but
+        // when included in the cache key they cause spurious manifest cache
+        // misses (and re-resolution) whenever the user `cd`s from a different
+        // directory before running SwiftPM.
+        "PWD",
+        "OLDPWD",
     ]).union(ConfigurableEnvVar.nonCachableEnvVars())
 }
 

--- a/Tests/BasicsTests/Environment/EnvironmentTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentTests.swift
@@ -185,13 +185,22 @@ struct EnvironmentTests {
     @Test
     func cachable() {
         let term = EnvironmentKey("TERM")
+        let pwd = EnvironmentKey("PWD")
+        let oldpwd = EnvironmentKey("OLDPWD")
         var environment = Environment()
         environment[.path] = "/usr/bin"
         environment[term] = "xterm-256color"
+        environment[pwd] = "/some/working/dir"
+        environment[oldpwd] = "/some/previous/dir"
 
         let cachableEnvironment = environment.cachable
         #expect(cachableEnvironment[.path] != nil)
         #expect(cachableEnvironment[term] == nil)
+        // Shell-maintained cwd variables must be stripped so that running
+        // SwiftPM from different shells (or after `cd`ing) does not bust the
+        // manifest cache.
+        #expect(cachableEnvironment[pwd] == nil)
+        #expect(cachableEnvironment[oldpwd] == nil)
     }
 
     @Test


### PR DESCRIPTION
## Motivation

`ManifestLoader.CacheKey` hashes the process environment (after filtering through `Environment.cachable`) into the SHA256 key used for `manifest.db`. The `nonCachable` set in `EnvironmentKey.swift` strips terminal- and session-scoped variables but does not strip `PWD` or `OLDPWD`, which are maintained by the invoking shell.

As a result, running the same SwiftPM command in the same package directory produces different cache keys depending on the shell's prior working directory. Each distinct `OLDPWD` (or `PWD`) value inserts a new row into `MANIFEST_CACHE` and forces manifest re-compilation, even though none of the inputs to manifest evaluation have changed.

## Reproduction

With an isolated cache (`--cache-path`) and identical `Package.swift`, varying only the shell's working-directory variables:

| Run | OLDPWD | PWD | Rows in `MANIFEST_CACHE` |
|-----|--------|-----|--------------------------|
| 1 | `/tmp` | `/tmp/pkg` | 1 (insert) |
| 2 | **`/Users`** | `/tmp/pkg` | **2 (miss)** |
| 3 | `/tmp` | `/tmp/pkg` | 2 (hit) |
| 4 | `/tmp` | **`/elsewhere`** | **3 (miss)** |

Each change to `PWD` or `OLDPWD` alone is enough to bust the cache and re-evaluate the manifest.

## Fix

Add `PWD` and `OLDPWD` to `EnvironmentKey.nonCachable`. These are shell-maintained variables that do not influence manifest compilation, so including them in the cache key only produces spurious misses.

## Test plan

- [x] Extended the existing `EnvironmentTests.cachable()` test to assert that both `PWD` and `OLDPWD` are stripped by `Environment.cachable`.
- [x] Manually reproduced the cache-miss behavior with `--cache-path` and confirmed that, with the fix, `manifest.db` row count no longer grows when only `PWD`/`OLDPWD` differ across runs.