### PR TITLE
Fix implicit default trait requests and persist new enabled traits in resolution

### DIFF
--- a/Sources/Basics/Collections/IdentifiableSet.swift
+++ b/Sources/Basics/Collections/IdentifiableSet.swift
@@ -13,7 +13,7 @@
 import struct OrderedCollections.OrderedDictionary
 
 /// Replacement for `Set` elements that can't be `Hashable`, but can be `Identifiable`.
-public struct IdentifiableSet<Element: Identifiable>: Collection {
+public struct IdentifiableSet<Element: Identifiable & Sendable>: Collection, Sendable where Element.ID: Sendable {
     public init() {
         self.storage = [:]
     }

--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -39,17 +39,24 @@ extension Manifest {
         productFilter: ProductFilter,
         _ enabledTraits: EnabledTraits = ["default"]
     ) throws -> [PackageContainerConstraint] {
-        return try self.dependenciesRequired(for: productFilter, enabledTraits).map({
-            let explicitlyEnabledTraits = $0.traits?.filter {
-                guard let condition = $0.condition else { return true }
-                return condition.isSatisfied(by: enabledTraits.names)
-            }.map(\.name)
-            let enabledTraitsSet = EnabledTraits(explicitlyEnabledTraits ?? [], setBy: .package(.init(identity: self.packageIdentity, name: self.displayName)))
+        return try self.dependenciesRequired(for: productFilter, enabledTraits).map({ dependency in
+            let setter: EnabledTrait.Setter = .package(.init(identity: self.packageIdentity, name: self.displayName))
+            let enabledTraitsSet: EnabledTraits
+            if let dependencyTraits = dependency.traits {
+                let explicitlyEnabledTraits = dependencyTraits.filter {
+                    guard let condition = $0.condition else { return true }
+                    return condition.isSatisfied(by: enabledTraits.names)
+                }.map(\.name)
+                enabledTraitsSet = EnabledTraits(explicitlyEnabledTraits, setBy: setter)
+            } else {
+                // Implicit default traits requested by parent.
+                enabledTraitsSet = EnabledTraits(["default"], setBy: setter)
+            }
 
             return PackageContainerConstraint(
-                package: $0.packageRef,
-                requirement: try $0.toConstraintRequirement(),
-                products: $0.productFilter,
+                package: dependency.packageRef,
+                requirement: try dependency.toConstraintRequirement(),
+                products: dependency.productFilter,
                 enabledTraits: enabledTraitsSet
             )
         })

--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -44,7 +44,6 @@ extension Manifest {
                 guard let condition = $0.condition else { return true }
                 return condition.isSatisfied(by: enabledTraits.names)
             }.map(\.name)
-
             let enabledTraitsSet = EnabledTraits(explicitlyEnabledTraits ?? [], setBy: .package(.init(identity: self.packageIdentity, name: self.displayName)))
 
             return PackageContainerConstraint(

--- a/Sources/PackageGraph/Resolution/DependencyResolutionNode.swift
+++ b/Sources/PackageGraph/Resolution/DependencyResolutionNode.swift
@@ -100,22 +100,6 @@ public enum DependencyResolutionNode {
         }
     }
 
-    /// Returns a node identical to this one but carrying a different `enabledTraits` payload.
-    /// Used to query a package's dependencies using its true, unified enabled traits (e.g.
-    /// `PubGrubDependencyResolver.State`'s own accumulated `EnabledTraitsMap`) without
-    /// mutating the original node, which still needs to reflect exactly what its originating parent declared
-    /// for provenance/diagnostics purposes.
-    func withEnabledTraits(_ enabledTraits: EnabledTraits) -> DependencyResolutionNode {
-        switch self {
-        case .empty:
-            return self
-        case .product(let product, let package, _):
-            return .product(product, package: package, enabledTraits: enabledTraits)
-        case .root(let package, _):
-            return .root(package: package, enabledTraits: enabledTraits)
-        }
-    }
-
     /// Returns the dependency that a product has on its own package, if relevant.
     ///
     /// This is the constraint that requires all products from a package resolve to the same version.

--- a/Sources/PackageGraph/Resolution/DependencyResolutionNode.swift
+++ b/Sources/PackageGraph/Resolution/DependencyResolutionNode.swift
@@ -100,6 +100,22 @@ public enum DependencyResolutionNode {
         }
     }
 
+    /// Returns a node identical to this one but carrying a different `enabledTraits` payload.
+    /// Used to query a package's dependencies using its true, unified enabled traits (e.g.
+    /// `PubGrubDependencyResolver.State`'s own accumulated `EnabledTraitsMap`) without
+    /// mutating the original node, which still needs to reflect exactly what its originating parent declared
+    /// for provenance/diagnostics purposes.
+    func withEnabledTraits(_ enabledTraits: EnabledTraits) -> DependencyResolutionNode {
+        switch self {
+        case .empty:
+            return self
+        case .product(let product, let package, _):
+            return .product(product, package: package, enabledTraits: enabledTraits)
+        case .root(let package, _):
+            return .root(package: package, enabledTraits: enabledTraits)
+        }
+    }
+
     /// Returns the dependency that a product has on its own package, if relevant.
     ///
     /// This is the constraint that requires all products from a package resolve to the same version.

--- a/Sources/PackageGraph/Resolution/PubGrub/PartialSolution.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PartialSolution.swift
@@ -14,6 +14,7 @@ import Basics
 import OrderedCollections
 
 import struct TSCUtility.Version
+import struct PackageModel.PackageIdentity
 
 /// The partial solution is a constantly updated solution used throughout the
 /// dependency resolution process, tracking known assignments.
@@ -68,6 +69,11 @@ public struct PartialSolution {
         let decision = Assignment.decision(term, decisionLevel: self.decisionLevel)
         self.assignments.append(decision)
         self.register(decision)
+    }
+
+    /// Returns the decisions made for a given package identity.
+    public func decisions(for packageIdentity: PackageIdentity) -> [DependencyResolutionNode] {
+        self.decisions.keys.filter({ $0.package.identity == packageIdentity })
     }
 
     /// Populates the _positive and _negative properties with the assignment.

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -39,6 +39,13 @@ public struct PubGrubDependencyResolver {
         /// refer to. This means an incompatibility can occur several times.
         public private(set) var incompatibilities: [DependencyResolutionNode: [Incompatibility]] = [:]
 
+        /// The resolver's own accumulated view of enabled traits per package, fed incrementally by
+        /// `addIncompatibility` as the resolver itself discovers each parent's request. A single
+        /// `DependencyResolutionNode` only ever carries whichever parent edge constructed it,
+        /// namely the traits that parent enabled on the dependency; this map represents the unified
+        /// trait enablement for a given package.
+        private var enabledTraitsMap = EnabledTraitsMap()
+
         /// The current best guess for a solution satisfying all requirements.
         public private(set) var solution: PartialSolution
 
@@ -55,7 +62,10 @@ public struct PubGrubDependencyResolver {
 
         func addIncompatibility(_ incompatibility: Incompatibility, at location: LogLocation) {
             self.lock.withLock {
-                // log("incompat: \(incompatibility) \(location)")
+                for term in incompatibility.terms {
+                    let identity = term.node.package.identity
+                    self.enabledTraitsMap[identity] = term.node.enabledTraits
+                }
                 for package in incompatibility.terms.map(\.node) {
                     if let incompats = self.incompatibilities[package] {
                         if !incompats.contains(incompatibility) {
@@ -77,6 +87,15 @@ public struct PubGrubDependencyResolver {
                 return all.filter {
                     $0.terms.first { $0.node == node }!.isPositive
                 }
+            }
+        }
+
+        /// Returns this package's true, unified enabled traits, as accumulated from every
+        /// incompatibility seen so far (i.e. as new levels in the package dependency graph are
+        /// discovered and loaded).
+        func enabledTraits(for node: DependencyResolutionNode) -> EnabledTraits {
+            self.lock.withLock {
+                self.enabledTraitsMap[node.package.identity]
             }
         }
 
@@ -750,9 +769,12 @@ public struct PubGrubDependencyResolver {
         }
 
         // Add all of this version's dependencies as incompatibilities.
+        // Query the resolver's own accumulated enabled-traits map rather than trusting
+        // pkgTerm.node's own value alone.
+        let queryNode = pkgTerm.node.withEnabledTraits(state.enabledTraits(for: pkgTerm.node))
         let depIncompatibilities = try await container.incompatibilites(
             at: version,
-            node: pkgTerm.node,
+            node: queryNode,
             overriddenPackages: state.overriddenPackages,
             root: state.root
         )

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -46,6 +46,11 @@ public struct PubGrubDependencyResolver {
         /// trait enablement for a given package.
         private var enabledTraitsMap = EnabledTraitsMap()
 
+        /// Already-decided packages whose `enabledTraitsMap` entry changed *after* they were
+        /// decided - detected inline in `addIncompatibility`, the instant a new request for an
+        /// already-decided package's traits arrives.
+        public var decisionsToRepair: Set<DependencyResolutionNode> = []
+
         /// The current best guess for a solution satisfying all requirements.
         public private(set) var solution: PartialSolution
 
@@ -62,11 +67,21 @@ public struct PubGrubDependencyResolver {
 
         func addIncompatibility(_ incompatibility: Incompatibility, at location: LogLocation) {
             self.lock.withLock {
-                for term in incompatibility.terms {
-                    let identity = term.node.package.identity
-                    self.enabledTraitsMap[identity] = term.node.enabledTraits
-                }
                 for package in incompatibility.terms.map(\.node) {
+                    // Pre-resolution computation ensures we already handled root package dependency requests,
+                    // and therefore should not need repairs.
+                    if !package.package.kind.isRoot {
+                        let identity = package.package.identity
+                        let previousDecisionEnabledTraits = self.enabledTraitsMap[identity]
+                        self.enabledTraitsMap[identity] = package.enabledTraits
+                        // If a decision has already been made for this package but a change in enabled traits
+                        // is detected, flag it so the resolver can repair the shape of the package graph below
+                        // it (if applicable due to trait-guarded dependencies).
+                        if !package.enabledTraits.isSubset(of: previousDecisionEnabledTraits)
+                        {
+                            self.decisionsToRepair.formUnion(self.solution.decisions(for: identity))
+                        }
+                    }
                     if let incompats = self.incompatibilities[package] {
                         if !incompats.contains(incompatibility) {
                             self.incompatibilities[package]!.append(incompatibility)
@@ -533,7 +548,26 @@ public struct PubGrubDependencyResolver {
 
             // If decision making determines that no more decisions are to be
             // made, it returns nil to signal that version solving is done.
-            next = try await self.makeDecision(state: state)
+
+            // Ensure that decisions that need repairing are prioritized.
+            if let repairNode = state.decisionsToRepair.popFirst(),
+               let version = state.solution.decisions[repairNode] {
+                next = repairNode
+                // Update incompatibilities for this node.
+                let container = try self.provider.getCachedContainer(for: repairNode.package)
+                let incompatibilities = try await container.incompatibilites(
+                    at: version,
+                    node: repairNode,
+                    overriddenPackages: state.overriddenPackages,
+                    root: state.root,
+                    enabledTraits: state.enabledTraits(for: repairNode)
+                )
+                for incompatibility in incompatibilities {
+                    state.addIncompatibility(incompatibility, at: .decisionMaking)
+                }
+            } else {
+                next = try await self.makeDecision(state: state)
+            }
         }
     }
 
@@ -769,14 +803,12 @@ public struct PubGrubDependencyResolver {
         }
 
         // Add all of this version's dependencies as incompatibilities.
-        // Query the resolver's own accumulated enabled-traits map rather than trusting
-        // pkgTerm.node's own value alone.
-        let queryNode = pkgTerm.node.withEnabledTraits(state.enabledTraits(for: pkgTerm.node))
         let depIncompatibilities = try await container.incompatibilites(
             at: version,
-            node: queryNode,
+            node: pkgTerm.node,
             overriddenPackages: state.overriddenPackages,
-            root: state.root
+            root: state.root,
+            enabledTraits: state.enabledTraits(for: pkgTerm.node)
         )
 
         var haveConflict = false

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
@@ -154,7 +154,8 @@ final class PubGrubPackageContainer {
         at version: Version,
         node: DependencyResolutionNode,
         overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)],
-        root: DependencyResolutionNode
+        root: DependencyResolutionNode,
+        enabledTraits: EnabledTraits? = nil
     ) async throws -> [Incompatibility] {
         // FIXME: It would be nice to compute bounds for this as well.
         if await !self.underlying.isToolsVersionCompatible(at: version) {
@@ -170,7 +171,7 @@ final class PubGrubPackageContainer {
         var unprocessedDependencies = try await self.underlying.getDependencies(
             at: version,
             productFilter: node.productFilter,
-            node.enabledTraits
+            enabledTraits ?? node.enabledTraits
         )
         if let sharedVersion = node.versionLock(version: version) {
             unprocessedDependencies.append(sharedVersion)

--- a/Sources/PackageModel/EnabledTrait.swift
+++ b/Sources/PackageModel/EnabledTrait.swift
@@ -393,7 +393,7 @@ extension EnabledTraitsMap: ExpressibleByDictionaryLiteral {
 /// convenience. When unifying two `EnabledTrait`s, it will combine the list of setters if the `name`s match. This is assuming
 /// that an `EnabledTrait` is correctly associated with the same `PackageIdentity` in the `EnabledTraitsMap`.
 ///
-public struct EnabledTrait: Identifiable {
+public struct EnabledTrait: Identifiable, Sendable {
     /// Convenience typealias for a list of `Setter`
     public typealias Setters = Set<Setter>
 
@@ -450,7 +450,7 @@ public struct EnabledTrait: Identifiable {
 
 extension EnabledTrait {
     /// An enumeration that describes how a given trait was set as enabled.
-    public enum Setter: Hashable, CustomStringConvertible {
+    public enum Setter: Hashable, CustomStringConvertible, Sendable {
         case traitConfiguration
         case package(Manifest.PackageIdentifier)
         case trait(String)
@@ -546,7 +546,7 @@ extension EnabledTrait: ExpressibleByStringLiteral {
 /// An `EnabledTraits` instance can represent a "disabled" state when created with an empty collection
 /// and a `Setter`. In this case, the `disabledBy` property returns the setter that disabled default traits,
 /// allowing callers to track which parent package or configuration explicitly disabled default traits for a package.
-public struct EnabledTraits: Hashable {
+public struct EnabledTraits: Hashable, Sendable {
     public typealias Element = EnabledTrait
     public typealias Index = IdentifiableSet<Element>.Index
 
@@ -608,6 +608,10 @@ public struct EnabledTraits: Hashable {
 
     public static func ==(_ lhs: EnabledTraits, _ rhs: EnabledTraits) -> Bool {
         lhs._traits.names == rhs._traits.names
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self._traits.names)
     }
 }
 

--- a/Sources/PackageModel/EnabledTrait.swift
+++ b/Sources/PackageModel/EnabledTrait.swift
@@ -48,6 +48,14 @@ import struct TSCUtility.Version
 /// Only packages (via `Setter.package`) and trait configurations (via `Setter.traitConfiguration`)
 /// can disable default traits. Traits themselves cannot disable other packages' default traits.
 ///
+/// Disablers, default-setters (below), and explicitly-named traits are tracked as three independent,
+/// order-independent signals (each accumulated via plain Set/union operations) and only combined when
+/// read. This is deliberate: it guarantees the combined result never depends on the order in which
+/// concurrent parents register edges onto the same dependency. The combining rule, applied whenever a
+/// package's explicit traits are read, is: named traits win outright if any exist; otherwise a
+/// default-setter wins over a coexisting disabler (they're meant to coexist); otherwise a disabler
+/// alone means nothing is enabled; otherwise nothing was recorded at all.
+///
 /// Example:
 /// ```swift
 /// var traits = EnabledTraitsMap()
@@ -71,6 +79,8 @@ import struct TSCUtility.Version
 /// ## Default Setters
 /// When a parent package or trait configuration explicitly requests  the`default` trait (or leaves the set of
 /// traits unspecified), those setters are tracked separately. Query these using the `defaultSettersFor` subscript.
+/// A default-setter coexisting with a disabler for the same package (and no named traits) resolves to
+/// "defaults are wanted" - regardless of which of the two was registered first.
 public struct EnabledTraitsMap {
     public typealias Key = PackageIdentity
     public typealias Value = EnabledTraits
@@ -78,8 +88,11 @@ public struct EnabledTraitsMap {
     struct VersionedTraits {
         var map: [Version: EnabledTraits] = [:]
 
-        public func at(_ version: Version) -> EnabledTraits {
-            self.map[version] ?? ["default"]
+        /// Returns the named traits explicitly recorded for this version, or `nil` if none have
+        /// been recorded for it yet. Unlike the old `at(_:)`, this never substitutes a fallback
+        /// sentinel, so callers can distinguish "nothing recorded" from "recorded as empty".
+        public func namedTraits(at version: Version) -> EnabledTraits? {
+            self.map[version]
         }
 
         public mutating func set(_ version: Version, enabledTraits: EnabledTraits) {
@@ -90,16 +103,19 @@ public struct EnabledTraitsMap {
     }
 
     private struct Storage {
-        /// Proxy storage for explicitly enabled traits per package before versions are known.
-        /// Omits packages with only the "default" trait.
+        /// Proxy storage for explicitly *named* (non-"default") enabled traits per package before
+        /// versions are known. Never touched by disabler or default-setter registrations - see
+        /// `resolvedExplicitTraits(named:for:)`.
         var traits: [Key: EnabledTraits] = [:]
 
-        /// Storage for explicitly enabled traits per package wherein the package kind
-        /// is not versionable (e.g. a filesystem package).
+        /// Storage for explicitly *named* (non-"default") enabled traits per package wherein the
+        /// package kind is not versionable (e.g. a filesystem package). Never touched by disabler
+        /// or default-setter registrations - see `resolvedExplicitTraits(named:for:)`.
         var unversionedTraits: [Key: EnabledTraits] = [:]
 
-        /// Storage for explicitly enabled traits per package wherein the package kind
-        /// is versionable (e.g. a source control package).
+        /// Storage for explicitly *named* (non-"default") enabled traits per package wherein the
+        /// package kind is versionable (e.g. a source control package). Never touched by disabler
+        /// or default-setter registrations - see `resolvedExplicitTraits(named:for:)`.
         var versionedTraits: [Key: VersionedTraits] = [:]
 
         /// Tracks setters that explicitly disabled default traits (via []) for each package.
@@ -114,6 +130,36 @@ public struct EnabledTraitsMap {
 
         init(_ traits: [Key: EnabledTraits]) {
             self.traits = traits
+        }
+
+        /// Resolves the externally-visible explicit traits for a package from the three
+        /// independently-tracked signals recorded for it (named traits, disablers, default-setters).
+        ///
+        /// This is computed fresh from those signals, rather than accumulated destructively as each
+        /// write arrives, so the result never depends on the order in which concurrent parents
+        /// register edges onto the same dependency - each signal is tracked via plain Set/union
+        /// operations, which are inherently commutative and idempotent regardless of write order.
+        ///
+        /// Priority:
+        /// 1. Explicit named traits, if any, always win outright - an explicit selection by any
+        ///    parent must override other parents' mere requests for defaults.
+        /// 2. Otherwise, if any parent requested defaults (explicitly, or implicitly by not
+        ///    specifying traits), that request wins over a coexisting disabler: disablers and
+        ///    default-setters are meant to coexist, with the default-setter's request winning if
+        ///    nothing else was explicitly picked.
+        /// 3. Otherwise, if only disablers exist, nothing is enabled (`[]`).
+        /// 4. Otherwise, nothing was recorded at all (`nil`).
+        func resolvedExplicitTraits(named: EnabledTraits?, for identity: PackageIdentity) -> EnabledTraits? {
+            if let named, !named.isEmpty {
+                return named
+            }
+            if let defaultSetters = self._defaultSetters[identity], !defaultSetters.isEmpty {
+                return nil
+            }
+            if let disablers = self._disablers[identity], let firstDisabler = disablers.first {
+                return EnabledTraits([], setBy: firstDisabler)
+            }
+            return nil
         }
     }
 
@@ -134,7 +180,9 @@ public struct EnabledTraitsMap {
                 return self[identity]
             }
 
-            return self.storage.get().versionedTraits[identity]?.at(version) ?? ["default"]
+            let state = self.storage.get()
+            let named = state.versionedTraits[identity]?.namedTraits(at: version)
+            return state.resolvedExplicitTraits(named: named, for: identity) ?? .defaults
         }
         set {
             self.set(
@@ -168,27 +216,25 @@ public struct EnabledTraitsMap {
                 return state
             }
 
-            // Track default setters
+            // Track default setters. A default-setter carries no information about named,
+            // non-default traits, so it must never touch the named-trait storage below - doing
+            // so was the source of an order-dependent bug where the final result of registering
+            // a disabler and a default-setter for the same package (in either order) depended on
+            // which one happened to register first. See `resolvedExplicitTraits(named:for:)`.
             if value.isExplicitlySetDefault {
                 if let defaultSetter = value.first?.setters.first {
                     state._defaultSetters[identity, default: []].insert(defaultSetter)
                 }
-                if let version {
-                    // first assure there is an entry for the versioned traits.
-                    if state.versionedTraits[identity, default: .init()].at(version) == [] {
-                        state.versionedTraits[identity]?.set(version, enabledTraits: value)
-                    }
-                } else {
-                    if state.unversionedTraits[identity] == [] {
-                        state.unversionedTraits[identity] = value
-                    }
-                }
                 return state
             }
 
-            // Track disablers
-            if value.isEmpty, let disabler = value.disabledBy {
-                state._disablers[identity, default: []].insert(disabler)
+            // Track disablers. Like default-setters, a disabler carries no named-trait
+            // information and must never touch the named-trait storage below, for the same reason.
+            if value.isEmpty {
+                if let disabler = value.disabledBy {
+                    state._disablers[identity, default: []].insert(disabler)
+                }
+                return state
             }
 
             // Union or create; the set of enabled traits is strictly additive.
@@ -199,8 +245,7 @@ public struct EnabledTraitsMap {
             }
 
             // Keep the proxy in sync so PackageIdentity-keyed reads (enabledTraitsMap[identity])
-            // reflect the current traits after the proxy was cleared above.
-            state.traits[identity, default: []].formUnion(value)
+            // reflect the current named traits after the proxy was cleared above.
             if state.traits[identity] == nil {
                 state.traits[identity] = value
             } else {
@@ -218,7 +263,7 @@ public struct EnabledTraitsMap {
     }
 
     public subscript(key: PackageIdentity) -> EnabledTraits {
-        get { storage.get().traits[key] ?? ["default"] }
+        get { self[explicitlyEnabledTraitsFor: key] ?? .defaults }
         set {
             storage.mutate { (state: Storage) -> Storage in
                 var state = state
@@ -234,20 +279,21 @@ public struct EnabledTraitsMap {
                     return state
                 }
 
-                // Track default setters
+                // Track default setters. See the analogous comment in
+                // `set(identity:value:version:)` for why this must never touch `state.traits`.
                 if newValue.isExplicitlySetDefault {
                     if let defaultSetter = newValue.first?.setters.first {
                         state._defaultSetters[key, default: []].insert(defaultSetter)
                     }
-                    if state.traits[key] == [] {
-                        state.traits[key] = nil
-                    }
                     return state
                 }
 
-                // Track disablers
-                if newValue.isEmpty, let disabler = newValue.disabledBy {
-                    state._disablers[key, default: []].insert(disabler)
+                // Track disablers. See the analogous comment in `set(identity:value:version:)`.
+                if newValue.isEmpty {
+                    if let disabler = newValue.disabledBy {
+                        state._disablers[key, default: []].insert(disabler)
+                    }
+                    return state
                 }
 
                 // Union or create; the set of enabled traits is strictly additive.
@@ -309,7 +355,8 @@ public struct EnabledTraitsMap {
     /// - Parameter key: The package identity to query.
     /// - Returns: The explicitly enabled traits, or `nil` if no traits were explicitly set (meaning the package uses defaults).
     public subscript(explicitlyEnabledTraitsFor key: PackageIdentity) -> EnabledTraits? {
-        storage.get().traits[key]
+        let state = storage.get()
+        return state.resolvedExplicitTraits(named: state.traits[key], for: key)
     }
 
     /// Returns a list of traits that were explicitly enabled for a given package.

--- a/Sources/PackageModel/EnabledTrait.swift
+++ b/Sources/PackageModel/EnabledTrait.swift
@@ -203,8 +203,7 @@ public struct EnabledTraitsMap {
             // for nil entries in the stored dictionary, which tells us whether
             // traits have been explicitly enabled or not.
             //
-            // However, if "default" is explicitly set by a parent (has setters),
-            // track it in the `defaultSetters` property.
+            // However, if "default" is set by a parent track it in the `defaultSetters` property.
             guard !(value == .defaults && !value.isExplicitlySetDefault) else {
                 return state
             }
@@ -261,8 +260,7 @@ public struct EnabledTraitsMap {
                 // for nil entries in the stored dictionary, which tells us whether
                 // traits have been explicitly enabled or not.
                 //
-                // However, if "default" is explicitly set by a parent (has setters),
-                // track it in the `defaultSetters` property.
+                // However, if "default" is explicitly set by a parent track it in the `defaultSetters` property.
                 guard !(newValue == .defaults && !newValue.isExplicitlySetDefault) else {
                     return state
                 }
@@ -392,7 +390,8 @@ extension EnabledTraitsMap: ExpressibleByDictionaryLiteral {
 /// a parent package that has defined enabled traits for its dependency package, or transitively by another trait (including the default case).
 ///
 /// An `EnabledTrait` is differentiated by its `name`, and all other data stored in this struct is treated as metadata for
-/// convenience. When unifying two `EnabledTrait`s, it will combine the list of setters if the `name`s match.
+/// convenience. When unifying two `EnabledTrait`s, it will combine the list of setters if the `name`s match. This is assuming
+/// that an `EnabledTrait` is correctly associated with the same `PackageIdentity` in the `EnabledTraitsMap`.
 ///
 public struct EnabledTrait: Identifiable {
     /// Convenience typealias for a list of `Setter`
@@ -543,7 +542,7 @@ extension EnabledTrait: ExpressibleByStringLiteral {
 /// convenient set operations like union and intersection, along with collection protocol conformance for
 /// easy iteration and manipulation of enabled traits.
 ///
-/// ## Disabling All Traits
+/// ## Disabling Default Traits
 /// An `EnabledTraits` instance can represent a "disabled" state when created with an empty collection
 /// and a `Setter`. In this case, the `disabledBy` property returns the setter that disabled default traits,
 /// allowing callers to track which parent package or configuration explicitly disabled default traits for a package.
@@ -740,8 +739,6 @@ extension IdentifiableSet where Element == EnabledTrait {
         if let oldElement = self.remove(member), let newElement = oldElement.unify(member) {
             insert(newElement)
         } else {
-            // See if other enabled traits that have same parent (if parent case)
-            // exist,
             insert(member)
         }
     }

--- a/Sources/PackageModel/EnabledTrait.swift
+++ b/Sources/PackageModel/EnabledTrait.swift
@@ -50,11 +50,7 @@ import struct TSCUtility.Version
 ///
 /// Disablers, default-setters (below), and explicitly-named traits are tracked as three independent,
 /// order-independent signals (each accumulated via plain Set/union operations) and only combined when
-/// read. This is deliberate: it guarantees the combined result never depends on the order in which
-/// concurrent parents register edges onto the same dependency. The combining rule, applied whenever a
-/// package's explicit traits are read, is: named traits win outright if any exist; otherwise a
-/// default-setter wins over a coexisting disabler (they're meant to coexist); otherwise a disabler
-/// alone means nothing is enabled; otherwise nothing was recorded at all.
+/// read.
 ///
 /// Example:
 /// ```swift
@@ -103,19 +99,16 @@ public struct EnabledTraitsMap {
     }
 
     private struct Storage {
-        /// Proxy storage for explicitly *named* (non-"default") enabled traits per package before
-        /// versions are known. Never touched by disabler or default-setter registrations - see
-        /// `resolvedExplicitTraits(named:for:)`.
+        /// Proxy storage for explicitly *named* (non-default) enabled traits per package before
+        /// versions are known.
         var traits: [Key: EnabledTraits] = [:]
 
-        /// Storage for explicitly *named* (non-"default") enabled traits per package wherein the
-        /// package kind is not versionable (e.g. a filesystem package). Never touched by disabler
-        /// or default-setter registrations - see `resolvedExplicitTraits(named:for:)`.
+        /// Storage for explicitly *named* (non-default) enabled traits per package wherein the
+        /// package kind is not versionable (e.g. a filesystem package).
         var unversionedTraits: [Key: EnabledTraits] = [:]
 
-        /// Storage for explicitly *named* (non-"default") enabled traits per package wherein the
-        /// package kind is versionable (e.g. a source control package). Never touched by disabler
-        /// or default-setter registrations - see `resolvedExplicitTraits(named:for:)`.
+        /// Storage for explicitly *named* (non-default) enabled traits per package wherein the
+        /// package kind is versionable (e.g. a source control package).
         var versionedTraits: [Key: VersionedTraits] = [:]
 
         /// Tracks setters that explicitly disabled default traits (via []) for each package.
@@ -137,8 +130,7 @@ public struct EnabledTraitsMap {
         ///
         /// This is computed fresh from those signals, rather than accumulated destructively as each
         /// write arrives, so the result never depends on the order in which concurrent parents
-        /// register edges onto the same dependency - each signal is tracked via plain Set/union
-        /// operations, which are inherently commutative and idempotent regardless of write order.
+        /// register edges onto the same dependency.
         ///
         /// Priority:
         /// 1. Explicit named traits, if any, always win outright - an explicit selection by any

--- a/Sources/PackageModel/EnabledTrait.swift
+++ b/Sources/PackageModel/EnabledTrait.swift
@@ -217,11 +217,11 @@ public struct EnabledTraitsMap {
                 return state
             }
 
-            // Track trait disablers.
+            // Track trait disablers. An empty value always means "disabled" and must always be
+            // attributable to a setter - fall back to `.traitConfiguration` if none was attached.
             if value.isEmpty {
-                if let disabler = value.disabledBy {
-                    state._disablers[identity, default: []].insert(disabler)
-                }
+                let disabler = value.disabledBy ?? .traitConfiguration
+                state._disablers[identity, default: []].insert(disabler)
                 return state
             }
 
@@ -275,11 +275,11 @@ public struct EnabledTraitsMap {
                     return state
                 }
 
-                // Track disablers.
+                // Track disablers. An empty value always means "disabled" and must always be
+                // attributable to a setter - fall back to `.traitConfiguration` if none was attached.
                 if newValue.isEmpty {
-                    if let disabler = newValue.disabledBy {
-                        state._disablers[key, default: []].insert(disabler)
-                    }
+                    let disabler = newValue.disabledBy ?? .traitConfiguration
+                    state._disablers[key, default: []].insert(disabler)
                     return state
                 }
 

--- a/Sources/PackageModel/EnabledTrait.swift
+++ b/Sources/PackageModel/EnabledTrait.swift
@@ -199,9 +199,10 @@ public struct EnabledTraitsMap {
             var value = value
             // Fetch traits from proxy map; this could have been
             // a package dependency that now has a manifest.
-            if let proxyTraits = state.traits[identity] {
+            if var proxyTraits = state.traits[identity] {
+                // Remove 'default' trait keyword and clear proxy list.
+                _ = proxyTraits.remove("default")
                 value.formUnion(proxyTraits)
-                // Clear out proxy.
                 state.traits[identity] = nil
             }
 
@@ -216,11 +217,7 @@ public struct EnabledTraitsMap {
                 return state
             }
 
-            // Track default setters. A default-setter carries no information about named,
-            // non-default traits, so it must never touch the named-trait storage below - doing
-            // so was the source of an order-dependent bug where the final result of registering
-            // a disabler and a default-setter for the same package (in either order) depended on
-            // which one happened to register first. See `resolvedExplicitTraits(named:for:)`.
+            // Track default setters.
             if value.isExplicitlySetDefault {
                 if let defaultSetter = value.first?.setters.first {
                     state._defaultSetters[identity, default: []].insert(defaultSetter)
@@ -228,8 +225,7 @@ public struct EnabledTraitsMap {
                 return state
             }
 
-            // Track disablers. Like default-setters, a disabler carries no named-trait
-            // information and must never touch the named-trait storage below, for the same reason.
+            // Track trait disablers.
             if value.isEmpty {
                 if let disabler = value.disabledBy {
                     state._disablers[identity, default: []].insert(disabler)
@@ -279,8 +275,7 @@ public struct EnabledTraitsMap {
                     return state
                 }
 
-                // Track default setters. See the analogous comment in
-                // `set(identity:value:version:)` for why this must never touch `state.traits`.
+                // Track default setters.
                 if newValue.isExplicitlySetDefault {
                     if let defaultSetter = newValue.first?.setters.first {
                         state._defaultSetters[key, default: []].insert(defaultSetter)
@@ -288,7 +283,7 @@ public struct EnabledTraitsMap {
                     return state
                 }
 
-                // Track disablers. See the analogous comment in `set(identity:value:version:)`.
+                // Track disablers.
                 if newValue.isEmpty {
                     if let disabler = newValue.disabledBy {
                         state._disablers[key, default: []].insert(disabler)

--- a/Sources/PackageModel/EnabledTrait.swift
+++ b/Sources/PackageModel/EnabledTrait.swift
@@ -685,6 +685,12 @@ extension EnabledTraits: Collection {
         return EnabledTraits(transformedTraits)
     }
 
+    public func isSubset<C: Collection>(of other: C) -> Bool where C.Element == Self.Element {
+        self._traits.allSatisfy({ trait in
+            other.contains(trait)
+        })
+    }
+
     public static func ==<C: Collection>(_ lhs: EnabledTraits, _ rhs: C) -> Bool where C.Element == Element {
         lhs._traits.names == rhs.names
     }

--- a/Sources/PackageModel/Manifest/Manifest+Traits.swift
+++ b/Sources/PackageModel/Manifest/Manifest+Traits.swift
@@ -18,7 +18,7 @@ import Foundation
 /// Validator methods that check the correctness of traits and their support as defined in the manifest.
 extension Manifest {
     /// Struct that contains information about a package's identity, as well as its name.
-    public struct PackageIdentifier: Hashable, CustomStringConvertible, Comparable, ExpressibleByStringLiteral {
+    public struct PackageIdentifier: Hashable, CustomStringConvertible, Comparable, ExpressibleByStringLiteral, Sendable {
         public var identity: String
         public var name: String?
 

--- a/Sources/PackageModel/Manifest/Manifest+Traits.swift
+++ b/Sources/PackageModel/Manifest/Manifest+Traits.swift
@@ -189,7 +189,7 @@ extension Manifest {
                 enabledTraits = EnabledTraits(defaultTraits, setBy: .default)
             }
         case .disableAllTraits:
-            return []
+            enabledTraits = EnabledTraits([], setBy: .traitConfiguration)
         case .enabledTraits(let explicitlyEnabledTraits):
             enabledTraits = EnabledTraits(explicitlyEnabledTraits, setBy: .traitConfiguration)
         }

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -109,7 +109,7 @@ public final class Manifest: Sendable {
     /// can depend on which traits are enabled (trait-guarded dependencies).
     private let _requiredDependencies = ThreadSafeKeyValueStore<RequiredDependenciesCacheKey, [PackageDependency]>()
 
-    private struct RequiredDependenciesCacheKey: Hashable {
+    private struct RequiredDependenciesCacheKey: Hashable, Sendable {
         let productFilter: ProductFilter
         let enabledTraits: EnabledTraits
     }

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -105,7 +105,14 @@ public final class Manifest: Sendable {
     private let _requiredTargets = ThreadSafeKeyValueStore<ProductFilter, [TargetDescription]>()
 
     /// Dependencies required for building particular product filters.
-    private let _requiredDependencies = ThreadSafeKeyValueStore<ProductFilter, [PackageDependency]>()
+    /// Keyed by both `ProductFilter` and `EnabledTraits` since which dependencies are required
+    /// can depend on which traits are enabled (trait-guarded dependencies).
+    private let _requiredDependencies = ThreadSafeKeyValueStore<RequiredDependenciesCacheKey, [PackageDependency]>()
+
+    private struct RequiredDependenciesCacheKey: Hashable {
+        let productFilter: ProductFilter
+        let enabledTraits: EnabledTraits
+    }
 
     public let pruneDependencies: Bool
 
@@ -223,7 +230,7 @@ public final class Manifest: Sendable {
             return deps
         }
 
-        if let dependencies = self._requiredDependencies[.nothing] {
+        if let dependencies = self._requiredDependencies[.init(productFilter: .nothing, enabledTraits: enabledTraits)] {
             let deps = dependencies.filter {
                 var result = false
                 for guardedTargetDeps in traitGuardedDeps[$0.identity.description] ?? [] {
@@ -283,7 +290,8 @@ public final class Manifest: Sendable {
             return dependencies
         }
         #else
-
+        // use .nothing as productFilter for cache key while ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION is false.
+        let requiredDependenciesCacheKey = RequiredDependenciesCacheKey(productFilter: .nothing, enabledTraits: enabledTraits)
         guard self.toolsVersion >= .v5_2 && !self.packageKind.isRoot else {
             var dependencies = self.dependencies
                 dependencies = try dependencies.filter({
@@ -293,8 +301,7 @@ public final class Manifest: Sendable {
             return dependencies
         }
 
-        // using .nothing as cache key while ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION is false
-        if var dependencies = self._requiredDependencies[.nothing] {
+        if var dependencies = self._requiredDependencies[requiredDependenciesCacheKey] {
                 dependencies = try dependencies.filter({
                     return try self.isPackageDependencyUsed($0, enabledTraits: enabledTraits)
                 })
@@ -321,8 +328,7 @@ public final class Manifest: Sendable {
             }
 
             let dependencies = self.dependencies.filter { requiredDependencies.contains($0.identity) }
-            // using .nothing as cache key while ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION is false
-            self._requiredDependencies[.nothing] = dependencies
+            self._requiredDependencies[requiredDependenciesCacheKey] = dependencies
             return dependencies
         }
         #endif

--- a/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
@@ -66,8 +66,15 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     private let observabilityScope: ObservabilityScope
 
     /// The cached dependency information.
-    private var dependenciesCache = [String: [ProductFilter: (Manifest, [Constraint])]]()
+    /// Keyed by `enabledTraits` in addition to identifier and product filter.
+    private var dependenciesCache = [String: [ProductFilter: CachedDependency]]()
     private var dependenciesCacheLock = NSLock()
+
+    private struct CachedDependency {
+        let manifest: Manifest
+        let constraints: [Constraint]
+        let enabledTraits: EnabledTraits
+    }
 
     private var knownVersionsCache = ThreadSafeBox<[Version: String]?>()
     private var manifestsCache = ThrowingAsyncKeyValueMemoizer<String, Manifest>()
@@ -246,12 +253,12 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
 
     public func getDependencies(at version: Version, productFilter: ProductFilter, _ enabledTraits: EnabledTraits = ["default"]) async throws -> [Constraint] {
         do {
-            return try await self.getCachedDependencies(forIdentifier: version.description, productFilter: productFilter) {
+            return try await self.getCachedDependencies(forIdentifier: version.description, productFilter: productFilter, enabledTraits: enabledTraits) {
                 guard let tag = try self.knownVersions()[version] else {
                     throw StringError("unknown tag \(version)")
                 }
                 return try await self.loadDependencies(tag: tag, version: version, productFilter: productFilter, enabledTraits: enabledTraits)
-            }.1
+            }.constraints
         } catch {
             throw GetDependenciesError(
                 repository: self.repositorySpecifier,
@@ -264,11 +271,11 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
 
     public func getDependencies(at revision: String, productFilter: ProductFilter, _ enabledTraits: EnabledTraits = ["default"]) async throws -> [Constraint] {
         do {
-            return try await self.getCachedDependencies(forIdentifier: revision, productFilter: productFilter) {
+            return try await self.getCachedDependencies(forIdentifier: revision, productFilter: productFilter, enabledTraits: enabledTraits) {
                 // resolve the revision identifier and return its dependencies.
                 let revision = try repository.resolveRevision(identifier: revision)
                 return try await self.loadDependencies(at: revision, productFilter: productFilter, enabledTraits: enabledTraits)
-            }.1
+            }.constraints
         } catch {
             // Examine the error to see if we can come up with a more informative and actionable error message.  We know that the revision is expected to be a branch name or a hash (tags are handled through a different code path).
             if let error = error as? GitRepositoryError, error.description.contains("Needed a single revision") {
@@ -309,9 +316,10 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     private func getCachedDependencies(
         forIdentifier identifier: String,
         productFilter: ProductFilter,
-        getDependencies: () async throws -> (Manifest, [Constraint])
-    ) async throws -> (Manifest, [Constraint]) {
-        if let result = (self.dependenciesCacheLock.withLock { self.dependenciesCache[identifier, default: [:]][productFilter] }) {
+        enabledTraits: EnabledTraits,
+        getDependencies: () async throws -> CachedDependency
+    ) async throws -> CachedDependency {
+        if let result = (self.dependenciesCacheLock.withLock { self.dependenciesCache[identifier, default: [:]][productFilter] }), result.enabledTraits == enabledTraits {
             return result
         }
         let result = try await getDependencies()
@@ -327,9 +335,9 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         version: Version? = nil,
         productFilter: ProductFilter,
         enabledTraits: EnabledTraits
-    ) async throws -> (Manifest, [Constraint]) {
+    ) async throws -> CachedDependency {
         let manifest = try await self.loadManifest(tag: tag, version: version)
-        return (manifest, try manifest.dependencyConstraints(productFilter: productFilter, enabledTraits))
+        return .init(manifest: manifest, constraints: try manifest.dependencyConstraints(productFilter: productFilter, enabledTraits), enabledTraits: enabledTraits)
     }
 
     /// Returns dependencies of a container at the given revision.
@@ -338,9 +346,9 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         version: Version? = nil,
         productFilter: ProductFilter,
         enabledTraits: EnabledTraits
-    ) async throws -> (Manifest, [Constraint]) {
+    ) async throws -> CachedDependency {
         let manifest = try await self.loadManifest(at: revision, version: version)
-        return (manifest, try manifest.dependencyConstraints(productFilter: productFilter, enabledTraits))
+        return .init(manifest: manifest, constraints: try manifest.dependencyConstraints(productFilter: productFilter, enabledTraits), enabledTraits: enabledTraits)
     }
 
     public func getUnversionedDependencies(productFilter: ProductFilter, _ enabledTraits: EnabledTraits = ["default"]) throws -> [Constraint] {

--- a/Sources/Workspace/Workspace+Traits.swift
+++ b/Sources/Workspace/Workspace+Traits.swift
@@ -46,24 +46,15 @@ extension Workspace {
 
         var enabledTraits = try manifest.enabledTraits(using: explicitlyEnabledTraits)
 
-        // Check if any parents requested default traits for this package, but only expand and
-        // union them in if nobody has explicitly enabled a non-default trait for this package yet.
+        // Check if any parents requested default traits for this package, and expand and
+        // union them.
         // Traits are unified across the graph, so once a parent explicitly opts into specific
-        // traits, that explicit selection must win over other parents' implicit defaults.
-        if explicitlyEnabledTraits == .defaults,
-           let defaultSetters = self.enabledTraitsMap[defaultSettersFor: manifest.packageIdentity],
+        // traits, that explicit selection must be unioned with its defaults.
+        if let defaultSetters = self.enabledTraitsMap[defaultSettersFor: manifest.packageIdentity],
            !defaultSetters.isEmpty {
             // Calculate what the default traits are for this manifest
             let defaultTraits = try manifest.enabledTraits(using: .defaults)
-
-            // Create enabled traits for each setter that requested defaults
-            for setter in defaultSetters {
-                let traitsFromSetter = EnabledTraits(
-                    defaultTraits.map(\.name),
-                    setBy: setter
-                )
-                enabledTraits.formUnion(traitsFromSetter)
-            }
+            enabledTraits.formUnion(defaultTraits)
         }
 
         self.enabledTraitsMap[manifest] = enabledTraits

--- a/Sources/Workspace/Workspace+Traits.swift
+++ b/Sources/Workspace/Workspace+Traits.swift
@@ -49,12 +49,7 @@ extension Workspace {
         // Check if any parents requested default traits for this package, but only expand and
         // union them in if nobody has explicitly enabled a non-default trait for this package yet.
         // Traits are unified across the graph, so once a parent explicitly opts into specific
-        // traits, that explicit selection must win over other parents' implicit defaults;
-        // otherwise defaults requested elsewhere would leak in alongside it. This is a plain
-        // sentinel-equality check because EnabledTraitsMap's storage guarantees `explicitlyEnabledTraits`
-        // can only equal `.defaults` when no parent has explicitly enabled a real trait for this
-        // package - a disabler alone can never produce this value if a default-setter also exists,
-        // since default-setters always take precedence over disablers when nothing else was picked.
+        // traits, that explicit selection must win over other parents' implicit defaults.
         if explicitlyEnabledTraits == .defaults,
            let defaultSetters = self.enabledTraitsMap[defaultSettersFor: manifest.packageIdentity],
            !defaultSetters.isEmpty {

--- a/Sources/Workspace/Workspace+Traits.swift
+++ b/Sources/Workspace/Workspace+Traits.swift
@@ -47,11 +47,15 @@ extension Workspace {
         var enabledTraits = try manifest.enabledTraits(using: explicitlyEnabledTraits)
 
         // Check if any parents requested default traits for this package, but only expand and
-        // union them in if no parent has *explicitly* enabled specific traits. Traits are unified
-        // across the graph, so once a parent explicitly opts into a set of traits (rather than
-        // simply requesting defaults), that explicit selection must win over other parents'
-        // implicit defaults; otherwise defaults requested elsewhere would leak in alongside it.
-        if explicitlyEnabledTraits == ["default"],
+        // union them in if nobody has explicitly enabled a non-default trait for this package yet.
+        // Traits are unified across the graph, so once a parent explicitly opts into specific
+        // traits, that explicit selection must win over other parents' implicit defaults;
+        // otherwise defaults requested elsewhere would leak in alongside it. This is a plain
+        // sentinel-equality check because EnabledTraitsMap's storage guarantees `explicitlyEnabledTraits`
+        // can only equal `.defaults` when no parent has explicitly enabled a real trait for this
+        // package - a disabler alone can never produce this value if a default-setter also exists,
+        // since default-setters always take precedence over disablers when nothing else was picked.
+        if explicitlyEnabledTraits == .defaults,
            let defaultSetters = self.enabledTraitsMap[defaultSettersFor: manifest.packageIdentity],
            !defaultSetters.isEmpty {
             // Calculate what the default traits are for this manifest

--- a/Sources/Workspace/Workspace+Traits.swift
+++ b/Sources/Workspace/Workspace+Traits.swift
@@ -46,9 +46,13 @@ extension Workspace {
 
         var enabledTraits = try manifest.enabledTraits(using: explicitlyEnabledTraits)
 
-        // Check if any parents requested default traits for this package
-        // If so, expand the default traits and union them with existing traits
-        if let defaultSetters = self.enabledTraitsMap[defaultSettersFor: manifest.packageIdentity],
+        // Check if any parents requested default traits for this package, but only expand and
+        // union them in if no parent has *explicitly* enabled specific traits. Traits are unified
+        // across the graph, so once a parent explicitly opts into a set of traits (rather than
+        // simply requesting defaults), that explicit selection must win over other parents'
+        // implicit defaults; otherwise defaults requested elsewhere would leak in alongside it.
+        if explicitlyEnabledTraits == ["default"],
+           let defaultSetters = self.enabledTraitsMap[defaultSettersFor: manifest.packageIdentity],
            !defaultSetters.isEmpty {
             // Calculate what the default traits are for this manifest
             let defaultTraits = try manifest.enabledTraits(using: .defaults)

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -1073,6 +1073,35 @@ class ManifestTests: XCTestCase {
         }
     }
 
+    func testDependenciesRequired_EqualEnabledTraitsWithDifferentDisablersDoNotCrashCache() throws {
+        let manifest = Manifest.createFileSystemManifest(
+            displayName: "Foo",
+            path: "/Foo",
+            toolsVersion: .v5_9,
+            dependencies: [
+                .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+            ],
+            targets: [
+                try TargetDescription(
+                    name: "FooTarget",
+                    dependencies: [
+                        .product(name: "Bar", package: "Bar", condition: .init(traits: ["Trait1"])),
+                    ]
+                ),
+            ],
+            traits: ["Trait1"]
+        )
+
+        let disabledByPackage = EnabledTraits([], setBy: .package("Parent1"))
+        let disabledByTraitConfiguration = EnabledTraits([], setBy: .traitConfiguration)
+        XCTAssertEqual(disabledByPackage, disabledByTraitConfiguration)
+
+        let first = try manifest.dependenciesRequired(for: .everything, disabledByPackage)
+        let second = try manifest.dependenciesRequired(for: .everything, disabledByTraitConfiguration)
+
+        XCTAssertEqual(first.map(\.identity), second.map(\.identity))
+    }
+
     func testIsPackageDependencyUsed_AllUsesGuarded_ReturnsFalse() throws {
         let manifest = Manifest.createRootManifest(
             displayName: "MyPackage",

--- a/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
@@ -1599,5 +1599,87 @@ extension WorkspaceTests {
             result.check(dependency: "guardedpackage", at: .checkout(.version("1.1.0")))
         }
     }
+
+    func testDependencyTraitEnabledViaMultipleRoots() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "RootTarget",
+                            dependencies: [
+                                .product(name: "RemoteProduct", package: "RemoteWithTraits"),
+                                .product(name: "SecondRootProduct", package: "SecondRoot")
+                            ]
+                        )
+                    ],
+                    dependencies: [
+                        .fileSystem(path: "../SecondRoot"),
+                        .sourceControl(path: "./RemoteWithTraits", requirement: .range("1.0.0"..<"3.0.0"), traits: ["NotDefaultTrait"]),
+                    ],
+                ),
+                MockPackage(
+                    name: "SecondRoot",
+                    targets: [
+                        MockTarget(
+                            name: "SecondRootTarget",
+                            dependencies: [.product(name: "RemoteProduct", package: "RemoteWithTraits")]
+                        )
+                    ],
+                    products: [
+                        MockProduct(
+                            name: "SecondRootProduct",
+                            modules: ["SecondRootTarget"]
+                        )
+                    ],
+                    dependencies: [
+                        .sourceControl(path: "./RemoteWithTraits", requirement: .range("1.0.0"..<"3.0.0"))
+                    ]
+                )
+            ],
+            packages: [
+                MockPackage(
+                    name: "RemoteWithTraits",
+                    targets: [
+                        MockTarget(
+                            name: "RemoteTarget"
+                        )
+                    ],
+                    products: [
+                        MockProduct(
+                            name: "RemoteProduct",
+                            modules: ["RemoteTarget"]
+                        )
+                    ],
+                    traits: [
+                        .init(name: "default", enabledTraits: ["EnabledByDefault"]),
+                        "EnabledByDefault",
+                        "NotDefaultTrait"
+                    ],
+                    versions: ["1.0.0", "1.0.1", "2.0.0", "3.0.0"]
+                )
+            ]
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Root", "SecondRoot"]) { graph, diagnostics in
+            PackageGraphTesterXCTest(graph) { result in
+                XCTAssertNoDiagnostics(diagnostics)
+                result.checkPackage("RemoteWithTraits") { package in
+                    guard let enabledTraits = package.enabledTraits else {
+                        XCTFail("No enabled traits on RemoteWithTraits package.")
+                        return
+                    }
+
+                    XCTAssertTrue(enabledTraits == ["NotDefaultTrait"])
+                }
+            }
+        }
+    }
 }
 

--- a/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
@@ -1681,5 +1681,216 @@ extension WorkspaceTests {
             }
         }
     }
-}
 
+    func testDependencyDefaultTraitsExplicitlyEnabled() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "RootTarget",
+                            dependencies: [
+                                .product(name: "RemoteProduct", package: "RemoteWithTraits"),
+                                .product(name: "SecondRootProduct", package: "SecondRoot")
+                            ]
+                        )
+                    ],
+                    dependencies: [
+                        .fileSystem(path: "../SecondRoot"),
+                        .sourceControl(path: "./RemoteWithTraits", requirement: .range("1.0.0"..<"3.0.0"), traits: ["default", "NotDefaultTrait"]),
+                    ],
+                ),
+                MockPackage(
+                    name: "SecondRoot",
+                    targets: [
+                        MockTarget(
+                            name: "SecondRootTarget",
+                            dependencies: [.product(name: "RemoteProduct", package: "RemoteWithTraits")]
+                        )
+                    ],
+                    products: [
+                        MockProduct(
+                            name: "SecondRootProduct",
+                            modules: ["SecondRootTarget"]
+                        )
+                    ],
+                    dependencies: [
+                        .sourceControl(path: "./RemoteWithTraits", requirement: .range("1.0.0"..<"3.0.0"))
+                    ]
+                )
+            ],
+            packages: [
+                MockPackage(
+                    name: "RemoteWithTraits",
+                    targets: [
+                        MockTarget(
+                            name: "RemoteTarget",
+                            dependencies: [
+                                .product(name: "Yaml", package: "Yams", condition: .init(traits: ["NotDefaultTrait"]))
+                            ]
+                        )
+                    ],
+                    products: [
+                        MockProduct(
+                            name: "RemoteProduct",
+                            modules: ["RemoteTarget"]
+                        )
+                    ],
+                    dependencies: [
+                        .sourceControl(path: "./Yams", requirement: .range("1.0.0"..<"2.0.0"))
+                    ],
+                    traits: [
+                        .init(name: "default", enabledTraits: ["EnabledByDefault"]),
+                        "EnabledByDefault",
+                        "NotDefaultTrait"
+                    ],
+                    versions: ["1.0.0", "1.0.1", "2.0.0", "3.0.0"]
+                ),
+                MockPackage(
+                    name: "Yams",
+                    targets: [
+                        MockTarget(
+                            name: "YamlTarget",
+                        )
+                    ],
+                    products: [
+                        MockProduct(
+                            name: "Yaml",
+                            modules: ["YamlTarget"]
+                        )
+                    ],
+                    versions: ["1.0.0"]
+                )
+            ]
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Root", "SecondRoot"]) { graph, diagnostics in
+            PackageGraphTesterXCTest(graph) { result in
+                XCTAssertNoDiagnostics(diagnostics)
+                result.checkPackage("RemoteWithTraits") { package in
+                    guard let enabledTraits = package.enabledTraits else {
+                        XCTFail("No enabled traits on RemoteWithTraits package.")
+                        return
+                    }
+
+                    XCTAssertTrue(enabledTraits == ["EnabledByDefault", "NotDefaultTrait"])
+                }
+            }
+        }
+    }
+
+    /// Reproduces a scenario where two root packages both depend on the same intermediary package
+    /// (`Configuration`): the package being built (`Dependent`) explicitly enables `["default", "YAMLSupport"]`
+    /// on it, while a sibling root (`Dependency`) declares it with no `traits:` at all (implicit defaults).
+    /// `Configuration`'s own dependency on `Yams` is guarded by the `YAMLSupport` trait and has no
+    /// `traits:` parameter of its own - `Yams` must still be resolved and fetched.
+    func testTraitGuardedTransitiveDependency_MultipleRootsWithImplicitDefaults() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Dependent",
+                    targets: [
+                        MockTarget(
+                            name: "DependentTarget",
+                            dependencies: [
+                                .product(name: "Configuration", package: "Configuration"),
+                            ]
+                        ),
+                    ],
+                    products: [
+                        MockProduct(name: "DependentProduct", modules: ["DependentTarget"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(
+                            path: "./Configuration",
+                            requirement: .upToNextMajor(from: "1.0.0"),
+                            traits: ["default", "YAMLSupport"]
+                        ),
+                    ]
+                ),
+                MockPackage(
+                    name: "Dependency",
+                    targets: [
+                        MockTarget(
+                            name: "DependencyTarget",
+                            dependencies: [
+                                .product(name: "Configuration", package: "Configuration"),
+                            ]
+                        ),
+                    ],
+                    products: [
+                        MockProduct(name: "DependencyProduct", modules: ["DependencyTarget"]),
+                    ],
+                    dependencies: [
+                        // No `traits:` specified - implicit defaults for Configuration.
+                        .sourceControl(path: "./Configuration", requirement: .upToNextMajor(from: "1.0.0")),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "Configuration",
+                    targets: [
+                        MockTarget(
+                            name: "ConfigurationTarget",
+                            dependencies: [
+                                .product(
+                                    name: "Yams",
+                                    package: "Yams",
+                                    condition: .init(traits: ["YAMLSupport"])
+                                ),
+                            ]
+                        ),
+                    ],
+                    products: [
+                        MockProduct(name: "Configuration", modules: ["ConfigurationTarget"]),
+                    ],
+                    dependencies: [
+                        // Deliberately no `traits:` here - mirrors swift-configuration's real
+                        // dependency on Yams, which has no explicit trait selection.
+                        .sourceControl(path: "./Yams", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    traits: [
+                        .init(name: "default", enabledTraits: []),
+                        "YAMLSupport",
+                    ],
+                    versions: ["1.0.0"]
+                ),
+                MockPackage(
+                    name: "Yams",
+                    targets: [
+                        MockTarget(name: "YamsTarget"),
+                    ],
+                    products: [
+                        MockProduct(name: "Yams", modules: ["YamsTarget"]),
+                    ],
+                    versions: ["1.0.0"]
+                ),
+            ]
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Dependent", "Dependency"]) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTesterXCTest(graph) { result in
+                result.check(roots: "Dependent", "Dependency")
+                result.check(packages: "Dependent", "Dependency", "Configuration", "Yams")
+                result.check(modules: "DependentTarget", "DependencyTarget", "ConfigurationTarget", "YamsTarget")
+            }
+        }
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "configuration", at: .checkout(.version("1.0.0")))
+            result.check(dependency: "yams", at: .checkout(.version("1.0.0")))
+        }
+    }
+}

--- a/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
@@ -2194,4 +2194,278 @@ extension WorkspaceTests {
             result.check(dependency: "yams", at: .checkout(.version("1.0.0")))
         }
     }
+
+    /// Two siblings depend on the same shared package with different trait requests, decided at
+    /// different points during resolution rather than both being known upfront - unlike the
+    /// root-level case, nothing guarantees every parent's request is known before the shared
+    /// dependency itself is decided.
+    func testTraitGuardedTransitiveDependency_enabledTraitsAtDifferentLevels() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "RootTarget",
+                            dependencies: [
+                                .product(name: "SiblingAProduct", package: "SiblingA"),
+                                .product(name: "SiblingBProduct", package: "SiblingB"),
+                            ]
+                        ),
+                    ],
+                    dependencies: [
+                        .sourceControl(path: "./SiblingA", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(path: "./SiblingB", requirement: .upToNextMajor(from: "1.0.0")),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "SiblingA",
+                    targets: [
+                        MockTarget(
+                            name: "SiblingATarget",
+                            dependencies: [
+                                .product(name: "SharedProduct", package: "SharedDependency"),
+                            ]
+                        ),
+                    ],
+                    products: [
+                        MockProduct(name: "SiblingAProduct", modules: ["SiblingATarget"]),
+                    ],
+                    dependencies: [
+                        // No `traits:` specified - implicit defaults for SharedDependency.
+                        .sourceControl(path: "./SharedDependency", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    versions: ["1.0.0"]
+                ),
+                MockPackage(
+                    name: "SiblingB",
+                    targets: [
+                        MockTarget(
+                            name: "SiblingBTarget",
+                            dependencies: [
+                                .product(name: "SharedProduct", package: "SharedDependency"),
+                            ]
+                        ),
+                    ],
+                    products: [
+                        MockProduct(name: "SiblingBProduct", modules: ["SiblingBTarget"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(
+                            path: "./SharedDependency",
+                            requirement: .upToNextMajor(from: "1.0.0"),
+                            traits: ["default", "FeatureX"]
+                        ),
+                    ],
+                    versions: ["1.0.0", "1.2.0"]
+                ),
+                MockPackage(
+                    name: "SharedDependency",
+                    targets: [
+                        MockTarget(
+                            name: "SharedTarget",
+                            dependencies: [
+                                .product(
+                                    name: "GuardedProduct",
+                                    package: "GuardedLeaf",
+                                    condition: .init(traits: ["FeatureX"])
+                                ),
+                            ]
+                        ),
+                    ],
+                    products: [
+                        MockProduct(name: "SharedProduct", modules: ["SharedTarget"]),
+                    ],
+                    dependencies: [
+                        // Deliberately no `traits:` here
+                        .sourceControl(path: "./GuardedLeaf", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    traits: [
+                        .init(name: "default", enabledTraits: ["DefaultTrait"]),
+                        "DefaultTrait",
+                        "FeatureX",
+                    ],
+                    versions: ["1.0.0"]
+                ),
+                MockPackage(
+                    name: "GuardedLeaf",
+                    targets: [
+                        MockTarget(name: "GuardedLeafTarget"),
+                    ],
+                    products: [
+                        MockProduct(name: "GuardedProduct", modules: ["GuardedLeafTarget"]),
+                    ],
+                    versions: ["1.0.0"]
+                ),
+            ]
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTesterXCTest(graph) { result in
+                result.check(roots: "Root")
+                result.check(packages: "Root", "SiblingA", "SiblingB", "SharedDependency", "GuardedLeaf")
+                result.check(modules: "RootTarget", "SiblingATarget", "SiblingBTarget", "SharedTarget", "GuardedLeafTarget")
+                result.checkPackage("SharedDependency") { package in
+                    guard let enabledTraits = package.enabledTraits else {
+                        XCTFail("Expected enabled traits for package SharedDependency.")
+                        return
+                    }
+
+                    XCTAssertEqual(enabledTraits, ["DefaultTrait", "FeatureX"])
+                }
+            }
+        }
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "shareddependency", at: .checkout(.version("1.0.0")))
+            result.check(dependency: "guardedleaf", at: .checkout(.version("1.0.0")))
+        }
+    }
+
+    /// Same shape as the test above, but the guarding trait is never requested directly.
+    /// `SiblingB` only asks for `FeatureX`, and `SharedDependency`'s own trait declarations
+    /// should recursively unfurl into the trait that actually guards `GuardedLeaf`.
+    func testTraitGuardedTransitiveDependency_TransitivelyEnabledTraits_enabledTraitsAtDifferentLevels() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "RootTarget",
+                            dependencies: [
+                                .product(name: "SiblingAProduct", package: "SiblingA"),
+                                .product(name: "SiblingBProduct", package: "SiblingB"),
+                            ]
+                        ),
+                    ],
+                    dependencies: [
+                        .sourceControl(path: "./SiblingA", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(path: "./SiblingB", requirement: .upToNextMajor(from: "1.0.0")),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "SiblingA",
+                    targets: [
+                        MockTarget(
+                            name: "SiblingATarget",
+                            dependencies: [
+                                .product(name: "SharedProduct", package: "SharedDependency"),
+                            ]
+                        ),
+                    ],
+                    products: [
+                        MockProduct(name: "SiblingAProduct", modules: ["SiblingATarget"]),
+                    ],
+                    dependencies: [
+                        // No `traits:` specified - implicit defaults for SharedDependency.
+                        .sourceControl(path: "./SharedDependency", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    versions: ["1.0.0"]
+                ),
+                MockPackage(
+                    name: "SiblingB",
+                    targets: [
+                        MockTarget(
+                            name: "SiblingBTarget",
+                            dependencies: [
+                                .product(name: "SharedProduct", package: "SharedDependency"),
+                            ]
+                        ),
+                    ],
+                    products: [
+                        MockProduct(name: "SiblingBProduct", modules: ["SiblingBTarget"]),
+                    ],
+                    dependencies: [
+                        // Only ever requests defaults and `FeatureX` directly
+                        .sourceControl(
+                            path: "./SharedDependency",
+                            requirement: .upToNextMajor(from: "1.0.0"),
+                            traits: ["default", "FeatureX"]
+                        ),
+                    ],
+                    versions: ["1.0.0", "1.2.0"]
+                ),
+                MockPackage(
+                    name: "SharedDependency",
+                    targets: [
+                        MockTarget(
+                            name: "SharedTarget",
+                            dependencies: [
+                                // Guarded by `FeatureXImpl`, not `FeatureX` - only reachable via
+                                // `FeatureX`'s recursive `enabledTraits` unfurling below.
+                                .product(
+                                    name: "GuardedProduct",
+                                    package: "GuardedLeaf",
+                                    condition: .init(traits: ["FeatureXImpl"])
+                                ),
+                            ]
+                        ),
+                    ],
+                    products: [
+                        MockProduct(name: "SharedProduct", modules: ["SharedTarget"]),
+                    ],
+                    dependencies: [
+                        // Deliberately no `traits:` here
+                        .sourceControl(path: "./GuardedLeaf", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    traits: [
+                        .init(name: "default", enabledTraits: ["Surprise"]),
+                        // `FeatureX` recursively enables `FeatureXImpl` - `SiblingB` never asks
+                        // for `FeatureXImpl` by name.
+                        "Surprise",
+                        .init(name: "FeatureX", enabledTraits: ["FeatureXImpl"]),
+                        .init(name: "FeatureXImpl", enabledTraits: ["LastTrait"]),
+                        "LastTrait"
+                    ],
+                    versions: ["1.0.0"]
+                ),
+                MockPackage(
+                    name: "GuardedLeaf",
+                    targets: [
+                        MockTarget(name: "GuardedLeafTarget"),
+                    ],
+                    products: [
+                        MockProduct(name: "GuardedProduct", modules: ["GuardedLeafTarget"]),
+                    ],
+                    versions: ["1.0.0"]
+                ),
+            ]
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTesterXCTest(graph) { result in
+                result.check(roots: "Root")
+                result.check(packages: "Root", "SiblingA", "SiblingB", "SharedDependency", "GuardedLeaf")
+                result.check(modules: "RootTarget", "SiblingATarget", "SiblingBTarget", "SharedTarget", "GuardedLeafTarget")
+                result.checkPackage("SharedDependency") { package in
+                    guard let enabledTraits = package.enabledTraits else {
+                        XCTFail("No traits enabled on SharedDependency -- expected to find FeatureX, FeatureXImpl, and LastTrait.")
+                        return
+                    }
+
+                    XCTAssertEqual(enabledTraits, ["FeatureX", "FeatureXImpl", "LastTrait", "Surprise"])
+                }
+            }
+        }
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "shareddependency", at: .checkout(.version("1.0.0")))
+            result.check(dependency: "guardedleaf", at: .checkout(.version("1.0.0")))
+        }
+    }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
@@ -1676,7 +1676,7 @@ extension WorkspaceTests {
                         return
                     }
 
-                    XCTAssertTrue(enabledTraits == ["NotDefaultTrait"])
+                    XCTAssertTrue(enabledTraits == ["EnabledByDefault", "NotDefaultTrait"])
                 }
             }
         }
@@ -1785,6 +1785,298 @@ extension WorkspaceTests {
         }
     }
 
+    /// Verifies that when one parent explicitly disables a dependency's default traits (`traits: []`)
+    /// and another parent depends on the same package without specifying traits at all (an implicit
+    /// request for defaults), the two coexist rather than the disabler winning outright: the
+    /// default-setter's request is honored and the dependency's default traits are enabled.
+    func testDependencyDisabledTraitsCoexistWithImplicitDefaultsAcrossRoots() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "RootTarget",
+                            dependencies: [
+                                .product(name: "RemoteProduct", package: "RemoteWithTraits"),
+                                .product(name: "SecondRootProduct", package: "SecondRoot")
+                            ]
+                        )
+                    ],
+                    dependencies: [
+                        .fileSystem(path: "../SecondRoot"),
+                        // Root explicitly disables RemoteWithTraits' default traits.
+                        .sourceControl(path: "./RemoteWithTraits", requirement: .range("1.0.0"..<"3.0.0"), traits: []),
+                    ],
+                ),
+                MockPackage(
+                    name: "SecondRoot",
+                    targets: [
+                        MockTarget(
+                            name: "SecondRootTarget",
+                            dependencies: [.product(name: "RemoteProduct", package: "RemoteWithTraits")]
+                        )
+                    ],
+                    products: [
+                        MockProduct(
+                            name: "SecondRootProduct",
+                            modules: ["SecondRootTarget"]
+                        )
+                    ],
+                    dependencies: [
+                        // SecondRoot doesn't specify traits - implicit request for defaults.
+                        .sourceControl(path: "./RemoteWithTraits", requirement: .range("1.0.0"..<"3.0.0"))
+                    ]
+                )
+            ],
+            packages: [
+                MockPackage(
+                    name: "RemoteWithTraits",
+                    targets: [
+                        MockTarget(
+                            name: "RemoteTarget"
+                        )
+                    ],
+                    products: [
+                        MockProduct(
+                            name: "RemoteProduct",
+                            modules: ["RemoteTarget"]
+                        )
+                    ],
+                    traits: [
+                        .init(name: "default", enabledTraits: ["EnabledByDefault"]),
+                        "EnabledByDefault",
+                        "NotDefaultTrait"
+                    ],
+                    versions: ["1.0.0", "1.0.1", "2.0.0", "3.0.0"]
+                )
+            ]
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Root", "SecondRoot"]) { graph, diagnostics in
+            PackageGraphTesterXCTest(graph) { result in
+                XCTAssertNoDiagnostics(diagnostics)
+                result.checkPackage("RemoteWithTraits") { package in
+                    guard let enabledTraits = package.enabledTraits else {
+                        XCTFail("No enabled traits on RemoteWithTraits package.")
+                        return
+                    }
+
+                    // SecondRoot's implicit default request is honored despite Root's disabler.
+                    XCTAssertTrue(enabledTraits == ["EnabledByDefault"])
+                }
+            }
+        }
+    }
+
+    /// Verifies that when one parent explicitly disables a dependency's default traits (`traits: []`)
+    /// and another parent explicitly enables a specific non-default trait for the same dependency
+    /// (`traits: ["NotDefaultTrait"]`, without naming `default`), the explicit named selection wins
+    /// outright over the disabler - the dependency ends up with just that named trait, not `[]`.
+    func testDependencyExplicitTraitsWinOverDisablerAcrossRoots() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "RootTarget",
+                            dependencies: [
+                                .product(name: "RemoteProduct", package: "RemoteWithTraits"),
+                                .product(name: "SecondRootProduct", package: "SecondRoot")
+                            ]
+                        )
+                    ],
+                    dependencies: [
+                        .fileSystem(path: "../SecondRoot"),
+                        // Root explicitly disables RemoteWithTraits' default traits.
+                        .sourceControl(path: "./RemoteWithTraits", requirement: .range("1.0.0"..<"3.0.0"), traits: []),
+                    ],
+                ),
+                MockPackage(
+                    name: "SecondRoot",
+                    targets: [
+                        MockTarget(
+                            name: "SecondRootTarget",
+                            dependencies: [.product(name: "RemoteProduct", package: "RemoteWithTraits")]
+                        )
+                    ],
+                    products: [
+                        MockProduct(
+                            name: "SecondRootProduct",
+                            modules: ["SecondRootTarget"]
+                        )
+                    ],
+                    dependencies: [
+                        // SecondRoot explicitly enables a non-default trait, without naming "default".
+                        .sourceControl(path: "./RemoteWithTraits", requirement: .range("1.0.0"..<"3.0.0"), traits: ["NotDefaultTrait"])
+                    ]
+                )
+            ],
+            packages: [
+                MockPackage(
+                    name: "RemoteWithTraits",
+                    targets: [
+                        MockTarget(
+                            name: "RemoteTarget"
+                        )
+                    ],
+                    products: [
+                        MockProduct(
+                            name: "RemoteProduct",
+                            modules: ["RemoteTarget"]
+                        )
+                    ],
+                    traits: [
+                        .init(name: "default", enabledTraits: ["EnabledByDefault"]),
+                        "EnabledByDefault",
+                        "NotDefaultTrait"
+                    ],
+                    versions: ["1.0.0", "1.0.1", "2.0.0", "3.0.0"]
+                )
+            ]
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Root", "SecondRoot"]) { graph, diagnostics in
+            PackageGraphTesterXCTest(graph) { result in
+                XCTAssertNoDiagnostics(diagnostics)
+                result.checkPackage("RemoteWithTraits") { package in
+                    guard let enabledTraits = package.enabledTraits else {
+                        XCTFail("No enabled traits on RemoteWithTraits package.")
+                        return
+                    }
+
+                    // SecondRoot's explicit named trait wins outright over Root's disabler;
+                    // "EnabledByDefault" is absent since nobody requested defaults.
+                    XCTAssertTrue(enabledTraits == ["NotDefaultTrait"])
+                }
+            }
+        }
+    }
+
+    /// Extends the previous test with a third parent: one parent disables a dependency's default
+    /// traits (`traits: []`), another explicitly enables a non-default trait (`traits:
+    /// ["NotDefaultTrait"]`), and a third depends on the same package without specifying traits at
+    /// all (an implicit request for defaults). The explicit named trait still wins outright over the
+    /// disabler, and the implicit default request unions in on top of it - all three signals combine
+    /// to enable both `NotDefaultTrait` and the dependency's default traits.
+    func testDependencyExplicitTraitsCoexistWithDisablerAndImplicitDefaultsAcrossRoots() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "RootTarget",
+                            dependencies: [
+                                .product(name: "RemoteProduct", package: "RemoteWithTraits"),
+                                .product(name: "SecondRootProduct", package: "SecondRoot"),
+                                .product(name: "ThirdRootProduct", package: "ThirdRoot")
+                            ]
+                        )
+                    ],
+                    dependencies: [
+                        .fileSystem(path: "../SecondRoot"),
+                        .fileSystem(path: "../ThirdRoot"),
+                        // Root explicitly disables RemoteWithTraits' default traits.
+                        .sourceControl(path: "./RemoteWithTraits", requirement: .range("1.0.0"..<"3.0.0"), traits: []),
+                    ],
+                ),
+                MockPackage(
+                    name: "SecondRoot",
+                    targets: [
+                        MockTarget(
+                            name: "SecondRootTarget",
+                            dependencies: [.product(name: "RemoteProduct", package: "RemoteWithTraits")]
+                        )
+                    ],
+                    products: [
+                        MockProduct(
+                            name: "SecondRootProduct",
+                            modules: ["SecondRootTarget"]
+                        )
+                    ],
+                    dependencies: [
+                        // SecondRoot explicitly enables a non-default trait, without naming "default".
+                        .sourceControl(path: "./RemoteWithTraits", requirement: .range("1.0.0"..<"3.0.0"), traits: ["NotDefaultTrait"])
+                    ]
+                ),
+                MockPackage(
+                    name: "ThirdRoot",
+                    targets: [
+                        MockTarget(
+                            name: "ThirdRootTarget",
+                            dependencies: [.product(name: "RemoteProduct", package: "RemoteWithTraits")]
+                        )
+                    ],
+                    products: [
+                        MockProduct(
+                            name: "ThirdRootProduct",
+                            modules: ["ThirdRootTarget"]
+                        )
+                    ],
+                    dependencies: [
+                        // ThirdRoot doesn't specify traits - implicit request for defaults.
+                        .sourceControl(path: "./RemoteWithTraits", requirement: .range("1.0.0"..<"3.0.0"))
+                    ]
+                )
+            ],
+            packages: [
+                MockPackage(
+                    name: "RemoteWithTraits",
+                    targets: [
+                        MockTarget(
+                            name: "RemoteTarget"
+                        )
+                    ],
+                    products: [
+                        MockProduct(
+                            name: "RemoteProduct",
+                            modules: ["RemoteTarget"]
+                        )
+                    ],
+                    traits: [
+                        .init(name: "default", enabledTraits: ["EnabledByDefault"]),
+                        "EnabledByDefault",
+                        "NotDefaultTrait"
+                    ],
+                    versions: ["1.0.0", "1.0.1", "2.0.0", "3.0.0"]
+                )
+            ]
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Root", "SecondRoot", "ThirdRoot"]) { graph, diagnostics in
+            PackageGraphTesterXCTest(graph) { result in
+                XCTAssertNoDiagnostics(diagnostics)
+                result.checkPackage("RemoteWithTraits") { package in
+                    guard let enabledTraits = package.enabledTraits else {
+                        XCTFail("No enabled traits on RemoteWithTraits package.")
+                        return
+                    }
+
+                    // SecondRoot's explicit named trait wins outright over Root's disabler, and
+                    // ThirdRoot's implicit default request unions "EnabledByDefault" on top of it.
+                    XCTAssertTrue(enabledTraits == ["NotDefaultTrait", "EnabledByDefault"])
+                }
+            }
+        }
+    }
+
     /// Reproduces a scenario where two root packages both depend on the same intermediary package
     /// (`Configuration`): the package being built (`Dependent`) explicitly enables `["default", "YAMLSupport"]`
     /// on it, while a sibling root (`Dependency`) declares it with no `traits:` at all (implicit defaults).
@@ -1862,7 +2154,8 @@ extension WorkspaceTests {
                         .sourceControl(path: "./Yams", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     traits: [
-                        .init(name: "default", enabledTraits: []),
+                        .init(name: "default", enabledTraits: ["DefaultTrait"]),
+                        "DefaultTrait",
                         "YAMLSupport",
                     ],
                     versions: ["1.0.0"]
@@ -1886,6 +2179,14 @@ extension WorkspaceTests {
                 result.check(roots: "Dependent", "Dependency")
                 result.check(packages: "Dependent", "Dependency", "Configuration", "Yams")
                 result.check(modules: "DependentTarget", "DependencyTarget", "ConfigurationTarget", "YamsTarget")
+                result.checkPackage("Configuration") { package in
+                    guard let enabledTraits = package.enabledTraits else {
+                        XCTFail("Expected DefaultTrait, YAMLSupport traits to be enabled on package Configuration.")
+                        return
+                    }
+
+                    XCTAssertEqual(enabledTraits, ["DefaultTrait", "YAMLSupport"])
+                }
             }
         }
         await workspace.checkManagedDependencies { result in


### PR DESCRIPTION
## Impact:

Dependencies on packages whilst declaring **explicitly** `.defaults` (or implicitly elsewhere in the graph) **and** other traits would fail in instances where the child package's dependencies were incorrectly computed as trait-guarded, leaving them out of the dependency graph. This was due to how SwiftPM was handling the enablement of traits at deeper levels in the dependency graph, and would not consider to union newly discovered enabled traits for a given package.

## Explanation: 

Implicit or explicit requests for default traits of a package should both be treated the same; at times, especially for implicit default trait requests, the enablement is found deeper in the dependency graph as resolution unveils new constraints amongst the dependency edges. The PubGrubDependencyResolver should have an awareness of the dependency edges that need to be revisited due to this change in enabled traits, ultimately affecting the derived incompatibilities for its own dependencies (and therefore possibly allowing for the use of a previously trait-guarded dependency).

Since the EnabledTraitsMap already stores the various setters of explicit traits, in addition to packages that have requested default traits/disabled a package's traits, whenever a set of traits is requested and fetch from the storage we should resolve in priority order what traits are actually meant to be returned.

## Scope:
A new method on `EnabledTraitsMap.Storage` has been added: `resolvedExplicitTraits(named:,identity:)` to be called on any getters returning a list of enabled traits for a given package identity.

Additionally, persist the `enabledTraitsMap` in the `PubGrubResolver` as new package dependencies are discovered and loaded at each level. Particularly, once new incompatibilities are computed (via `addIncompatibility(_:at:)`) ensure that the enabled traits are updated. There is also a new property on the `PubGrubDependencyResolver.State` entitled `decisionsToRepair`, that represent a set of `DependencyResolutionNode`s for which new incompatibilities may have been introduced with the discovery of new enabled traits on that node's package.

## Issues:
Fixes #10397 and [#90253](https://github.com/swiftlang/swift/issues/90253)

## Testing:
- `testDependencyTraitEnabledViaMultipleRoots`
- `testTraitGuardedTransitiveDependency_MultipleRootsWithImplicitDefaults`
- `testDependencyDefaultTraitsExplicitlyEnabled`

[tranistive-trait-error.zip](https://github.com/user-attachments/files/31191490/tranistive-trait-error.zip)
