### PR TITLE
Add `swift package-registry search` subcommand

### DIFF
--- a/Examples/package-registry/Sources/RegistryExample/Models/SearchQuery.swift
+++ b/Examples/package-registry/Sources/RegistryExample/Models/SearchQuery.swift
@@ -1,0 +1,149 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// An error thrown while parsing a ``SearchQuery``.
+public enum SearchQueryError: Error, Equatable, Sendable {
+    /// A term used a `qualifier:value` form whose qualifier isn't one of the
+    /// recognized ``SearchQuery/Field`` keys. The associated value is that
+    /// qualifier.
+    case unknownQualifier(String)
+}
+
+/// A parsed package search query, as accepted by the `q` parameter of the
+/// *Search packages* endpoint (`GET /search`).
+///
+/// A query is a whitespace-separated list of *terms*. Each term is either a
+/// free-text term or a `qualifier:value` term that restricts matching to a
+/// single field:
+///
+/// - **Free text** matches case-insensitively against a package's identity,
+///   description, or author name.
+/// - **`scope:`**, **`name:`**, **`author:`**, and **`description:`** match
+///   only against the named field.
+///
+/// A value that spans multiple words may be wrapped in double quotes, for
+/// example `author:"Mona Lisa"` or `"linked list"`. All terms must match for
+/// a package to be included (implicit logical *AND*); an empty query matches
+/// nothing. The `OR`/`NOT`/`-` operators and the `pkg:` (package-URL)
+/// qualifier described by the proposal are intentionally out of scope for this
+/// reference implementation.
+public struct SearchQuery: Sendable {
+    /// The fields that a `qualifier:value` term may target.
+    enum Field: String, Sendable, CaseIterable {
+        case scope
+        case name
+        case author
+        case description
+    }
+
+    /// A single parsed term of a ``SearchQuery``.
+    ///
+    /// Both cases carry case-normalized (lowercased) needles, so matching only
+    /// needs to lowercase the fields it compares against.
+    enum Term: Sendable {
+        /// A free-text term matched against identity, description, and author.
+        case freeText(String)
+        /// A `qualifier:value` term matched against a single ``Field``.
+        case qualifier(field: Field, value: String)
+    }
+
+    let terms: [Term]
+
+    /// Whether the query carries no terms and therefore matches nothing.
+    public var isEmpty: Bool { terms.isEmpty }
+
+    /// Parses a raw query string into its terms.
+    ///
+    /// - Parameter raw: The raw value of the `q` query parameter.
+    /// - Throws: ``SearchQueryError/unknownQualifier(_:)`` if a term uses an
+    ///   unrecognized qualifier (for example `foo:bar`).
+    public init(parsing raw: String) throws {
+        self.terms = try Self.tokenize(raw).map(Self.parseTerm)
+    }
+
+    /// Splits a raw query into tokens, treating double-quoted spans as a single
+    /// token and discarding the quote characters.
+    private static func tokenize(_ raw: String) -> [String] {
+        var tokens: [String] = []
+        var current = ""
+        var inQuotes = false
+        var inToken = false
+        for character in raw {
+            if character == "\"" {
+                inQuotes.toggle()
+                inToken = true
+                continue
+            }
+            if character.isWhitespace, !inQuotes {
+                if inToken {
+                    tokens.append(current)
+                    current = ""
+                    inToken = false
+                }
+                continue
+            }
+            current.append(character)
+            inToken = true
+        }
+        if inToken { tokens.append(current) }
+        return tokens
+    }
+
+    /// Classifies a token as a free-text or qualifier term, normalizing its
+    /// needle to lowercase for case-insensitive matching.
+    ///
+    /// A token whose portion before the first colon is a run of ASCII letters
+    /// is treated as a qualifier; an unrecognized qualifier key is rejected.
+    private static func parseTerm(_ token: String) throws -> Term {
+        guard let colon = token.firstIndex(of: ":") else {
+            return .freeText(token.lowercased())
+        }
+        let key = token[token.startIndex..<colon]
+        guard !key.isEmpty, key.allSatisfy({ $0.isASCII && $0.isLetter }) else {
+            return .freeText(token.lowercased())
+        }
+        guard let field = Field(rawValue: key.lowercased()) else {
+            throw SearchQueryError.unknownQualifier(String(key))
+        }
+        return .qualifier(field: field, value: token[token.index(after: colon)...].lowercased())
+    }
+
+    /// Reports whether a package with the given fields satisfies every term.
+    ///
+    /// - Parameters:
+    ///   - scope: The package scope.
+    ///   - name: The package name.
+    ///   - description: The package's free-form description, if any.
+    ///   - author: The package author's name, if any.
+    /// - Returns: `true` if the query is non-empty and all of its terms match.
+    func matches(scope: String, name: String, description: String?, author: String?) -> Bool {
+        guard !terms.isEmpty else { return false }
+        let identity = "\(scope).\(name)"
+        return terms.allSatisfy { term in
+            switch term {
+            case .freeText(let needle):
+                return [identity, description, author].contains { $0?.lowercased().contains(needle) ?? false }
+            case .qualifier(let field, let needle):
+                let haystack: String?
+                switch field {
+                case .scope: haystack = scope
+                case .name: haystack = name
+                case .author: haystack = author
+                case .description: haystack = description
+                }
+                return haystack?.lowercased().contains(needle) ?? false
+            }
+        }
+    }
+}

--- a/Examples/package-registry/Sources/RegistryExample/Routes/AvailabilityRoutes.swift
+++ b/Examples/package-registry/Sources/RegistryExample/Routes/AvailabilityRoutes.swift
@@ -14,9 +14,10 @@ import Vapor
 
 /// Route handler for `GET /availability`.
 ///
