### PR TITLE
Respect product filters when selecting SwiftSyntax prebuilts

### DIFF
--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -905,8 +905,8 @@ private func handlePrebuilts(packageBuilders: [ResolvedPackageBuilder], root: Pa
     }
 
     // First decorate the platform constraints from products in the root packages
-    for packageBuilder in packageBuilders where root.isExporting(packageBuilder.package.identity) {
-        for productBuilder in packageBuilder.products {
+    for packageBuilder in packageBuilders {
+        for productBuilder in packageBuilder.products where root.isExporting(packageBuilder.package.identity, product: productBuilder.product.name) {
             for moduleBuilder in productBuilder.moduleBuilders {
                 func markExternal(_ depModule: ResolvedModuleBuilder) {
                     guard depModule.platformConstraint != .all else {

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -78,9 +78,10 @@ public struct PackageGraphRoot {
         }
     }
 
-    /// Whether a package is exporting out the root, i.e. a root package or a root dependency
-    public func isExporting(_ identity: PackageIdentity) -> Bool{
-        return packages[identity] != nil || dependencies.contains(where: { $0.identity == identity })
+    /// Whether a package's product is exporting out the root, i.e. a product of a root package
+    /// or a product included in a root dependency's product filter
+    public func isExporting(_ identity: PackageIdentity, product: String) -> Bool {
+        return packages[identity] != nil || dependencies.contains(where: { $0.identity == identity && $0.productFilter.contains(product) })
     }
 
     private let dependencyMapper: DependencyMapper?

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -610,6 +610,7 @@ public final class MockWorkspace {
     public func checkPackageGraph(
         roots: [String] = [],
         dependencies: [PackageDependency] = [],
+        explicitProduct: String? = nil,
         forceResolvedVersions: Bool = false,
         expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
         _ result: (ModulesGraph, [Basics.Diagnostic]) throws -> Void
@@ -622,6 +623,7 @@ public final class MockWorkspace {
         do {
             let graph = try await workspace.loadPackageGraph(
                 rootInput: rootInput,
+                explicitProduct: explicitProduct,
                 forceResolvedVersions: forceResolvedVersions,
                 expectedSigningEntities: expectedSigningEntities,
                 observabilityScope: observability.topScope


### PR DESCRIPTION
Check whether a package’s product filter contains a product before marking it as exported.

### Motivation:

This change attempts to fix the long build times I was experiencing while using --enable-experimental-prebuilts and building a specific product. When doing this, Swift Package Manager builds Swift Syntax from source instead of using a prebuilt.

### Modifications:

I have updated `isExporting` so products from root dependencies are marked as exported only when included in the dependency’s product filter.

### Result:

This will allow Swift Syntax prebuilts and any future prebuilt libraries to be used instead of built from source when building a specific product.

Fixes #10366 