### PR TITLE
Adopt Mutex in the pending lookup managers

### DIFF
--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -16,6 +16,7 @@ import Dispatch
 import Foundation
 import PackageLoading
 import PackageModel
+import Synchronization
 import TSCBasic
 
 import struct TSCUtility.Version
@@ -34,8 +35,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
         let version: Version
     }
 
-    private var pendingLookups = [PackageLookup: Task<Basics.AbsolutePath, Error>]()
-    private var pendingLookupsLock = NSLock()
+    private let pendingLookups = Mutex<[PackageLookup: Task<Basics.AbsolutePath, Error>]>([:])
 
     public init(
         fileSystem: FileSystem,
@@ -70,44 +70,43 @@ public class RegistryDownloadsManager: AsyncCancellable {
 
         let lookupId = PackageLookup(package: package, version: version)
         let task = await withCheckedContinuation { continuation in
-            self.pendingLookupsLock.lock()
-            defer { self.pendingLookupsLock.unlock() }
+            self.pendingLookups.withLock { pendingLookups in
+                // Check if we've already resolved/are in the process of resolving for this package.
+                if let inFlight = pendingLookups[lookupId] {
+                    continuation.resume(returning: inFlight)
+                } else {
+                    let lookupTask = Task {
+                        // inform delegate that we are starting to fetch
+                        // calculate if cached (for delegate call) outside queue as it may change while queue is processing
+                        let isCached = self.cachePath.map { self.fileSystem.exists($0.appending(packageRelativePath)) } ?? false
+                        let details = FetchDetails(fromCache: isCached, updatedCache: false)
+                        delegate?.emit { $0.willFetch(package: package, version: version, fetchDetails: details) }
 
-            // Check if we've already resolved/are in the process of resolving for this package.
-            if let inFlight = self.pendingLookups[lookupId] {
-                continuation.resume(returning: inFlight)
-            } else {
-                let lookupTask = Task {
-                    // inform delegate that we are starting to fetch
-                    // calculate if cached (for delegate call) outside queue as it may change while queue is processing
-                    let isCached = self.cachePath.map { self.fileSystem.exists($0.appending(packageRelativePath)) } ?? false
-                    let details = FetchDetails(fromCache: isCached, updatedCache: false)
-                    delegate?.emit { $0.willFetch(package: package, version: version, fetchDetails: details) }
+                        // make sure destination is free.
+                        try? self.fileSystem.removeFileTree(packagePath)
 
-                    // make sure destination is free.
-                    try? self.fileSystem.removeFileTree(packagePath)
-
-                    let start = DispatchTime.now()
-                    do {
-                        let result = try await self.downloadAndPopulateCache(
-                            package: package,
-                            version: version,
-                            packagePath: packagePath,
-                            observabilityScope: observabilityScope
-                        )
-                        // inform delegate that we finished to fetch
-                        let duration = start.distance(to: .now())
-                        delegate?.emit { $0.didFetch(package: package, version: version, result: .success(result), duration: duration) }
-                    } catch {
-                        let duration = start.distance(to: .now())
-                        delegate?.emit { $0.didFetch(package: package, version: version, result: .failure(error), duration: duration) }
-                        throw error
+                        let start = DispatchTime.now()
+                        do {
+                            let result = try await self.downloadAndPopulateCache(
+                                package: package,
+                                version: version,
+                                packagePath: packagePath,
+                                observabilityScope: observabilityScope
+                            )
+                            // inform delegate that we finished to fetch
+                            let duration = start.distance(to: .now())
+                            delegate?.emit { $0.didFetch(package: package, version: version, result: .success(result), duration: duration) }
+                        } catch {
+                            let duration = start.distance(to: .now())
+                            delegate?.emit { $0.didFetch(package: package, version: version, result: .failure(error), duration: duration) }
+                            throw error
+                        }
+                        return packagePath
                     }
-                    return packagePath
-                }
 
-                self.pendingLookups[lookupId] = lookupTask
-                continuation.resume(returning: lookupTask)
+                    pendingLookups[lookupId] = lookupTask
+                    continuation.resume(returning: lookupTask)
+                }
             }
         }
         return try await task.value
@@ -245,7 +244,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
     public func remove(package: PackageIdentity) throws {
         let relativePath = try package.downloadPath()
         let packagesPath = self.path.appending(relativePath)
-        self.pendingLookups.removeValue(forPackage: package)
+        self.pendingLookups.withLock { $0.removeValue(forPackage: package) }
         try self.fileSystem.removeFileTree(packagesPath)
     }
 

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -15,6 +15,7 @@ import _Concurrency
 import Dispatch
 import Foundation
 import PackageModel
+import Synchronization
 import TSCBasic
 
 /// Manages a collection of bare repositories.
@@ -43,8 +44,7 @@ public class RepositoryManager: Cancellable {
     // repository can be de-duped. Each entry is tagged with a unique id so that
     // a completing lookup only removes its own entry and never a newer one for
     // the same repository.
-    private var pendingLookups = [RepositorySpecifier: (id: UUID, task: Task<RepositoryManager.RepositoryHandle, Error>)]()
-    private var pendingLookupsLock = NSLock()
+    private let pendingLookups = Mutex<[RepositorySpecifier: (id: UUID, task: Task<RepositoryManager.RepositoryHandle, Error>)]>([:])
 
     // Limits how many concurrent operations can be performed at once.
     private let asyncOperationQueue: AsyncOperationQueue
@@ -131,43 +131,42 @@ public class RepositoryManager: Cancellable {
     ) async throws -> RepositoryHandle {
         return try await self.asyncOperationQueue.withOperation {
             let task = await withCheckedContinuation { continuation in
-                self.pendingLookupsLock.lock()
-                defer { self.pendingLookupsLock.unlock() }
+                self.pendingLookups.withLock { pendingLookups in
+                    // Identifies this lookup so that, on completion, it only removes
+                    // its own entry from `pendingLookups`.
+                    let lookupID = UUID()
+                    let inFlight = pendingLookups[repositorySpecifier]?.task
 
-                // Identifies this lookup so that, on completion, it only removes
-                // its own entry from `pendingLookups`.
-                let lookupID = UUID()
-                let inFlight = self.pendingLookups[repositorySpecifier]?.task
+                    // Serialize lookups per repository, but each caller runs its own `performLookup` to honor its own `updateStrategy`.
+                    let lookupTask = Task { () throws -> RepositoryManager.RepositoryHandle in
+                        defer { self.removePendingLookup(for: repositorySpecifier, id: lookupID) }
 
-                // Serialize lookups per repository, but each caller runs its own `performLookup` to honor its own `updateStrategy`.
-                let lookupTask = Task { () throws -> RepositoryManager.RepositoryHandle in
-                    defer { self.removePendingLookup(for: repositorySpecifier, id: lookupID) }
+                        // Let the existing in-flight task finish before queuing up the new one
+                        if let inFlight {
+                            _ = try? await inFlight.value
+                        }
 
-                    // Let the existing in-flight task finish before queuing up the new one
-                    if let inFlight {
-                        _ = try? await inFlight.value
+                        if Task.isCancelled {
+                            throw CancellationError()
+                        }
+
+                        let result = try await self.performLookup(
+                            package: package,
+                            repository: repositorySpecifier,
+                            updateStrategy: updateStrategy,
+                            observabilityScope: observabilityScope
+                        )
+
+                        if Task.isCancelled {
+                            throw CancellationError()
+                        }
+
+                        return result
                     }
 
-                    if Task.isCancelled {
-                        throw CancellationError()
-                    }
-
-                    let result = try await self.performLookup(
-                        package: package,
-                        repository: repositorySpecifier,
-                        updateStrategy: updateStrategy,
-                        observabilityScope: observabilityScope
-                    )
-
-                    if Task.isCancelled {
-                        throw CancellationError()
-                    }
-
-                    return result
+                    pendingLookups[repositorySpecifier] = (id: lookupID, task: lookupTask)
+                    continuation.resume(returning: lookupTask)
                 }
-
-                self.pendingLookups[repositorySpecifier] = (id: lookupID, task: lookupTask)
-                continuation.resume(returning: lookupTask)
             }
 
             return try await task.value
@@ -178,10 +177,10 @@ public class RepositoryManager: Cancellable {
     /// if it is still the lookup identified by `id`. A newer in-flight lookup for
     /// the same repository is left in place.
     private func removePendingLookup(for repositorySpecifier: RepositorySpecifier, id: UUID) {
-        self.pendingLookupsLock.lock()
-        defer { self.pendingLookupsLock.unlock() }
-        if self.pendingLookups[repositorySpecifier]?.id == id {
-            self.pendingLookups[repositorySpecifier] = nil
+        self.pendingLookups.withLock { pendingLookups in
+            if pendingLookups[repositorySpecifier]?.id == id {
+                pendingLookups[repositorySpecifier] = nil
+            }
         }
     }
 
@@ -255,12 +254,12 @@ public class RepositoryManager: Cancellable {
         // ask the provider to cancel
         try self.provider.cancel(deadline: deadline)
 
-        self.pendingLookupsLock.lock()
-        defer { self.pendingLookupsLock.unlock() }
-        for entry in self.pendingLookups.values {
-            entry.task.cancel()
+        self.pendingLookups.withLock { pendingLookups in
+            for entry in pendingLookups.values {
+                entry.task.cancel()
+            }
+            pendingLookups = [:]
         }
-        self.pendingLookups = [:]
     }
 
     /// Fetches the repository into the cache. If no `cachePath` is set or an error occurred fall back to fetching the repository without populating the cache.


### PR DESCRIPTION
`RepositoryManager` and `RegistryDownloadsManager` each track in-flight lookups in a dictionary guarded by a hand-managed `NSLock`: `lock()` followed by a `defer` to unlock. Move both dictionaries inside a `Mutex` so the state can't be reached without holding the lock.

This actually caught a bug in `RegistryDownloadsManager` where `remove(package:)` mutated `pendingLookups` without taking the lock at all. Now there is no way to acces `pendingLookups` without going through `withLock`, so the race is eliminated. 
