### PR TITLE
Support debugging manifests and plugins from Xcode

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -27,3 +27,4 @@ Utilities/bootstrap
 Utilities/build-using-self
 Utilities/new-bootstrap
 Utilities/test-toolchain
+Utilities/mk-toolchain/mk-toolchain

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -721,11 +721,19 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
         // which produces a framework for dynamic package products.
         if runtimePath.extension == "framework" {
+            let parent = runtimePath.parentDirectory
             cmd += [
-                "-I", runtimePath.parentDirectory.pathString,
-                "-F", runtimePath.parentDirectory.pathString,
-                "-Xlinker", "-rpath", "-Xlinker", runtimePath.parentDirectory.pathString,
+                "-F", parent.pathString,
+                "-Xlinker", "-rpath", "-Xlinker", parent.pathString,
             ]
+
+            // Make sure we can find the swiftmodule
+            if parent.basename == "PackageFrameworks" {
+                // Need to look up one more
+                cmd += ["-I", parent.parentDirectory.pathString]
+            } else {
+                cmd += ["-I", parent.pathString]
+            }
 
             // Explicitly link `AppleProductTypes` since auto-linking won't work here.
 #if ENABLE_APPLE_PRODUCT_TYPES
@@ -958,11 +966,12 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
         // which produces a framework for dynamic package products.
         if modulesPath.extension == "framework" {
-            if modulesPath.parentDirectory.basename == "ManifestAPI" {
-                // If the framework is linked into a toolchain, the swiftmodule is here
-                cmd += ["-I", modulesPath.parentDirectory.pathString]
+            let parent = modulesPath.parentDirectory
+            cmd += ["-F", parent.pathString]
+            if parent.basename == "PackageFrameworks" {
+                cmd += ["-I", parent.parentDirectory.pathString]
             } else {
-                cmd += ["-I", modulesPath.parentDirectory.parentDirectory.pathString]
+                cmd += ["-I", parent.pathString]
             }
         } else {
             cmd += ["-I", modulesPath.pathString]

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -722,6 +722,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // which produces a framework for dynamic package products.
         if runtimePath.extension == "framework" {
             cmd += [
+                "-I", runtimePath.parentDirectory.pathString,
                 "-F", runtimePath.parentDirectory.pathString,
                 "-Xlinker", "-rpath", "-Xlinker", runtimePath.parentDirectory.pathString,
             ]
@@ -957,7 +958,12 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
         // which produces a framework for dynamic package products.
         if modulesPath.extension == "framework" {
-            cmd += ["-I", modulesPath.parentDirectory.parentDirectory.pathString]
+            if modulesPath.parentDirectory.basename == "ManifestAPI" {
+                // If the framework is linked into a toolchain, the swiftmodule is here
+                cmd += ["-I", modulesPath.parentDirectory.pathString]
+            } else {
+                cmd += ["-I", modulesPath.parentDirectory.parentDirectory.pathString]
+            }
         } else {
             cmd += ["-I", modulesPath.pathString]
         }

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -1039,15 +1039,22 @@ public final class UserToolchain: Toolchain {
             }
 
             // this tests if we are debugging / testing SwiftPM with Xcode
-            let manifestFrameworksPath = applicationPath.appending(
-                components: "PackageFrameworks",
-                "PackageDescription.framework"
-            )
+            let manifestFrameworksPath = applicationPath.appending(components: "PackageFrameworks", "PackageDescription.framework")
             let pluginFrameworksPath = applicationPath.appending(components: "PackageFrameworks", "PackagePlugin.framework")
             if fileSystem.exists(manifestFrameworksPath), fileSystem.exists(pluginFrameworksPath) {
                 return .init(
                     manifestLibraryPath: manifestFrameworksPath,
                     pluginLibraryPath: pluginFrameworksPath
+                )
+            }
+
+            // The frameworks may also appear at the root of the applicationPath
+            let manifestFrameworksRootPath = applicationPath.appending("PackageDescription.framework")
+            let pluginFrameworksRootPath = applicationPath.appending("PackagePlugin.framework")
+            if fileSystem.exists(manifestFrameworksRootPath), fileSystem.exists(pluginFrameworksRootPath) {
+                return .init(
+                    manifestLibraryPath: manifestFrameworksRootPath,
+                    pluginLibraryPath: pluginFrameworksRootPath
                 )
             }
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -1026,6 +1026,15 @@ public final class UserToolchain: Toolchain {
             // this is the normal case when using the toolchain
             let librariesPath = applicationPath.parentDirectory.appending(components: "lib", "swift", "pm")
             if fileSystem.exists(librariesPath) {
+                // Check if we have frameworks there and hook them up
+                let manifestFrameworksPath = librariesPath.appending(components: "ManifestAPI", "PackageDescription.framework")
+                let pluginFrameworksPath = librariesPath.appending(components: "PluginAPI", "PackagePlugin.framework")
+                if fileSystem.exists(manifestFrameworksPath), fileSystem.exists(pluginFrameworksPath) {
+                    return .init(
+                        manifestLibraryPath: manifestFrameworksPath,
+                        pluginLibraryPath: pluginFrameworksPath
+                    )
+                }
                 return .init(root: librariesPath)
             }
 

--- a/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
@@ -138,12 +138,19 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
         // which produces a framework for dynamic package products.
         if pluginLibraryPath.extension == "framework" {
+            let parent = pluginLibraryPath.parentDirectory
             commandLine += [
-                "-I", pluginLibraryPath.parentDirectory.pathString,
-                "-F", pluginLibraryPath.parentDirectory.pathString,
+                "-F", parent.pathString,
                 "-framework", "PackagePlugin",
-                "-Xlinker", "-rpath", "-Xlinker", pluginLibraryPath.parentDirectory.pathString,
+                "-Xlinker", "-rpath", "-Xlinker", parent.pathString,
             ]
+
+            // Make sure we can find the swiftmodule
+            if parent.basename == "PackageFrameworks" {
+                commandLine += ["-I", parent.parentDirectory.pathString]
+            } else {
+                commandLine += ["-I", parent.pathString]
+            }
         } else {
             commandLine += [
                 "-L", pluginLibraryPath.pathString,

--- a/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
@@ -139,6 +139,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         // which produces a framework for dynamic package products.
         if pluginLibraryPath.extension == "framework" {
             commandLine += [
+                "-I", pluginLibraryPath.parentDirectory.pathString,
                 "-F", pluginLibraryPath.parentDirectory.pathString,
                 "-framework", "PackagePlugin",
                 "-Xlinker", "-rpath", "-Xlinker", pluginLibraryPath.parentDirectory.pathString,

--- a/Utilities/mk-toolchain/README.md
+++ b/Utilities/mk-toolchain/README.md
@@ -1,0 +1,63 @@
+# Testing Manifest and Plugin API changes
+
+To test the ergonomics of package manifest or plugin API changes while making them, the best approach would be to create an example package that exercises the features and live it in VSCode Swift. To do that, you need to create a custom toolchain and link over the build artifacts from the build output of the development workspace. This document describes how to do that on MacOS when using Xcode. Contributions would be appreciated for similar tools for the the other host platforms.
+
+## Set up the workspace
+
+Prepare the three main repos that SwiftPM developers use into the same directory.
+
+```
+git clone https://github.com/swiftlang/swift-build
+git clone https://github.com/swiftlang/swift-package-manager
+git clone https://github.com/swiftlang/sourcekit-lsp
+```
+
+In that directory, also create an xcworkspace directory, e.g. `myNewFeature.xcworkspace`. In that directory create a `contents.xcworkspacedata` file with the following contents.
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:swift-build">
+   </FileRef>
+   <FileRef
+      location = "group:swift-package-manager">
+   </FileRef>
+   <FileRef
+      location = "group:sourcekit-lsp">
+   </FileRef>
+</Workspace>
+```
+
+Open the xcworkspace file in Xcode. Create a scheme to build the necessary components for the toolchain and add the following targets into the Build section of that scheme:
+
+```
+PackageDescription
+PackagePlugin
+swift-package
+swift-build
+swift-test
+swiftpm-testing-helper
+sourcekit-lsp
+```
+
+Build the scheme to produce the artifacts and then run the `mk-toolchain` script in this directory from the directory containing the git repos and the xcworkspace file. This script creates a copy of the XcodeDefault.xctoolchain from the currently xcode-selected Xcode. It locates the derived data for the workspace and overwrites the files in the toolchain copy with soft links over to the build artifacts above.
+
+Make sure you recreate the toolchain every time your Xcode updates to ensure you are using the same version of the toolchain and SDK files.
+
+To test this new toolchain, create a new plugin package in a new directory.
+
+```
+swift package init --type build-tool-plugin
+```
+
+Open VSCode in that directory pointing the TOOLCHAINS environment variable at the name you selected for your xcworkspace.
+
+```
+TOOLCHAINS=myNewFeature code .
+```
+
+Make sure that VSCode is able to resolve the package. Execute a build on the package and make sure that succeeds. Add some tests and ensure the tests are detected and run. In the Package.swift file and start to add a new target and make sure you get content assist that shows you the different target functions. Do the same for the plugin Swift file by trying content assist on the `context` and `target` parameters of the `createBuildCommands` function.
+
+If all those succeed, you have a working toolchain and an environment with which to test your changes.

--- a/Utilities/mk-toolchain/mk-toolchain
+++ b/Utilities/mk-toolchain/mk-toolchain
@@ -3,7 +3,7 @@
 #
 # This source file is part of the Swift open source project
 #
-# Copyright (c) 2025 Apple Inc. and the Swift project authors
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information

--- a/Utilities/mk-toolchain/mk-toolchain
+++ b/Utilities/mk-toolchain/mk-toolchain
@@ -1,3 +1,16 @@
+#!/bin/zsh
+# ===----------------------------------------------------------------------===##
+#
+# This source file is part of the Swift open source project
+#
+# Copyright (c) 2025 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===----------------------------------------------------------------------===##
+
 name=$(basename *.xcworkspace .xcworkspace)
 src=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
 dest=~/Library/Developer/Toolchains/${name}.xctoolchain

--- a/Utilities/mk-toolchain/mk-toolchain
+++ b/Utilities/mk-toolchain/mk-toolchain
@@ -1,0 +1,81 @@
+name=$(basename *.xcworkspace .xcworkspace)
+src=$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain
+dest=~/Library/Developer/Toolchains/${name}.xctoolchain
+#derivedData=~/Library/Developer/Xcode/DerivedData/${name}-*/Build/Products/Debug
+derivedData=~/Library/Developer/Xcode/DerivedData/${name}-*/Build/Intermediates.noindex/InstallIntermediates/macosx/Products/Debug
+
+if [ -z "$derivedData" ]; then
+   echo run from the directory containing the xcworkspace
+   exit 1
+fi
+
+if [ ! -d $src ]; then
+   echo Source toolchain not found: $src
+   exit 1
+fi
+
+if [ ! -d $derivedData ]; then
+   echo Derived data not found: $derivedData
+   exit 1
+fi
+
+echo Creating $name.xctoolchain
+
+rm -fr $dest
+ditto $src $dest
+chmod -R -N $dest
+
+ditto $src/../../../SharedFrameworks/llbuild.framework $dest/usr/lib/swift/pm/llbuild/llbuild.framework
+
+for bin in swift-package swift-build swift-test sourcekit-lsp; do
+    ln -sf $derivedData/$bin $dest/usr/bin
+done
+
+rm -fr $dest/usr/lib/swift/pm/ManifestAPI/*
+ln -sf $derivedData/CompilerPluginSupport.swiftmodule $dest/usr/lib/swift/pm/ManifestAPI
+ln -sf $derivedData/PackageDescription.swiftmodule $dest/usr/lib/swift/pm/ManifestAPI
+ln -sf $derivedData/PackageDescription.framework $dest/usr/lib/swift/pm/ManifestAPI
+
+rm -fr $dest/usr/lib/swift/pm/PluginAPI/*
+ln -sf $derivedData/PackagePlugin.swiftmodule $dest/usr/lib/swift/pm/PluginAPI
+ln -sf $derivedData/PackagePlugin.framework $dest/usr/lib/swift/pm/PluginAPI
+
+rm $dest/ToolchainInfo.plist
+cat >$dest/Info.plist <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>Aliases</key>
+        <array>
+                <string>swift</string>
+        </array>
+        <key>CFBundleIdentifier</key>
+        <string>$name</string>
+        <key>CompatibilityVersion</key>
+        <integer>2</integer>
+        <key>CreatedDate</key>
+        <date>2026-06-16T03:23:00Z</date>
+        <key>DisplayName</key>
+        <string>Swift Development Snapshot 2026-06-15 (a)</string>
+        <key>OverrideBuildSettings</key>
+        <dict>
+                <key>OTHER_SWIFT_FLAGS</key>
+                <string>\$(inherited) -plugin-path \$(TOOLCHAIN_DIR)/usr/lib/swift/host/plugins</string>
+                <key>SWIFT_DEVELOPMENT_TOOLCHAIN</key>
+                <string>YES</string>
+                <key>SWIFT_USE_DEVELOPMENT_TOOLCHAIN_RUNTIME</key>
+                <string>YES</string>
+        </dict>
+        <key>ReportProblemURL</key>
+        <string>https://bugs.swift.org/</string>
+        <key>ShortDisplayName</key>
+        <string>Swift Development Snapshot</string>
+        <key>Version</key>
+        <string>6.4.20260615101</string>
+</dict>
+</plist>
+EOF
+
+TOOLCHAINS=$name swift --version
+TOOLCHAINS=$name swift build --version


### PR DESCRIPTION
As we start working on extending the package manifest and plugin APIs, we need to work in a development environment that brings together SwiftPM, swift-build, and sourcekit-lsp into a single Xcode workspace. This changes the derived data layout when looking for the PackageDescription and PackagePlugin frameworks.

Also to properly support sourcekit-lsp, you need to create a toolchain that links in the build artifacts which includes both the framework and swiftmodule for these libraries into ManifestAPI and PluginAPI folders.

This patch looks for this new layout and hooks up the include and framework paths to properly find things. Tested in VSCode which launches sourcekit-lsp and swift-package and both are now finding the frameworks and properly interpreting package manifests and plugin scripts.

To reproduce, checkout the three repos next to each other, create an `<something>.xcworkspace` directory next to them which contains the `contents.xcworkspacedata` file containing:

```
<?xml version="1.0" encoding="UTF-8"?>
<Workspace
   version = "1.0">
   <FileRef
      location = "group:swift-build">
   </FileRef>
   <FileRef
      location = "group:swift-package-manager">
   </FileRef>
   <FileRef
      location = "group:sourcekit-lsp">
   </FileRef>
</Workspace>
```