### PR TITLE
CMake: Update minimum required to 3.29

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.29)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 

--- a/Sources/Runtimes/CMakeLists.txt
+++ b/Sources/Runtimes/CMakeLists.txt
@@ -8,10 +8,6 @@
 
 cmake_minimum_required(VERSION 3.29)
 
-if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
-  cmake_policy(SET CMP0157 OLD)
-endif()
-
 project(SwiftPMRuntime
   LANGUAGES Swift)
 

--- a/Sources/swift-bootstrap/CMakeLists.txt
+++ b/Sources/swift-bootstrap/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-bootstrap
     main.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-bootstrap PROPERTIES
+  Swift_MODULE_NAME swift_bootstrap)
+
 target_link_libraries(swift-bootstrap PRIVATE
   ArgumentParser
   Basics

--- a/Sources/swift-build/CMakeLists.txt
+++ b/Sources/swift-build/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-build
     Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-build PROPERTIES
+  Swift_MODULE_NAME swift_build)
+
 target_link_libraries(swift-build PRIVATE
     Commands)
 

--- a/Sources/swift-experimental-sdk/CMakeLists.txt
+++ b/Sources/swift-experimental-sdk/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-experimental-sdk
   Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-experimental-sdk PROPERTIES
+  Swift_MODULE_NAME swift_experimental_sdk)
+
 target_link_libraries(swift-experimental-sdk PRIVATE
   SwiftSDKCommand)
 

--- a/Sources/swift-package-collection/CMakeLists.txt
+++ b/Sources/swift-package-collection/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-package-collection
   Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-package-collection PROPERTIES
+  Swift_MODULE_NAME swift_package_collection)
+
 target_link_libraries(swift-package-collection PRIVATE
   PackageCollectionsCommand)
 

--- a/Sources/swift-package-registry/CMakeLists.txt
+++ b/Sources/swift-package-registry/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-package-registry
   runner.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-package-registry PROPERTIES
+  Swift_MODULE_NAME swift_package_registry)
+
 target_link_libraries(swift-package-registry PRIVATE
   PackageRegistryCommand)
 

--- a/Sources/swift-package/CMakeLists.txt
+++ b/Sources/swift-package/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-package
   Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-package PROPERTIES
+  Swift_MODULE_NAME swift_package)
+
 target_link_libraries(swift-package PRIVATE
   Commands
   TSCBasic)

--- a/Sources/swift-run/CMakeLists.txt
+++ b/Sources/swift-run/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-run
   Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-run PROPERTIES
+  Swift_MODULE_NAME swift_run)
+
 target_link_libraries(swift-run PRIVATE
   Commands)
 

--- a/Sources/swift-sdk/CMakeLists.txt
+++ b/Sources/swift-sdk/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-sdk
   Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-sdk PROPERTIES
+  Swift_MODULE_NAME swift_sdk)
+
 target_link_libraries(swift-sdk PRIVATE
   SwiftSDKCommand)
 

--- a/Sources/swift-test/CMakeLists.txt
+++ b/Sources/swift-test/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-test
   Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-test PROPERTIES
+  Swift_MODULE_NAME swift_test)
+
 target_link_libraries(swift-test PRIVATE
   Commands)
 


### PR DESCRIPTION
CMake 3.29 brings in CMP0157, which improves the build graph.

### Motivation:

Linux and macOS already build with CMake 3.30. Windows builds with CMake 4.4. It is no longer necessary to support earlier versions. Furthermore, the SPM Runtime build already uses 3.29 as the minimum required. Other projects have been increasing the minimum too: swiftlang/swift-syntax#3321

### Modifications:

* Increase the minimum required to 3.29.
* Removes setting CMP0157 to OLD since every platform now builds with a swift-driver.
* Set Swift_MODULE_NAME explicitly on the nine hyphenated targets.


### Result:

No functional change. Build outputs should be identical.