### PR TITLE
fix(test): Hide 'last' subcommand from help

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1176,6 +1176,10 @@ fileprivate extension Triple {
 
 extension SwiftTestCommand {
     struct Last: AsyncSwiftCommand {
+        static let configuration = CommandConfiguration(
+            shouldDisplay: false
+            )
+
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -97,13 +97,22 @@ struct TestCommandTests {
         let stdout = try await execute(
             ["--help"],
             configuration: configuration,
-            buildSystem: buildSystem,).stdout
-        let lines = stdout.components(separatedBy: "\n")
-        #expect(
-            !lines.contains(where: {
-                $0.trimmingCharacters(in: .whitespaces) == "last" }),
-            "got stdout: \n\(stdout)",
-        )    }
+            buildSystem: buildSystem,
+        ).stdout
+        guard let subcommandsHeaderRange = stdout.range(of: "SUBCOMMANDS:") else {
+               Issue.record("Could not locate SUBCOMMANDS: section in --help output:\n\(stdout)"
+               )
+               return
+           }
+           let afterHeader = stdout[subcommandsHeaderRange.upperBound...]
+           let subcommandsSection = afterHeader.components(separatedBy: "\n\n").first ?? String(afterHeader)
+
+           let lastSubcommandRegex = try Regex(#"(?m)^\s*last\s*$"#)
+           #expect(
+               !subcommandsSection.contains(lastSubcommandRegex),
+               "got stdout:\n\(stdout)",
+        )
+    }
 
     @Test( arguments: SupportedBuildSystemOnAllPlatforms,)
     func lastSubcommandStillRunsWhenInvokedDirectly(

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -89,6 +89,40 @@ struct TestCommandTests {
         )
     }
 
+    @Test( .bug("https://github.com/swiftlang/swift-package-manager/issues/10381", "swift test last subcommand isn't hidden by default"), arguments: SupportedBuildSystemOnAllPlatforms,)
+    func lastSubcommandIsHiddenFromHelp(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        let stdout = try await execute(
+            ["--help"],
+            configuration: configuration,
+            buildSystem: buildSystem,).stdout
+        let lines = stdout.components(separatedBy: "\n")
+        #expect(
+            !lines.contains(where: {
+                $0.trimmingCharacters(in: .whitespaces) == "last" }),
+            "got stdout: \n\(stdout)",
+        )    }
+
+    @Test( arguments: SupportedBuildSystemOnAllPlatforms,)
+    func lastSubcommandStillRunsWhenInvokedDirectly(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
+            _ = try await execute([],
+                                  packagePath: fixturePath,
+                                  configuration: configuration,
+                                  buildSystem: buildSystem
+            )
+            _ = try await execute(["last"],
+                                  packagePath: fixturePath,
+                                  configuration: configuration, buildSystem: buildSystem
+            )
+        }
+    }
+    
     @Test(
         arguments: SupportedBuildSystemOnAllPlatforms,
     )


### PR DESCRIPTION
Hide the `swift test last` subcommand from help output

### Motivation:

The `last` subcommand of `swift test` is an experimental/internal implementation detail that was never marked hidden, so it appears in `swift help test` with no description. This confuses users — see the report on the [Swift Forums](https://forums.swift.org/t/how-to-use-swift-test-last/88648) from someone who found it in the help output and couldn't figure out what it does. It should be hidden from the default help listing, consistent with how other internal-only commands (e.g. `experimental-build-server`) are already handled in this codebase.

### Modifications:

Added a `CommandConfiguration` with `shouldDisplay: false` to the `Last` subcommand struct in `Sources/Commands/SwiftTestCommand.swift`. This mirrors the existing pattern used elsewhere in the codebase for hiding experimental subcommands.

Added two tests to `Tests/CommandsTests/TestCommandTests.swift`:
- `lastSubcommandIsHiddenFromHelp` — asserts `last` no longer appears in `swift test --help` output.
- `lastSubcommandStillRunsWhenInvokedDirectly` — asserts `swift test last` still runs successfully when invoked directly, confirming the subcommand is hidden, not removed.

### Result:

`last` no longer appears in `swift help test`'s `SUBCOMMANDS:` list. The subcommand itself is unaffected — `swift test last` still runs exactly as before. This is now covered by automated tests in addition to manual `--help` diff verification.

Fixes #10381