### PR TITLE
 SE-0541: Implementation: Flexible Swift/C Interoperability in Packages

### DIFF
--- a/Fixtures/CFamilyTargets/CrossLanguageObjCType/Package.swift
+++ b/Fixtures/CFamilyTargets/CrossLanguageObjCType/Package.swift
@@ -1,0 +1,11 @@
+// swift-tools-version: 6.4
+import PackageDescription
+
+let package = Package(
+    name: "CrossLanguageObjCType",
+    targets: [
+        .target(name: "TargetA"),
+        .target(name: "TargetB", dependencies: ["TargetA"]),
+        .target(name: "TargetC", dependencies: ["TargetB"]),
+    ]
+)

--- a/Fixtures/CFamilyTargets/CrossLanguageObjCType/Sources/TargetA/Widget.swift
+++ b/Fixtures/CFamilyTargets/CrossLanguageObjCType/Sources/TargetA/Widget.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+@objc public class Widget: NSObject {
+    @objc public let value: Int
+
+    @objc public init(value: Int) {
+        self.value = value
+        super.init()
+    }
+}

--- a/Fixtures/CFamilyTargets/CrossLanguageObjCType/Sources/TargetB/WidgetFactory.m
+++ b/Fixtures/CFamilyTargets/CrossLanguageObjCType/Sources/TargetB/WidgetFactory.m
@@ -1,0 +1,5 @@
+#import "WidgetFactory.h"
+
+Widget * _Nonnull makeWidget(void) {
+    return [[Widget alloc] initWithValue:42];
+}

--- a/Fixtures/CFamilyTargets/CrossLanguageObjCType/Sources/TargetB/include/WidgetFactory.h
+++ b/Fixtures/CFamilyTargets/CrossLanguageObjCType/Sources/TargetB/include/WidgetFactory.h
@@ -1,0 +1,8 @@
+#ifndef WIDGET_FACTORY_H
+#define WIDGET_FACTORY_H
+
+@import TargetA;
+
+Widget * _Nonnull makeWidget(void);
+
+#endif

--- a/Fixtures/CFamilyTargets/CrossLanguageObjCType/Sources/TargetC/Consumer.swift
+++ b/Fixtures/CFamilyTargets/CrossLanguageObjCType/Sources/TargetC/Consumer.swift
@@ -1,0 +1,6 @@
+import TargetB
+
+public func widgetValue() -> Int {
+    let widget = makeWidget()
+    return widget.value
+}