-/// The `/availability` endpoint serves as a liveness probe: a `200 OK`
-/// indicates the registry is reachable. The response has an empty body;
-/// this registry advertises no optional capabilities.
+/// The `/availability` endpoint is a liveness probe: a `200 OK` means the
+/// registry is reachable. The body advertises the optional capabilities this
+/// registry supports, so a client can check whether `search` is available
+/// before calling it.
 public struct AvailabilityRoutes: Sendable {
     /// Creates a new `AvailabilityRoutes`.
     public init() {}
@@ -28,6 +29,20 @@ public struct AvailabilityRoutes: Sendable {
 
     @Sendable
     func availability(req: Request) async throws -> Response {
-        Response(status: .ok)
+        let body = AvailabilityResponse(capabilities: ["search": Capability()])
+        let data = try JSONEncoder.registry.encode(body)
+        let response = Response(status: .ok, body: .init(data: data))
+        response.headers.contentType = .json
+        return response
     }
 }
+
+/// The body of a `GET /availability` response, advertising each supported
+/// optional capability by name.
+struct AvailabilityResponse: Encodable {
+    var capabilities: [String: Capability]
+}
+
+/// Details of a single advertised capability. Empty for now; a capability's
+/// presence in ``AvailabilityResponse/capabilities`` is what signals support.
+struct Capability: Encodable {}

--- a/Examples/package-registry/Sources/RegistryExample/Routes/SearchRoutes.swift
+++ b/Examples/package-registry/Sources/RegistryExample/Routes/SearchRoutes.swift
@@ -1,0 +1,167 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Vapor
+
+/// Route handler for *Search packages* (`GET /search?q={query}`).
+///
+/// Given a query and optional pagination parameters, the registry responds
+/// with the matching packages and the total number of matches. Matching is
+/// delegated to ``SearchQuery`` and ``RegistryStore/search(_:limit:offset:)``.
+///
+/// Responses carry `first`/`prev`/`next`/`last` `Link` headers when the result
+/// set spans more than one page, mirroring the pagination links on the §4.1
+/// list-releases response.
+public struct SearchRoutes: Sendable {
+    static let defaultLimit = 20
+    static let maxLimit = 100
+
+    let store: RegistryStore
+
+    /// Creates a `SearchRoutes` handler backed by the given store.
+    ///
+    /// - Parameter store: The registry store to search.
+    public init(store: RegistryStore) {
+        self.store = store
+    }
+
+    /// Registers the `GET /search` route on the supplied router.
+    ///
+    /// - Parameter router: The Vapor routes builder to attach the handler to.
+    public func register(_ router: any RoutesBuilder) {
+        router.get("search", use: search)
+    }
+
+    @Sendable
+    func search(req: Request) async throws -> Response {
+        let rawQuery = (try? req.query.get(String.self, at: "q")) ?? ""
+        let query = try parseQuery(rawQuery)
+        let limit = try parseLimit(req)
+        let offset = try parseOffset(req)
+
+        let (hits, total) = await store.search(query, limit: limit, offset: offset)
+        let baseURL = req.baseURL
+        let results = hits.map { hit in
+            SearchResult(
+                identity: hit.identifier.description,
+                summary: hit.summary,
+                latestVersion: hit.latestVersion,
+                author: hit.author,
+                licenseURL: hit.licenseURL?.absoluteString,
+                url: "\(baseURL)/\(hit.identifier.scope)/\(hit.identifier.name)"
+            )
+        }
+
+        let body = SearchResponse(results: results, total: total, offset: offset, limit: limit)
+        let data = try JSONEncoder.registry.encode(body)
+        let response = Response(status: .ok, body: .init(data: data))
+        response.headers.contentType = .json
+        let links = paginationLinks(
+            baseURL: baseURL,
+            query: rawQuery,
+            limit: limit,
+            offset: offset,
+            total: total
+        )
+        if !links.isEmpty {
+            response.headers.links = links
+        }
+        return response
+    }
+
+    /// Parses the query string, translating a parse failure into a
+    /// `400 Bad Request` problem.
+    private func parseQuery(_ raw: String) throws -> SearchQuery {
+        do {
+            return try SearchQuery(parsing: raw)
+        } catch SearchQueryError.unknownQualifier(let key) {
+            throw ProblemDetails.badRequest("unknown search qualifier '\(key)'")
+        }
+    }
+
+    /// Parses the `limit` parameter, clamping it into `1...maxLimit`.
+    ///
+    /// A missing value defaults to ``defaultLimit``; a present but
+    /// non-integer value is rejected with `400 Bad Request`.
+    private func parseLimit(_ req: Request) throws -> Int {
+        guard let raw = try? req.query.get(String.self, at: "limit") else {
+            return Self.defaultLimit
+        }
+        guard let value = Int(raw) else {
+            throw ProblemDetails.badRequest("invalid limit parameter")
+        }
+        return min(max(value, 1), Self.maxLimit)
+    }
+
+    /// Parses the `offset` parameter. A missing value defaults to `0`; a
+    /// present value must be a non-negative integer.
+    private func parseOffset(_ req: Request) throws -> Int {
+        guard let raw = try? req.query.get(String.self, at: "offset") else { return 0 }
+        guard let value = Int(raw), value >= 0 else {
+            throw ProblemDetails.badRequest("invalid offset parameter")
+        }
+        return value
+    }
+
+    /// Builds the `first`/`prev`/`next`/`last` pagination links for a search
+    /// response, preserving the query and page size. Returns an empty array
+    /// when the results fit on a single page.
+    private func paginationLinks(
+        baseURL: String,
+        query: String,
+        limit: Int,
+        offset: Int,
+        total: Int
+    ) -> [HTTPHeaders.Link] {
+        guard total > limit else { return [] }
+        let lastOffset = ((total - 1) / limit) * limit
+        let pageURL = { (offset: Int) -> URL? in
+            var components = URLComponents(string: "\(baseURL)/search")
+            components?.queryItems = [
+                URLQueryItem(name: "q", value: query),
+                URLQueryItem(name: "limit", value: String(limit)),
+                URLQueryItem(name: "offset", value: String(offset)),
+            ]
+            return components?.url
+        }
+        var specs: [(Int, HTTPHeaders.Link.Relation)] = [(0, .first)]
+        if offset > 0 {
+            specs.append((max(0, offset - limit), .prev))
+        }
+        if offset + limit < total {
+            specs.append((offset + limit, .next))
+        }
+        specs.append((lastOffset, .last))
+        return specs.compactMap { offset, relation in
+            pageURL(offset).map {
+                HTTPHeaders.Link(uri: $0.absoluteString, relation: relation, attributes: [:])
+            }
+        }
+    }
+}
+
+struct SearchResponse: Encodable {
+    var results: [SearchResult]
+    var total: Int
+    var offset: Int
+    var limit: Int
+}
+
+struct SearchResult: Encodable {
+    var identity: String
+    var summary: String?
+    var latestVersion: String?
+    var author: String?
+    var licenseURL: String?
+    var url: String?
+}

--- a/Examples/package-registry/Sources/RegistryExample/Storage/RegistryStore.swift
+++ b/Examples/package-registry/Sources/RegistryExample/Storage/RegistryStore.swift
@@ -120,4 +120,61 @@ public actor RegistryStore {
         }
         return matched.sorted { $0.storageKey < $1.storageKey }
     }
+
+    /// Searches published packages for those matching `query`.
+    ///
+    /// Each package is represented by its highest-precedence release, the same
+    /// one ``list(_:)`` returns first; its metadata supplies the summary,
+    /// author, and license. A package matches when the query hits its identity,
+    /// description, or author, subject to any qualifier terms. Results are
+    /// sorted by ``PackageIdentifier/storageKey`` so pagination is stable.
+    ///
+    /// - Parameters:
+    ///   - query: The parsed query. An empty query matches nothing.
+    ///   - limit: The maximum number of hits to return.
+    ///   - offset: The number of leading hits to skip.
+    /// - Returns: The requested page of hits and the total number of matching
+    ///   packages (before `offset`/`limit` are applied).
+    public func search(_ query: SearchQuery, limit: Int, offset: Int) -> (hits: [SearchHit], total: Int) {
+        guard !query.isEmpty else { return ([], 0) }
+        let sorted = releases.compactMap { identifier, versions -> SearchHit? in
+            guard let latest = versions.values.max(by: { $0.version < $1.version }) else {
+                return nil
+            }
+            let metadata = latest.metadata
+            guard query.matches(
+                scope: identifier.scope,
+                name: identifier.name,
+                description: metadata?.description,
+                author: metadata?.author?.name
+            ) else { return nil }
+            return SearchHit(
+                identifier: identifier,
+                summary: metadata?.description,
+                latestVersion: latest.version.description,
+                author: metadata?.author?.name,
+                licenseURL: metadata?.licenseURL
+            )
+        }.sorted { $0.identifier.storageKey < $1.identifier.storageKey }
+        guard offset < sorted.count else { return ([], sorted.count) }
+        let end = min(offset + limit, sorted.count)
+        return (Array(sorted[offset..<end]), sorted.count)
+    }
+}
+
+/// A single package match returned by ``RegistryStore/search(_:limit:offset:)``.
+///
+/// The fields are derived from the package's highest-precedence release; all
+/// but ``identifier`` may be absent when the release carries no metadata.
+public struct SearchHit: Sendable {
+    /// The matching package's identifier.
+    public let identifier: PackageIdentifier
+    /// The package's free-form description, if any.
+    public let summary: String?
+    /// The version string of the highest-precedence release.
+    public let latestVersion: String?
+    /// The author's name, if any.
+    public let author: String?
+    /// The URL of the release's license document, if any.
+    public let licenseURL: URL?
 }

