### PR TITLE
fix(plugins): avoid exposing compilation result internals

### DIFF
--- a/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
@@ -675,8 +675,8 @@ public enum DefaultPluginScriptRunnerError: Error, CustomStringConvertible {
             return "plugin is unavailable: \(reason)"
         case .compilationPreparationFailed(let error):
             return "plugin compilation preparation failed: \(error.interpolationDescription)"
-        case .compilationFailed(let result):
-            return "plugin compilation failed: \(result)"
+        case .compilationFailed:
+            return "plugin compilation failed"
         case .invocationFailed(let error, let command):
             return "plugin invocation failed: \(error.interpolationDescription) \(makeContextString(command, ""))"
         case .invocationEndedBySignal(let signal, let command, let output):

--- a/Tests/BuildTests/PluginInvocationTests.swift
+++ b/Tests/BuildTests/PluginInvocationTests.swift
@@ -495,6 +495,25 @@ final class PluginInvocationTests: XCTestCase {
         )
     }
 
+    func testCompilationFailureDescriptionDoesNotIncludeDebugResult() {
+        let executableFile = AbsolutePath.root.appending("MyPlugin")
+        let result = PluginCompilationResult(
+            succeeded: false,
+            commandLine: ["swiftc", "plugin.swift"],
+            executableFile: executableFile,
+            diagnosticsFile: AbsolutePath.root.appending("MyPlugin.dia"),
+            compilerOutput: "plugin.swift:1:1: error: invalid plugin",
+            cached: false
+        )
+
+        let error = DefaultPluginScriptRunnerError.compilationFailed(result)
+
+        XCTAssertEqual(error.description, "plugin compilation failed")
+        XCTAssertFalse(error.description.contains("PluginCompilationResult"))
+        XCTAssertFalse(error.description.contains("commandLine"))
+        XCTAssertFalse(error.description.contains(result.compilerOutput))
+    }
+
     func testCompilationDiagnostics() async throws {
         try await testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin.

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -4982,10 +4982,14 @@ struct PackageCommandTests {
                         buildSystem: buildSystem,
                     )
                 ) { error in
+                    let output = error.consoleOutput
                     #expect(
-                        error.consoleOutput.contains("intentionalCompilerError"),
-                        "Plugin compiler diagnostic was not shown: \(error.consoleOutput)"
+                        output.contains("intentionalCompilerError"),
+                        "Plugin compiler diagnostic was not shown: \(output)"
                     )
+                    #expect(!output.contains("<PluginCompilationResult("))
+                    #expect(!output.contains("commandLine:"))
+                    #expect(!output.contains("compilerOutput:"))
                 }
             }
         }


### PR DESCRIPTION
Fixes #8091

## Summary

Avoid exposing the internal `PluginCompilationResult` representation when plugin compilation fails.

SwiftPM currently interpolates the entire result into the user-facing error. This includes the compiler command line, executable and diagnostics paths, cached state, and captured compiler output.

The plugin runner already surfaces the actionable compiler diagnostic separately, so including the structured result is noisy, exposes implementation details, and can duplicate compiler output.

## Changes

- Replace the interpolated compilation result with a concise `plugin compilation failed` message.
- Add focused unit coverage for the compilation failure description.
- Extend the existing build-tool compiler regression test to verify that:
  - The actionable compiler diagnostic remains visible.
  - `PluginCompilationResult` and its internal fields are not included.
  - The behavior is covered by both the native and SwiftBuild backends.

## Alternatives considered

Customizing `PluginCompilationResult`’s debug representation was considered. However, the result contains structured compilation state that should not be part of a user-facing diagnostic.

Routing compiler output through additional build-system delegates was also considered. This is no longer necessary because #10346 centralized compiler-output handling in the plugin script runner and already covers diagnostic visibility and verbosity behavior.

## Notes

The `PluginCompilationResult` remains attached to the error and available to callers. This change only prevents its debug representation from being rendered directly to users.

Successful plugin compilation and compiler-diagnostic visibility are unchanged.

## Testing

- `swift test --filter PluginInvocationTests.testCompilationFailureDescriptionDoesNotIncludeDebugResult --filter buildToolPluginCompilerErrorIsVisible`
- The focused unit test passed.
- The command-level regression test passed for both native and SwiftBuild.