--- a/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedClangSuperclassSwiftSubclass",
+    targets: [
+        .target(name: "MixedLib"),
+        .target(name: "Consumer", dependencies: ["MixedLib"]),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Sources/Consumer/Consumer.m
+++ b/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Sources/Consumer/Consumer.m
@@ -1,0 +1,8 @@
+#import "Consumer.h"
+
+@import MixedLib;
+
+void consumer(void) {
+    Rectangle *rectangle = [[Rectangle alloc] init];
+    return;
+}

--- a/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Sources/Consumer/include/Consumer.h
+++ b/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Sources/Consumer/include/Consumer.h
@@ -1,0 +1,6 @@
+#ifndef CONSUMER_H
+#define CONSUMER_H
+
+void consumer(void);
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Sources/MixedLib/Circle.swift
+++ b/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Sources/MixedLib/Circle.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+@objc public class Rectangle: Shape {
+
+}

--- a/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Sources/MixedLib/Shape.m
+++ b/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Sources/MixedLib/Shape.m
@@ -1,0 +1,5 @@
+#import "Shape.h"
+
+@implementation Shape
+
+@end

--- a/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Sources/MixedLib/include/Shape.h
+++ b/Fixtures/CFamilyTargets/MixedClangSuperclassSwiftSubclass/Sources/MixedLib/include/Shape.h
@@ -1,0 +1,10 @@
+#ifndef SHAPE_H
+#define SHAPE_H
+
+@import Foundation;
+
+@interface Shape : NSObject
+
+@end
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedCxxUsesSwiftHeader",
+    targets: [
+        .target(
+            name: "MixedLib",
+            swiftSettings: [.interoperabilityMode(.Cxx)]
+        ),
+        .executableTarget(
+            name: "Runner",
+            dependencies: ["MixedLib"],
+            swiftSettings: [.interoperabilityMode(.Cxx)]
+        ),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Sources/MixedLib/Compute.swift
+++ b/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Sources/MixedLib/Compute.swift
@@ -1,0 +1,7 @@
+public func swiftValue() -> Int32 {
+    return 7
+}
+
+public func value() -> Int32 {
+    return bridge_value()
+}

--- a/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Sources/MixedLib/bridge.cpp
+++ b/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Sources/MixedLib/bridge.cpp
@@ -1,0 +1,6 @@
+#include "bridge.h"
+#include "MixedLib-Swift.h"
+
+int bridge_value() {
+    return (int)MixedLib::swiftValue();
+}

--- a/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Sources/MixedLib/include/bridge.h
+++ b/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Sources/MixedLib/include/bridge.h
@@ -1,0 +1,6 @@
+#ifndef BRIDGE_H
+#define BRIDGE_H
+
+int bridge_value();
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Sources/MixedLib/include/module.modulemap
+++ b/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Sources/MixedLib/include/module.modulemap
@@ -1,0 +1,4 @@
+module MixedLib {
+    header "bridge.h"
+    export *
+}

--- a/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Sources/Runner/main.swift
+++ b/Fixtures/CFamilyTargets/MixedCxxUsesSwiftHeader/Sources/Runner/main.swift
@@ -1,0 +1,3 @@
+import MixedLib
+
+print("value = \(value())")

--- a/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedExecutableTestTarget",
+    targets: [
+        .executableTarget(name: "MixedTool"),
+        .testTarget(name: "MixedToolTests", dependencies: ["MixedTool"]),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Sources/MixedTool/Tool.swift
+++ b/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Sources/MixedTool/Tool.swift
@@ -1,0 +1,3 @@
+func toolSwiftValue() -> Int32 {
+    return 10
+}

--- a/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Sources/MixedTool/include/toolc.h
+++ b/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Sources/MixedTool/include/toolc.h
@@ -1,0 +1,6 @@
+#ifndef TOOLC_H
+#define TOOLC_H
+
+int tool_c_value(void);
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Sources/MixedTool/main.swift
+++ b/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Sources/MixedTool/main.swift
@@ -1,0 +1,1 @@
+print("total = \(toolSwiftValue() + tool_c_value())")

--- a/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Sources/MixedTool/toolc.c
+++ b/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Sources/MixedTool/toolc.c
@@ -1,0 +1,5 @@
+#include "toolc.h"
+
+int tool_c_value(void) {
+    return 20;
+}

--- a/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Tests/MixedToolTests/MixedToolTests.swift
+++ b/Fixtures/CFamilyTargets/MixedExecutableTestTarget/Tests/MixedToolTests/MixedToolTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import MixedTool
+
+final class MixedToolTests: XCTestCase {
+    func testSwiftAPI() {
+
+        XCTAssertEqual(toolSwiftValue(), 10)
+    }
+
+    func testClangAPI() {
+
+        XCTAssertEqual(tool_c_value(), 20)
+    }
+}

--- a/Fixtures/CFamilyTargets/MixedLanguageClient/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedLanguageClient/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedLanguageClient",
+    targets: [
+        .target(name: "MixedCore"),
+        .executableTarget(name: "Client", dependencies: ["MixedCore"]),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedLanguageClient/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedLanguageClient/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedLanguageClient/Sources/Client/main.swift
+++ b/Fixtures/CFamilyTargets/MixedLanguageClient/Sources/Client/main.swift
@@ -1,0 +1,4 @@
+import MixedCore
+
+print("add(1, 2) = \(add(1, 2))")
+print("c_add(2, 3) = \(c_add(2, 3))")

--- a/Fixtures/CFamilyTargets/MixedLanguageClient/Sources/MixedCore/Adder.swift
+++ b/Fixtures/CFamilyTargets/MixedLanguageClient/Sources/MixedCore/Adder.swift
@@ -1,0 +1,3 @@
+public func add(_ a: Int32, _ b: Int32) -> Int32 {
+    return c_add(a, b)
+}

--- a/Fixtures/CFamilyTargets/MixedLanguageClient/Sources/MixedCore/cadd.c
+++ b/Fixtures/CFamilyTargets/MixedLanguageClient/Sources/MixedCore/cadd.c
@@ -1,0 +1,5 @@
+#include "cadd.h"
+
+int c_add(int a, int b) {
+    return a + b;
+}

--- a/Fixtures/CFamilyTargets/MixedLanguageClient/Sources/MixedCore/include/cadd.h
+++ b/Fixtures/CFamilyTargets/MixedLanguageClient/Sources/MixedCore/include/cadd.h
@@ -1,0 +1,6 @@
+#ifndef CADD_H
+#define CADD_H
+
+int c_add(int a, int b);
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedLibraryCustomModuleMap",
+    targets: [
+        .target(name: "MixedCore"),
+        .executableTarget(name: "Client", dependencies: ["MixedCore"]),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Sources/Client/main.swift
+++ b/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Sources/Client/main.swift
@@ -1,0 +1,4 @@
+import MixedCore
+
+print("add(1, 2) = \(add(1, 2))")
+print("c_add(2, 3) = \(c_add(2, 3))")

--- a/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Sources/MixedCore/Adder.swift
+++ b/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Sources/MixedCore/Adder.swift
@@ -1,0 +1,3 @@
+public func add(_ a: Int32, _ b: Int32) -> Int32 {
+    return c_add(a, b)
+}

--- a/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Sources/MixedCore/cadd.c
+++ b/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Sources/MixedCore/cadd.c
@@ -1,0 +1,5 @@
+#include "cadd.h"
+
+int c_add(int a, int b) {
+    return a + b;
+}

--- a/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Sources/MixedCore/include/cadd.h
+++ b/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Sources/MixedCore/include/cadd.h
@@ -1,0 +1,6 @@
+#ifndef CADD_H
+#define CADD_H
+
+int c_add(int a, int b);
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Sources/MixedCore/include/module.modulemap
+++ b/Fixtures/CFamilyTargets/MixedLibraryCustomModuleMap/Sources/MixedCore/include/module.modulemap
@@ -1,0 +1,4 @@
+module MixedCore {
+    header "cadd.h"
+    export *
+}

--- a/Fixtures/CFamilyTargets/MixedLibraryTestTarget/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedLibraryTestTarget/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedLibraryTestTarget",
+    targets: [
+        .target(name: "MixedCore"),
+        .testTarget(name: "MixedCoreTests", dependencies: ["MixedCore"]),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedLibraryTestTarget/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedLibraryTestTarget/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedLibraryTestTarget/Sources/MixedCore/Adder.swift
+++ b/Fixtures/CFamilyTargets/MixedLibraryTestTarget/Sources/MixedCore/Adder.swift
@@ -1,0 +1,3 @@
+public func add(_ a: Int32, _ b: Int32) -> Int32 {
+    return c_add(a, b)
+}

--- a/Fixtures/CFamilyTargets/MixedLibraryTestTarget/Sources/MixedCore/cadd.c
+++ b/Fixtures/CFamilyTargets/MixedLibraryTestTarget/Sources/MixedCore/cadd.c
@@ -1,0 +1,5 @@
+#include "cadd.h"
+
+int c_add(int a, int b) {
+    return a + b;
+}

--- a/Fixtures/CFamilyTargets/MixedLibraryTestTarget/Sources/MixedCore/include/cadd.h
+++ b/Fixtures/CFamilyTargets/MixedLibraryTestTarget/Sources/MixedCore/include/cadd.h
@@ -1,0 +1,6 @@
+#ifndef CADD_H
+#define CADD_H
+
+int c_add(int a, int b);
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedLibraryTestTarget/Tests/MixedCoreTests/MixedCoreTests.swift
+++ b/Fixtures/CFamilyTargets/MixedLibraryTestTarget/Tests/MixedCoreTests/MixedCoreTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+import MixedCore
+
+final class MixedCoreTests: XCTestCase {
+    func testSwiftAPI() {
+
+        XCTAssertEqual(MixedCore.add(1, 2), 3)
+    }
+
+    func testClangAPI() {
+
+        XCTAssertEqual(c_add(2, 3), 5)
+    }
+}

--- a/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedObjCUsesSwiftHeader",
+    targets: [
+        .target(name: "MixedLib"),
+        .executableTarget(name: "Runner", dependencies: ["MixedLib"]),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Sources/MixedLib/Bridge.m
+++ b/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Sources/MixedLib/Bridge.m
@@ -1,0 +1,7 @@
+#import "Bridge.h"
+
+#import "MixedLib-Swift.h"
+
+int bridge_value(void) {
+    return (int)[Greeter rawValue];
+}

--- a/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Sources/MixedLib/Greeter.swift
+++ b/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Sources/MixedLib/Greeter.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+@objc public class Greeter: NSObject {
+
+    @objc public class func rawValue() -> Int32 {
+        return 7
+    }
+}

--- a/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Sources/MixedLib/Value.swift
+++ b/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Sources/MixedLib/Value.swift
@@ -1,0 +1,3 @@
+public func value() -> Int32 {
+    return bridge_value()
+}

--- a/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Sources/MixedLib/include/Bridge.h
+++ b/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Sources/MixedLib/include/Bridge.h
@@ -1,0 +1,6 @@
+#ifndef BRIDGE_H
+#define BRIDGE_H
+
+int bridge_value(void);
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Sources/Runner/main.swift
+++ b/Fixtures/CFamilyTargets/MixedObjCUsesSwiftHeader/Sources/Runner/main.swift
@@ -1,0 +1,3 @@
+import MixedLib
+
+print("value = \(value())")

--- a/Fixtures/CFamilyTargets/MixedSourceMacro/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSourceMacro/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+import CompilerPluginSupport
+
+let package = Package(
+    name: "MixedSourceMacro",
+    platforms: [
+        .macOS(.v13),
+    ],
+    targets: [
+        .macro(name: "MacroImpl"),
+        .target(name: "MacroDef", dependencies: ["MacroImpl"]),
+        .executableTarget(name: "MacroClient", dependencies: ["MacroDef"]),
+    ],
+    swiftLanguageModes: [.v5]
+)

--- a/Fixtures/CFamilyTargets/MixedSourceMacro/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSourceMacro/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 import CompilerPluginSupport
 

--- a/Fixtures/CFamilyTargets/MixedSourceMacro/Sources/MacroClient/main.swift
+++ b/Fixtures/CFamilyTargets/MixedSourceMacro/Sources/MacroClient/main.swift
@@ -1,0 +1,3 @@
+import MacroDef
+
+print("answer = \(#answer)")

--- a/Fixtures/CFamilyTargets/MixedSourceMacro/Sources/MacroDef/MacroDef.swift
+++ b/Fixtures/CFamilyTargets/MixedSourceMacro/Sources/MacroDef/MacroDef.swift
@@ -1,0 +1,2 @@
+@freestanding(expression)
+public macro answer() -> Int = #externalMacro(module: "MacroImpl", type: "AnswerMacro")

--- a/Fixtures/CFamilyTargets/MixedSourceMacro/Sources/MacroImpl/Plugin.swift
+++ b/Fixtures/CFamilyTargets/MixedSourceMacro/Sources/MacroImpl/Plugin.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+@main
+struct MacroPlugin {
+    static func main() throws {
+        while true {
+            guard let headerData = try read(count: 8),
+                  headerData.count == 8 else {
+                break
+            }
+            let length = headerData.withUnsafeBytes { buffer in
+                buffer.load(as: UInt64.self)
+            }
+            let payloadLength = UInt64(littleEndian: length)
+
+            if payloadLength == 0 {
+                break
+            }
+
+            guard let payloadData = try read(count: Int(payloadLength)),
+                  payloadData.count == Int(payloadLength) else {
+                break
+            }
+
+            guard let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any] else {
+                continue
+            }
+
+            if json.keys.contains("getCapability") {
+                let response: [String: Any] = [
+                    "getCapabilityResult": [
+                        "capability": [
+                            "protocolVersion": 2
+                        ]
+                    ]
+                ]
+                if let responseData = try? JSONSerialization.data(withJSONObject: response) {
+                    try writeMessage(responseData, to: FileHandle.standardOutput)
+                }
+            } else if json.keys.contains("expandFreestandingMacro") {
+                let response: [String: Any] = [
+                    "expandMacroResult": [
+
+                        "expandedSource": "\(c_answer())",
+                        "diagnostics": []
+                    ]
+                ]
+                if let responseData = try? JSONSerialization.data(withJSONObject: response) {
+                    try writeMessage(responseData, to: FileHandle.standardOutput)
+                }
+            }
+        }
+    }
+}
+
+private func read(count: Int) throws -> Data? {
+    var accumulated = Data()
+    while accumulated.count < count {
+        let remaining = count - accumulated.count
+        guard let chunk = try FileHandle.standardInput.read(upToCount: remaining), !chunk.isEmpty else {
+            return accumulated.isEmpty ? nil : accumulated
+        }
+        accumulated.append(chunk)
+    }
+    return accumulated
+}
+
+private func writeMessage(_ data: Data, to handle: FileHandle) throws {
+    var length = UInt64(data.count).littleEndian
+    let headerData = withUnsafeBytes(of: &length) { buffer in
+        Data(buffer)
+    }
+    try handle.write(contentsOf: headerData)
+    try handle.write(contentsOf: data)
+}

--- a/Fixtures/CFamilyTargets/MixedSourceMacro/Sources/MacroImpl/helper.c
+++ b/Fixtures/CFamilyTargets/MixedSourceMacro/Sources/MacroImpl/helper.c
@@ -1,0 +1,5 @@
+#include "helper.h"
+
+int c_answer(void) {
+    return 42;
+}

--- a/Fixtures/CFamilyTargets/MixedSourceMacro/Sources/MacroImpl/include/helper.h
+++ b/Fixtures/CFamilyTargets/MixedSourceMacro/Sources/MacroImpl/include/helper.h
@@ -1,0 +1,6 @@
+#ifndef HELPER_H
+#define HELPER_H
+
+int c_answer(void);
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedSourceTestTarget/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSourceTestTarget/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedSourceTestTarget",
+    targets: [
+        .target(name: "Calculator"),
+        .testTarget(name: "CalculatorTests", dependencies: ["Calculator"]),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedSourceTestTarget/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSourceTestTarget/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedSourceTestTarget/Sources/Calculator/Calculator.swift
+++ b/Fixtures/CFamilyTargets/MixedSourceTestTarget/Sources/Calculator/Calculator.swift
@@ -1,0 +1,3 @@
+public func square(_ x: Int32) -> Int32 {
+    return x * x
+}

--- a/Fixtures/CFamilyTargets/MixedSourceTestTarget/Tests/CalculatorTests/CalculatorTests.swift
+++ b/Fixtures/CFamilyTargets/MixedSourceTestTarget/Tests/CalculatorTests/CalculatorTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+import Calculator
+
+final class CalculatorTests: XCTestCase {
+    func testLibraryUnderTest() {
+        XCTAssertEqual(square(4), 16)
+    }
+
+    func testOwnCHelper() {
+
+        XCTAssertEqual(test_c_helper(), 7)
+    }
+}

--- a/Fixtures/CFamilyTargets/MixedSourceTestTarget/Tests/CalculatorTests/include/test_helper.h
+++ b/Fixtures/CFamilyTargets/MixedSourceTestTarget/Tests/CalculatorTests/include/test_helper.h
@@ -1,0 +1,6 @@
+#ifndef TEST_HELPER_H
+#define TEST_HELPER_H
+
+int test_c_helper(void);
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedSourceTestTarget/Tests/CalculatorTests/test_helper.c
+++ b/Fixtures/CFamilyTargets/MixedSourceTestTarget/Tests/CalculatorTests/test_helper.c
@@ -1,0 +1,5 @@
+#include "test_helper.h"
+
+int test_c_helper(void) {
+    return 7;
+}

--- a/Fixtures/CFamilyTargets/MixedSwiftCExecutable/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCExecutable/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedSwiftCExecutable",
+    targets: [
+        .executableTarget(name: "MixedSwiftCExecutable"),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedSwiftCExecutable/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCExecutable/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedSwiftCExecutable/Sources/MixedSwiftCExecutable/helper.c
+++ b/Fixtures/CFamilyTargets/MixedSwiftCExecutable/Sources/MixedSwiftCExecutable/helper.c
@@ -1,0 +1,5 @@
+#include "helper.h"
+
+int exec_c_value(void) {
+    return 42;
+}

--- a/Fixtures/CFamilyTargets/MixedSwiftCExecutable/Sources/MixedSwiftCExecutable/include/helper.h
+++ b/Fixtures/CFamilyTargets/MixedSwiftCExecutable/Sources/MixedSwiftCExecutable/include/helper.h
@@ -1,0 +1,6 @@
+#ifndef HELPER_H
+#define HELPER_H
+
+int exec_c_value(void);
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedSwiftCExecutable/Sources/MixedSwiftCExecutable/main.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCExecutable/Sources/MixedSwiftCExecutable/main.swift
@@ -1,0 +1,2 @@
+let value = exec_c_value()
+print("exec_c_value = \(value)")

--- a/Fixtures/CFamilyTargets/MixedSwiftCLibrary/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCLibrary/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedSwiftCLibrary",
+    targets: [
+        .target(name: "MixedSwiftCLibrary"),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedSwiftCLibrary/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCLibrary/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedSwiftCLibrary/Sources/MixedSwiftCLibrary/Adder.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCLibrary/Sources/MixedSwiftCLibrary/Adder.swift
@@ -1,0 +1,3 @@
+public func add(_ a: Int32, _ b: Int32) -> Int32 {
+    return c_add(a, b)
+}

--- a/Fixtures/CFamilyTargets/MixedSwiftCLibrary/Sources/MixedSwiftCLibrary/cadd.c
+++ b/Fixtures/CFamilyTargets/MixedSwiftCLibrary/Sources/MixedSwiftCLibrary/cadd.c
@@ -1,0 +1,5 @@
+#include "cadd.h"
+
+int c_add(int a, int b) {
+    return a + b;
+}

--- a/Fixtures/CFamilyTargets/MixedSwiftCLibrary/Sources/MixedSwiftCLibrary/include/cadd.h
+++ b/Fixtures/CFamilyTargets/MixedSwiftCLibrary/Sources/MixedSwiftCLibrary/include/cadd.h
@@ -1,0 +1,6 @@
+#ifndef CADD_H
+#define CADD_H
+
+int c_add(int a, int b);
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedSwiftCLibraryNoHeaders/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCLibraryNoHeaders/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedSwiftCLibraryNoHeaders",
+    targets: [
+        .target(name: "MixedNoHeaders"),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedSwiftCLibraryNoHeaders/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCLibraryNoHeaders/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedSwiftCLibraryNoHeaders/Sources/MixedNoHeaders/Compute.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCLibraryNoHeaders/Sources/MixedNoHeaders/Compute.swift
@@ -1,0 +1,3 @@
+public func compute() -> Int32 {
+    return 42
+}

--- a/Fixtures/CFamilyTargets/MixedSwiftCLibraryNoHeaders/Sources/MixedNoHeaders/helper.c
+++ b/Fixtures/CFamilyTargets/MixedSwiftCLibraryNoHeaders/Sources/MixedNoHeaders/helper.c
@@ -1,0 +1,3 @@
+int no_header_helper(void) {
+    return 7;
+}

--- a/Fixtures/CFamilyTargets/MixedSwiftCxxExecutable/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCxxExecutable/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedSwiftCxxExecutable",
+    targets: [
+        .executableTarget(name: "MixedSwiftCxxExecutable"),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedSwiftCxxExecutable/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCxxExecutable/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedSwiftCxxExecutable/Sources/MixedSwiftCxxExecutable/calc.cpp
+++ b/Fixtures/CFamilyTargets/MixedSwiftCxxExecutable/Sources/MixedSwiftCxxExecutable/calc.cpp
@@ -1,0 +1,14 @@
+#include "calc.h"
+#include <vector>
+
+int cpp_sum(int n) {
+    std::vector<int> values;
+    for (int i = 1; i <= n; ++i) {
+        values.push_back(i);
+    }
+    int sum = 0;
+    for (int value : values) {
+        sum += value;
+    }
+    return sum;
+}

--- a/Fixtures/CFamilyTargets/MixedSwiftCxxExecutable/Sources/MixedSwiftCxxExecutable/include/calc.h
+++ b/Fixtures/CFamilyTargets/MixedSwiftCxxExecutable/Sources/MixedSwiftCxxExecutable/include/calc.h
@@ -1,0 +1,14 @@
+#ifndef CALC_H
+#define CALC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int cpp_sum(int n);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedSwiftCxxExecutable/Sources/MixedSwiftCxxExecutable/main.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCxxExecutable/Sources/MixedSwiftCxxExecutable/main.swift
@@ -1,0 +1,1 @@
+print("sum = \(cpp_sum(4))")

--- a/Fixtures/CFamilyTargets/MixedSwiftCxxLibrary/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCxxLibrary/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedSwiftCxxLibrary",
+    targets: [
+        .target(name: "MixedSwiftCxxLibrary"),
+    ]
+)

--- a/Fixtures/CFamilyTargets/MixedSwiftCxxLibrary/Package.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCxxLibrary/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/MixedSwiftCxxLibrary/Sources/MixedSwiftCxxLibrary/Multiplier.swift
+++ b/Fixtures/CFamilyTargets/MixedSwiftCxxLibrary/Sources/MixedSwiftCxxLibrary/Multiplier.swift
@@ -1,0 +1,3 @@
+public func multiply(_ a: Int32, _ b: Int32) -> Int32 {
+    return cpp_multiply(a, b)
+}

--- a/Fixtures/CFamilyTargets/MixedSwiftCxxLibrary/Sources/MixedSwiftCxxLibrary/include/mul.h
+++ b/Fixtures/CFamilyTargets/MixedSwiftCxxLibrary/Sources/MixedSwiftCxxLibrary/include/mul.h
@@ -1,0 +1,14 @@
+#ifndef MUL_H
+#define MUL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int cpp_multiply(int a, int b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Fixtures/CFamilyTargets/MixedSwiftCxxLibrary/Sources/MixedSwiftCxxLibrary/mul.cpp
+++ b/Fixtures/CFamilyTargets/MixedSwiftCxxLibrary/Sources/MixedSwiftCxxLibrary/mul.cpp
@@ -1,0 +1,14 @@
+#include "mul.h"
+#include <vector>
+
+int cpp_multiply(int a, int b) {
+    std::vector<int> values;
+    for (int i = 0; i < b; ++i) {
+        values.push_back(a);
+    }
+    int sum = 0;
+    for (int value : values) {
+        sum += value;
+    }
+    return sum;
+}

--- a/Fixtures/CFamilyTargets/ObjCImplementationInSwift/Package.swift
+++ b/Fixtures/CFamilyTargets/ObjCImplementationInSwift/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 6.4;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "ObjCImplementationInSwift",
+    targets: [
+        .target(
+            name: "MixedImpl",
+            swiftSettings: [.enableExperimentalFeature("ObjCImplementation")]
+        ),
+        .executableTarget(name: "Runner", dependencies: ["MixedImpl"]),
+    ]
+)

--- a/Fixtures/CFamilyTargets/ObjCImplementationInSwift/Package.swift
+++ b/Fixtures/CFamilyTargets/ObjCImplementationInSwift/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/CFamilyTargets/ObjCImplementationInSwift/Sources/MixedImpl/Widget.swift
+++ b/Fixtures/CFamilyTargets/ObjCImplementationInSwift/Sources/MixedImpl/Widget.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@objc @implementation extension Widget {
+    func value() -> Int32 {
+        return 42
+    }
+}

--- a/Fixtures/CFamilyTargets/ObjCImplementationInSwift/Sources/MixedImpl/include/Widget.h
+++ b/Fixtures/CFamilyTargets/ObjCImplementationInSwift/Sources/MixedImpl/include/Widget.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface Widget : NSObject
+- (int)value;
+@end

--- a/Fixtures/CFamilyTargets/ObjCImplementationInSwift/Sources/Runner/main.swift
+++ b/Fixtures/CFamilyTargets/ObjCImplementationInSwift/Sources/Runner/main.swift
@@ -1,0 +1,3 @@
+import MixedImpl
+
+print("value = \(Widget().value())")

--- a/Fixtures/Miscellaneous/BridgingHeader/Package.swift
+++ b/Fixtures/Miscellaneous/BridgingHeader/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 999.0
+import PackageDescription
+
+let package = Package(
+    name: "BridgingHeader",
+    targets: [
+        .executableTarget(
+            name: "App",
+            swiftSettings: [.bridgingHeader("Bridging.h", visibility: .public)]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/BridgingHeader/Package.swift
+++ b/Fixtures/Miscellaneous/BridgingHeader/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/BridgingHeader/Sources/App/Bridging.h
+++ b/Fixtures/Miscellaneous/BridgingHeader/Sources/App/Bridging.h
@@ -1,0 +1,6 @@
+#ifndef BRIDGING_H
+#define BRIDGING_H
+
+static inline int c_double(int x) { return x * 2; }
+
+#endif

--- a/Fixtures/Miscellaneous/BridgingHeader/Sources/App/main.swift
+++ b/Fixtures/Miscellaneous/BridgingHeader/Sources/App/main.swift
@@ -1,0 +1,1 @@
+print("c_double(21) = \(c_double(21))")

--- a/Fixtures/Miscellaneous/BridgingHeaderCxx/Package.swift
+++ b/Fixtures/Miscellaneous/BridgingHeaderCxx/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 999.0
+import PackageDescription
+
+let package = Package(
+    name: "BridgingHeaderCxx",
+    targets: [
+        .executableTarget(
+            name: "App",
+            swiftSettings: [
+                .interoperabilityMode(.Cxx),
+                .bridgingHeader("Bridging.h", visibility: .public),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/BridgingHeaderCxx/Package.swift
+++ b/Fixtures/Miscellaneous/BridgingHeaderCxx/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/BridgingHeaderCxx/Sources/App/Bridging.h
+++ b/Fixtures/Miscellaneous/BridgingHeaderCxx/Sources/App/Bridging.h
@@ -1,0 +1,6 @@
+#pragma once
+
+static inline int cxx_max(int a, int b) {
+    auto pick = [](int x, int y) { return x > y ? x : y; };
+    return pick(a, b);
+}

--- a/Fixtures/Miscellaneous/BridgingHeaderCxx/Sources/App/main.swift
+++ b/Fixtures/Miscellaneous/BridgingHeaderCxx/Sources/App/main.swift
@@ -1,0 +1,1 @@
+print("cxx_max(3, 9) = \(cxx_max(3, 9))")

--- a/Fixtures/Miscellaneous/BridgingHeaderSearchPaths/Package.swift
+++ b/Fixtures/Miscellaneous/BridgingHeaderSearchPaths/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 999.0;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "BridgingHeaderSearchPaths",
+    targets: [
+        .executableTarget(
+            name: "App",
+            cSettings: [.headerSearchPath("extra_headers")],
+            swiftSettings: [.bridgingHeader("Bridging.h", visibility: .public)]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/BridgingHeaderSearchPaths/Package.swift
+++ b/Fixtures/Miscellaneous/BridgingHeaderSearchPaths/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/BridgingHeaderSearchPaths/Sources/App/Bridging.h
+++ b/Fixtures/Miscellaneous/BridgingHeaderSearchPaths/Sources/App/Bridging.h
@@ -1,0 +1,6 @@
+#ifndef BRIDGING_H
+#define BRIDGING_H
+
+#include "math_shims.h"
+
+#endif

--- a/Fixtures/Miscellaneous/BridgingHeaderSearchPaths/Sources/App/extra_headers/math_shims.h
+++ b/Fixtures/Miscellaneous/BridgingHeaderSearchPaths/Sources/App/extra_headers/math_shims.h
@@ -1,0 +1,6 @@
+#ifndef MATH_SHIMS_H
+#define MATH_SHIMS_H
+
+static inline int shim_add(int a, int b) { return a + b; }
+
+#endif

--- a/Fixtures/Miscellaneous/BridgingHeaderSearchPaths/Sources/App/helper.c
+++ b/Fixtures/Miscellaneous/BridgingHeaderSearchPaths/Sources/App/helper.c
@@ -1,0 +1,3 @@
+#include "math_shims.h"
+
+int helper(void) { return shim_add(0, 0); }

--- a/Fixtures/Miscellaneous/BridgingHeaderSearchPaths/Sources/App/main.swift
+++ b/Fixtures/Miscellaneous/BridgingHeaderSearchPaths/Sources/App/main.swift
@@ -1,0 +1,1 @@
+print("shim_add(2, 3) = \(shim_add(2, 3))")

--- a/Fixtures/Miscellaneous/BridgingHeaderWithClangModule/Package.swift
+++ b/Fixtures/Miscellaneous/BridgingHeaderWithClangModule/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 999.0;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "BridgingHeaderWithClangModule",
+    targets: [
+        .target(
+            name: "Mixed",
+            swiftSettings: [.bridgingHeader("Bridging.h", visibility: .internal)]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/BridgingHeaderWithClangModule/Package.swift
+++ b/Fixtures/Miscellaneous/BridgingHeaderWithClangModule/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/BridgingHeaderWithClangModule/Sources/Mixed/Adder.swift
+++ b/Fixtures/Miscellaneous/BridgingHeaderWithClangModule/Sources/Mixed/Adder.swift
@@ -1,0 +1,3 @@
+public func compute() -> Int32 {
+    return c_add(1, 2) + Int32(bridged_value())
+}

--- a/Fixtures/Miscellaneous/BridgingHeaderWithClangModule/Sources/Mixed/Bridging.h
+++ b/Fixtures/Miscellaneous/BridgingHeaderWithClangModule/Sources/Mixed/Bridging.h
@@ -1,0 +1,6 @@
+#ifndef BRIDGING_H
+#define BRIDGING_H
+
+static inline int bridged_value(void) { return 99; }
+
+#endif

--- a/Fixtures/Miscellaneous/BridgingHeaderWithClangModule/Sources/Mixed/cadd.c
+++ b/Fixtures/Miscellaneous/BridgingHeaderWithClangModule/Sources/Mixed/cadd.c
@@ -1,0 +1,5 @@
+#include "cadd.h"
+
+int c_add(int a, int b) {
+    return a + b;
+}

--- a/Fixtures/Miscellaneous/BridgingHeaderWithClangModule/Sources/Mixed/include/cadd.h
+++ b/Fixtures/Miscellaneous/BridgingHeaderWithClangModule/Sources/Mixed/include/cadd.h
@@ -1,0 +1,6 @@
+#ifndef CADD_H
+#define CADD_H
+
+int c_add(int a, int b);
+
+#endif

--- a/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 999.0;(experimentalMultiLang)
+import PackageDescription
+
+let package = Package(
+    name: "MixedTargetPluginAPIs",
+    targets: [
+        .target(name: "SwiftOnly"),
+        .target(name: "ClangOnly"),
+        .target(
+            name: "Mixed",
+            cSettings: [.define("PREPROCESSOR_MACRO"), .headerSearchPath("extra_headers")],
+            swiftSettings: [.define("SWIFT_DEFINITION")]
+        ),
+        .plugin(
+            name: "DumpTargets",
+            capability: .command(
+                intent: .custom(verb: "dump-targets", description: "Dumps target metadata via the PackagePlugin API")
+            )
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0;(experimentalMultiLang)
+// swift-tools-version: 6.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Plugins/DumpTargets/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Plugins/DumpTargets/plugin.swift
@@ -1,0 +1,27 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct DumpTargets: CommandPlugin {
+    func performCommand(context: PluginContext, arguments: [String]) throws {
+        for module in context.package.sourceModules.sorted(by: { $0.name < $1.name }) {
+            let type: String
+            if module is SwiftSourceModuleTarget {
+                type = "swift"
+            } else if module is ClangSourceModuleTarget {
+                type = "clang"
+            } else {
+                type = "mixed"
+            }
+            let name = module.name
+            print("\(name).type = \(type)")
+            print("\(name).moduleName = \(module.moduleName)")
+            print("\(name).kind = \(module.kind)")
+            print("\(name).publicHeaders = \(module.publicHeadersDirectoryURL?.lastPathComponent ?? "none")")
+            print("\(name).swiftDefinitions = \(module.swiftCompilationConditions)")
+            print("\(name).clangDefinitions = \(module.clangPreprocessorDefinitions)")
+            print("\(name).headerSearchPaths = \(module.headerSearchPaths)")
+            print("\(name).sourceFiles = \(module.sourceFiles.map(\.url.lastPathComponent))")
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/ClangOnly/clang_only.c
+++ b/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/ClangOnly/clang_only.c
@@ -1,0 +1,5 @@
+#include "clang_only.h"
+
+int clang_only(void) {
+    return 2;
+}

--- a/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/ClangOnly/include/clang_only.h
+++ b/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/ClangOnly/include/clang_only.h
@@ -1,0 +1,6 @@
+#ifndef CLANG_ONLY_H
+#define CLANG_ONLY_H
+
+int clang_only(void);
+
+#endif

--- a/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/Mixed/Adder.swift
+++ b/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/Mixed/Adder.swift
@@ -1,0 +1,3 @@
+public func add(_ a: Int32, _ b: Int32) -> Int32 {
+    return c_add(a, b)
+}

--- a/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/Mixed/cadd.c
+++ b/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/Mixed/cadd.c
@@ -1,0 +1,5 @@
+#include "cadd.h"
+
+int c_add(int a, int b) {
+    return a + b;
+}

--- a/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/Mixed/extra_headers/extra.h
+++ b/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/Mixed/extra_headers/extra.h
@@ -1,0 +1,6 @@
+#ifndef EXTRA_H
+#define EXTRA_H
+
+int extra(void);
+
+#endif

--- a/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/Mixed/include/cadd.h
+++ b/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/Mixed/include/cadd.h
@@ -1,0 +1,6 @@
+#ifndef CADD_H
+#define CADD_H
+
+int c_add(int a, int b);
+
+#endif

--- a/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/SwiftOnly/SwiftOnly.swift
+++ b/Fixtures/Miscellaneous/Plugins/MixedTargetPluginAPIs/Sources/SwiftOnly/SwiftOnly.swift
@@ -1,0 +1,3 @@
+public func swiftOnly() -> Int32 {
+    return 1
+}

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -279,6 +279,11 @@ public final class SwiftModuleBuildDescription {
             throw StringError("\(target.name): mixed language source files in Swift targets are not supported by the native build system.")
         }
 
+        // Bridging headers are only supported by the Swift Build backend.
+        if !buildParameters.createScope(for: target).evaluate(.SWIFT_OBJC_BRIDGING_HEADER).isEmpty {
+            throw StringError("\(target.name): bridging headers are not supported when using the native build system.")
+        }
+
         guard let swiftTarget = target.underlying as? SwiftModule else {
             throw InternalError("underlying target type mismatch \(target)")
         }

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -718,6 +718,14 @@ extension TargetBuildSettingDescription.Kind {
                 throw InternalError("invalid build settings value")
             }
             return .interoperabilityMode(lang)
+        case "bridgingHeader":
+            guard values.count == 2 else {
+                throw InternalError("invalid build settings value")
+            }
+            guard let visibility = TargetBuildSettingDescription.BridgingHeaderVisibility(rawValue: values[1]) else {
+                throw InternalError("unknown bridging header visibility: \(values[1])")
+            }
+            return .bridgingHeader(values[0], visibility)
         case "enableUpcomingFeature":
             guard let value = values.first else {
                 throw InternalError("invalid (empty) build settings value")

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -75,6 +75,18 @@ public enum ModuleError: Swift.Error {
     /// Invalid header search path.
     case invalidHeaderSearchPath(String)
 
+    /// Invalid bridging header path.
+    case invalidBridgingHeaderPath(target: String, path: String)
+
+    /// A bridging header was placed inside the target's public headers directory.
+    case bridgingHeaderInPublicHeadersDirectory(target: String, path: String)
+
+    /// A library target attempted to use a public bridging header.
+    case publicBridgingHeaderInLibraryTarget(target: String)
+
+    /// More than one bridging header was specified for a target.
+    case multipleBridgingHeaders(target: String)
+
     /// Default localization not set in the presence of localized resources.
     case defaultLocalizationNotSet
 
@@ -145,6 +157,14 @@ extension ModuleError: CustomStringConvertible {
             return "invalid custom path '\(path)' for target '\(target)'"
         case .invalidHeaderSearchPath(let path):
             return "invalid header search path '\(path)'; header search path should not be outside the package root"
+        case .invalidBridgingHeaderPath(let target, let path):
+            return "invalid bridging header '\(path)' in target '\(target)'; the bridging header should not be outside the package root"
+        case .bridgingHeaderInPublicHeadersDirectory(let target, let path):
+            return "invalid bridging header '\(path)' in target '\(target)'; the bridging header must not be inside the target's public headers directory"
+        case .publicBridgingHeaderInLibraryTarget(let target):
+            return "library target '\(target)' cannot use a bridging header with '.public' visibility; only '.internal' visibility is supported in libraries"
+        case .multipleBridgingHeaders(let target):
+            return "target '\(target)' has more than one bridging header specified"
         case .defaultLocalizationNotSet:
             return "manifest property 'defaultLocalization' not set; it is required in the presence of localized resources"
         case .pluginCapabilityNotDeclared(let target):
@@ -1120,6 +1140,15 @@ public final class PackageBuilder {
 
         table.add(versionAssignment, for: .SWIFT_VERSION)
 
+        // A target may configure at most one bridging header.
+        let bridgingHeaderCount = target.settings.filter {
+            if case .bridgingHeader = $0.kind { return true }
+            return false
+        }.count
+        if bridgingHeaderCount > 1 {
+            throw ModuleError.multipleBridgingHeaders(target: target.name)
+        }
+
         // Process each setting.
         for setting in target.settings {
             if let traits = setting.condition?.traits, traits.intersection(self.enabledTraits.names).isEmpty {
@@ -1196,6 +1225,37 @@ public final class PackageBuilder {
                 } else {
                     values = []
                 }
+
+            case .bridgingHeader(let path, let visibility):
+                switch setting.tool {
+                case .c, .cxx, .linker:
+                    throw InternalError("only Swift supports bridging headers")
+                case .swift:
+                    decl = .SWIFT_OBJC_BRIDGING_HEADER
+                }
+
+                if target.type == .regular && visibility == .public {
+                    throw ModuleError.publicBridgingHeaderInLibraryTarget(target: target.name)
+                }
+
+                let bridgingHeaderPath = try AbsolutePath(validating: path, relativeTo: targetRoot)
+                guard bridgingHeaderPath.isDescendantOfOrEqual(to: self.packagePath) else {
+                    throw ModuleError.invalidBridgingHeaderPath(target: target.name, path: path)
+                }
+
+                let publicHeadersDir = try targetRoot.appending(
+                    RelativePath(validating: target.publicHeadersPath ?? "include")
+                )
+                if bridgingHeaderPath.isDescendantOfOrEqual(to: publicHeadersDir) {
+                    throw ModuleError.bridgingHeaderInPublicHeadersDirectory(target: target.name, path: path)
+                }
+
+                values = [bridgingHeaderPath.pathString]
+
+                var visibilityAssignment = BuildSettings.Assignment()
+                visibilityAssignment.values = [visibility == .internal ? "YES" : "NO"]
+                visibilityAssignment.conditions = self.buildConditions(from: setting.condition)
+                table.add(visibilityAssignment, for: .SWIFT_BRIDGING_HEADER_IS_INTERNAL)
 
             case .unsafeFlags(let _values):
                 values = _values

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -234,7 +234,7 @@ extension Module.Error: CustomStringConvertible {
         case .invalidName(let path, let problem):
             "invalid target name at '\(path)'; \(problem)"
         case .mixedSources(let path):
-            "target at '\(path)' contains mixed language source files; feature not supported"
+            "target at '\(path)' contains mixed language source files; mixed language targets require a tools version of 6.5 or later"
         }
     }
 }
@@ -1030,7 +1030,7 @@ public final class PackageBuilder {
             var clangModuleInfo: ClangModuleInfo? = nil
             // If this is a mixed source target, we also need to compute the clang module info.
             let hasPublicHeaders = self.fileSystem.exists(publicHeadersPath)
-            let hasHeaderOnlyCModule = self.manifest.toolsVersion.experimentalMultiLang && hasPublicHeaders
+            let hasHeaderOnlyCModule = self.manifest.toolsVersion >= .v6_5 && hasPublicHeaders
             if sources.hasClangSources || hasHeaderOnlyCModule {
                 let moduleMapType: ModuleMapType
                 let includeDir: AbsolutePath?

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1007,6 +1007,34 @@ public final class PackageBuilder {
 
         // Create and return the right kind of target depending on what kind of sources we found.
         if sources.hasSwiftSources {
+            var clangModuleInfo: ClangModuleInfo? = nil
+            // If this is a mixed source target, we also need to compute the clang module info.
+            let hasPublicHeaders = self.fileSystem.exists(publicHeadersPath)
+            let hasHeaderOnlyCModule = self.manifest.toolsVersion.experimentalMultiLang && hasPublicHeaders
+            if sources.hasClangSources || hasHeaderOnlyCModule {
+                let moduleMapType: ModuleMapType
+                let includeDir: AbsolutePath?
+                if hasPublicHeaders {
+                    let moduleMapGenerator = ModuleMapGenerator(
+                        targetName: potentialModule.name,
+                        moduleName: potentialModule.name.spm_mangledToC99ExtendedIdentifier(),
+                        publicHeadersDir: publicHeadersPath,
+                        fileSystem: self.fileSystem
+                    )
+                    moduleMapType = moduleMapGenerator.determineModuleMapType(observabilityScope: self.observabilityScope)
+                    includeDir = publicHeadersPath
+                } else {
+                    moduleMapType = .none
+                    includeDir = nil
+                }
+                clangModuleInfo = ClangModuleInfo(
+                    includeDir: includeDir,
+                    moduleMapType: moduleMapType,
+                    headers: headers,
+                    cLanguageStandard: self.manifest.cLanguageStandard,
+                    cxxLanguageStandard: self.manifest.cxxLanguageStandard
+                )
+            }
             return try SwiftModule(
                 name: potentialModule.name,
                 potentialBundleName: potentialBundleName,
@@ -1019,6 +1047,7 @@ public final class PackageBuilder {
                 dependencies: dependencies,
                 packageAccess: potentialModule.packageAccess,
                 declaredSwiftVersions: self.declaredSwiftVersions(),
+                clangModuleInfo: clangModuleInfo,
                 buildSettings: buildSettings,
                 buildSettingsDescription: manifestTarget.settings,
                 // unsafe flags check disabled in 6.2
@@ -1830,28 +1859,6 @@ extension Manifest {
 }
 
 extension Sources {
-    public var hasSwiftSources: Bool {
-        paths.contains { path in
-            guard let ext = path.extension else { return false }
-
-            return FileRuleDescription.swift.fileTypes.contains(ext)
-        }
-    }
-
-    public var hasClangSources: Bool {
-        let supportedClangFileExtensions = FileRuleDescription.clang.fileTypes.union(FileRuleDescription.asm.fileTypes)
-
-        return paths.contains { path in
-            guard let ext = path.extension else { return false }
-
-            return supportedClangFileExtensions.contains(ext)
-        }
-    }
-
-    public var containsMixedLanguage: Bool {
-        self.hasSwiftSources && self.hasClangSources
-    }
-
     /// Determine module type based on the sources.
     fileprivate func computeModuleKind() -> Module.Kind {
         let isLibrary = !relativePaths.contains { path in

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -222,7 +222,7 @@ public struct TargetSourcesBuilder {
 
         // It's an error to contain mixed language source files
         // Unless experimental flag is turned on
-        if sources.containsMixedLanguage && !toolsVersion.experimentalMultiLang {
+        if sources.containsMixedLanguage && toolsVersion < .v6_5 {
             throw Module.Error.mixedSources(targetPath)
         }
 

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -220,8 +220,7 @@ public struct TargetSourcesBuilder {
         try diagnoseInfoPlistConflicts(in: resources)
         diagnoseInvalidResource(in: target.resources)
 
-        // It's an error to contain mixed language source files
-        // Unless experimental flag is turned on
+        // Report an error if the tools version does not permit mixed language targets.
         if sources.containsMixedLanguage && toolsVersion < .v6_5 {
             throw Module.Error.mixedSources(targetPath)
         }

--- a/Sources/PackageLoading/ToolsVersionParser.swift
+++ b/Sources/PackageLoading/ToolsVersionParser.swift
@@ -358,7 +358,7 @@ public struct ToolsVersionParser {
         /// - Note: For a misspelt Swift tools version specification `"// swift-too1s-version:5.3"`, the first `"1"` is considered as the first character of the version specifier, and so `"1s-version:5.3"` is taken as the version specifier.
         let versionSpecifier = specificationSnippetFromLabelToLineTerminator[startIndexOfVersionSpecifier..<indexOfVersionSpecifierTerminator]
 
-        /// Look for experimental features. They are comma separated values contained in parenthases right after the ";", e.g. "// swift-tools-version: 6.4;(experimentalCGen,experimentalMultiLang)"
+        /// Look for experimental features. They are comma separated values contained in parenthases right after the ";", e.g. "// swift-tools-version: 6.3;(experimentalCGen)"
         var experimentalFeatures: Set<ToolsVersion.ExperimentalFeature> = []
         if indexOfVersionSpecifierTerminator < specificationWithIgnoredTrailingContents.endIndex, specificationWithIgnoredTrailingContents[indexOfVersionSpecifierTerminator...].hasPrefix(";(") {
             let startOfExperimentalFeatures = specificationWithIgnoredTrailingContents.index(indexOfVersionSpecifierTerminator, offsetBy: 2)

--- a/Sources/PackageManagerDocs/Documentation.docc/CreatingMixedLanguageTargets.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/CreatingMixedLanguageTargets.md
@@ -1,0 +1,46 @@
+# Creating Mixed Language Targets
+
+Combine Swift and C/C++/Objective-C sources in a single target.
+
+## Overview
+
+Targets in Swift packages which have adopted a tools version of 6.5 or later can leverage Swift's interoperability features to include both Swift and C/C++/Objective-C sources.
+
+### Exporting an Underlying Clang Module
+
+A Swift module can reexport an underlying Clang module with the same name, providing a unified Swift and C API surface to clients through a single import. To create a mixed language target with an underlying Clang module, specify a `publicHeadersPath` for a target which contains Swift source files. By default, SwiftPM will generate a module map for the headers within the `publicHeadersPath` according to the following rules:
+
+- If the public headers directory contains a `module.modulemap` file, it will be used and no modulemap will be generated. When using an explicit `module.modulemap`, it's important to ensure it defines a module whose name matches the name of the target's Swift module.
+- If the public headers directory contains a header whose basename matches the module name, a module map will be generated using that header as the umbrella header.
+- If the public headers directory contains a directory whose name matches the module name, that directory contains a header whose basename also matches the module name, and the top-level public headers directory is otherwise empty, a module map will be generated using that header as the umbrella header.
+- Otherwise, a module map will be generated using the public headers directory as an umbrella directory.
+
+When the target's Swift sources are compiled, it will implicitly import the underlying Clang module, allowing use of its API from the target's Swift sources. The Swift module also reexports the underlying Clang module, allowing any Swift client which imports the target's Swift API will also be able to access the API defined in its underlying Clang module.
+
+### Configuring a Bridging Header
+
+As an alternative to organizing its C/C++/Objective-C interface into a Clang module, a mixed source target may also specify a bridging header. A bridging header allows the Swift sources in the module to import non-modular C/C++/Objective-C code. A target can configure a bridging header by specifying the `bridgingHeader` option in its `swiftSettings` list:
+
+```swift
+  .target(
+    name: "MyTarget",
+    swiftSettings: [
+      .bridgingHeader("My-Bridging-Header.h", visibility: .public)
+    ]
+  )
+```
+
+A bridging header's path is specified relative to the target's sources directory, and must not be inside the target's public headers directory. Bridging header visibility may be `.public` or `.internal`, and determines whether API imported via a bridging header may appear in public declarations of the consumer. Regular (library) targets are only allowed to import a bridging header with `.internal` visibility to ensure they present a consistent interface to downstream targets. The existing `interoperabilityMode` setting determines how the bridging header is interpreted.
+
+As a general guideline, package authors should prefer to modularize their C code where possible instead of using a bridging header. However, modularization can be resource intensive when first adopting Swift as part of a large existing C codebase. Bridging headers are a good fit when they're used to facilitate incremental adoption of Swift, and allow packages to quickly get up and running with interoperability as they fully modularize over a longer period of time.
+
+### Exposing the Swift Generated Header to C/C++/Objective-C clients
+
+A Swift module provides a generated header which exposes `@c`/`@objc` annotated API to C/C++/Objective-C code, including sources in the same target:
+
+```c
+   #include "MyTarget-Swift.h" // C/C++ clients
+   #import "MyTarget-Swift.h"  // Objective-C clients
+```
+
+If a mixed language target has an underlying Clang module, SwiftPM will automatically include the Swift generated header in that module when generating a modulemap.

--- a/Sources/PackageManagerDocs/Documentation.docc/CreatingMixedLanguageTargets.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/CreatingMixedLanguageTargets.md
@@ -1,0 +1,46 @@
+# Creating Mixed Language Targets
+
+Combine Swift and C/C++/Objective-C sources in a single target.
+
+## Overview
+
+Targets in Swift packages which have adopted a tools version of 6.5 or later can leverage Swift's interoperability features to include both Swift and C/C++/Objective-C sources.
+
+### Exporting an Underlying Clang Module
+
+A Swift module can reexport an underlying Clang module with the same name, providing a unified Swift and C API surface to clients through a single import. To create a mixed language target with an underlying Clang module, specify a `publicHeadersPath` for a target which contains Swift source files. By default, SwiftPM will generate a module map for the headers within the `publicHeadersPath` according to the following rules:
+
+- If the public headers directory contains a `module.modulemap` file, it will be used and no modulemap will be generated. When using an explicit `module.modulemap`, it's important to ensure it defines a module whose name matches the name of the target's Swift module.
+- If the public headers directory contains a header whose basename matches the module name, a module map will be generated using that header as the umbrella header.
+- If the public headers directory contains a directory whose name matches the module name, that directory contains a header whose basename also matches the module name, and the top-level public headers directory is otherwise empty, a module map will be generated using that header as the umbrella header.
+- Otherwise, a module map will be generated using the public headers directory as an umbrella directory.
+
+When the target's Swift sources are compiled, it will implicitly import the underlying Clang module, allowing use of its API from the target's Swift sources. The Swift module also reexports the underlying Clang module, allowing any Swift client which imports the target's Swift API will also be able to access the API defined in its underlying Clang module.
+
+### Configuring a Bridging Header
+
+As an alternative to organizing its C/C++/Objective-C interface into a Clang module, a mixed source target may also specify a bridging header. A bridging header allows the Swift sources in the module to import non-modular C/C++/Objective-C code. A target can configure a bridging header by specifying the `bridgingHeader` option in its `swiftSettings` list:
+
+```swift
+  .target(
+    name: "MyTarget",
+    swiftSettings: [
+      .bridgingHeader("My-Bridging-Header.h", visibility: .internal)
+    ]
+  )
+```
+
+A bridging header's path is specified relative to the target's sources directory, and must not be inside the target's public headers directory. Bridging header visibility may be `.public` or `.internal`, and determines whether API imported via a bridging header may appear in public declarations of the consumer. Regular (library) targets are only allowed to import a bridging header with `.internal` visibility to ensure they present a consistent interface to downstream targets. The existing `interoperabilityMode` setting determines how the bridging header is interpreted.
+
+As a general guideline, package authors should prefer to modularize their C code where possible instead of using a bridging header. However, modularization can be resource intensive when first adopting Swift as part of a large existing C codebase. Bridging headers are a good fit when they're used to facilitate incremental adoption of Swift, and allow packages to quickly get up and running with interoperability as they fully modularize over a longer period of time.
+
+### Exposing the Swift Generated Header to C/C++/Objective-C clients
+
+A Swift module provides a generated header which exposes `@c`/`@objc` annotated API to C/C++/Objective-C code, including sources in the same target:
+
+```c
+   #include "MyTarget-Swift.h" // C/C++ clients
+   #import "MyTarget-Swift.h"  // Objective-C clients
+```
+
+If a mixed language target has an underlying Clang module, SwiftPM will automatically include the Swift generated header in that module when generating a modulemap.

--- a/Sources/PackageManagerDocs/Documentation.docc/Documentation.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Documentation.md
@@ -40,6 +40,7 @@ The Swift Package Manager lets you share your code as a package, depend on and u
 
 ### Targets
 - <doc:CreatingCLanguageTargets>
+- <doc:CreatingMixedLanguageTargets>
 - <doc:ModuleMaps>
 - <doc:ModuleAliasing>
 

--- a/Sources/PackageModel/BuildSettings.swift
+++ b/Sources/PackageModel/BuildSettings.swift
@@ -19,6 +19,8 @@ public enum BuildSettings {
             .init("SWIFT_ACTIVE_COMPILATION_CONDITIONS")
         public static let OTHER_SWIFT_FLAGS: Declaration = .init("OTHER_SWIFT_FLAGS")
         public static let SWIFT_VERSION: Declaration = .init("SWIFT_VERSION")
+        public static let SWIFT_OBJC_BRIDGING_HEADER: Declaration = .init("SWIFT_OBJC_BRIDGING_HEADER")
+        public static let SWIFT_BRIDGING_HEADER_IS_INTERNAL: Declaration = .init("SWIFT_BRIDGING_HEADER_IS_INTERNAL")
 
         // C family.
         public static let GCC_PREPROCESSOR_DEFINITIONS: Declaration = .init("GCC_PREPROCESSOR_DEFINITIONS")

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -36,6 +36,12 @@ public enum TargetBuildSettingDescription {
         case nonisolated
     }
 
+    /// The visibility of a bridging header's imported declarations.
+    public enum BridgingHeaderVisibility: String, Codable, Hashable, Sendable {
+        case `public`
+        case `internal`
+    }
+
     /// The kind of the build setting, with associate configuration
     public enum Kind: Codable, Hashable, Sendable {
         case headerSearchPath(String)
@@ -60,6 +66,8 @@ public enum TargetBuildSettingDescription {
 
         case defaultIsolation(DefaultIsolation)
 
+        case bridgingHeader(String, BridgingHeaderVisibility)
+
         public var isUnsafeFlags: Bool {
             switch self {
             case .unsafeFlags(let flags):
@@ -67,7 +75,8 @@ public enum TargetBuildSettingDescription {
                 return !flags.isEmpty
             case .headerSearchPath, .define, .linkedLibrary, .linkedFramework, .interoperabilityMode,
                  .enableUpcomingFeature, .enableExperimentalFeature, .strictMemorySafety, .swiftLanguageMode,
-                 .treatAllWarnings, .treatWarning, .enableWarning, .disableWarning, .defaultIsolation:
+                 .treatAllWarnings, .treatWarning, .enableWarning, .disableWarning, .defaultIsolation,
+                 .bridgingHeader:
                 return false
             }
         }

--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -419,12 +419,6 @@ public struct TargetDescription: Hashable, Encodable, Sendable {
                 propertyName: "resources",
                 value: String(describing: resources)
             ) }
-            if publicHeadersPath != nil { throw Error.disallowedPropertyInTarget(
-                targetName: name,
-                targetType: targetType,
-                propertyName: "publicHeadersPath",
-                value: publicHeadersPath ?? "<nil>"
-            ) }
             if pkgConfig != nil { throw Error.disallowedPropertyInTarget(
                 targetName: name,
                 targetType: targetType,

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -727,6 +727,13 @@ fileprivate extension SourceCodeFragment {
                 params.append(SourceCodeFragment(from: condition))
             }
             self.init(enum: setting.kind.name, subnodes: params)
+        case .bridgingHeader(let path, let visibility):
+            params.append(SourceCodeFragment(string: path))
+            params.append(SourceCodeFragment(key: "visibility", enum: visibility.rawValue))
+            if let condition = setting.condition {
+                params.append(SourceCodeFragment(from: condition))
+            }
+            self.init(enum: setting.kind.name, subnodes: params)
         }
     }
 
@@ -1215,6 +1222,8 @@ extension TargetBuildSettingDescription.Kind {
             return "disableWarning"
         case .defaultIsolation:
             return "defaultIsolation"
+        case .bridgingHeader:
+            return "bridgingHeader"
         }
     }
 }

--- a/Sources/PackageModel/Module/ClangModule.swift
+++ b/Sources/PackageModel/Module/ClangModule.swift
@@ -17,6 +17,39 @@ import TSCBasic
 @available(*, deprecated, renamed: "ClangModule")
 public typealias ClangTarget = ClangModule
 
+/// The C/C++/Objective-C module info for a ClangTarget or mixed-source SwiftTarget
+public struct ClangModuleInfo: Equatable, Codable {
+    /// The public headers ("include") directory, or `nil` if the target has no public C headers.
+    public var includeDir: Basics.AbsolutePath?
+
+    /// The module map type, which determines whether the target vends a custom module map,
+    /// a generated module map, or no module map at all.
+    public var moduleMapType: ModuleMapType
+
+    /// The headers present in the target (both public and non-public).
+    public var headers: [Basics.AbsolutePath]
+
+    /// The C language standard flag.
+    public var cLanguageStandard: String?
+
+    /// The C++ language standard flag.
+    public var cxxLanguageStandard: String?
+
+    public init(
+        includeDir: Basics.AbsolutePath?,
+        moduleMapType: ModuleMapType,
+        headers: [Basics.AbsolutePath] = [],
+        cLanguageStandard: String? = nil,
+        cxxLanguageStandard: String? = nil
+    ) {
+        self.includeDir = includeDir
+        self.moduleMapType = moduleMapType
+        self.headers = headers
+        self.cLanguageStandard = cLanguageStandard
+        self.cxxLanguageStandard = cxxLanguageStandard
+    }
+}
+
 public final class ClangModule: Module {
     /// Description of the module type used in `swift package describe` output. Preserved for backwards compatibility.
     public override class var typeDescription: String { "ClangTarget" }
@@ -24,25 +57,16 @@ public final class ClangModule: Module {
     /// The default public include directory component.
     public static let defaultPublicHeadersComponent = "include"
 
-    /// The path to include directory.
-    public let includeDir: Basics.AbsolutePath
+    public let clangModuleInfo: ClangModuleInfo
 
-    /// The target's module map type, which determines whether this target vends a custom module map, a generated module map, or no module map at all.
-    public let moduleMapType: ModuleMapType
-
-    /// The headers present in the target.
-    ///
-    /// Note that this contains both public and non-public headers.
-    public let headers: [Basics.AbsolutePath]
+    public var includeDir: Basics.AbsolutePath { self.clangModuleInfo.includeDir! }
+    public var moduleMapType: ModuleMapType { self.clangModuleInfo.moduleMapType }
+    public var headers: [Basics.AbsolutePath] { self.clangModuleInfo.headers }
+    public var cLanguageStandard: String? { self.clangModuleInfo.cLanguageStandard }
+    public var cxxLanguageStandard: String? { self.clangModuleInfo.cxxLanguageStandard }
 
     /// True if this is a C++ target.
     public let isCXX: Bool
-
-    /// The C language standard flag.
-    public let cLanguageStandard: String?
-
-    /// The C++ language standard flag.
-    public let cxxLanguageStandard: String?
 
     public init(
         name: String,
@@ -68,11 +92,13 @@ public final class ClangModule: Module {
             throw StringError("\(includeDir) should be contained in the source root \(sources.root)")
         }
         self.isCXX = sources.containsCXXFiles
-        self.cLanguageStandard = cLanguageStandard
-        self.cxxLanguageStandard = cxxLanguageStandard
-        self.includeDir = includeDir
-        self.moduleMapType = moduleMapType
-        self.headers = headers
+        self.clangModuleInfo = ClangModuleInfo(
+            includeDir: includeDir,
+            moduleMapType: moduleMapType,
+            headers: headers,
+            cLanguageStandard: cLanguageStandard,
+            cxxLanguageStandard: cxxLanguageStandard
+        )
         super.init(
             name: name,
             potentialBundleName: potentialBundleName,

--- a/Sources/PackageModel/Module/SwiftModule.swift
+++ b/Sources/PackageModel/Module/SwiftModule.swift
@@ -36,6 +36,7 @@ public final class SwiftModule: Module {
         buildSettings: BuildSettings.AssignmentTable = .init(),
         implicit: Bool) {
         self.declaredSwiftVersions = []
+        self.clangModuleInfo = nil
 
         super.init(
             name: name,
@@ -55,6 +56,15 @@ public final class SwiftModule: Module {
     /// The list of swift versions declared by the manifest.
     public let declaredSwiftVersions: [SwiftLanguageVersion]
 
+    /// Information about the underlying clang module, if this represents a mixed source target.
+    public let clangModuleInfo: ClangModuleInfo?
+
+    /// Whether this target contains C++ (or Objective-C++) sources.
+    public var containsCXX: Bool { self.sources.containsCXXFiles }
+
+    /// Whether this target mixes Swift and C-family sources.
+    public var isMixedLanguage: Bool { self.clangModuleInfo != nil }
+
     public init(
         name: String,
         potentialBundleName: String? = nil,
@@ -67,6 +77,7 @@ public final class SwiftModule: Module {
         dependencies: [Module.Dependency] = [],
         packageAccess: Bool,
         declaredSwiftVersions: [SwiftLanguageVersion] = [],
+        clangModuleInfo: ClangModuleInfo? = nil,
         buildSettings: BuildSettings.AssignmentTable = .init(),
         buildSettingsDescription: [TargetBuildSettingDescription.Setting] = [],
         pluginUsages: [PluginUsage] = [],
@@ -74,6 +85,7 @@ public final class SwiftModule: Module {
         implicit: Bool
     ) {
         self.declaredSwiftVersions = declaredSwiftVersions
+        self.clangModuleInfo = clangModuleInfo
         super.init(
             name: name,
             potentialBundleName: potentialBundleName,
@@ -125,6 +137,7 @@ public final class SwiftModule: Module {
         }
 
         self.declaredSwiftVersions = []
+        self.clangModuleInfo = nil
         let sources = Sources(paths: [testEntryPointPath], root: testEntryPointPath.parentDirectory)
 
         super.init(

--- a/Sources/PackageModel/Sources.swift
+++ b/Sources/PackageModel/Sources.swift
@@ -59,4 +59,31 @@ public struct Sources: Codable {
             return !SupportedLanguageExtension.swiftExtensions.contains(ext)
         })
     }
+
+    /// Returns true if the sources contain any Swift files.
+    ///
+    /// Note: the extension sets used here (`SupportedLanguageExtension`) are kept in sync
+    /// with `FileRuleDescription.swift`/`.clang`/`.asm` in `PackageLoading`.
+    public var hasSwiftSources: Bool {
+        paths.contains { path in
+            guard let ext = path.extension else { return false }
+            return SupportedLanguageExtension.swiftExtensions.contains(ext)
+        }
+    }
+
+    /// Returns true if the sources contain any C-family (C/C++/Objective-C) or assembly files.
+    public var hasClangSources: Bool {
+        let supportedClangFileExtensions = SupportedLanguageExtension.cExtensions
+            .union(SupportedLanguageExtension.cppExtensions)
+            .union(SupportedLanguageExtension.assemblyExtensions)
+        return paths.contains { path in
+            guard let ext = path.extension else { return false }
+            return supportedClangFileExtensions.contains(ext)
+        }
+    }
+
+    /// Returns true if the sources mix Swift and C-family sources.
+    public var containsMixedLanguage: Bool {
+        self.hasSwiftSources && self.hasClangSources
+    }
 }

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -36,6 +36,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
     public static let v6_2 = ToolsVersion(version: "6.2.0")
     public static let v6_3 = ToolsVersion(version: "6.3.0")
     public static let v6_4 = ToolsVersion(version: "6.4.0")
+    public static let v6_5 = ToolsVersion(version: "6.5.0")
     public static let vNext = ToolsVersion(version: "999.0.0")
 
     /// The current tools version in use.
@@ -90,7 +91,6 @@ public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
     /// Experimental features
     public enum ExperimentalFeature: String, Sendable, Codable {
         case experimentalCGen
-        case experimentalMultiLang
     }
     public let experimentalFeatures: Set<ExperimentalFeature>?
 
@@ -103,10 +103,6 @@ public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
     /// Helpers for experimental
     public var experimentalCGen: Bool {
         self >= .v6_3 && experimentalFeatures?.contains(.experimentalCGen) == true
-    }
-
-    public var experimentalMultiLang: Bool {
-        self >= .v6_4 && experimentalFeatures?.contains(.experimentalMultiLang) == true
     }
 
     /// Create an instance of tools version from a given string.

--- a/Sources/Runtimes/CompilerPluginSupport/TargetExtensions.swift
+++ b/Sources/Runtimes/CompilerPluginSupport/TargetExtensions.swift
@@ -13,7 +13,7 @@
 @_spi(PackageDescriptionInternal) import PackageDescription
 
 public extension Target {
-    @available(_PackageDescription, introduced: 5.9)
+    @available(_PackageDescription, introduced: 5.9, obsoleted: 999)
     static func macro(
         name: String,
         dependencies: [Dependency] = [],
@@ -25,16 +25,50 @@ public extension Target {
         linkerSettings: [LinkerSetting]? = nil,
         plugins: [PluginUsage]? = nil
     ) -> Target {
-        return Target(name: name,
-                      dependencies: dependencies,
-                      path: path,
-                      exclude: exclude,
-                      sources: sources,
-                      publicHeadersPath: nil,
-                      type: .macro,
-                      packageAccess: packageAccess,
-                      swiftSettings: swiftSettings,
-                      linkerSettings: linkerSettings,
-                      plugins: plugins)
+        return Target(
+            name: name,
+            dependencies: dependencies,
+            path: path,
+            exclude: exclude,
+            sources: sources,
+            publicHeadersPath: nil,
+            type: .macro,
+            packageAccess: packageAccess,
+            swiftSettings: swiftSettings,
+            linkerSettings: linkerSettings,
+            plugins: plugins
+        )
+    }
+
+    @available(_PackageDescription, introduced: 999)
+    static func macro(
+        name: String,
+        dependencies: [Dependency] = [],
+        path: String? = nil,
+        exclude: [String] = [],
+        sources: [String]? = nil,
+        publicHeadersPath: String? = nil,
+        packageAccess: Bool = true,
+        cSettings: [CSetting]? = nil,
+        cxxSettings: [CXXSetting]? = nil,
+        swiftSettings: [SwiftSetting]? = nil,
+        linkerSettings: [LinkerSetting]? = nil,
+        plugins: [PluginUsage]? = nil
+    ) -> Target {
+        return Target(
+            name: name,
+            dependencies: dependencies,
+            path: path,
+            exclude: exclude,
+            sources: sources,
+            publicHeadersPath: publicHeadersPath,
+            type: .macro,
+            packageAccess: packageAccess,
+            cSettings: cSettings,
+            cxxSettings: cxxSettings,
+            swiftSettings: swiftSettings,
+            linkerSettings: linkerSettings,
+            plugins: plugins
+        )
     }
 }

--- a/Sources/Runtimes/CompilerPluginSupport/TargetExtensions.swift
+++ b/Sources/Runtimes/CompilerPluginSupport/TargetExtensions.swift
@@ -13,7 +13,7 @@
 @_spi(PackageDescriptionInternal) import PackageDescription
 
 public extension Target {
-    @available(_PackageDescription, introduced: 5.9, obsoleted: 999)
+    @available(_PackageDescription, introduced: 5.9, obsoleted: 6.5)
     static func macro(
         name: String,
         dependencies: [Dependency] = [],
@@ -40,7 +40,7 @@ public extension Target {
         )
     }
 
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 6.5)
     static func macro(
         name: String,
         dependencies: [Dependency] = [],

--- a/Sources/Runtimes/PackageDescription/BuildSettings.swift
+++ b/Sources/Runtimes/PackageDescription/BuildSettings.swift
@@ -606,6 +606,34 @@ public struct SwiftSetting: Sendable {
           name: "interoperabilityMode", value: [mode.rawValue], condition: condition)
     }
 
+    /// The visibility of a bridging header's imported declarations.
+    @available(_PackageDescription, introduced: 999.0)
+    public enum BridgingHeaderVisibility: String {
+        /// Declarations imported via the bridging header may appear in the target's public API.
+        case `public`
+        /// Declarations imported via the bridging header may only be used internally.
+        case `internal`
+    }
+
+    /// Configures a bridging header for the target's Swift sources.
+    ///
+    /// A bridging header allows Swift code to import non-modular C/C++/Objective-C code.
+    ///
+    /// - Parameters:
+    ///   - path: The path of the bridging header, relative to the target's sources directory.
+    ///   - visibility: Whether declarations imported via the bridging header may appear in the
+    /// target's public API. Library targets may only use `.internal` visibility.
+    ///   - condition: A condition that restricts the application of the build setting.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func bridgingHeader(
+      _ path: String,
+      visibility: BridgingHeaderVisibility,
+      _ condition: BuildSettingCondition? = nil
+    ) -> SwiftSetting {
+        return SwiftSetting(
+          name: "bridgingHeader", value: [path, visibility.rawValue], condition: condition)
+    }
+
     /// Defines a `-swift-version` to pass  to the
     /// corresponding build tool.
     ///

--- a/Sources/Runtimes/PackageDescription/BuildSettings.swift
+++ b/Sources/Runtimes/PackageDescription/BuildSettings.swift
@@ -607,7 +607,7 @@ public struct SwiftSetting: Sendable {
     }
 
     /// The visibility of a bridging header's imported declarations.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.5)
     public enum BridgingHeaderVisibility: String {
         /// Declarations imported via the bridging header may appear in the target's public API.
         case `public`
@@ -624,7 +624,7 @@ public struct SwiftSetting: Sendable {
     ///   - visibility: Whether declarations imported via the bridging header may appear in the
     /// target's public API. Library targets may only use `.internal` visibility.
     ///   - condition: A condition that restricts the application of the build setting.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.5)
     public static func bridgingHeader(
       _ path: String,
       visibility: BridgingHeaderVisibility,

--- a/Sources/Runtimes/PackageDescription/Target.swift
+++ b/Sources/Runtimes/PackageDescription/Target.swift
@@ -331,12 +331,9 @@ public final class Target {
             precondition(
                 url == nil &&
                 resources == nil &&
-                publicHeadersPath == nil &&
                 pkgConfig == nil &&
                 providers == nil &&
-                pluginCapability == nil &&
-                cSettings == nil &&
-                cxxSettings == nil
+                pluginCapability == nil
             )
         }
     }
@@ -985,7 +982,7 @@ public final class Target {
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
     ///   - plugins: The plug-ins used by this target.
-    @available(_PackageDescription, introduced: 5.9)
+    @available(_PackageDescription, introduced: 5.9, obsoleted: 999)
     public static func testTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -1008,6 +1005,64 @@ public final class Target {
             sources: sources,
             resources: resources,
             publicHeadersPath: nil,
+            type: .test,
+            packageAccess: packageAccess,
+            cSettings: cSettings,
+            cxxSettings: cxxSettings,
+            swiftSettings: swiftSettings,
+            linkerSettings: linkerSettings,
+            plugins: plugins
+        )
+    }
+
+    /// Creates a test target.
+    ///
+    /// Write test targets using the Swift Testing or XCTest testing frameworks.
+    /// Test targets generally declare a dependency on the targets they test.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the target.
+    ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
+    ///   - path: The custom path for the target. By default, Swift Package Manager requires a target's sources to reside at predefined search paths;
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that Swift Package Manager shouldn't consider to be source or resource files.
+    ///       A path is relative to the target's directory.
+    ///       This parameter has precedence over the ``sources`` parameter.
+    ///   - sources: An explicit list of source files. If you provide a path to a directory,
+    ///       Swift Package Manager searches for valid source files recursively.
+    ///   - resources: An explicit list of resources files.
+    ///   - publicHeadersPath: The directory containing public headers of a target that contains C-family sources.
+    ///   - packageAccess: Allows access to package symbols from other targets in the package.
+    ///   - cSettings: The C settings for this target.
+    ///   - cxxSettings: The C++ settings for this target.
+    ///   - swiftSettings: The Swift settings for this target.
+    ///   - linkerSettings: The linker settings for this target.
+    ///   - plugins: The plug-ins used by this target.
+    @available(_PackageDescription, introduced: 999)
+    public static func testTarget(
+        name: String,
+        dependencies: [Dependency] = [],
+        path: String? = nil,
+        exclude: [String] = [],
+        sources: [String]? = nil,
+        resources: [Resource]? = nil,
+        publicHeadersPath: String? = nil,
+        packageAccess: Bool = true,
+        cSettings: [CSetting]? = nil,
+        cxxSettings: [CXXSetting]? = nil,
+        swiftSettings: [SwiftSetting]? = nil,
+        linkerSettings: [LinkerSetting]? = nil,
+        plugins: [PluginUsage]? = nil
+    ) -> Target {
+        return Target(
+            name: name,
+            dependencies: dependencies,
+            path: path,
+            exclude: exclude,
+            sources: sources,
+            resources: resources,
+            publicHeadersPath: publicHeadersPath,
             type: .test,
             packageAccess: packageAccess,
             cSettings: cSettings,

--- a/Sources/Runtimes/PackageDescription/Target.swift
+++ b/Sources/Runtimes/PackageDescription/Target.swift
@@ -982,7 +982,7 @@ public final class Target {
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
     ///   - plugins: The plug-ins used by this target.
-    @available(_PackageDescription, introduced: 5.9, obsoleted: 999)
+    @available(_PackageDescription, introduced: 5.9, obsoleted: 6.5)
     public static func testTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -1039,7 +1039,7 @@ public final class Target {
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
     ///   - plugins: The plug-ins used by this target.
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 6.5)
     public static func testTarget(
         name: String,
         dependencies: [Dependency] = [],

--- a/Sources/Runtimes/PackagePlugin/Documentation.docc/Curation/SourceModuleTarget.md
+++ b/Sources/Runtimes/PackagePlugin/Documentation.docc/Curation/SourceModuleTarget.md
@@ -12,3 +12,7 @@
 - ``pluginGeneratedResources``
 - ``sourceFiles``
 - ``sourceFiles(withSuffix:)``
+- ``swiftCompilationConditions``
+- ``clangPreprocessorDefinitions``
+- ``headerSearchPaths``
+- ``publicHeadersDirectoryURL``

--- a/Sources/Runtimes/PackagePlugin/PackageModel.swift
+++ b/Sources/Runtimes/PackagePlugin/PackageModel.swift
@@ -279,6 +279,22 @@ public protocol SourceModuleTarget: Target {
     /// target the current plugin is being applied to, but not necessarily to other targets in the package graph.
     @available(_PackageDescription, introduced: 6.0)
     var pluginGeneratedResources: [URL] { get }
+
+    /// Any custom compilation conditions for the Swift sources of the module.
+    @available(_PackageDescription, introduced: 999.0)
+    var swiftCompilationConditions: [String] { get }
+
+    /// Any preprocessor definitions for the C-family sources of the module.
+    @available(_PackageDescription, introduced: 999.0)
+    var clangPreprocessorDefinitions: [String] { get }
+
+    /// Any custom header search paths.
+    @available(_PackageDescription, introduced: 999.0)
+    var headerSearchPaths: [String] { get }
+
+    /// The directory containing public headers
+    @available(_PackageDescription, introduced: 999.0)
+    var publicHeadersDirectoryURL: URL? { get }
 }
 
 /// The kind of module.
@@ -298,6 +314,7 @@ public enum ModuleKind {
 }
 
 /// A target consisting of a source code module compiled using Swift.
+@available(_PackageDescription, deprecated: 999.0, message: "Use SourceModuleTarget directly instead of casting to a concrete type")
 public struct SwiftSourceModuleTarget: SourceModuleTarget {
     /// Unique identifier for the target.
     public let id: ID
@@ -357,9 +374,22 @@ public struct SwiftSourceModuleTarget: SourceModuleTarget {
     /// to the given target before the plugin being executed.
     @available(_PackageDescription, introduced: 6.0)
     public let pluginGeneratedResources: [URL]
+
+    @available(_PackageDescription, introduced: 999.0)
+    public var swiftCompilationConditions: [String] { self.compilationConditions }
+
+    @available(_PackageDescription, introduced: 999.0)
+    public var clangPreprocessorDefinitions: [String] { [] }
+
+    @available(_PackageDescription, introduced: 999.0)
+    public var headerSearchPaths: [String] { [] }
+
+    @available(_PackageDescription, introduced: 999.0)
+    public var publicHeadersDirectoryURL: URL? { nil }
 }
 
 /// A target consisting of a source code module compiled using Clang.
+@available(_PackageDescription, deprecated: 999.0, message: "Use SourceModuleTarget directly instead of casting to a concrete type")
 public struct ClangSourceModuleTarget: SourceModuleTarget {
     /// Unique identifier for the target.
     public let id: ID
@@ -435,6 +465,33 @@ public struct ClangSourceModuleTarget: SourceModuleTarget {
     /// to the given target before the plugin currently being executed.
     @available(_PackageDescription, introduced: 6.0)
     public let pluginGeneratedResources: [URL]
+
+    @available(_PackageDescription, introduced: 999.0)
+    public var swiftCompilationConditions: [String] { [] }
+
+    @available(_PackageDescription, introduced: 999.0)
+    public var clangPreprocessorDefinitions: [String] { self.preprocessorDefinitions }
+}
+
+/// A source module target containing any combination of sources. Thie is intentionally internal, clients should only interact
+/// with it via `SourceModuleTarget`.
+internal struct ConcreteSourceModuleTarget: SourceModuleTarget {
+    let id: ID
+    let name: String
+    let kind: ModuleKind
+    let directory: Path
+    let directoryURL: URL
+    let dependencies: [TargetDependency]
+    let moduleName: String
+    let sourceFiles: FileList
+    let swiftCompilationConditions: [String]
+    let clangPreprocessorDefinitions: [String]
+    let headerSearchPaths: [String]
+    let publicHeadersDirectoryURL: URL?
+    let linkedLibraries: [String]
+    let linkedFrameworks: [String]
+    let pluginGeneratedSources: [URL]
+    let pluginGeneratedResources: [URL]
 }
 
 /// A target describing an artifact that is distributed as a binary.

--- a/Sources/Runtimes/PackagePlugin/PackageModel.swift
+++ b/Sources/Runtimes/PackagePlugin/PackageModel.swift
@@ -281,19 +281,19 @@ public protocol SourceModuleTarget: Target {
     var pluginGeneratedResources: [URL] { get }
 
     /// Any custom compilation conditions for the Swift sources of the module.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.5)
     var swiftCompilationConditions: [String] { get }
 
     /// Any preprocessor definitions for the C-family sources of the module.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.5)
     var clangPreprocessorDefinitions: [String] { get }
 
     /// Any custom header search paths.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.5)
     var headerSearchPaths: [String] { get }
 
     /// The directory containing public headers
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.5)
     var publicHeadersDirectoryURL: URL? { get }
 }
 
@@ -314,7 +314,7 @@ public enum ModuleKind {
 }
 
 /// A target consisting of a source code module compiled using Swift.
-@available(_PackageDescription, deprecated: 999.0, message: "Use SourceModuleTarget directly instead of casting to a concrete type")
+@available(_PackageDescription, deprecated: 6.5, message: "Use SourceModuleTarget directly instead of casting to a concrete type")
 public struct SwiftSourceModuleTarget: SourceModuleTarget {
     /// Unique identifier for the target.
     public let id: ID
@@ -375,21 +375,21 @@ public struct SwiftSourceModuleTarget: SourceModuleTarget {
     @available(_PackageDescription, introduced: 6.0)
     public let pluginGeneratedResources: [URL]
 
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.5)
     public var swiftCompilationConditions: [String] { self.compilationConditions }
 
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.5)
     public var clangPreprocessorDefinitions: [String] { [] }
 
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.5)
     public var headerSearchPaths: [String] { [] }
 
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.5)
     public var publicHeadersDirectoryURL: URL? { nil }
 }
 
 /// A target consisting of a source code module compiled using Clang.
-@available(_PackageDescription, deprecated: 999.0, message: "Use SourceModuleTarget directly instead of casting to a concrete type")
+@available(_PackageDescription, deprecated: 6.5, message: "Use SourceModuleTarget directly instead of casting to a concrete type")
 public struct ClangSourceModuleTarget: SourceModuleTarget {
     /// Unique identifier for the target.
     public let id: ID
@@ -466,10 +466,10 @@ public struct ClangSourceModuleTarget: SourceModuleTarget {
     @available(_PackageDescription, introduced: 6.0)
     public let pluginGeneratedResources: [URL]
 
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.5)
     public var swiftCompilationConditions: [String] { [] }
 
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 6.5)
     public var clangPreprocessorDefinitions: [String] { self.preprocessorDefinitions }
 }
 

--- a/Sources/Runtimes/PackagePlugin/PluginContextDeserializer.swift
+++ b/Sources/Runtimes/PackagePlugin/PluginContextDeserializer.swift
@@ -158,6 +158,42 @@ internal struct PluginContextDeserializer {
                 pluginGeneratedResources: pluginGeneratedResources
             )
 
+        case let .mixedSourceModuleInfo(moduleName, kind, sourceFiles, compilationConditions, preprocessorDefinitions, headerSearchPaths, publicHeadersDirId, linkedLibraries, linkedFrameworks):
+            let publicHeadersDir = try publicHeadersDirId.map { try self.url(for: $0) }
+            let sourceFiles = FileList(try sourceFiles.map {
+                let path = try self.url(for: $0.basePathId).appendingPathComponent($0.name)
+                let type: FileType
+                switch $0.type {
+                case .source:
+                    type = .source
+                case .header:
+                    type = .header
+                case .resource:
+                    type = .resource
+                case .unknown:
+                    type = .unknown
+                }
+                return File(url: path, type: type)
+            })
+            target = try ConcreteSourceModuleTarget(
+                id: String(id),
+                name: wireTarget.name,
+                kind: .init(kind),
+                directory: Path(url: directory),
+                directoryURL: directory,
+                dependencies: dependencies,
+                moduleName: moduleName,
+                sourceFiles: sourceFiles,
+                swiftCompilationConditions: compilationConditions,
+                clangPreprocessorDefinitions: preprocessorDefinitions,
+                headerSearchPaths: headerSearchPaths,
+                publicHeadersDirectoryURL: publicHeadersDir,
+                linkedLibraries: linkedLibraries,
+                linkedFrameworks: linkedFrameworks,
+                pluginGeneratedSources: pluginGeneratedSources,
+                pluginGeneratedResources: pluginGeneratedResources
+            )
+
         case let .binaryArtifactInfo(kind, origin, artifactId):
             let artifact = try self.url(for: artifactId)
             let artifactKind: BinaryArtifactTarget.Kind

--- a/Sources/Runtimes/PackagePlugin/PluginMessages.swift
+++ b/Sources/Runtimes/PackagePlugin/PluginMessages.swift
@@ -166,6 +166,17 @@ enum HostToPluginMessage: Codable {
                         publicHeadersDirId: URL.Id?,
                         linkedLibraries: [String],
                         linkedFrameworks: [String])
+
+                    case mixedSourceModuleInfo(
+                        moduleName: String,
+                        kind: SourceModuleKind,
+                        sourceFiles: [File],
+                        compilationConditions: [String],
+                        preprocessorDefinitions: [String],
+                        headerSearchPaths: [String],
+                        publicHeadersDirId: URL.Id?,
+                        linkedLibraries: [String],
+                        linkedFrameworks: [String])
                     
                     case binaryArtifactInfo(
                         kind: BinaryArtifactKind,

--- a/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
@@ -103,13 +103,27 @@ internal struct PluginContextSerializer {
         let targetInfo: WireInput.Target.TargetInfo
         switch target.underlying {
         case let target as SwiftModule:
-            targetInfo = .swiftSourceModuleInfo(
-                moduleName: target.c99name,
-                kind: try .init(target.type),
-                sourceFiles: targetFiles,
-                compilationConditions: scope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS),
-                linkedLibraries: scope.evaluate(.LINK_LIBRARIES),
-                linkedFrameworks: scope.evaluate(.LINK_FRAMEWORKS))
+            if target.isMixedLanguage {
+                let publicHeadersDir = target.clangModuleInfo?.includeDir
+                targetInfo = .mixedSourceModuleInfo(
+                    moduleName: target.c99name,
+                    kind: try .init(target.type),
+                    sourceFiles: targetFiles,
+                    compilationConditions: scope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS),
+                    preprocessorDefinitions: scope.evaluate(.GCC_PREPROCESSOR_DEFINITIONS),
+                    headerSearchPaths: scope.evaluate(.HEADER_SEARCH_PATHS),
+                    publicHeadersDirId: try publicHeadersDir.map { try serialize(path: $0) },
+                    linkedLibraries: scope.evaluate(.LINK_LIBRARIES),
+                    linkedFrameworks: scope.evaluate(.LINK_FRAMEWORKS))
+            } else {
+                targetInfo = .swiftSourceModuleInfo(
+                    moduleName: target.c99name,
+                    kind: try .init(target.type),
+                    sourceFiles: targetFiles,
+                    compilationConditions: scope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS),
+                    linkedLibraries: scope.evaluate(.LINK_LIBRARIES),
+                    linkedFrameworks: scope.evaluate(.LINK_FRAMEWORKS))
+            }
 
         case let target as ClangModule:
             targetInfo = .clangSourceModuleInfo(

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -26,6 +26,7 @@ import class Basics.ThreadSafeArrayStore
 
 import enum PackageModel.BuildConfiguration
 import enum PackageModel.BuildSettings
+import struct PackageModel.ClangModuleInfo
 import class PackageModel.ClangModule
 import struct PackageModel.ConfigurationCondition
 import class PackageModel.Manifest
@@ -492,16 +493,22 @@ extension PackageGraph.ResolvedModule {
         try! AbsolutePath(validating: self.sources.root.pathString)
     }
 
-    /// Absolute paths to each of the header files  (*only* applies to C-language modules).
-    var headerFileAbsolutePaths: [AbsolutePath] {
-        guard let clangTarget = self.underlying as? ClangModule else { return [] }
-        return clangTarget.headers
+    private var clangModuleInfo: ClangModuleInfo? {
+        if let clangModule = self.underlying as? ClangModule {
+            return clangModule.clangModuleInfo
+        }
+        return (self.underlying as? SwiftModule)?.clangModuleInfo
     }
 
-    /// Relative path of the `include` directory (*only* applies to C-language modules).
+    /// Absolute paths to each of the header files.
+    var headerFileAbsolutePaths: [AbsolutePath] {
+        self.clangModuleInfo?.headers ?? []
+    }
+
+    /// Relative path of the `include` directory (applies to C-language and mixed-language modules).
     var includeDirRelativePath: RelativePath? {
-        guard let clangModule = self.underlying as? ClangModule else { return nil }
-        let relativePath = clangModule.includeDir.relative(to: self.sources.root).pathString
+        guard let includeDir = self.clangModuleInfo?.includeDir else { return nil }
+        let relativePath = includeDir.relative(to: self.sources.root).pathString
         return try! RelativePath(validating: relativePath)
     }
 
@@ -511,28 +518,30 @@ extension PackageGraph.ResolvedModule {
         return self.sourceDirAbsolutePath.appending(includeDirRelativePath)
     }
 
-    /// Module map type (*only* applies to C-language modules).
+    /// Module map type.
     var moduleMapType: ModuleMapType? {
-        guard let clangModule = self.underlying as? ClangModule else { return nil }
-        return clangModule.moduleMapType
+        self.clangModuleInfo?.moduleMapType
     }
 
-    /// The C language standard for which the module is configured (*only* applies to C-language modules).
+    /// The C language standard for which the module is configured.
     var cLanguageStandard: String? {
-        guard let clangModule = self.underlying as? ClangModule else { return nil }
-        return clangModule.cLanguageStandard
+        self.clangModuleInfo?.cLanguageStandard
     }
 
-    /// The C++ language standard for which the module is configured (*only* applies to C-language modules).
+    /// The C++ language standard for which the module is configured.
     var cxxLanguageStandard: String? {
-        guard let clangTarget = self.underlying as? ClangModule else { return nil }
-        return clangTarget.cxxLanguageStandard
+        self.clangModuleInfo?.cxxLanguageStandard
     }
 
-    /// Whether or not this module contains C++ sources (*only* applies to C-language modules).
+    /// Whether or not this module contains C++ sources.
     var isCxx: Bool {
-        guard let clangTarget = self.underlying as? ClangModule else { return false }
-        return clangTarget.isCXX
+        if let clangModule = self.underlying as? ClangModule {
+            return clangModule.isCXX
+        }
+        if let swiftModule = self.underlying as? SwiftModule {
+            return swiftModule.containsCXX
+        }
+        return false
     }
 
     /// The list of swift versions declared by the manifest.
@@ -544,6 +553,11 @@ extension PackageGraph.ResolvedModule {
     /// Is this a Swift module?
     var usesSwift: Bool {
         self.declaredSwiftVersions != nil
+    }
+
+    /// Whether this module mixes Swift and C-family sources.
+    var isMixedLanguageModule: Bool {
+        (self.underlying as? SwiftModule)?.isMixedLanguage ?? false
     }
 
     /// Swift language version for which the module is configured.

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -367,6 +367,9 @@ extension PackageModel.BuildSettings.Declaration {
         case .SWIFT_VERSION:
             false
 
+        case .SWIFT_OBJC_BRIDGING_HEADER, .SWIFT_BRIDGING_HEADER_IS_INTERNAL:
+            false
+
         // C family.
         case .GCC_PREPROCESSOR_DEFINITIONS, .HEADER_SEARCH_PATHS, .OTHER_CFLAGS, .OTHER_CPLUSPLUSFLAGS:
             true
@@ -1238,6 +1241,10 @@ extension ProjectModel.BuildSettings.SingleValueSetting {
         switch declaration {
         case .SWIFT_VERSION:
             self = .SWIFT_VERSION
+        case .SWIFT_OBJC_BRIDGING_HEADER:
+            self = .SWIFT_OBJC_BRIDGING_HEADER
+        case .SWIFT_BRIDGING_HEADER_IS_INTERNAL:
+            self = .SWIFT_BRIDGING_HEADER_IS_INTERNAL
         default:
             return nil
         }

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -367,6 +367,9 @@ extension PackageModel.BuildSettings.Declaration {
         case .SWIFT_VERSION:
             false
 
+        case .SWIFT_OBJC_BRIDGING_HEADER, .SWIFT_BRIDGING_HEADER_IS_INTERNAL:
+            false
+
         // C family.
         case .GCC_PREPROCESSOR_DEFINITIONS, .HEADER_SEARCH_PATHS, .OTHER_CFLAGS, .OTHER_CPLUSPLUSFLAGS:
             true
@@ -1245,6 +1248,10 @@ extension ProjectModel.BuildSettings.SingleValueSetting {
         switch declaration {
         case .SWIFT_VERSION:
             self = .SWIFT_VERSION
+        case .SWIFT_OBJC_BRIDGING_HEADER:
+            self = .SWIFT_OBJC_BRIDGING_HEADER
+        case .SWIFT_BRIDGING_HEADER_IS_INTERNAL:
+            self = .SWIFT_BRIDGING_HEADER_IS_INTERNAL
         default:
             return nil
         }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -257,6 +257,102 @@ extension PackagePIFProjectBuilder {
         return FileReference(id: id, path: binaryModule.artifactPath.pathString, fileType: fileTypeIdentifier)
     }
 
+    /// Configures module map settings for a Swift-only or mixed-source source target.
+    func configureSwiftTargetModuleMap(
+        for sourceModule: PackageGraph.ResolvedModule,
+        targetSuffix: TargetSuffix?,
+        settings: inout BuildSettings,
+        impartedSettings: inout BuildSettings
+    ) throws -> (contents: String?, path: String?) {
+        // The generated header should be adjacent to the generated module map.
+        settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR] = "$(GENERATED_MODULEMAP_DIR)"
+        settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME] = "\(sourceModule.name)-Swift.h"
+
+        // Ensure the generated module map of the testable variant of an executable/macro does not conflict with the
+        // primary copy.
+        let moduleMapFileName = "\(sourceModule.name)\(targetSuffix.uniqueDescription(forName: sourceModule.name)).modulemap"
+        let generatedModuleMapPath = try RelativePath(
+            validating: "$(GENERATED_MODULEMAP_DIR)/\(moduleMapFileName)"
+        ).pathString
+
+        var cUmbrellaDeclaration: String? = nil
+        switch sourceModule.moduleMapType {
+        case .umbrellaHeader(let path):
+            log(.debug, "\(package.name).\(sourceModule.name) generated umbrella header")
+            cUmbrellaDeclaration = "umbrella header \"\(path.escapedPathString)\""
+        case .umbrellaDirectory(let path):
+            log(.debug, "\(package.name).\(sourceModule.name) generated umbrella directory")
+            cUmbrellaDeclaration = "umbrella \"\(path.escapedPathString)\""
+        case .custom(let customModuleMapPath):
+            let customModuleMapPathString = customModuleMapPath.pathString
+            settings[.OTHER_SWIFT_FLAGS].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
+                $0.append(contentsOf: [
+                    "-import-underlying-module",
+                    "-Xcc", "-fmodule-map-file=\(customModuleMapPathString)",
+                ])
+            }
+            self.impartModuleMap(at: customModuleMapPathString, to: &impartedSettings)
+            return (nil, customModuleMapPathString)
+        case nil, .some(.none):
+            break
+        }
+
+        let moduleMapFileContents: String
+        if let cUmbrellaDeclaration {
+            // If the target has a public C interface, set the top-level module map contents and allow
+            // Swift Build to inject the submodule for the generated header.
+            settings[.SWIFT_INSTALL_OBJC_HEADER] = "YES"
+            // Opt into Swift Build extending these provided module map contents (the underlying C
+            // module) with the generated `.Swift` submodule, forming a single mixed-language module.
+            settings[.SWIFT_EXTEND_MODULEMAP_FILE_CONTENTS] = "YES"
+            moduleMapFileContents = """
+            module \(sourceModule.c99name) {
+            \(cUmbrellaDeclaration)
+            export *
+            }
+            """
+            // The target must be able to load its own underlying Clang module when compiling Swift sources.
+            settings[.OTHER_SWIFT_FLAGS].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
+                $0.append(contentsOf: ["-Xcc", "-fmodule-map-file=\(generatedModuleMapPath)"])
+            }
+        } else {
+            // In a target with no public C interface, only the generated header is exposed via the Clang module.
+            moduleMapFileContents = """
+            module \(sourceModule.c99name) {
+            header "\(sourceModule.name)-Swift.h"
+            export *
+            }
+            """
+        }
+
+        self.impartModuleMap(at: generatedModuleMapPath, to: &impartedSettings)
+
+        return (moduleMapFileContents, generatedModuleMapPath)
+    }
+
+    private func impartModuleMap(at moduleMapPath: String, to impartedSettings: inout BuildSettings) {
+        // Impart the module map to Clang clients.
+        impartedSettings[.OTHER_CFLAGS].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
+            $0.append("-fmodule-map-file=\(moduleMapPath)")
+        }
+
+        // Whether to impart the module map to Swift dependents in addition to Clang dependents.
+        // Previously, SwiftPM would only impart the module map for the Swift-generated header on the clang
+        // compiles of transitive dependencies. This prevented use of generated C/ObjC interfaces in the API
+        // of a Clang target imported by Swift. For example, if:
+        // - TargetA is Swift-only and produces a generated header exposing type Foo
+        // - TargetB is Clang-only and exposes a function bar which returns a value of type Foo
+        // - TargetC is Swift-only and calls bar
+        // then TargetA must impart settings on TargetC allowing it to load the underlying Clang module of TargetA. When
+        // using the experimentalMultiLang flag, we impart settings such that this now works.
+        let impartsModuleMapToSwiftClients = self.package.manifest.toolsVersion.experimentalMultiLang
+        if impartsModuleMapToSwiftClients {
+            impartedSettings[.OTHER_SWIFT_FLAGS].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
+                $0.append(contentsOf: ["-Xcc", "-fmodule-map-file=\(moduleMapPath)"])
+            }
+        }
+    }
+
     /// Constructs a *PIF target* for building a *module* as a particular type.
     /// An optional target identifier suffix is passed when building variants of a target.
     @discardableResult
@@ -404,21 +500,13 @@ extension PackagePIFProjectBuilder {
         let moduleMapFileContents: String?
         let moduleMapPath: String?
 
-        if sourceModule.usesSwift && desiredModuleType != .macro {
-            // Generate ObjC compatibility header for Swift library targets.
-            settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR] = "$(GENERATED_MODULEMAP_DIR)"
-            settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME] = "\(sourceModule.name)-Swift.h"
-
-            moduleMapFileContents = """
-            module \(sourceModule.c99name) {
-            header "\(sourceModule.name)-Swift.h"
-            export *
-            }
-            """
-            let generatedModuleMapPath = try RelativePath(validating:"$(GENERATED_MODULEMAP_DIR)/\(sourceModule.name).modulemap").pathString
-            moduleMapPath = generatedModuleMapPath
-            // We only need to impart this to C clients.
-            impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(generatedModuleMapPath)", "$(inherited)"]
+        if sourceModule.usesSwift {
+            (moduleMapFileContents, moduleMapPath) = try self.configureSwiftTargetModuleMap(
+                for: sourceModule,
+                targetSuffix: targetSuffix,
+                settings: &settings,
+                impartedSettings: &impartedSettings
+            )
         } else {
             // Otherwise, this is a C library module and we generate a modulemap if one is already not provided.
             if let pluginGeneratedModuleMapPath = generatedFiles.moduleMaps.first {
@@ -600,6 +688,13 @@ extension PackagePIFProjectBuilder {
             }
         }
 
+        // A mixed-language target's Objective-C sources may import its own Swift-generated header, which is emitted into `$(GENERATED_MODULEMAP_DIR)`.
+        if sourceModule.usesSwift && sourceModule.isMixedLanguageModule {
+            settings[.HEADER_SEARCH_PATHS].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
+                $0.append("$(GENERATED_MODULEMAP_DIR)")
+            }
+        }
+
         // Additional settings for the linker.
         let enableDuplicateLinkageCulling = UserDefaults.standard.bool(
             forKey: "IDESwiftPackagesEnableDuplicateLinkageCulling",
@@ -608,19 +703,7 @@ extension PackagePIFProjectBuilder {
         if enableDuplicateLinkageCulling {
             impartedSettings[.LD_WARN_DUPLICATE_LIBRARIES] = "NO"
         }
-        if sourceModule.isCxx {
-            for platform in ProjectModel.BuildSettings.Platform.allCases {
-                // darwin & freebsd
-                switch platform {
-                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd:
-                        impartedSettings[.OTHER_LDFLAGS, platform] = ["-lc++", "$(inherited)"]
-                    case .android, .linux, .wasi, .openbsd:
-                        impartedSettings[.OTHER_LDFLAGS, platform] = ["-lstdc++", "$(inherited)"]
-                    case .windows, ._iOSDevice:
-                        break
-                }
-            }
-        }
+        self.addCxxStandardLibraryLinkSettings(for: sourceModule, to: &impartedSettings)
         // This should be only for dynamic targets, but that isn't possible today.
         // Improvement is tracked by rdar://77403529 (Only impart `PackageFrameworks` search paths to clients of dynamic
         // package targets and products).
@@ -979,6 +1062,29 @@ extension PackagePIFProjectBuilder {
         )
 
         return (moduleOrProduct, resourceBundleName)
+    }
+
+    func addCxxStandardLibraryLinkSettings(
+        for module: ResolvedModule,
+        to settings: inout ProjectModel.BuildSettings
+    ) {
+        guard module.isCxx else { return }
+
+        for platform in ProjectModel.BuildSettings.Platform.allCases {
+            let standardLibraryFlag: String
+            switch platform {
+                case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd:
+                    // darwin & freebsd
+                    standardLibraryFlag = "-lc++"
+                case .android, .linux, .wasi, .openbsd:
+                    standardLibraryFlag = "-lstdc++"
+                case .windows, ._iOSDevice:
+                    continue
+            }
+            settings[.OTHER_LDFLAGS, platform].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
+                $0.append(standardLibraryFlag)
+            }
+        }
     }
 
     private func applyPackageCompatibilityWorkarounds(for sourceModule: ResolvedModule, to settings: inout BuildSettings) {

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -349,8 +349,8 @@ extension PackagePIFProjectBuilder {
         // - TargetB is Clang-only and exposes a function bar which returns a value of type Foo
         // - TargetC is Swift-only and calls bar
         // then TargetA must impart settings on TargetC allowing it to load the underlying Clang module of TargetA. When
-        // using the experimentalMultiLang flag, we impart settings such that this now works.
-        let impartsModuleMapToSwiftClients = self.package.manifest.toolsVersion.experimentalMultiLang
+        // using a new enough tools version, we impart settings such that this now works.
+        let impartsModuleMapToSwiftClients = self.package.manifest.toolsVersion >= .v6_5
         if impartsModuleMapToSwiftClients {
             impartedSettings[.OTHER_SWIFT_FLAGS].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
                 $0.append(contentsOf: ["-Xcc", "-fmodule-map-file=\(moduleMapPath)"])

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -325,6 +325,11 @@ extension PackagePIFProjectBuilder {
             """
         }
 
+        if let includeDirAbsolutePath = sourceModule.includeDirAbsolutePath {
+            settings[.GENERATED_HEADER_UNDERLYING_MODULE_INCLUDE_BASE] =
+                includeDirAbsolutePath.pathString
+        }
+
         self.impartModuleMap(at: generatedModuleMapPath, to: &impartedSettings)
 
         return (moduleMapFileContents, generatedModuleMapPath)

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -113,6 +113,7 @@ extension PackagePIFProjectBuilder {
         // Configure the target-wide build settings. The details depend on the kind of product we're building,
         // but are in general the ones that are suitable for end-product artifacts such as executables and test bundles.
         var settings: ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
+        var impartedSettings = BuildSettings()
         settings[.TARGET_NAME] = product.name
         settings[.BUILD_SERVER_PROTOCOL_TARGET_DISPLAY_NAME] = product.name
         settings[.TARGET_TEMP_DIR_SUFFIX] = "-p"
@@ -234,6 +235,25 @@ extension PackagePIFProjectBuilder {
         settings[.GCC_C_LANGUAGE_STANDARD] = mainModule.cLanguageStandard
         settings[.CLANG_CXX_LANGUAGE_STANDARD] = mainModule.cxxLanguageStandard
         settings[.SWIFT_ENABLE_BARE_SLASH_REGEX] = "NO"
+
+        // A mixed-source main module product (executable/test target) needs its own C sources exposed
+        // for import by its Swift sources. Test targets must also impart settings on the corresponding
+        // test runner.
+        if mainModule.usesSwift && mainModule.isMixedLanguageModule && mainModule.type != .macro {
+            let (moduleMapFileContents, moduleMapPath) = try self.configureSwiftTargetModuleMap(
+                for: mainModule,
+                targetSuffix: nil,
+                settings: &settings,
+                impartedSettings: &impartedSettings
+            )
+            settings[.DEFINES_MODULE] = "YES"
+            if let moduleMapFileContents {
+                settings[.MODULEMAP_FILE_CONTENTS] = moduleMapFileContents
+            }
+            if let moduleMapPath {
+                settings[.MODULEMAP_PATH] = moduleMapPath
+            }
+        }
 
         // Create a group for the source files of the main module
         // For now we use an absolute path for it, but we should really make it
@@ -544,6 +564,8 @@ extension PackagePIFProjectBuilder {
         // Custom source module build settings, if any.
         pifBuilder.delegate.configureSourceModuleBuildSettings(sourceModule: mainModule, settings: &settings)
 
+        self.addCxxStandardLibraryLinkSettings(for: mainModule, to: &settings)
+
         // Until this point the build settings for the target have been the same between debug and release
         // configurations.
         // The custom manifest settings might cause them to diverge.
@@ -557,10 +579,10 @@ extension PackagePIFProjectBuilder {
         allBuildSettings.apply(to: &debugSettings, for: .debug)
         allBuildSettings.apply(to: &releaseSettings, for: .release)
         self.project[keyPath: mainModuleTargetKeyPath].common.addBuildConfig { id in
-            BuildConfig(id: id, name: "Debug", settings: debugSettings)
+            BuildConfig(id: id, name: "Debug", settings: debugSettings, impartedBuildSettings: impartedSettings)
         }
         self.project[keyPath: mainModuleTargetKeyPath].common.addBuildConfig { id in
-            BuildConfig(id: id, name: "Release", settings: releaseSettings)
+            BuildConfig(id: id, name: "Release", settings: releaseSettings, impartedBuildSettings: impartedSettings)
         }
 
         // Collect linked binaries.

--- a/Tests/BuildTests/NativeBuildPlanTests.swift
+++ b/Tests/BuildTests/NativeBuildPlanTests.swift
@@ -37,7 +37,7 @@ struct NativeBuildPlanTests {
                 Manifest.createRootManifest(
                     displayName: "Pkg",
                     path: "/Pkg",
-                    toolsVersion: #require(ToolsVersion(string: "6.4.0", experimentalFeatures: [.experimentalMultiLang])),
+                    toolsVersion: #require(ToolsVersion(string: "6.5.0")),
                     targets: [
                         TargetDescription(name: "lib"),
                     ]

--- a/Tests/FunctionalTests/BridgingHeaderTests.swift
+++ b/Tests/FunctionalTests/BridgingHeaderTests.swift
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+import Basics
+import _InternalTestSupport
+import Testing
+
+@Suite(
+    .serializedIfOnWindows,
+    .tags(
+        .TestSize.large,
+        .Feature.CTargets,
+    ),
+)
+struct BridgingHeaderTests {
+    /// A Swift executable that uses a bridging header.
+    @Test
+    func bridgingHeaderBasics() async throws {
+        try await fixture(name: "Miscellaneous/BridgingHeader") { fixturePath in
+            try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                buildSystem: .swiftbuild,
+            )
+        }
+    }
+
+    /// A bridging header that imports C++ code.
+    @Test
+    func bridgingHeaderImportingCxx() async throws {
+        try await fixture(name: "Miscellaneous/BridgingHeaderCxx") { fixturePath in
+            try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                buildSystem: .swiftbuild,
+            )
+        }
+    }
+
+    /// A mixed source target with both an underlying module and a bridging header.
+    @Test
+    func bridgingHeaderWithUnderlyingClangModule() async throws {
+        try await fixture(name: "Miscellaneous/BridgingHeaderWithClangModule") { fixturePath in
+            try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                buildSystem: .swiftbuild,
+            )
+        }
+    }
+
+    /// A mixed source target whose bridging header includes a header found via custom search paths.
+    @Test
+    func bridgingHeaderWithCustomHeaderSearchPaths() async throws {
+        try await fixture(name: "Miscellaneous/BridgingHeaderSearchPaths") { fixturePath in
+            try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                buildSystem: .swiftbuild,
+            )
+        }
+    }
+
+    @Test
+    func bridgingHeaderRejectedByNativeBuildSystem() async throws {
+        try await fixture(name: "Miscellaneous/BridgingHeader") { fixturePath in
+            await expectThrowsCommandExecutionError(
+                try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: .debug,
+                    buildSystem: .native,
+                )
+            ) { error in
+                #expect(
+                    error.consoleOutput.contains(
+                        "bridging headers are not supported when using the native build system"
+                    )
+                )
+            }
+        }
+    }
+}

--- a/Tests/FunctionalTests/MixedLanguageTargetTests.swift
+++ b/Tests/FunctionalTests/MixedLanguageTargetTests.swift
@@ -1,0 +1,212 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+
+import Basics
+import Commands
+import PackageGraph
+import PackageLoading
+import PackageModel
+import SourceControl
+import _InternalTestSupport
+import Workspace
+import Testing
+
+@Suite(
+    .serializedIfOnWindows,
+    .tags(
+        .TestSize.large,
+        .Feature.CTargets,
+    ),
+)
+struct MixedLanguageTargetTests {
+    private func testMixedLanguageFixture(
+        _ fixtureName: String,
+        buildExtraArgs: [String] = [],
+    ) async throws {
+        try await fixture(name: fixtureName) { fixturePath in
+            try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                extraArgs: buildExtraArgs,
+                buildSystem: .swiftbuild,
+            )
+        }
+    }
+
+    /// A library target that mixes Swift and C sources.
+    @Test(
+        .tags(.Feature.Command.Build)
+    )
+    func mixedSwiftCLibrary() async throws {
+        try await testMixedLanguageFixture("CFamilyTargets/MixedSwiftCLibrary")
+    }
+
+    /// A library target that mixes Swift and C sources but has no public headers directory.
+    @Test(
+        .tags(.Feature.Command.Build)
+    )
+    func mixedSwiftCLibraryWithNoHeaders() async throws {
+        try await testMixedLanguageFixture("CFamilyTargets/MixedSwiftCLibraryNoHeaders")
+    }
+
+    /// A library target that mixes Swift and C++ sources.
+    @Test(
+        .tags(.Feature.Command.Build)
+    )
+    func mixedSwiftCxxLibrary() async throws {
+        try await testMixedLanguageFixture("CFamilyTargets/MixedSwiftCxxLibrary")
+    }
+
+    /// An executable target that mixes Swift and C sources.
+    @Test(
+        .tags(.Feature.Command.Build),
+    )
+    func mixedSwiftCExecutable() async throws {
+        try await testMixedLanguageFixture("CFamilyTargets/MixedSwiftCExecutable")
+    }
+
+    /// An executable target that mixes Swift and C++ sources.
+    @Test(
+        .tags(.Feature.Command.Build)
+    )
+    func mixedSwiftCxxExecutable() async throws {
+        try await testMixedLanguageFixture("CFamilyTargets/MixedSwiftCxxExecutable")
+    }
+
+    /// A pure-Swift executable that consumes a mixed-language library, calling both its
+    /// Swift API and its C API.
+    @Test(
+        .tags(.Feature.Command.Build)
+    )
+    func mixedLanguageClient() async throws {
+        try await testMixedLanguageFixture("CFamilyTargets/MixedLanguageClient")
+    }
+
+    /// A pure-Swift executable that consumes a mixed-language library with a custom modulemap, calling both its
+    /// Swift API and its C API.
+    @Test(
+        .tags(.Feature.Command.Build)
+    )
+    func mixedLibraryWithCustomModuleMap() async throws {
+        try await testMixedLanguageFixture("CFamilyTargets/MixedLibraryCustomModuleMap")
+    }
+
+    /// A mixed-language library exercising bidirectional Swift/C++ interop.
+    @Test(
+        .tags(.Feature.Command.Build)
+    )
+    func mixedCxxImportsGeneratedSwiftHeader() async throws {
+        try await testMixedLanguageFixture("CFamilyTargets/MixedCxxUsesSwiftHeader")
+    }
+
+    /// A test target that imports both the Swift and C API of a mixed-language library.
+    @Test(
+        .tags(.Feature.Command.Build)
+    )
+    func testTargetImportingMixedLibrary() async throws {
+        try await testMixedLanguageFixture(
+            "CFamilyTargets/MixedLibraryTestTarget",
+            buildExtraArgs: ["--build-tests"],
+        )
+    }
+
+    /// A test target that `@testable`-imports both the Swift and C API of a mixed-language executable.
+    @Test(
+        .tags(.Feature.Command.Build)
+    )
+    func testTargetImportingMixedExecutable() async throws {
+        try await testMixedLanguageFixture(
+            "CFamilyTargets/MixedExecutableTestTarget",
+            buildExtraArgs: ["--build-tests"],
+        )
+    }
+
+    /// A test target that itself mixes Swift and C sources.
+    @Test(
+        .tags(.Feature.Command.Build)
+    )
+    func mixedSourceTestTarget() async throws {
+        try await testMixedLanguageFixture(
+            "CFamilyTargets/MixedSourceTestTarget",
+            buildExtraArgs: ["--build-tests"],
+        )
+    }
+
+    /// A `.macro` target that mixes Swift and C sources.
+    @Test(
+        .tags(.Feature.Command.Build)
+    )
+    func mixedSourceMacro() async throws {
+        try await testMixedLanguageFixture("CFamilyTargets/MixedSourceMacro")
+    }
+
+    @Test(.tags(.Feature.Command.Build))
+    func nativeBuildSystemRejectsMixedSources() async throws {
+        try await fixture(name: "CFamilyTargets/MixedSwiftCLibrary") { fixturePath in
+            do {
+                try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: .debug,
+                    buildSystem: .native,
+                )
+                Issue.record("expected the native build system to reject the mixed-language target")
+            } catch {
+                #expect(
+                    "\(error)".contains(
+                        "mixed language source files in Swift targets are not supported by the native build system"
+                    )
+                )
+            }
+        }
+    }
+
+    /// A Swift target that transitively uses another Swift target's generated Objective-C interface.
+    @Test(.requireHostOS(.macOS), .tags(.Feature.Command.Build))
+    func crossLanguageObjCTypeThroughObjCTarget() async throws {
+        try await fixture(name: "CFamilyTargets/CrossLanguageObjCType") { fixturePath in
+            let manifestPath = fixturePath.appending("Package.swift").pathString
+
+            // Without `experimentalMultiLang`, TargetA does not impart its generated Objective-C
+            // header module map to Swift dependents, so TargetC cannot resolve TargetA's type
+            // through TargetB and the build fails.
+            await #expect(throws: (any Error).self) {
+                try await executeSwiftBuild(fixturePath, configuration: .debug, buildSystem: .swiftbuild)
+            }
+
+            // Enabling the experimental feature lets TargetC resolve TargetA's module, so it builds.
+            let manifest = try String(contentsOfFile: manifestPath, encoding: .utf8)
+            try manifest
+                .replacingOccurrences(
+                    of: "// swift-tools-version: 6.4",
+                    with: "// swift-tools-version: 6.4;(experimentalMultiLang)"
+                )
+                .write(toFile: manifestPath, atomically: true, encoding: .utf8)
+
+            try await executeSwiftBuild(fixturePath, configuration: .debug, buildSystem: .swiftbuild)
+        }
+    }
+
+    /// A mixed source library whose Objective-C code imports the Swift-generated header
+    @Test(
+        .requireHostOS(.macOS),
+        .tags(.Feature.Command.Build)
+    )
+    func mixedTargetObjCImportsGeneratedSwiftHeader() async throws {
+        try await testMixedLanguageFixture("CFamilyTargets/MixedObjCUsesSwiftHeader")
+    }
+
+    @Test(.requireHostOS(.macOS), .tags(.Feature.Command.Build))
+    func objCImplementationInSwift() async throws {
+        try await testMixedLanguageFixture("CFamilyTargets/ObjCImplementationInSwift")
+    }
+}

--- a/Tests/FunctionalTests/MixedLanguageTargetTests.swift
+++ b/Tests/FunctionalTests/MixedLanguageTargetTests.swift
@@ -209,4 +209,15 @@ struct MixedLanguageTargetTests {
     func objCImplementationInSwift() async throws {
         try await testMixedLanguageFixture("CFamilyTargets/ObjCImplementationInSwift")
     }
+
+    /// A Clang-only target that imports a mixed-language library and uses an `@objc` Swift
+    /// subclass whose Objective-C superclass is declared in the library's underlying Clang module.
+    @Test(
+        .requireHostOS(.macOS),
+        .requiresFrontEndFlags(flags: ["generated-header-import-underlying-module-headers-using-quoted-includes-relative-to"]),
+        .tags(.Feature.Command.Build)
+    )
+    func clangTargetUsesMixedSwiftSubclassOfClangSuperclass() async throws {
+        try await testMixedLanguageFixture("CFamilyTargets/MixedClangSuperclassSwiftSubclass")
+    }
 }

--- a/Tests/FunctionalTests/MixedLanguageTargetTests.swift
+++ b/Tests/FunctionalTests/MixedLanguageTargetTests.swift
@@ -153,19 +153,14 @@ struct MixedLanguageTargetTests {
     @Test(.tags(.Feature.Command.Build))
     func nativeBuildSystemRejectsMixedSources() async throws {
         try await fixture(name: "CFamilyTargets/MixedSwiftCLibrary") { fixturePath in
-            do {
+            await expectThrowsCommandExecutionError(
                 try await executeSwiftBuild(
                     fixturePath,
                     configuration: .debug,
                     buildSystem: .native,
                 )
-                Issue.record("expected the native build system to reject the mixed-language target")
-            } catch {
-                #expect(
-                    "\(error)".contains(
-                        "mixed language source files in Swift targets are not supported by the native build system"
-                    )
-                )
+            ) { error in
+                #expect(error.stderr.contains("mixed language source files in Swift targets are not supported by the native build system"))
             }
         }
     }
@@ -176,19 +171,19 @@ struct MixedLanguageTargetTests {
         try await fixture(name: "CFamilyTargets/CrossLanguageObjCType") { fixturePath in
             let manifestPath = fixturePath.appending("Package.swift").pathString
 
-            // Without `experimentalMultiLang`, TargetA does not impart its generated Objective-C
+            // Without a tools version >= 6.5, TargetA does not impart its generated Objective-C
             // header module map to Swift dependents, so TargetC cannot resolve TargetA's type
             // through TargetB and the build fails.
             await #expect(throws: (any Error).self) {
                 try await executeSwiftBuild(fixturePath, configuration: .debug, buildSystem: .swiftbuild)
             }
 
-            // Enabling the experimental feature lets TargetC resolve TargetA's module, so it builds.
+            // A 6.5 tools version lets TargetC resolve TargetA's module, so it builds.
             let manifest = try String(contentsOfFile: manifestPath, encoding: .utf8)
             try manifest
                 .replacingOccurrences(
                     of: "// swift-tools-version: 6.4",
-                    with: "// swift-tools-version: 6.4;(experimentalMultiLang)"
+                    with: "// swift-tools-version: 6.5"
                 )
                 .write(toFile: manifestPath, atomically: true, encoding: .utf8)
 

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -847,6 +847,34 @@ struct PluginTests {
     }
 
     @Test(
+        .tags(
+            .Feature.Command.Package.Plugin,
+        )
+    )
+    func testPluginAPIsForMixedLanguageTargets() async throws {
+        try await fixture(name: "Miscellaneous/Plugins/MixedTargetPluginAPIs") { fixturePath in
+            let (stdout, _) = try await executeSwiftPackage(
+                fixturePath,
+                extraArgs: ["dump-targets"],
+                buildSystem: .swiftbuild,
+            )
+
+            #expect(stdout.contains("SwiftOnly.type = swift"))
+            #expect(stdout.contains("SwiftOnly.publicHeaders = none"))
+            #expect(stdout.contains("SwiftOnly.headerSearchPaths = []"))
+
+            #expect(stdout.contains("ClangOnly.type = clang"))
+            #expect(stdout.contains("ClangOnly.publicHeaders = include"))
+
+            #expect(stdout.contains("Mixed.type = mixed"))
+            #expect(stdout.contains("Mixed.publicHeaders = include"))
+            #expect(stdout.contains(#"Mixed.swiftDefinitions = ["SWIFT_DEFINITION"]"#))
+            #expect(stdout.contains(#"Mixed.clangDefinitions = ["PREPROCESSOR_MACRO"]"#))
+            #expect(stdout.contains(#"Mixed.headerSearchPaths = ["extra_headers"]"#))
+        }
+    }
+
+    @Test(
         .requiresSwiftConcurrencySupport,
     )
     func testPluginUsageDoesntAffectTestTargetMappings() async throws {

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2764,6 +2764,42 @@ struct PackageBuilderTests {
     }
 
     @Test
+    func macroCanDeclareCSettings() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/MyMacro/MyMacro.swift",
+            "/Sources/MyMacro/helper.c"
+        )
+
+        let manifest = Manifest.createRootManifest(
+            displayName: "pkg",
+            toolsVersion: try #require(ToolsVersion(string: "6.4.0", experimentalFeatures: [.experimentalMultiLang])),
+            targets: [
+                try TargetDescription(
+                    name: "MyMacro",
+                    type: .macro,
+                    settings: [
+                        .init(tool: .c, kind: .define("MACRO_C_DEFINE")),
+                        .init(tool: .cxx, kind: .define("MACRO_CXX_DEFINE")),
+                        .init(tool: .c, kind: .headerSearchPath("Sources/MyMacro/shims")),
+                    ]
+                ),
+            ]
+        )
+
+        try PackageBuilderTester(manifest, in: fs) { package, _ in
+            try package.checkModule("MyMacro") { package in
+                let scope = BuildSettings.Scope(
+                    package.target.buildSettings,
+                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                )
+                #expect(scope.evaluate(.GCC_PREPROCESSOR_DEFINITIONS) == ["MACRO_C_DEFINE", "MACRO_CXX_DEFINE"])
+                #expect(scope.evaluate(.HEADER_SEARCH_PATHS) == ["Sources/MyMacro/shims"])
+            }
+            package.checkProduct("MyMacro")
+        }
+    }
+
+    @Test
     func bridgingHeaderBuildSetting() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/exe/main.swift",

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -78,7 +78,7 @@ struct PackageBuilderTests {
         let manifest = Manifest.createRootManifest(
             displayName: "pkg",
             path: .root,
-            toolsVersion: try #require(ToolsVersion(string: "6.4.0", experimentalFeatures: [.experimentalMultiLang])),
+            toolsVersion: try #require(ToolsVersion(string: "6.5.0")),
             targets: [
                 try TargetDescription(name: "foo"),
             ]
@@ -115,7 +115,7 @@ struct PackageBuilderTests {
             ]
         )
         try PackageBuilderTester(manifest, in: fs) { package, diagnostics in
-            diagnostics.check(diagnostic: "target at '\(foo)' contains mixed language source files; feature not supported", severity: .error)
+            diagnostics.check(diagnostic: "target at '\(foo)' contains mixed language source files; mixed language targets require a tools version of 6.5 or later", severity: .error)
         }
     }
 
@@ -2772,7 +2772,7 @@ struct PackageBuilderTests {
 
         let manifest = Manifest.createRootManifest(
             displayName: "pkg",
-            toolsVersion: try #require(ToolsVersion(string: "6.4.0", experimentalFeatures: [.experimentalMultiLang])),
+            toolsVersion: try #require(ToolsVersion(string: "6.5.0")),
             targets: [
                 try TargetDescription(
                     name: "MyMacro",

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2764,6 +2764,132 @@ struct PackageBuilderTests {
     }
 
     @Test
+    func bridgingHeaderBuildSetting() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/exe/main.swift",
+            "/Sources/lib/lib.swift"
+        )
+
+        let manifest = Manifest.createRootManifest(
+            displayName: "pkg",
+            targets: [
+                try TargetDescription(
+                    name: "exe",
+                    type: .executable,
+                    settings: [
+                        .init(tool: .swift, kind: .bridgingHeader("Bridging.h", .public)),
+                    ]
+                ),
+                try TargetDescription(
+                    name: "lib",
+                    settings: [
+                        .init(
+                            tool: .swift,
+                            kind: .bridgingHeader("Shims.h", .internal),
+                            condition: .init(platformNames: ["macos"])
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        try PackageBuilderTester(manifest, in: fs) { package, _ in
+            try package.checkModule("exe") { package in
+                let scope = BuildSettings.Scope(
+                    package.target.buildSettings,
+                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                )
+                #expect(scope.evaluate(.SWIFT_OBJC_BRIDGING_HEADER) == ["/Sources/exe/Bridging.h"])
+                #expect(scope.evaluate(.SWIFT_BRIDGING_HEADER_IS_INTERNAL) == ["NO"])
+            }
+
+            try package.checkModule("lib") { package in
+                let macOSScope = BuildSettings.Scope(
+                    package.target.buildSettings,
+                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                )
+                #expect(macOSScope.evaluate(.SWIFT_OBJC_BRIDGING_HEADER) == ["/Sources/lib/Shims.h"])
+                #expect(macOSScope.evaluate(.SWIFT_BRIDGING_HEADER_IS_INTERNAL) == ["YES"])
+
+                let linuxScope = BuildSettings.Scope(
+                    package.target.buildSettings,
+                    environment: BuildEnvironment(platform: .linux, configuration: .debug)
+                )
+                #expect(linuxScope.evaluate(.SWIFT_OBJC_BRIDGING_HEADER) == [])
+                #expect(linuxScope.evaluate(.SWIFT_BRIDGING_HEADER_IS_INTERNAL) == [])
+            }
+
+            package.checkProduct("exe")
+        }
+    }
+
+    @Test
+    func bridgingHeaderInLibraryMustBeInternal() throws {
+        let fs = InMemoryFileSystem(emptyFiles: "/Sources/lib/lib.swift")
+        let manifest = Manifest.createRootManifest(
+            displayName: "pkg",
+            targets: [
+                try TargetDescription(
+                    name: "lib",
+                    settings: [.init(tool: .swift, kind: .bridgingHeader("Bridging.h", .public))]
+                ),
+            ]
+        )
+        try PackageBuilderTester(manifest, in: fs) { _, diagnostics in
+            diagnostics.check(
+                diagnostic: .contains("library target 'lib' cannot use a bridging header with '.public' visibility"),
+                severity: .error
+            )
+        }
+    }
+
+    @Test
+    func bridgingHeaderMustNotBeInPublicHeadersDirectory() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/lib/lib.swift",
+            "/Sources/lib/include/Public.h"
+        )
+        let manifest = Manifest.createRootManifest(
+            displayName: "pkg",
+            targets: [
+                try TargetDescription(
+                    name: "lib",
+                    settings: [.init(tool: .swift, kind: .bridgingHeader("include/Public.h", .internal))]
+                ),
+            ]
+        )
+        try PackageBuilderTester(manifest, in: fs) { _, diagnostics in
+            diagnostics.check(
+                diagnostic: .contains("the bridging header must not be inside the target's public headers directory"),
+                severity: .error
+            )
+        }
+    }
+
+    @Test
+    func testAtMostOneBridgingHeader() throws {
+        let fs = InMemoryFileSystem(emptyFiles: "/Sources/lib/lib.swift")
+        let manifest = Manifest.createRootManifest(
+            displayName: "pkg",
+            targets: [
+                try TargetDescription(
+                    name: "lib",
+                    settings: [
+                        .init(tool: .swift, kind: .bridgingHeader("A.h", .internal)),
+                        .init(tool: .swift, kind: .bridgingHeader("B.h", .internal)),
+                    ]
+                ),
+            ]
+        )
+        try PackageBuilderTester(manifest, in: fs) { _, diagnostics in
+            diagnostics.check(
+                diagnostic: .contains("target 'lib' has more than one bridging header specified"),
+                severity: .error
+            )
+        }
+    }
+
+    @Test
     func testEmptyUnsafeFlagsAreAllowed() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/foo/foo.swift",

--- a/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
@@ -842,17 +842,6 @@ final class ToolsVersionParserTests: XCTestCase {
         let cgen = try ToolsVersionParser.parse(utf8String: "// swift-tools-version: 6.3;(experimentalCGen)")
         XCTAssertEqual(cgen, ToolsVersion(version: .init(6, 3, 0)))
         XCTAssertTrue(cgen.experimentalFeatures?.contains(.experimentalCGen) == true)
-        XCTAssertTrue(cgen.experimentalFeatures?.contains(.experimentalMultiLang) ?? false == false)
-
-        let multiLang = try ToolsVersionParser.parse(utf8String: "// swift-tools-version: 6.4;(experimentalMultiLang)")
-        XCTAssertEqual(multiLang, ToolsVersion(version: .init(6, 4, 0)))
-        XCTAssertTrue(multiLang.experimentalFeatures?.contains(.experimentalMultiLang) == true)
-        XCTAssertTrue(multiLang.experimentalFeatures?.contains(.experimentalCGen) ?? false == false)
-
-        let both = try ToolsVersionParser.parse(utf8String: "// swift-tools-version: 6.4;(experimentalCGen,experimentalMultiLang)")
-        XCTAssertEqual(both, ToolsVersion(version: .init(6, 4, 0)))
-        XCTAssertTrue(both.experimentalFeatures?.contains(.experimentalMultiLang) == true)
-        XCTAssertTrue(both.experimentalFeatures?.contains(.experimentalCGen) == true)
 
         let invalid = try ToolsVersionParser.parse(utf8String: "// swift-tools-version: 6.3;(experimentalIgnored)")
         XCTAssertEqual(invalid, ToolsVersion(version: .init(6, 3, 0)))

--- a/Tests/SwiftBuildSupportTests/MixedLanguagePIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/MixedLanguagePIFTests.swift
@@ -391,6 +391,34 @@ struct MixedLanguagePIFTests {
         let ownSwiftFlags = try #require(config.settings[.OTHER_SWIFT_FLAGS])
         #expect(ownSwiftFlags.contains("-fmodule-map-file=$(GENERATED_MODULEMAP_DIR)/MacroImpl.modulemap"))
     }
+
+    @Test func macroWithCSettings() async throws {
+        let project = try await makeProject(
+            packageName: "MacroWithCSettings",
+            files: [
+                "/MacroWithCSettings/Sources/MacroImpl/Plugin.swift",
+                "/MacroWithCSettings/Sources/MacroImpl/helper.c",
+                "/MacroWithCSettings/Sources/MacroImpl/include/helper.h",
+            ],
+            targets: [
+                TargetDescription(
+                    name: "MacroImpl",
+                    type: .macro,
+                    settings: [
+                        .init(tool: .c, kind: .define("MACRO_C_DEFINE")),
+                        .init(tool: .cxx, kind: .define("MACRO_CXX_DEFINE")),
+                    ]
+                ),
+            ],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let macro = try project.requireTarget(named: "MacroImpl")
+        let config = try macro.buildConfig(named: .debug)
+
+        let defines = try #require(config.settings[.GCC_PREPROCESSOR_DEFINITIONS])
+        #expect(defines.contains("MACRO_C_DEFINE"))
+        #expect(defines.contains("MACRO_CXX_DEFINE"))
+    }
 }
 
 extension SwiftBuildSupport.PIF.Project {

--- a/Tests/SwiftBuildSupportTests/MixedLanguagePIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/MixedLanguagePIFTests.swift
@@ -68,6 +68,57 @@ struct MixedLanguagePIFTests {
         try #require(ToolsVersion(string: "6.4.0", experimentalFeatures: [.experimentalMultiLang]))
     }
 
+    @Test func bridgingHeaderPublicVisibility() async throws {
+        let project = try await makeProject(
+            packageName: "BridgeApp",
+            files: [
+                "/BridgeApp/Sources/App/main.swift",
+                "/BridgeApp/Sources/App/Bridging.h",
+            ],
+            targets: [
+                TargetDescription(
+                    name: "App",
+                    type: .executable,
+                    settings: [.init(tool: .swift, kind: .bridgingHeader("Bridging.h", .public))]
+                ),
+            ],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let target = try project.requireTarget(named: "App")
+        let config = try target.buildConfig(named: .debug)
+        #expect(config.settings[.SWIFT_OBJC_BRIDGING_HEADER] == "/BridgeApp/Sources/App/Bridging.h")
+        #expect(config.settings[.SWIFT_BRIDGING_HEADER_IS_INTERNAL] == "NO")
+    }
+
+    @Test func bridgingHeaderInternalConditional() async throws {
+        let project = try await makeProject(
+            packageName: "BridgeLib",
+            files: [
+                "/BridgeLib/Sources/Lib/lib.swift",
+                "/BridgeLib/Sources/Lib/Shims.h",
+            ],
+            targets: [
+                TargetDescription(
+                    name: "Lib",
+                    settings: [
+                        .init(
+                            tool: .swift,
+                            kind: .bridgingHeader("Shims.h", .internal),
+                            condition: .init(platformNames: ["macos"])
+                        ),
+                    ]
+                ),
+            ],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let target = try project.requireTarget(named: "Lib")
+        let config = try target.buildConfig(named: .debug)
+
+        #expect(config.settings[.SWIFT_OBJC_BRIDGING_HEADER, .macOS] == "/BridgeLib/Sources/Lib/Shims.h")
+        #expect(config.settings[.SWIFT_BRIDGING_HEADER_IS_INTERNAL, .macOS] == "YES")
+        #expect(config.settings[.SWIFT_OBJC_BRIDGING_HEADER] == nil)
+    }
+
     @Test func mixedSwiftCLibrary() async throws {
         let project = try await makeProject(
             packageName: "MixedSwiftCLibrary",

--- a/Tests/SwiftBuildSupportTests/MixedLanguagePIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/MixedLanguagePIFTests.swift
@@ -1,0 +1,352 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Foundation
+import Testing
+import PackageGraph
+import PackageLoading
+import PackageModel
+import SPMBuildCore
+import SwiftBuild
+import SwiftBuildSupport
+import _InternalTestSupport
+import Workspace
+
+@_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly) import PackageGraph
+
+@Suite
+struct MixedLanguagePIFTests {
+    private func makeProject(
+        packageName: String,
+        files: [String],
+        targets: [TargetDescription],
+        toolsVersion: ToolsVersion,
+    ) async throws -> SwiftBuildSupport.PIF.Project {
+        let packagePath = AbsolutePath("/\(packageName)")
+        let fs = InMemoryFileSystem(emptyFiles: files)
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: packageName,
+                    path: packagePath,
+                    toolsVersion: toolsVersion,
+                    targets: targets,
+                ),
+            ],
+            observabilityScope: observability.topScope,
+        )
+        #expect(observability.diagnostics.isEmpty, "unexpected diagnostics loading \(packageName)")
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: .always
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope,
+        )
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+        return try pif.workspace.project(named: packageName)
+    }
+
+    private func mixedLanguageToolsVersion() throws -> ToolsVersion {
+        try #require(ToolsVersion(string: "6.4.0", experimentalFeatures: [.experimentalMultiLang]))
+    }
+
+    @Test func mixedSwiftCLibrary() async throws {
+        let project = try await makeProject(
+            packageName: "MixedSwiftCLibrary",
+            files: [
+                "/MixedSwiftCLibrary/Sources/MixedSwiftCLibrary/Adder.swift",
+                "/MixedSwiftCLibrary/Sources/MixedSwiftCLibrary/cadd.c",
+                "/MixedSwiftCLibrary/Sources/MixedSwiftCLibrary/include/cadd.h",
+            ],
+            targets: [TargetDescription(name: "MixedSwiftCLibrary")],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let target = try project.target(named: "MixedSwiftCLibrary")
+        let config = try target.buildConfig(named: .debug)
+
+        #expect(config.settings[.SWIFT_INSTALL_OBJC_HEADER] == "YES")
+        #expect(config.settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME] == "MixedSwiftCLibrary-Swift.h")
+        #expect(config.settings[.DEFINES_MODULE] == "YES")
+
+        let moduleMap = try #require(config.settings[.MODULEMAP_FILE_CONTENTS])
+        #expect(moduleMap.contains("module MixedSwiftCLibrary"))
+
+        let headerSearchPaths = try #require(config.settings[.HEADER_SEARCH_PATHS])
+        #expect(headerSearchPaths.contains("/MixedSwiftCLibrary/Sources/MixedSwiftCLibrary/include"))
+        let ownSwiftFlags = try #require(config.settings[.OTHER_SWIFT_FLAGS])
+        #expect(ownSwiftFlags.contains("-fmodule-map-file=$(GENERATED_MODULEMAP_DIR)/MixedSwiftCLibrary.modulemap"))
+    }
+
+    @Test func mixedTargetWithCustomModuleMap() async throws {
+        let customModuleMapPath = "/CustomModuleMapMixed/Sources/MixedCustom/include/module.modulemap"
+        let project = try await makeProject(
+            packageName: "CustomModuleMapMixed",
+            files: [
+                "/CustomModuleMapMixed/Sources/MixedCustom/Adder.swift",
+                "/CustomModuleMapMixed/Sources/MixedCustom/cadd.c",
+                "/CustomModuleMapMixed/Sources/MixedCustom/include/cadd.h",
+                customModuleMapPath,
+            ],
+            targets: [TargetDescription(name: "MixedCustom")],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let target = try project.requireTarget(named: "MixedCustom")
+        let config = try target.buildConfig(named: .debug)
+
+        #expect(config.settings[.MODULEMAP_PATH] == customModuleMapPath)
+        #expect(config.settings[.MODULEMAP_FILE_CONTENTS] == nil)
+        #expect(config.settings[.SWIFT_EXTEND_MODULEMAP_FILE_CONTENTS] == nil)
+        let ownSwiftFlags = try #require(config.settings[.OTHER_SWIFT_FLAGS])
+        #expect(ownSwiftFlags.contains("-fmodule-map-file=\(customModuleMapPath)"))
+        #expect(ownSwiftFlags.contains("-import-underlying-module"))
+
+        let impartedCFlags = try #require(config.impartedBuildProperties.settings[.OTHER_CFLAGS])
+        #expect(impartedCFlags.contains("-fmodule-map-file=\(customModuleMapPath)"))
+        let impartedSwiftFlags = try #require(config.impartedBuildProperties.settings[.OTHER_SWIFT_FLAGS])
+        #expect(impartedSwiftFlags.contains("-fmodule-map-file=\(customModuleMapPath)"))
+    }
+
+    @Test func mixedTargetOwnHeaderSearchPathIncludesGeneratedDir() async throws {
+        let project = try await makeProject(
+            packageName: "MixedObjCUsesSwiftHeader",
+            files: [
+                "/MixedObjCUsesSwiftHeader/Sources/MixedLib/Greeter.swift",
+                "/MixedObjCUsesSwiftHeader/Sources/MixedLib/Value.swift",
+                "/MixedObjCUsesSwiftHeader/Sources/MixedLib/Bridge.m",
+                "/MixedObjCUsesSwiftHeader/Sources/MixedLib/include/Bridge.h",
+            ],
+            targets: [TargetDescription(name: "MixedLib")],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let target = try project.requireTarget(named: "MixedLib")
+        let config = try target.buildConfig(named: .debug)
+        let headerSearchPaths = try #require(config.settings[.HEADER_SEARCH_PATHS])
+        #expect(headerSearchPaths.contains("$(GENERATED_MODULEMAP_DIR)"))
+    }
+
+    @Test func headerOnlyObjCTargetIsMixed() async throws {
+        let project = try await makeProject(
+            packageName: "ObjCImplementationInSwift",
+            files: [
+                "/ObjCImplementationInSwift/Sources/MixedImpl/Widget.swift",
+                "/ObjCImplementationInSwift/Sources/MixedImpl/include/Widget.h",
+            ],
+            targets: [TargetDescription(name: "MixedImpl")],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let target = try project.requireTarget(named: "MixedImpl")
+        let config = try target.buildConfig(named: .debug)
+
+        #expect(config.settings[.SWIFT_INSTALL_OBJC_HEADER] == "YES")
+        #expect(config.settings[.MODULEMAP_FILE_CONTENTS] != nil)
+        let headerSearchPaths = try #require(config.settings[.HEADER_SEARCH_PATHS])
+        #expect(headerSearchPaths.contains("$(GENERATED_MODULEMAP_DIR)"))
+    }
+
+    @Test func mixedSwiftCLibraryWithNoHeaders() async throws {
+        let project = try await makeProject(
+            packageName: "MixedSwiftCLibraryNoHeaders",
+            files: [
+                "/MixedSwiftCLibraryNoHeaders/Sources/MixedNoHeaders/Compute.swift",
+                "/MixedSwiftCLibraryNoHeaders/Sources/MixedNoHeaders/helper.c",
+            ],
+            targets: [TargetDescription(name: "MixedNoHeaders")],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let target = try project.requireTarget(named: "MixedNoHeaders")
+        let config = try target.buildConfig(named: .debug)
+
+        let moduleMap = try #require(config.settings[.MODULEMAP_FILE_CONTENTS])
+        #expect(moduleMap.contains("header \"MixedNoHeaders-Swift.h\""))
+        #expect(!moduleMap.contains("umbrella"))
+        #expect(config.settings[.HEADER_SEARCH_PATHS] == ["$(inherited)", "$(GENERATED_MODULEMAP_DIR)"])
+    }
+
+    @Test func mixedSwiftCxxLibrary() async throws {
+        let project = try await makeProject(
+            packageName: "MixedSwiftCxxLibrary",
+            files: [
+                "/MixedSwiftCxxLibrary/Sources/MixedSwiftCxxLibrary/Multiplier.swift",
+                "/MixedSwiftCxxLibrary/Sources/MixedSwiftCxxLibrary/mul.cpp",
+                "/MixedSwiftCxxLibrary/Sources/MixedSwiftCxxLibrary/include/mul.h",
+            ],
+            targets: [TargetDescription(name: "MixedSwiftCxxLibrary")],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let target = try project.target(named: "MixedSwiftCxxLibrary")
+        let config = try target.buildConfig(named: .debug)
+
+        #expect(config.settings[.DEFINES_MODULE] == "YES")
+        #expect(config.settings[.MODULEMAP_FILE_CONTENTS] != nil)
+
+        #expect(config.impartedBuildProperties.settings[.OTHER_LDFLAGS, .macOS] == ["$(inherited)", "-lc++"])
+        #expect(config.impartedBuildProperties.settings[.OTHER_LDFLAGS, .linux] == ["$(inherited)", "-lstdc++"])
+    }
+
+    @Test func mixedSwiftCExecutable() async throws {
+        let project = try await makeProject(
+            packageName: "MixedSwiftCExecutable",
+            files: [
+                "/MixedSwiftCExecutable/Sources/MixedSwiftCExecutable/main.swift",
+                "/MixedSwiftCExecutable/Sources/MixedSwiftCExecutable/helper.c",
+                "/MixedSwiftCExecutable/Sources/MixedSwiftCExecutable/include/helper.h",
+            ],
+            targets: [TargetDescription(name: "MixedSwiftCExecutable", type: .executable)],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let target = try project.target(named: "MixedSwiftCExecutable")
+        let config = try target.buildConfig(named: .debug)
+
+        #expect(config.settings[.DEFINES_MODULE] == "YES")
+        #expect(config.settings[.SWIFT_INSTALL_OBJC_HEADER] == "YES")
+        let moduleMap = try #require(config.settings[.MODULEMAP_FILE_CONTENTS])
+        #expect(moduleMap.contains("module MixedSwiftCExecutable"))
+    }
+
+    @Test func mixedLanguageClient() async throws {
+        let project = try await makeProject(
+            packageName: "MixedLanguageClient",
+            files: [
+                "/MixedLanguageClient/Sources/MixedCore/Adder.swift",
+                "/MixedLanguageClient/Sources/MixedCore/cadd.c",
+                "/MixedLanguageClient/Sources/MixedCore/include/cadd.h",
+                "/MixedLanguageClient/Sources/Client/main.swift",
+            ],
+            targets: [
+                TargetDescription(name: "MixedCore"),
+                TargetDescription(name: "Client", dependencies: ["MixedCore"], type: .executable),
+            ],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let core = try project.target(named: "MixedCore")
+        let config = try core.buildConfig(named: .debug)
+
+        let impartedSwiftFlags = try #require(config.impartedBuildProperties.settings[.OTHER_SWIFT_FLAGS])
+        #expect(impartedSwiftFlags.contains("-fmodule-map-file=$(GENERATED_MODULEMAP_DIR)/MixedCore.modulemap"))
+        let impartedCFlags = try #require(config.impartedBuildProperties.settings[.OTHER_CFLAGS])
+        #expect(impartedCFlags.contains("-fmodule-map-file=$(GENERATED_MODULEMAP_DIR)/MixedCore.modulemap"))
+    }
+
+    @Test func testTargetImportingMixedLibrary() async throws {
+        let project = try await makeProject(
+            packageName: "MixedLibraryTestTarget",
+            files: [
+                "/MixedLibraryTestTarget/Sources/MixedCore/Adder.swift",
+                "/MixedLibraryTestTarget/Sources/MixedCore/cadd.c",
+                "/MixedLibraryTestTarget/Sources/MixedCore/include/cadd.h",
+                "/MixedLibraryTestTarget/Tests/MixedCoreTests/MixedCoreTests.swift",
+            ],
+            targets: [
+                TargetDescription(name: "MixedCore"),
+                TargetDescription(name: "MixedCoreTests", dependencies: ["MixedCore"], type: .test),
+            ],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let core = try project.requireTarget(named: "MixedCore")
+        let config = try core.buildConfig(named: .debug)
+        let impartedSwiftFlags = try #require(config.impartedBuildProperties.settings[.OTHER_SWIFT_FLAGS])
+        #expect(impartedSwiftFlags.contains("-fmodule-map-file=$(GENERATED_MODULEMAP_DIR)/MixedCore.modulemap"))
+    }
+
+    @Test func testTargetImportingMixedExecutable() async throws {
+        let project = try await makeProject(
+            packageName: "MixedExecutableTestTarget",
+            files: [
+                "/MixedExecutableTestTarget/Sources/MixedTool/Tool.swift",
+                "/MixedExecutableTestTarget/Sources/MixedTool/main.swift",
+                "/MixedExecutableTestTarget/Sources/MixedTool/toolc.c",
+                "/MixedExecutableTestTarget/Sources/MixedTool/include/toolc.h",
+                "/MixedExecutableTestTarget/Tests/MixedToolTests/MixedToolTests.swift",
+            ],
+            targets: [
+                TargetDescription(name: "MixedTool", type: .executable),
+                TargetDescription(name: "MixedToolTests", dependencies: ["MixedTool"], type: .test),
+            ],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let tool = try project.requireTarget(named: "MixedTool")
+        let config = try tool.buildConfig(named: .debug)
+        #expect(config.settings[.DEFINES_MODULE] == "YES")
+        #expect(config.settings[.SWIFT_INSTALL_OBJC_HEADER] == "YES")
+        let moduleMap = try #require(config.settings[.MODULEMAP_FILE_CONTENTS])
+        #expect(moduleMap.contains("module MixedTool"))
+    }
+
+    @Test func mixedSourceTestTarget() async throws {
+        let project = try await makeProject(
+            packageName: "MixedSourceTestTarget",
+            files: [
+                "/MixedSourceTestTarget/Sources/Calculator/Calculator.swift",
+                "/MixedSourceTestTarget/Tests/CalculatorTests/CalculatorTests.swift",
+                "/MixedSourceTestTarget/Tests/CalculatorTests/test_helper.c",
+                "/MixedSourceTestTarget/Tests/CalculatorTests/include/test_helper.h",
+            ],
+            targets: [
+                TargetDescription(name: "Calculator"),
+                TargetDescription(name: "CalculatorTests", dependencies: ["Calculator"], type: .test),
+            ],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let testTarget = try project.requireTarget(named: "MixedSourceTestTargetPackageTests-product")
+        let config = try testTarget.buildConfig(named: .debug)
+        #expect(config.settings[.DEFINES_MODULE] == "YES")
+        #expect(config.settings[.SWIFT_INSTALL_OBJC_HEADER] == "YES")
+        let moduleMap = try #require(config.settings[.MODULEMAP_FILE_CONTENTS])
+        #expect(moduleMap.contains("umbrella"))
+    }
+
+    @Test func mixedSourceMacro() async throws {
+        let project = try await makeProject(
+            packageName: "MixedSourceMacro",
+            files: [
+                "/MixedSourceMacro/Sources/MacroImpl/Plugin.swift",
+                "/MixedSourceMacro/Sources/MacroImpl/helper.c",
+                "/MixedSourceMacro/Sources/MacroImpl/include/helper.h",
+                "/MixedSourceMacro/Sources/MacroDef/MacroDef.swift",
+                "/MixedSourceMacro/Sources/MacroClient/main.swift",
+            ],
+            targets: [
+                TargetDescription(name: "MacroImpl", type: .macro),
+                TargetDescription(name: "MacroDef", dependencies: ["MacroImpl"]),
+                TargetDescription(name: "MacroClient", dependencies: ["MacroDef"], type: .executable),
+            ],
+            toolsVersion: try mixedLanguageToolsVersion(),
+        )
+        let macro = try project.requireTarget(named: "MacroImpl")
+        let config = try macro.buildConfig(named: .debug)
+
+        #expect(config.settings[.SWIFT_INSTALL_OBJC_HEADER] == "YES")
+        let moduleMap = try #require(config.settings[.MODULEMAP_FILE_CONTENTS])
+        #expect(moduleMap.contains("module MacroImpl"))
+        #expect(moduleMap.contains("umbrella"))
+        let ownSwiftFlags = try #require(config.settings[.OTHER_SWIFT_FLAGS])
+        #expect(ownSwiftFlags.contains("-fmodule-map-file=$(GENERATED_MODULEMAP_DIR)/MacroImpl.modulemap"))
+    }
+}
+
+extension SwiftBuildSupport.PIF.Project {
+    fileprivate func requireTarget(named name: String) throws -> ProjectModel.BaseTarget {
+        if let target = underlying.targets.first(where: { $0.common.name == name }) {
+            return target
+        }
+        throw StringError("no target named '\(name)'; available: \(underlying.targets.map(\.common.name))")
+    }
+}

--- a/Tests/SwiftBuildSupportTests/MixedLanguagePIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/MixedLanguagePIFTests.swift
@@ -65,7 +65,7 @@ struct MixedLanguagePIFTests {
     }
 
     private func mixedLanguageToolsVersion() throws -> ToolsVersion {
-        try #require(ToolsVersion(string: "6.4.0", experimentalFeatures: [.experimentalMultiLang]))
+        try #require(ToolsVersion(string: "6.5.0"))
     }
 
     @Test func bridgingHeaderPublicVisibility() async throws {
@@ -423,9 +423,10 @@ struct MixedLanguagePIFTests {
 
 extension SwiftBuildSupport.PIF.Project {
     fileprivate func requireTarget(named name: String) throws -> ProjectModel.BaseTarget {
-        if let target = underlying.targets.first(where: { $0.common.name == name }) {
-            return target
-        }
-        throw StringError("no target named '\(name)'; available: \(underlying.targets.map(\.common.name))")
+        let target = try #require(
+            underlying.targets.first(where: { $0.common.name == name }),
+            "no target named '\(name)'; available: \(underlying.targets.map(\.common.name))",
+        )
+        return target
     }
 }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -113,7 +113,7 @@ fileprivate func withGeneratedPIF(
 }
 
 extension SwiftBuildSupport.PIF.Workspace {
-    fileprivate func project(named name: String) throws -> SwiftBuildSupport.PIF.Project {
+    func project(named name: String) throws -> SwiftBuildSupport.PIF.Project {
         let matchingProjects = projects.filter {
             $0.underlying.name == name
         }
@@ -141,7 +141,7 @@ extension SwiftBuildSupport.PIF.Project {
         }
     }
 
-    fileprivate func target(named name: String) throws -> ProjectModel.BaseTarget {
+    func target(named name: String) throws -> ProjectModel.BaseTarget {
         let matchingTargets = underlying.targets.filter {
             $0.common.name == name
         }
@@ -176,7 +176,7 @@ extension SwiftBuildSupport.PIF.Project {
 }
 
 extension SwiftBuild.ProjectModel.BaseTarget {
-    fileprivate func buildConfig(named name: BuildConfiguration) throws -> SwiftBuild.ProjectModel.BuildConfig {
+    func buildConfig(named name: BuildConfiguration) throws -> SwiftBuild.ProjectModel.BuildConfig {
         let matchingConfigs = common.buildConfigs.filter {
             $0.name == name.pifConfiguration
         }
@@ -646,9 +646,9 @@ struct PIFBuilderTests {
                 let ld_flags = releaseConfig.impartedBuildProperties.settings[.OTHER_LDFLAGS, platform]
                 switch platform {
                     case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd:
-                         #expect(ld_flags == ["-lc++", "$(inherited)"], "for platform \(platform)")
+                         #expect(ld_flags == ["$(inherited)", "-lc++"], "for platform \(platform)")
                     case .android, .linux, .wasi, .openbsd:
-                        #expect(ld_flags == ["-lstdc++", "$(inherited)"], "for platform \(platform)")
+                        #expect(ld_flags == ["$(inherited)", "-lstdc++"], "for platform \(platform)")
                     case .windows, ._iOSDevice:
                         #expect(ld_flags == nil, "for platform \(platform)")
                 }
@@ -1773,7 +1773,8 @@ struct PIFBuilderTests {
         let fs = InMemoryFileSystem(
             emptyFiles:
                 "/Pkg/Sources/lib/file1.swift",
-                "/Pkg/Sources/lib/file2.c"
+                "/Pkg/Sources/lib/file2.c",
+                "/Pkg/Sources/lib/include/lib.h"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadModulesGraph(
@@ -1828,6 +1829,19 @@ struct PIFBuilderTests {
             "/Pkg/Sources/lib/file2.c",
         ]
         #expect(sources == expected)
+
+        let libConfig = try lib.buildConfig(named: .debug)
+        #expect(libConfig.settings[.SWIFT_INSTALL_OBJC_HEADER] == "YES")
+        #expect(libConfig.settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME] == "lib-Swift.h")
+        #expect(libConfig.settings[.DEFINES_MODULE] == "YES")
+
+        let moduleMapContents = try #require(libConfig.settings[.MODULEMAP_FILE_CONTENTS])
+        #expect(moduleMapContents.contains("module lib"))
+        #expect(moduleMapContents.contains("umbrella header"))
+        #expect(!moduleMapContents.contains("lib-Swift.h"))
+
+        let headerSearchPaths = try #require(libConfig.settings[.HEADER_SEARCH_PATHS])
+        #expect(headerSearchPaths.contains("/Pkg/Sources/lib/include"))
      }
 
     @Test func testTargetDependsOnTestTarget() async throws {

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1783,7 +1783,7 @@ struct PIFBuilderTests {
                 Manifest.createRootManifest(
                     displayName: "Pkg",
                     path: "/Pkg",
-                    toolsVersion: try #require(ToolsVersion(string: "6.4.0", experimentalFeatures: [.experimentalMultiLang])),
+                    toolsVersion: try #require(ToolsVersion(string: "6.5.0")),
                     targets: [
                         TargetDescription(name: "lib"),
                     ]

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -114,7 +114,7 @@ fileprivate func withGeneratedPIF(
 }
 
 extension SwiftBuildSupport.PIF.Workspace {
-    fileprivate func project(named name: String) throws -> SwiftBuildSupport.PIF.Project {
+    func project(named name: String) throws -> SwiftBuildSupport.PIF.Project {
         let matchingProjects = projects.filter {
             $0.underlying.name == name
         }
@@ -142,7 +142,7 @@ extension SwiftBuildSupport.PIF.Project {
         }
     }
 
-    fileprivate func target(named name: String) throws -> ProjectModel.BaseTarget {
+    func target(named name: String) throws -> ProjectModel.BaseTarget {
         let matchingTargets = underlying.targets.filter {
             $0.common.name == name
         }
@@ -177,7 +177,7 @@ extension SwiftBuildSupport.PIF.Project {
 }
 
 extension SwiftBuild.ProjectModel.BaseTarget {
-    fileprivate func buildConfig(named name: BuildConfiguration) throws -> SwiftBuild.ProjectModel.BuildConfig {
+    func buildConfig(named name: BuildConfiguration) throws -> SwiftBuild.ProjectModel.BuildConfig {
         let matchingConfigs = common.buildConfigs.filter {
             $0.name == name.pifConfiguration
         }
@@ -647,9 +647,9 @@ struct PIFBuilderTests {
                 let ld_flags = releaseConfig.impartedBuildProperties.settings[.OTHER_LDFLAGS, platform]
                 switch platform {
                     case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd:
-                         #expect(ld_flags == ["-lc++", "$(inherited)"], "for platform \(platform)")
+                         #expect(ld_flags == ["$(inherited)", "-lc++"], "for platform \(platform)")
                     case .android, .linux, .wasi, .openbsd:
-                        #expect(ld_flags == ["-lstdc++", "$(inherited)"], "for platform \(platform)")
+                        #expect(ld_flags == ["$(inherited)", "-lstdc++"], "for platform \(platform)")
                     case .windows, ._iOSDevice:
                         #expect(ld_flags == nil, "for platform \(platform)")
                 }
@@ -1976,7 +1976,8 @@ struct PIFBuilderTests {
         let fs = InMemoryFileSystem(
             emptyFiles:
                 "/Pkg/Sources/lib/file1.swift",
-                "/Pkg/Sources/lib/file2.c"
+                "/Pkg/Sources/lib/file2.c",
+                "/Pkg/Sources/lib/include/lib.h"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadModulesGraph(
@@ -2031,6 +2032,19 @@ struct PIFBuilderTests {
             "/Pkg/Sources/lib/file2.c",
         ]
         #expect(sources == expected)
+
+        let libConfig = try lib.buildConfig(named: .debug)
+        #expect(libConfig.settings[.SWIFT_INSTALL_OBJC_HEADER] == "YES")
+        #expect(libConfig.settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME] == "lib-Swift.h")
+        #expect(libConfig.settings[.DEFINES_MODULE] == "YES")
+
+        let moduleMapContents = try #require(libConfig.settings[.MODULEMAP_FILE_CONTENTS])
+        #expect(moduleMapContents.contains("module lib"))
+        #expect(moduleMapContents.contains("umbrella header"))
+        #expect(!moduleMapContents.contains("lib-Swift.h"))
+
+        let headerSearchPaths = try #require(libConfig.settings[.HEADER_SEARCH_PATHS])
+        #expect(headerSearchPaths.contains("/Pkg/Sources/lib/include"))
      }
 
     @Test func testTargetDependsOnTestTarget() async throws {

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1986,7 +1986,7 @@ struct PIFBuilderTests {
                 Manifest.createRootManifest(
                     displayName: "Pkg",
                     path: "/Pkg",
-                    toolsVersion: try #require(ToolsVersion(string: "6.4.0", experimentalFeatures: [.experimentalMultiLang])),
+                    toolsVersion: try #require(ToolsVersion(string: "6.5.0")),
                     targets: [
                         TargetDescription(name: "lib"),
                     ]


### PR DESCRIPTION
- Improve support for Swift/C interoperability in mixed source targets, gated behind the existing experimentalMultiLang option. Targets with Swift and C-family sources are modeled as a SwiftTarget at the PackageLoading layer, but now optionally include clang module info as well. When lowering them to PIF, we configure the modulemap and generated header to allow bidirectional interop.
-  Update the PackagePlugin API is updated to accommodate mixed source targets. 
- Allow configuring a bridging header
- Add missing cSettings API on various target types

This is a big diff but most of it is tests.


Proposal: [SE-0541: Flexible Swift/C Interoperability for Packages](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0541-flexible-swift-c-interoperability-for-packages.md)