--- a/Examples/package-registry/Sources/RegistryExample/configure.swift
+++ b/Examples/package-registry/Sources/RegistryExample/configure.swift
@@ -28,6 +28,7 @@ public func configure(_ app: Application) async throws {
     IdentifiersRoutes(store: store).register(app)
     PublishRoutes(publisher: ReleasePublisher(store: store)).register(app)
     MetadataRoutes(store: store).register(app)
+    SearchRoutes(store: store).register(app)
 }
 
 private func configureTLS(_ app: Application) throws {

--- a/Examples/package-registry/Tests/RegistryExampleTests/AvailabilityTests.swift
+++ b/Examples/package-registry/Tests/RegistryExampleTests/AvailabilityTests.swift
@@ -17,11 +17,13 @@ import VaporTesting
 
 @Suite("Availability")
 struct AvailabilityTests {
-    @Test func `GET availability returns an empty 200`() async throws {
+    @Test func `GET availability advertises the search capability`() async throws {
         try await withRegistryApp { app in
             try await app.testing().test(.GET, "/availability") { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.readableBytes == 0)
+                #expect(res.headers.contentType == .json)
+                #expect(res.body.string.contains("\"capabilities\""))
+                #expect(res.body.string.contains("\"search\""))
             }
         }
     }

--- a/Examples/package-registry/Tests/RegistryExampleTests/SearchQueryTests.swift
+++ b/Examples/package-registry/Tests/RegistryExampleTests/SearchQueryTests.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+@testable import RegistryExample
+
+@Suite("Search query parsing")
+struct SearchQueryTests {
+    @Test func `empty query has no terms and matches nothing`() throws {
+        let query = try SearchQuery(parsing: "   ")
+        #expect(query.isEmpty)
+        #expect(!query.matches(scope: "mona", name: "LinkedList", description: "links", author: "Mona"))
+    }
+
+    @Test func `free text matches identity and description case-insensitively`() throws {
+        let query = try SearchQuery(parsing: "LINK")
+        #expect(query.matches(scope: "mona", name: "LinkedList", description: nil, author: nil))
+        #expect(query.matches(scope: "acme", name: "Widget", description: "a Linkable thing", author: nil))
+        #expect(!query.matches(scope: "acme", name: "Widget", description: "unrelated", author: nil))
+    }
+
+    @Test func `multiple free-text terms all must match`() throws {
+        let query = try SearchQuery(parsing: "linked list")
+        #expect(query.matches(scope: "mona", name: "LinkedList", description: nil, author: nil))
+        let unmet = try SearchQuery(parsing: "linked queue")
+        #expect(!unmet.matches(scope: "mona", name: "LinkedList", description: nil, author: nil))
+    }
+
+    @Test func `scope qualifier matches only the scope`() throws {
+        let query = try SearchQuery(parsing: "scope:mona")
+        #expect(query.matches(scope: "mona", name: "LinkedList", description: nil, author: nil))
+        #expect(!query.matches(scope: "apple", name: "mona-tools", description: nil, author: nil))
+    }
+
+    @Test func `author qualifier with quoted multi-word value`() throws {
+        let query = try SearchQuery(parsing: "author:\"Mona Lisa\"")
+        #expect(query.matches(scope: "mona", name: "LinkedList", description: nil, author: "Mona Lisa Octocat"))
+        #expect(!query.matches(scope: "mona", name: "LinkedList", description: nil, author: "Bob"))
+    }
+
+    @Test func `description qualifier matches only the description`() throws {
+        let query = try SearchQuery(parsing: "description:another")
+        #expect(query.matches(scope: "mona", name: "LinkedList", description: "one thing links to another", author: nil))
+        #expect(!query.matches(scope: "another", name: "pkg", description: "unrelated", author: nil))
+    }
+
+    @Test func `unknown qualifier is rejected`() throws {
+        #expect(throws: SearchQueryError.unknownQualifier("foo")) {
+            _ = try SearchQuery(parsing: "foo:bar")
+        }
+    }
+
+    @Test func `token with non-qualifier colon is treated as free text`() throws {
+        let query = try SearchQuery(parsing: "1.0:beta")
+        #expect(!query.isEmpty)
+        #expect(query.matches(scope: "acme", name: "pkg", description: "the 1.0:beta build", author: nil))
+    }
+}

--- a/Examples/package-registry/Tests/RegistryExampleTests/SearchRouteTests.swift
+++ b/Examples/package-registry/Tests/RegistryExampleTests/SearchRouteTests.swift
@@ -1,0 +1,190 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+@testable import RegistryExample
+
+@Suite("Search endpoint")
+struct SearchRouteTests {
+    @Test func `search returns a matching package with its metadata fields`() async throws {
+        try await withRegistryApp { app in
+            let metadata = #"""
+            {"description":"One thing links to another.","author":{"name":"Mona Lisa Octocat"},"licenseURL":"https://example.com/LICENSE"}
+            """#
+            try await publishHelloWorld(app: app, version: "1.1.1", metadata: metadata)
+            try await app.testing().test(.GET, "/search?q=HelloWorld", headers: acceptJSON) { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.contentType == .json)
+                #expect(res.headers.first(name: "Content-Version") == "1")
+                let body = res.body.string
+                #expect(body.contains("\"identity\":\"exampleregistry.HelloWorld\""))
+                #expect(body.contains("\"summary\":\"One thing links to another.\""))
+                #expect(body.contains("\"latestVersion\":\"1.1.1\""))
+                #expect(body.contains("\"author\":\"Mona Lisa Octocat\""))
+                #expect(body.contains("\"licenseURL\":\"https://example.com/LICENSE\""))
+                #expect(body.contains("/exampleregistry/HelloWorld\""))
+                #expect(body.contains("\"total\":1"))
+                #expect(body.contains("\"offset\":0"))
+                #expect(body.contains("\"limit\":20"))
+            }
+        }
+    }
+
+    @Test func `latestVersion reflects the highest-precedence release including prereleases`() async throws {
+        try await withRegistryApp { app in
+            try await publishHelloWorld(app: app, version: "1.0.0")
+            try await publishHelloWorld(app: app, version: "2.0.0-beta.1")
+            try await app.testing().test(.GET, "/search?q=HelloWorld", headers: acceptJSON) { res async in
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("\"latestVersion\":\"2.0.0-beta.1\""))
+            }
+        }
+    }
+
+    @Test func `empty query returns no results`() async throws {
+        try await withRegistryApp { app in
+            try await publishHelloWorld(app: app, version: "1.0.0")
+            try await app.testing().test(.GET, "/search?q=", headers: acceptJSON) { res async in
+                #expect(res.status == .ok)
+                let body = res.body.string
+                #expect(body.contains("\"results\":[]"))
+                #expect(body.contains("\"total\":0"))
+            }
+        }
+    }
+
+    @Test func `results are ordered by identity and paginate deterministically`() async throws {
+        try await withRegistryApp { app in
+            try await seedPackages(app: app, names: ["Delta", "Alpha", "Charlie", "Bravo"])
+            try await app.testing().test(
+                .GET, "/search?q=exampleregistry&limit=2&offset=0", headers: acceptJSON
+            ) { res async in
+                #expect(res.status == .ok)
+                let body = res.body.string
+                #expect(body.contains("\"total\":4"))
+                #expect(body.contains("\"limit\":2"))
+                #expect(body.contains("exampleregistry.Alpha"))
+                #expect(body.contains("exampleregistry.Bravo"))
+                #expect(!body.contains("exampleregistry.Charlie"))
+                #expect(!body.contains("exampleregistry.Delta"))
+                let link = res.headers.first(name: .link) ?? ""
+                #expect(link.contains("rel=\"first\""))
+                #expect(link.contains("rel=\"next\""))
+                #expect(link.contains("rel=\"last\""))
+                #expect(!link.contains("rel=\"prev\""))
+            }
+
+            try await app.testing().test(
+                .GET, "/search?q=exampleregistry&limit=2&offset=2", headers: acceptJSON
+            ) { res async in
+                #expect(res.status == .ok)
+                let body = res.body.string
+                #expect(body.contains("exampleregistry.Charlie"))
+                #expect(body.contains("exampleregistry.Delta"))
+                #expect(!body.contains("exampleregistry.Alpha"))
+                let link = res.headers.first(name: .link) ?? ""
+                #expect(link.contains("rel=\"prev\""))
+                #expect(link.contains("rel=\"last\""))
+                #expect(!link.contains("rel=\"next\""))
+            }
+        }
+    }
+
+    @Test func `single page of results emits no pagination links`() async throws {
+        try await withRegistryApp { app in
+            try await seedPackages(app: app, names: ["Alpha", "Bravo"])
+            try await app.testing().test(.GET, "/search?q=exampleregistry", headers: acceptJSON) { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: .link) == nil)
+            }
+        }
+    }
+
+    @Test func `out-of-range limit is clamped rather than rejected`() async throws {
+        try await withRegistryApp { app in
+            try await publishHelloWorld(app: app, version: "1.0.0")
+            try await app.testing().test(.GET, "/search?q=HelloWorld&limit=500", headers: acceptJSON) { res async in
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("\"limit\":100"))
+            }
+            try await app.testing().test(.GET, "/search?q=HelloWorld&limit=0", headers: acceptJSON) { res async in
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("\"limit\":1"))
+            }
+        }
+    }
+
+    @Test func `invalid parameters and unknown qualifiers return 400`() async throws {
+        try await withRegistryApp { app in
+            let badPaths = [
+                "/search?q=x&limit=abc",
+                "/search?q=x&offset=-1",
+                "/search?q=foo:bar",
+            ]
+            for path in badPaths {
+                try await app.testing().test(.GET, path, headers: acceptJSON) { res async in
+                    #expect(res.status == .badRequest)
+                }
+            }
+        }
+    }
+
+    @Test func `scope qualifier narrows results to a single scope`() async throws {
+        try await withRegistryApp { app in
+            try await seedPackages(app: app, names: ["Alpha"], scope: "acme")
+            try await seedPackages(app: app, names: ["Bravo"], scope: "other")
+            try await app.testing().test(.GET, "/search?q=scope:acme", headers: acceptJSON) { res async in
+                #expect(res.status == .ok)
+                let body = res.body.string
+                #expect(body.contains("acme.Alpha"))
+                #expect(!body.contains("other.Bravo"))
+                #expect(body.contains("\"total\":1"))
+            }
+        }
+    }
+
+    @Test func `author qualifier matches the metadata author name`() async throws {
+        try await withRegistryApp { app in
+            try await publishHelloWorld(
+                app: app,
+                version: "1.0.0",
+                metadata: #"{"author":{"name":"Mona Lisa Octocat"}}"#
+            )
+            try await app.testing().test(
+                .GET, "/search?q=author:%22Mona%20Lisa%22", headers: acceptJSON
+            ) { res async in
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("exampleregistry.HelloWorld"))
+            }
+        }
+    }
+}
+
+func seedPackages(app: Application, names: [String], scope: String = "exampleregistry") async throws {
+    for name in names {
+        let identifier = try PackageIdentifier(scope: scope, name: name)
+        let release = StoredRelease(
+            identifier: identifier,
+            version: try PackageVersion("1.0.0"),
+            sourceArchive: Data(),
+            sourceArchiveChecksum: "",
+            manifests: [:],
+            metadata: nil,
+            metadataRaw: nil,
+            publishedAt: Date()
+        )
+        try await app.registryStore.publish(release)
+    }
+}

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -1193,7 +1193,6 @@ public final class RegistryClient: AsyncCancellable {
                     SearchResults.Result(
                         identity: r.identity,
                         summary: r.summary,
-                        versions: r.versions ?? [],
                         latestVersion: r.latestVersion,
                         author: r.author,
                         licenseURL: r.licenseURL.flatMap(URL.init(string:)),
@@ -1960,7 +1959,6 @@ extension RegistryClient {
         public struct Result: Sendable {
             public let identity: String
             public let summary: String?
-            public let versions: [String]
             public let latestVersion: String?
             public let author: String?
             public let licenseURL: URL?
@@ -1969,7 +1967,6 @@ extension RegistryClient {
             public init(
                 identity: String,
                 summary: String? = nil,
-                versions: [String] = [],
                 latestVersion: String? = nil,
                 author: String? = nil,
                 licenseURL: URL? = nil,
@@ -1977,7 +1974,6 @@ extension RegistryClient {
             ) {
                 self.identity = identity
                 self.summary = summary
-                self.versions = versions
                 self.latestVersion = latestVersion
                 self.author = author
                 self.licenseURL = licenseURL
@@ -2413,7 +2409,6 @@ extension RegistryClient {
         public struct SearchResult: Codable {
             public let identity: String
             public let summary: String?
-            public let versions: [String]?
             public let latestVersion: String?
             public let author: String?
             public let licenseURL: String?
@@ -2422,7 +2417,6 @@ extension RegistryClient {
             public init(
                 identity: String,
                 summary: String? = nil,
-                versions: [String]? = nil,
                 latestVersion: String? = nil,
                 author: String? = nil,
                 licenseURL: String? = nil,
@@ -2430,7 +2424,6 @@ extension RegistryClient {
             ) {
                 self.identity = identity
                 self.summary = summary
-                self.versions = versions
                 self.latestVersion = latestVersion
                 self.author = author
                 self.licenseURL = licenseURL

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -1145,7 +1145,7 @@ public final class RegistryClient: AsyncCancellable {
     ) async throws -> SearchResults {
         try await withAvailabilityCheck(
             registry: registry,
-            requiring: "search",
+            requiring: .search,
             observabilityScope: observabilityScope
         )
 
@@ -1205,7 +1205,7 @@ public final class RegistryClient: AsyncCancellable {
                 limit: decoded.limit
             )
         case 404:
-            throw RegistryError.capabilityNotSupported(registry: registry, capability: "search")
+            throw RegistryError.capabilityNotSupported(registry: registry, capability: .search)
         default:
             throw RegistryError.searchFailed(
                 registry: registry,
@@ -1536,7 +1536,7 @@ public final class RegistryClient: AsyncCancellable {
     @discardableResult
     func withAvailabilityCheck(
         registry: Registry,
-        requiring capability: String? = nil,
+        requiring capability: Capability? = nil,
         observabilityScope: ObservabilityScope
     ) async throws -> Set<String> {
         if !registry.supportsAvailability {
@@ -1551,7 +1551,7 @@ public final class RegistryClient: AsyncCancellable {
             case .success(let status):
                 switch status {
                 case .available(let capabilities):
-                    if let capability, !capabilities.contains(capability) {
+                    if let capability, !capabilities.contains(capability.rawValue) {
                         throw RegistryError.capabilityNotSupported(registry: registry, capability: capability)
                     }
                     return capabilities
@@ -1669,7 +1669,7 @@ public enum RegistryError: Error, CustomStringConvertible {
     case loginFailed(url: URL, error: Error)
     case availabilityCheckFailed(registry: Registry, error: Error)
     case registryNotAvailable(Registry)
-    case capabilityNotSupported(registry: Registry, capability: String)
+    case capabilityNotSupported(registry: Registry, capability: RegistryClient.Capability)
     case searchFailed(registry: Registry, error: Error)
     case packageNotFound
     case packageVersionNotFound
@@ -1776,7 +1776,7 @@ public enum RegistryError: Error, CustomStringConvertible {
         case .registryNotAvailable(let registry):
             return "registry at '\(registry.url)' is not available at this time, please try again later"
         case .capabilityNotSupported(let registry, let capability):
-            return "registry at '\(registry.url)' does not support the '\(capability)' capability"
+            return "registry at '\(registry.url)' does not support the '\(capability.rawValue)' capability"
         case .searchFailed(let registry, let error):
             return "failed searching registry at '\(registry.url)': \(error.interpolationDescription)"
         case .packageNotFound:
@@ -2007,6 +2007,10 @@ extension RegistryClient {
 
         // marked internal for testing
         static var unavailableStatusCodes = [404, 501]
+    }
+
+    public enum Capability: String, Hashable, Sendable, CaseIterable {
+        case search
     }
 }
 

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -1135,6 +1135,85 @@ public final class RegistryClient: AsyncCancellable {
         }
     }
 
+    public func search(
+        query: String,
+        limit: Int = 20,
+        offset: Int = 0,
+        registry: Registry,
+        timeout: DispatchTimeInterval? = .none,
+        observabilityScope: ObservabilityScope
+    ) async throws -> SearchResults {
+        try await withAvailabilityCheck(
+            registry: registry,
+            requiring: "search",
+            observabilityScope: observabilityScope
+        )
+
+        guard var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true) else {
+            throw RegistryError.invalidURL(registry.url)
+        }
+        components.appendPathComponents("search")
+        components.queryItems = [
+            URLQueryItem(name: "q", value: query),
+            URLQueryItem(name: "limit", value: String(limit)),
+            URLQueryItem(name: "offset", value: String(offset)),
+        ]
+
+        guard let url = components.url else {
+            throw RegistryError.invalidURL(registry.url)
+        }
+
+        let start = DispatchTime.now()
+        observabilityScope.emit(info: "searching \(registry.url) with query '\(query)'")
+
+        let response: HTTPClient.Response
+        do {
+            response = try await self.httpClient.get(
+                url,
+                headers: ["Accept": self.acceptHeader(mediaType: .json)],
+                options: self.defaultRequestOptions(timeout: timeout)
+            )
+        } catch let error where !(error is _Concurrency.CancellationError) {
+            throw RegistryError.searchFailed(registry: registry, error: error)
+        }
+
+        observabilityScope
+            .emit(
+                debug: "server response for \(url): \(response.statusCode) in \(start.distance(to: .now()).descriptionInSeconds)"
+            )
+
+        switch response.statusCode {
+        case 200:
+            let decoded = try response.parseJSON(
+                Serialization.SearchResponse.self,
+                decoder: self.jsonDecoder
+            )
+            return SearchResults(
+                results: decoded.results.map { r in
+                    SearchResults.Result(
+                        identity: r.identity,
+                        summary: r.summary,
+                        versions: r.versions ?? [],
+                        latestVersion: r.latestVersion,
+                        author: r.author,
+                        licenseURL: r.licenseURL.flatMap(URL.init(string:)),
+                        url: r.url.flatMap(URL.init(string:))
+                    )
+                },
+                total: decoded.total,
+                offset: decoded.offset,
+                limit: decoded.limit
+            )
+        case 404:
+            throw RegistryError.capabilityNotSupported(registry: registry, capability: "search")
+        default:
+            throw RegistryError.searchFailed(
+                registry: registry,
+                error: self.unexpectedStatusError(response, expectedStatus: [200])
+            )
+        }
+    }
+
     public func login(
         loginURL: URL,
         timeout: DispatchTimeInterval? = .none,
@@ -1431,7 +1510,15 @@ public final class RegistryClient: AsyncCancellable {
 
         switch response.statusCode {
         case 200:
-            return .available
+            let capabilities: Set<String>
+            if let body = response.body, !body.isEmpty,
+               let decoded = try? self.jsonDecoder.decode(Serialization.AvailabilityResponse.self, from: body),
+               let advertised = decoded.capabilities {
+                capabilities = Set(advertised.keys)
+            } else {
+                capabilities = []
+            }
+            return .available(capabilities: capabilities)
         case let value where AvailabilityStatus.unavailableStatusCodes.contains(value):
             return .unavailable
         default:
@@ -1442,21 +1529,32 @@ public final class RegistryClient: AsyncCancellable {
         }
     }
 
-    // If the registry is available, the function returns, otherwise an error
-    // explaining why the registry is unavailable is thrown.
+    // If the registry is available, the function returns its advertised
+    // capability set (empty if none were advertised). If `capability` is
+    // provided, throws `RegistryError.capabilityNotSupported` when the
+    // registry does not advertise that capability.
+    @discardableResult
     func withAvailabilityCheck(
         registry: Registry,
+        requiring capability: String? = nil,
         observabilityScope: ObservabilityScope
-    ) async throws {
+    ) async throws -> Set<String> {
         if !registry.supportsAvailability {
-            return
+            if let capability {
+                throw RegistryError.capabilityNotSupported(registry: registry, capability: capability)
+            }
+            return []
         }
 
-        let availabilityHandler: (Result<AvailabilityStatus, Error>) throws -> Void = { result in
+        let availabilityHandler: (Result<AvailabilityStatus, Error>) throws -> Set<String> = { result in
             switch result {
             case .success(let status):
                 switch status {
-                case .available: return
+                case .available(let capabilities):
+                    if let capability, !capabilities.contains(capability) {
+                        throw RegistryError.capabilityNotSupported(registry: registry, capability: capability)
+                    }
+                    return capabilities
                 case .unavailable: throw RegistryError.registryNotAvailable(registry)
                 case .error(let error): throw StringError(error)
                 }
@@ -1571,6 +1669,8 @@ public enum RegistryError: Error, CustomStringConvertible {
     case loginFailed(url: URL, error: Error)
     case availabilityCheckFailed(registry: Registry, error: Error)
     case registryNotAvailable(Registry)
+    case capabilityNotSupported(registry: Registry, capability: String)
+    case searchFailed(registry: Registry, error: Error)
     case packageNotFound
     case packageVersionNotFound
     case sourceArchiveMissingChecksum(registry: Registry, package: PackageIdentity, version: Version)
@@ -1675,6 +1775,10 @@ public enum RegistryError: Error, CustomStringConvertible {
             return "failed checking availability of registry at '\(registry.url)': \(error.interpolationDescription)"
         case .registryNotAvailable(let registry):
             return "registry at '\(registry.url)' is not available at this time, please try again later"
+        case .capabilityNotSupported(let registry, let capability):
+            return "registry at '\(registry.url)' does not support the '\(capability)' capability"
+        case .searchFailed(let registry, let error):
+            return "failed searching registry at '\(registry.url)': \(error.interpolationDescription)"
         case .packageNotFound:
             return "package not found on registry"
         case .packageVersionNotFound:
@@ -1852,8 +1956,52 @@ extension RegistryClient {
 }
 
 extension RegistryClient {
+    public struct SearchResults: Sendable {
+        public struct Result: Sendable {
+            public let identity: String
+            public let summary: String?
+            public let versions: [String]
+            public let latestVersion: String?
+            public let author: String?
+            public let licenseURL: URL?
+            public let url: URL?
+
+            public init(
+                identity: String,
+                summary: String? = nil,
+                versions: [String] = [],
+                latestVersion: String? = nil,
+                author: String? = nil,
+                licenseURL: URL? = nil,
+                url: URL? = nil
+            ) {
+                self.identity = identity
+                self.summary = summary
+                self.versions = versions
+                self.latestVersion = latestVersion
+                self.author = author
+                self.licenseURL = licenseURL
+                self.url = url
+            }
+        }
+
+        public let results: [Result]
+        public let total: Int
+        public let offset: Int
+        public let limit: Int
+
+        public init(results: [Result], total: Int, offset: Int, limit: Int) {
+            self.results = results
+            self.total = total
+            self.offset = offset
+            self.limit = limit
+        }
+    }
+}
+
+extension RegistryClient {
     public enum AvailabilityStatus: Equatable {
-        case available
+        case available(capabilities: Set<String> = [])
         case unavailable
         case error(String)
 
@@ -2229,6 +2377,60 @@ extension RegistryClient {
 
             public init(identifiers: [String]) {
                 self.identifiers = identifiers
+            }
+        }
+
+        public struct AvailabilityResponse: Codable {
+            public let capabilities: [String: Capability]?
+
+            public init(capabilities: [String: Capability]?) {
+                self.capabilities = capabilities
+            }
+        }
+
+        public struct Capability: Codable {
+            public init() {}
+        }
+
+        public struct SearchResponse: Codable {
+            public let results: [SearchResult]
+            public let total: Int
+            public let offset: Int
+            public let limit: Int
+
+            public init(results: [SearchResult], total: Int, offset: Int, limit: Int) {
+                self.results = results
+                self.total = total
+                self.offset = offset
+                self.limit = limit
+            }
+        }
+
+        public struct SearchResult: Codable {
+            public let identity: String
+            public let summary: String?
+            public let versions: [String]?
+            public let latestVersion: String?
+            public let author: String?
+            public let licenseURL: String?
+            public let url: String?
+
+            public init(
+                identity: String,
+                summary: String? = nil,
+                versions: [String]? = nil,
+                latestVersion: String? = nil,
+                author: String? = nil,
+                licenseURL: String? = nil,
+                url: String? = nil
+            ) {
+                self.identity = identity
+                self.summary = summary
+                self.versions = versions
+                self.latestVersion = latestVersion
+                self.author = author
+                self.licenseURL = licenseURL
+                self.url = url
             }
         }
     }

--- a/Sources/PackageRegistryCommand/CMakeLists.txt
+++ b/Sources/PackageRegistryCommand/CMakeLists.txt
@@ -9,6 +9,7 @@
 add_library(PackageRegistryCommand
   PackageRegistryCommand+Auth.swift
   PackageRegistryCommand+Publish.swift
+  PackageRegistryCommand+Search.swift
   PackageRegistryCommand.swift)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(PackageRegistryCommand PROPERTIES

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Search.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Search.swift
@@ -1,0 +1,263 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Basics
+import Commands
+import CoreCommands
+import Foundation
+import PackageFingerprint
+import PackageModel
+import PackageRegistry
+import PackageSigning
+import Workspace
+
+import struct TSCBasic.SHA256
+
+extension PackageRegistryCommand {
+    struct Search: AsyncSwiftCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Search configured package registries."
+        )
+
+        @OptionGroup(visibility: .hidden)
+        var globalOptions: GlobalOptions
+
+        @Argument(help: "Search query (free text and/or qualifiers like author:\"Mona\", scope:apple).")
+        var query: [String] = []
+
+        @Option(help: "Maximum results to return (1-100).")
+        var limit: Int = 20
+
+        @Option(help: "Number of results to skip.")
+        var offset: Int = 0
+
+        @Option(help: "Restrict search to a single registry URL.")
+        var registry: URL?
+
+        @Flag(help: "Output results as JSON.")
+        var json: Bool = false
+
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
+            let configuration = try PackageRegistryCommand.getRegistriesConfig(
+                swiftCommandState,
+                global: false
+            ).configuration
+
+            let targets = try resolveTargets(configuration: configuration)
+            guard !targets.isEmpty else {
+                throw ValidationError.unknownRegistry
+            }
+
+            let authorizationProvider = try swiftCommandState.getRegistryAuthorizationProvider()
+            let registryClient = RegistryClient(
+                configuration: configuration,
+                fingerprintStorage: .none,
+                fingerprintCheckingMode: .strict,
+                skipSignatureValidation: false,
+                signingEntityStorage: .none,
+                signingEntityCheckingMode: .strict,
+                authorizationProvider: authorizationProvider,
+                delegate: .none,
+                checksumAlgorithm: SHA256()
+            )
+
+            let queryString = self.query.joined(separator: " ")
+            let observabilityScope = swiftCommandState.observabilityScope
+
+            let outcomes = await withTaskGroup(of: RegistryOutcome.self) { group in
+                for registry in targets {
+                    group.addTask {
+                        do {
+                            let results = try await registryClient.search(
+                                query: queryString,
+                                limit: self.limit,
+                                offset: self.offset,
+                                registry: registry,
+                                observabilityScope: observabilityScope
+                            )
+                            return RegistryOutcome(registry: registry, kind: .success(results))
+                        } catch let error as RegistryError {
+                            switch error {
+                            case .capabilityNotSupported, .registryNotAvailable:
+                                return RegistryOutcome(registry: registry, kind: .unsupported)
+                            default:
+                                return RegistryOutcome(registry: registry, kind: .failed(error))
+                            }
+                        } catch {
+                            return RegistryOutcome(registry: registry, kind: .failed(error))
+                        }
+                    }
+                }
+
+                var collected: [RegistryOutcome] = []
+                for await outcome in group {
+                    collected.append(outcome)
+                }
+                return collected
+            }
+
+            let unsupported = outcomes.filter { if case .unsupported = $0.kind { return true } else { return false } }
+            let failed = outcomes.compactMap { outcome -> (Registry, Error)? in
+                if case .failed(let error) = outcome.kind { return (outcome.registry, error) }
+                return nil
+            }
+            let successes = outcomes.compactMap { outcome -> (Registry, RegistryClient.SearchResults)? in
+                if case .success(let results) = outcome.kind { return (outcome.registry, results) }
+                return nil
+            }
+
+            for (registry, error) in failed {
+                observabilityScope.emit(
+                    warning: "search against registry at '\(registry.url)' failed: \(error.interpolationDescription)"
+                )
+            }
+
+            if successes.isEmpty {
+                if !unsupported.isEmpty && failed.isEmpty {
+                    throw StringError("none of the configured registries support search")
+                }
+                throw StringError("no search results were returned by any configured registry")
+            }
+
+            if !unsupported.isEmpty && !self.json {
+                let urls = unsupported.map { "'\($0.registry.url)'" }.joined(separator: ", ")
+                observabilityScope.emit(
+                    warning: "the following registries do not support search and were skipped: \(urls)"
+                )
+            }
+
+            let multiRegistry = successes.count > 1
+            let items = Self.interleavePairs(successes)
+            let totalSum = successes.reduce(0) { $0 + $1.1.total }
+
+            if self.json {
+                try printJSON(
+                    items: items,
+                    multiRegistry: multiRegistry,
+                    total: totalSum
+                )
+            } else if items.isEmpty {
+                print("No packages matched your query.")
+            } else {
+                printText(items: items, multiRegistry: multiRegistry)
+            }
+        }
+
+        private func resolveTargets(configuration: RegistryConfiguration) throws -> [Registry] {
+            if let url = self.registry {
+                try url.validateRegistryURL(allowHTTP: false)
+                return [Registry(url: url, supportsAvailability: true)]
+            }
+
+            var seen = Swift.Set<URL>()
+            var ordered: [Registry] = []
+            if let defaultRegistry = configuration.defaultRegistry, seen.insert(defaultRegistry.url).inserted {
+                ordered.append(Registry(url: defaultRegistry.url, supportsAvailability: true))
+            }
+            for (_, registry) in configuration.scopedRegistries where seen.insert(registry.url).inserted {
+                ordered.append(Registry(url: registry.url, supportsAvailability: true))
+            }
+            return ordered
+        }
+
+        static func interleavePairs(
+            _ successes: [(Registry, RegistryClient.SearchResults)]
+        ) -> [(registry: Registry, result: RegistryClient.SearchResults.Result)] {
+            var iterators = successes.map { ($0.0, $0.1.results.makeIterator()) }
+            var merged: [(registry: Registry, result: RegistryClient.SearchResults.Result)] = []
+            var stillProducing = true
+            while stillProducing {
+                stillProducing = false
+                for index in iterators.indices {
+                    if let next = iterators[index].1.next() {
+                        merged.append((registry: iterators[index].0, result: next))
+                        stillProducing = true
+                    }
+                }
+            }
+            return merged
+        }
+
+        private func printText(
+            items: [(registry: Registry, result: RegistryClient.SearchResults.Result)],
+            multiRegistry: Bool
+        ) {
+            for item in items {
+                let summary = item.result.summary ?? ""
+                let version = item.result.latestVersion.map { " (v\($0))" } ?? ""
+                let suffix = summary.isEmpty ? "" : " - \(summary)"
+                let registryAnnotation = multiRegistry ? " [\(item.registry.url)]" : ""
+                print("\(item.result.identity)\(suffix)\(version)\(registryAnnotation)")
+            }
+        }
+
+        private func printJSON(
+            items: [(registry: Registry, result: RegistryClient.SearchResults.Result)],
+            multiRegistry: Bool,
+            total: Int
+        ) throws {
+            let encoder = JSONEncoder.makeWithDefaults()
+            encoder.outputFormatting.insert(.sortedKeys)
+            let payload = JSONOutput(
+                results: items.map { item in
+                    JSONOutput.Result(
+                        identity: item.result.identity,
+                        summary: item.result.summary,
+                        versions: item.result.versions.isEmpty ? nil : item.result.versions,
+                        latestVersion: item.result.latestVersion,
+                        author: item.result.author,
+                        licenseURL: item.result.licenseURL?.absoluteString,
+                        url: item.result.url?.absoluteString,
+                        registry: multiRegistry ? item.registry.url.absoluteString : nil
+                    )
+                },
+                total: total,
+                offset: self.offset,
+                limit: self.limit
+            )
+            let data = try encoder.encode(payload)
+            if let string = String(data: data, encoding: .utf8) {
+                print(string)
+            }
+        }
+
+        private struct RegistryOutcome {
+            let registry: Registry
+            let kind: Kind
+
+            enum Kind {
+                case success(RegistryClient.SearchResults)
+                case unsupported
+                case failed(Error)
+            }
+        }
+
+        private struct JSONOutput: Encodable {
+            let results: [Result]
+            let total: Int
+            let offset: Int
+            let limit: Int
+
+            struct Result: Encodable {
+                let identity: String
+                let summary: String?
+                let versions: [String]?
+                let latestVersion: String?
+                let author: String?
+                let licenseURL: String?
+                let url: String?
+                let registry: String?
+            }
+        }
+    }
+}

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Search.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Search.swift
@@ -213,7 +213,6 @@ extension PackageRegistryCommand {
                     JSONOutput.Result(
                         identity: item.result.identity,
                         summary: item.result.summary,
-                        versions: item.result.versions.isEmpty ? nil : item.result.versions,
                         latestVersion: item.result.latestVersion,
                         author: item.result.author,
                         licenseURL: item.result.licenseURL?.absoluteString,
@@ -251,7 +250,6 @@ extension PackageRegistryCommand {
             struct Result: Encodable {
                 let identity: String
                 let summary: String?
-                let versions: [String]?
                 let latestVersion: String?
                 let author: String?
                 let licenseURL: String?

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand.swift
@@ -32,6 +32,7 @@ public struct PackageRegistryCommand: AsyncParsableCommand {
             Login.self,
             Logout.self,
             Publish.self,
+            Search.self,
         ],
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)]
     )

--- a/Tests/CommandsTests/PackageRegistryCommandTests.swift
+++ b/Tests/CommandsTests/PackageRegistryCommandTests.swift
@@ -1433,3 +1433,50 @@ struct PackageRegistryCommandTests {
         )
     }
 }
+
+@Suite struct PackageRegistrySearchTests {
+    @Test func helpListsSearchSubcommand() async throws {
+        let stdout = try await SwiftPM.Registry.execute(["--help"]).stdout
+        #expect(stdout.contains("search"), "expected 'search' subcommand in help output, got: \(stdout)")
+    }
+
+    @Test func searchHelpReferencesQualifiers() async throws {
+        let stdout = try await SwiftPM.Registry.execute(["search", "--help"]).stdout
+        #expect(stdout.contains("--limit"))
+        #expect(stdout.contains("--offset"))
+        #expect(stdout.contains("--registry"))
+        #expect(stdout.contains("--json"))
+    }
+
+    @Test func interleavingRoundRobinsAcrossRegistries() {
+        let registryA = Registry(url: URL("https://a.example.com"), supportsAvailability: true)
+        let registryB = Registry(url: URL("https://b.example.com"), supportsAvailability: true)
+        let resultsA = RegistryClient.SearchResults(
+            results: [
+                .init(identity: "a.one"),
+                .init(identity: "a.two"),
+                .init(identity: "a.three"),
+            ],
+            total: 3,
+            offset: 0,
+            limit: 20
+        )
+        let resultsB = RegistryClient.SearchResults(
+            results: [
+                .init(identity: "b.one"),
+                .init(identity: "b.two"),
+            ],
+            total: 2,
+            offset: 0,
+            limit: 20
+        )
+
+        let interleaved = PackageRegistryCommand.Search.interleavePairs([
+            (registryA, resultsA),
+            (registryB, resultsB),
+        ])
+
+        #expect(interleaved.map(\.result.identity) == ["a.one", "b.one", "a.two", "b.two", "a.three"])
+        #expect(interleaved.map(\.registry.url.host) == ["a.example.com", "b.example.com", "a.example.com", "b.example.com", "a.example.com"])
+    }
+}

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -4510,9 +4510,12 @@ fileprivate var searchURL = URL("\(registryURL)/search?q=foo&limit=20&offset=0")
                 let url = request.url
                 let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
                 let queryItems = components?.queryItems ?? []
-                #expect(queryItems.contains(where: { $0.name == "q" && $0.value == "author:Mona networking" }))
-                #expect(queryItems.contains(where: { $0.name == "limit" && $0.value == "50" }))
-                #expect(queryItems.contains(where: { $0.name == "offset" && $0.value == "10" }))
+                let hasQuery = queryItems.contains { $0.name == "q" && $0.value == "author:Mona networking" }
+                let hasLimit = queryItems.contains { $0.name == "limit" && $0.value == "50" }
+                let hasOffset = queryItems.contains { $0.name == "offset" && $0.value == "10" }
+                #expect(hasQuery)
+                #expect(hasLimit)
+                #expect(hasOffset)
                 return Self.responseBody(Self.searchBody)
             default:
                 throw StringError("unexpected request: \(request.method) \(request.url)")

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -4360,7 +4360,6 @@ fileprivate var searchURL = URL("\(registryURL)/search?q=foo&limit=20&offset=0")
             {
                 "identity": "mona.LinkedList",
                 "summary": "One thing links to another.",
-                "versions": ["1.1.1", "1.0.0"],
                 "latestVersion": "1.1.1",
                 "author": "Mona Lisa Octocat",
                 "licenseURL": "https://example.com/LICENSE",
@@ -4419,7 +4418,6 @@ fileprivate var searchURL = URL("\(registryURL)/search?q=foo&limit=20&offset=0")
         let first = try #require(results.results.first)
         #expect(first.identity == "mona.LinkedList")
         #expect(first.summary == "One thing links to another.")
-        #expect(first.versions == ["1.1.1", "1.0.0"])
         #expect(first.latestVersion == "1.1.1")
         #expect(first.author == "Mona Lisa Octocat")
         #expect(first.licenseURL?.absoluteString == "https://example.com/LICENSE")

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -4262,7 +4262,7 @@ fileprivate var searchURL = URL("\(registryURL)/search?q=foo&limit=20&offset=0")
 
         let capabilities = try await registryClient.withAvailabilityCheck(
             registry: registry,
-            requiring: "search",
+            requiring: .search,
             observabilityScope: ObservabilitySystem.NOOP
         )
         #expect(capabilities == ["search"])
@@ -4272,7 +4272,7 @@ fileprivate var searchURL = URL("\(registryURL)/search?q=foo&limit=20&offset=0")
         let handler: HTTPClient.Implementation = { request, _ in
             switch (request.method, request.url) {
             case (.get, availabilityURL):
-                return Self.okJSON(#"{"capabilities":{"search":{}}}"#)
+                return Self.okJSON(#"{"capabilities":{"publish":{}}}"#)
             default:
                 throw StringError("method and url should match")
             }
@@ -4287,12 +4287,12 @@ fileprivate var searchURL = URL("\(registryURL)/search?q=foo&limit=20&offset=0")
         await #expect {
             try await registryClient.withAvailabilityCheck(
                 registry: registry,
-                requiring: "publish",
+                requiring: .search,
                 observabilityScope: ObservabilitySystem.NOOP
             )
         } throws: { error in
             guard case RegistryError.capabilityNotSupported(_, let capability) = error else { return false }
-            return capability == "publish"
+            return capability == .search
         }
     }
 
@@ -4321,7 +4321,7 @@ fileprivate var searchURL = URL("\(registryURL)/search?q=foo&limit=20&offset=0")
         await #expect {
             try await registryClient.withAvailabilityCheck(
                 registry: registry,
-                requiring: "search",
+                requiring: .search,
                 observabilityScope: ObservabilitySystem.NOOP
             )
         } throws: { error in
@@ -4343,7 +4343,7 @@ fileprivate var searchURL = URL("\(registryURL)/search?q=foo&limit=20&offset=0")
         await #expect {
             try await registryClient.withAvailabilityCheck(
                 registry: registry,
-                requiring: "search",
+                requiring: .search,
                 observabilityScope: ObservabilitySystem.NOOP
             )
         } throws: { error in
@@ -4456,7 +4456,7 @@ fileprivate var searchURL = URL("\(registryURL)/search?q=foo&limit=20&offset=0")
             )
         } throws: { error in
             if case RegistryError.capabilityNotSupported(_, let capability) = error {
-                return capability == "search"
+                return capability == .search
             }
             return false
         }

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -36,6 +36,7 @@ fileprivate var downloadURL = URL("\(registryURL)/\(identity.registry!.scope)/\(
 fileprivate var identifiersURL = URL("\(registryURL)/identifiers?url=\(packageURL.absoluteString)")
 fileprivate var publishURL = URL("\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)")
 fileprivate var availabilityURL = URL("\(registryURL)/availability")
+fileprivate var searchURL = URL("\(registryURL)/search?q=foo&limit=20&offset=0")
 
 @Suite("Package Metadata") struct PackageMetadata {
     @Test func getPackageMetadata() async throws {
@@ -4068,7 +4069,7 @@ fileprivate var availabilityURL = URL("\(registryURL)/availability")
         )
 
         let status = try await registryClient.checkAvailability(registry: registry)
-        #expect(status == .available)
+        #expect(status == .available())
 
         let syncStatus = try await withCheckedThrowingContinuation { continuation in
             registryClient.checkAvailability(
@@ -4078,7 +4079,7 @@ fileprivate var availabilityURL = URL("\(registryURL)/availability")
                 completion: { continuation.resume(with: $0) }
             )
         }
-        #expect(syncStatus == .available)
+        #expect(syncStatus == .available())
     }
 
     @Test func handleNotAvailable() async throws {
@@ -4229,6 +4230,312 @@ fileprivate var availabilityURL = URL("\(registryURL)/availability")
             let count = await counter.value
             #expect(count == 1)
         }
+    }
+}
+
+@Suite("Registry Capabilities") struct RegistryCapabilities {
+    private static func okJSON(_ body: String) -> HTTPClient.Response {
+        .init(
+            statusCode: 200,
+            headers: .init([
+                .init(name: "Content-Type", value: "application/json"),
+            ]),
+            body: Data(body.utf8)
+        )
+    }
+
+    @Test func discoversAdvertisedCapability() async throws {
+        let handler: HTTPClient.Implementation = { request, _ in
+            switch (request.method, request.url) {
+            case (.get, availabilityURL):
+                return Self.okJSON(#"{"capabilities":{"search":{}}}"#)
+            default:
+                throw StringError("method and url should match")
+            }
+        }
+
+        let registry = Registry(url: registryURL, supportsAvailability: true)
+        let registryClient = makeRegistryClient(
+            configuration: .init(),
+            httpClient: HTTPClient(implementation: handler)
+        )
+
+        let capabilities = try await registryClient.withAvailabilityCheck(
+            registry: registry,
+            requiring: "search",
+            observabilityScope: ObservabilitySystem.NOOP
+        )
+        #expect(capabilities == ["search"])
+    }
+
+    @Test func missingCapabilityThrows() async throws {
+        let handler: HTTPClient.Implementation = { request, _ in
+            switch (request.method, request.url) {
+            case (.get, availabilityURL):
+                return Self.okJSON(#"{"capabilities":{"search":{}}}"#)
+            default:
+                throw StringError("method and url should match")
+            }
+        }
+
+        let registry = Registry(url: registryURL, supportsAvailability: true)
+        let registryClient = makeRegistryClient(
+            configuration: .init(),
+            httpClient: HTTPClient(implementation: handler)
+        )
+
+        await #expect {
+            try await registryClient.withAvailabilityCheck(
+                registry: registry,
+                requiring: "publish",
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+        } throws: { error in
+            guard case RegistryError.capabilityNotSupported(_, let capability) = error else { return false }
+            return capability == "publish"
+        }
+    }
+
+    @Test func emptyBodyHasNoCapabilities() async throws {
+        let handler: HTTPClient.Implementation = { request, _ in
+            switch (request.method, request.url) {
+            case (.get, availabilityURL):
+                return .okay()
+            default:
+                throw StringError("method and url should match")
+            }
+        }
+
+        let registry = Registry(url: registryURL, supportsAvailability: true)
+        let registryClient = makeRegistryClient(
+            configuration: .init(),
+            httpClient: HTTPClient(implementation: handler)
+        )
+
+        let capabilities = try await registryClient.withAvailabilityCheck(
+            registry: registry,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
+        #expect(capabilities.isEmpty)
+
+        await #expect {
+            try await registryClient.withAvailabilityCheck(
+                registry: registry,
+                requiring: "search",
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+        } throws: { error in
+            if case RegistryError.capabilityNotSupported = error { return true }
+            return false
+        }
+    }
+
+    @Test func registryWithoutAvailabilityFailsCapabilityRequirement() async throws {
+        let handler: HTTPClient.Implementation = { _, _ in
+            throw StringError("availability check should not be issued")
+        }
+        let registry = Registry(url: registryURL, supportsAvailability: false)
+        let registryClient = makeRegistryClient(
+            configuration: .init(),
+            httpClient: HTTPClient(implementation: handler)
+        )
+
+        await #expect {
+            try await registryClient.withAvailabilityCheck(
+                registry: registry,
+                requiring: "search",
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+        } throws: { error in
+            if case RegistryError.capabilityNotSupported = error { return true }
+            return false
+        }
+    }
+}
+
+@Suite("Registry Search") struct RegistrySearch {
+    private static let searchBody = #"""
+    {
+        "results": [
+            {
+                "identity": "mona.LinkedList",
+                "summary": "One thing links to another.",
+                "versions": ["1.1.1", "1.0.0"],
+                "latestVersion": "1.1.1",
+                "author": "Mona Lisa Octocat",
+                "licenseURL": "https://example.com/LICENSE",
+                "url": "https://packages.example.com/mona/LinkedList"
+            }
+        ],
+        "total": 1,
+        "offset": 0,
+        "limit": 20
+    }
+    """#
+
+    private static func responseBody(_ body: String, statusCode: Int = 200) -> HTTPClient.Response {
+        .init(
+            statusCode: statusCode,
+            headers: .init([
+                .init(name: "Content-Type", value: "application/json"),
+                .init(name: "Content-Version", value: "1"),
+            ]),
+            body: Data(body.utf8)
+        )
+    }
+
+    @Test func decodesResults() async throws {
+        let handler: HTTPClient.Implementation = { request, _ in
+            switch (request.method, request.url) {
+            case (.get, availabilityURL):
+                return .init(
+                    statusCode: 200,
+                    headers: .init([.init(name: "Content-Type", value: "application/json")]),
+                    body: Data(#"{"capabilities":{"search":{}}}"#.utf8)
+                )
+            case (.get, searchURL):
+                #expect(request.headers.get("Accept").first == "application/vnd.swift.registry.v1+json")
+                return Self.responseBody(Self.searchBody)
+            default:
+                throw StringError("unexpected request: \(request.method) \(request.url)")
+            }
+        }
+
+        let registry = Registry(url: registryURL, supportsAvailability: true)
+        let registryClient = makeRegistryClient(
+            configuration: .init(),
+            httpClient: HTTPClient(implementation: handler)
+        )
+
+        let results = try await registryClient.search(
+            query: "foo",
+            registry: registry,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
+        #expect(results.total == 1)
+        #expect(results.offset == 0)
+        #expect(results.limit == 20)
+        #expect(results.results.count == 1)
+        let first = try #require(results.results.first)
+        #expect(first.identity == "mona.LinkedList")
+        #expect(first.summary == "One thing links to another.")
+        #expect(first.versions == ["1.1.1", "1.0.0"])
+        #expect(first.latestVersion == "1.1.1")
+        #expect(first.author == "Mona Lisa Octocat")
+        #expect(first.licenseURL?.absoluteString == "https://example.com/LICENSE")
+        #expect(first.url?.absoluteString == "https://packages.example.com/mona/LinkedList")
+    }
+
+    @Test func notFoundFromSearchEndpointMapsToCapabilityNotSupported() async throws {
+        let handler: HTTPClient.Implementation = { request, _ in
+            switch (request.method, request.url) {
+            case (.get, availabilityURL):
+                return .init(
+                    statusCode: 200,
+                    headers: .init([.init(name: "Content-Type", value: "application/json")]),
+                    body: Data(#"{"capabilities":{"search":{}}}"#.utf8)
+                )
+            case (.get, searchURL):
+                return .notFound()
+            default:
+                throw StringError("unexpected request: \(request.method) \(request.url)")
+            }
+        }
+
+        let registry = Registry(url: registryURL, supportsAvailability: true)
+        let registryClient = makeRegistryClient(
+            configuration: .init(),
+            httpClient: HTTPClient(implementation: handler)
+        )
+
+        await #expect {
+            _ = try await registryClient.search(
+                query: "foo",
+                registry: registry,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+        } throws: { error in
+            if case RegistryError.capabilityNotSupported(_, let capability) = error {
+                return capability == "search"
+            }
+            return false
+        }
+    }
+
+    @Test func serverErrorIsWrappedAsSearchFailed() async throws {
+        let handler: HTTPClient.Implementation = { request, _ in
+            switch (request.method, request.url) {
+            case (.get, availabilityURL):
+                return .init(
+                    statusCode: 200,
+                    headers: .init([.init(name: "Content-Type", value: "application/json")]),
+                    body: Data(#"{"capabilities":{"search":{}}}"#.utf8)
+                )
+            case (.get, searchURL):
+                return Self.responseBody(#"{"detail":"query too long"}"#, statusCode: 400)
+            default:
+                throw StringError("unexpected request: \(request.method) \(request.url)")
+            }
+        }
+
+        let registry = Registry(url: registryURL, supportsAvailability: true)
+        let registryClient = makeRegistryClient(
+            configuration: .init(),
+            httpClient: HTTPClient(implementation: handler)
+        )
+
+        await #expect {
+            _ = try await registryClient.search(
+                query: "foo",
+                registry: registry,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+        } throws: { error in
+            if case RegistryError.searchFailed = error { return true }
+            return false
+        }
+    }
+
+    @Test func encodesQueryParameters() async throws {
+        let counter = SendableBox(0)
+        let handler: HTTPClient.Implementation = { request, _ in
+            await counter.increment()
+            switch request.method {
+            case .get where request.url == availabilityURL:
+                return .init(
+                    statusCode: 200,
+                    headers: .init([.init(name: "Content-Type", value: "application/json")]),
+                    body: Data(#"{"capabilities":{"search":{}}}"#.utf8)
+                )
+            case .get:
+                // Verify query string contains expected components
+                let url = request.url
+                let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                let queryItems = components?.queryItems ?? []
+                #expect(queryItems.contains(where: { $0.name == "q" && $0.value == "author:Mona networking" }))
+                #expect(queryItems.contains(where: { $0.name == "limit" && $0.value == "50" }))
+                #expect(queryItems.contains(where: { $0.name == "offset" && $0.value == "10" }))
+                return Self.responseBody(Self.searchBody)
+            default:
+                throw StringError("unexpected request: \(request.method) \(request.url)")
+            }
+        }
+
+        let registry = Registry(url: registryURL, supportsAvailability: true)
+        let registryClient = makeRegistryClient(
+            configuration: .init(),
+            httpClient: HTTPClient(implementation: handler)
+        )
+
+        _ = try await registryClient.search(
+            query: "author:Mona networking",
+            limit: 50,
+            offset: 10,
+            registry: registry,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
+        let count = await counter.value
+        #expect(count == 2) // availability + search
     }
 }
 


### PR DESCRIPTION
### Motivation:

Implements the SwiftPM client side of the registry search pitch https://forums.swift.org/t/pitch-package-registry-search/86320, https://github.com/swiftlang/swift-evolution/pull/3309.

### Modifications:

- Extends GET /availability to discover advertised capabilities. The `available` AvailabilityStatus case now carries a Set<String> of capability keys parsed from the response body; an empty body still signals availability (backwards compatible).
- `withAvailabilityCheck` gains a `requiring:` parameter that throws `RegistryError.capabilityNotSupported` when a registry does not advertise a required capability. All existing call sites are unaffected.
- Adds `RegistryClient.search(query:limit:offset:registry:...)` hitting GET /search; 404 maps to `capabilityNotSupported`, other errors to a new `searchFailed` case.
- New `swift package-registry search` subcommand iterates default and scoped registries (or `--registry <url>`), runs searches in parallel across all the registries the user has configured, and aggregates with round-robin interleaving. All registries unsupported -> error; some unsupported -> warning naming them (suppressed by `--json`). Per-result `registry` annotation appears only when multiple registries contribute.

### Result:

The `swift package-registry search` command allows for users and tools to query their configured registries for packages that match their search criteria.
