### PR TITLE
Adopt Mutex in InMemoryFileSystem

### DIFF
--- a/Sources/Basics/FileSystem/InMemoryFileSystem.swift
+++ b/Sources/Basics/FileSystem/InMemoryFileSystem.swift
@@ -21,7 +21,6 @@ import struct TSCBasic.FileSystemError
 /// Concrete FileSystem implementation which simulates an empty disk.
 public final class InMemoryFileSystem: FileSystem {
     /// Private internal representation of a file system node.
-    /// Not thread-safe.
     private class Node {
         /// The actual node data.
         let contents: NodeContents
@@ -37,6 +36,109 @@ public final class InMemoryFileSystem: FileSystem {
         /// Creates deep copy of the object.
         func copy() -> sending Node {
             return Node(contents.copy())
+        }
+
+        /// Looks up the node corresponding to `path`.
+        func node(at path: TSCBasic.AbsolutePath, followSymlink: Bool = true) throws -> Node? {
+            // If this is the root node, return it.
+            if path.isRoot {
+                return self
+            }
+
+            // Otherwise, get the parent node.
+            guard let parent = try self.node(at: path.parentDirectory, followSymlink: followSymlink) else {
+                return nil
+            }
+
+            // If we didn't find a directory, this is an error.
+            guard case .directory(let contents) = parent.contents else {
+                throw FileSystemError(.notDirectory, path.parentDirectory)
+            }
+
+            // Return the directory entry.
+            let node = contents.entries[path.basename]
+
+            switch node?.contents {
+            case .directory, .file:
+                return node
+            case .symlink(let destination):
+                let destination = try TSCBasic.AbsolutePath(validating: destination, relativeTo: path.parentDirectory)
+                return followSymlink ? try self.node(at: destination, followSymlink: followSymlink) : node
+            case .none:
+                return nil
+            }
+        }
+
+        /// Creates a directory at `path`.
+        func createDirectory(at path: TSCBasic.AbsolutePath, recursive: Bool) throws {
+            // Ignore if client passes root.
+            guard !path.isRoot else {
+                return
+            }
+            // Get the parent directory node.
+            let parentPath = path.parentDirectory
+            guard let parent = try self.node(at: parentPath) else {
+                // If the parent doesn't exist, and we are recursive, then attempt
+                // to create the parent and retry.
+                if recursive && path != parentPath {
+                    // Attempt to create the parent.
+                    try self.createDirectory(at: parentPath, recursive: true)
+
+                    // Re-attempt creation, non-recursively.
+                    return try self.createDirectory(at: path, recursive: false)
+                } else {
+                    // Otherwise, we failed.
+                    throw FileSystemError(.noEntry, parentPath)
+                }
+            }
+
+            // Check that the parent is a directory.
+            guard case .directory(let contents) = parent.contents else {
+                // The parent isn't a directory, this is an error.
+                throw FileSystemError(.notDirectory, parentPath)
+            }
+
+            // Check if the node already exists.
+            if let node = contents.entries[path.basename] {
+                // Verify it is a directory.
+                guard case .directory = node.contents else {
+                    // The path itself isn't a directory, this is an error.
+                    throw FileSystemError(.notDirectory, path)
+                }
+
+                // We are done.
+                return
+            }
+
+            // Otherwise, the node does not exist, create it.
+            contents.entries[path.basename] = Node(.directory(DirectoryContents()))
+        }
+
+        /// Grafts the node at `sourcePath` onto `destinationPath`.
+        ///
+        /// The destination shares the source's node rather than deep copying it; see `copy()` for a
+        /// deep copy.
+        func graft(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {
+            // Get the source node.
+            guard let source = try self.node(at: sourcePath) else {
+                throw FileSystemError(.noEntry, sourcePath)
+            }
+
+            // Create directory to destination parent.
+            guard let destinationParent = try self.node(at: destinationPath.parentDirectory) else {
+                throw FileSystemError(.noEntry, destinationPath.parentDirectory)
+            }
+
+            // Check that the parent is a directory.
+            guard case .directory(let contents) = destinationParent.contents else {
+                throw FileSystemError(.notDirectory, destinationPath.parentDirectory)
+            }
+
+            guard contents.entries[destinationPath.basename] == nil else {
+                throw FileSystemError(.alreadyExistsAtDestination, destinationPath)
+            }
+
+            contents.entries[destinationPath.basename] = source
         }
     }
 
@@ -121,53 +223,12 @@ public final class InMemoryFileSystem: FileSystem {
         }
     }
 
-    /// Private function to look up the node corresponding to a path.
-    /// Not thread-safe; callers must hold the state lock and pass its root in.
-    private static func getNode(
-        _ root: Node,
-        _ path: TSCBasic.AbsolutePath,
-        followSymlink: Bool = true
-    ) throws -> Node? {
-        func getNodeInternal(_ path: TSCBasic.AbsolutePath) throws -> Node? {
-            // If this is the root node, return it.
-            if path.isRoot {
-                return root
-            }
-
-            // Otherwise, get the parent node.
-            guard let parent = try getNodeInternal(path.parentDirectory) else {
-                return nil
-            }
-
-            // If we didn't find a directory, this is an error.
-            guard case .directory(let contents) = parent.contents else {
-                throw FileSystemError(.notDirectory, path.parentDirectory)
-            }
-
-            // Return the directory entry.
-            let node = contents.entries[path.basename]
-
-            switch node?.contents {
-            case .directory, .file:
-                return node
-            case .symlink(let destination):
-                let destination = try TSCBasic.AbsolutePath(validating: destination, relativeTo: path.parentDirectory)
-                return followSymlink ? try getNodeInternal(destination) : node
-            case .none:
-                return nil
-            }
-        }
-
-        // Get the node that corresponds to the path.
-        return try getNodeInternal(path)
-    }
-
     // MARK: FileSystem Implementation
 
     public func exists(_ path: TSCBasic.AbsolutePath, followSymlink: Bool) -> Bool {
         return self.state.withLock { state in
             do {
-                switch try Self.getNode(state.root, path, followSymlink: followSymlink)?.contents {
+                switch try state.root.node(at: path, followSymlink: followSymlink)?.contents {
                 case .file, .directory, .symlink: return true
                 case .none: return false
                 }
@@ -180,7 +241,7 @@ public final class InMemoryFileSystem: FileSystem {
     public func isDirectory(_ path: TSCBasic.AbsolutePath) -> Bool {
         return self.state.withLock { state in
             do {
-                if case .directory? = try Self.getNode(state.root, path)?.contents {
+                if case .directory? = try state.root.node(at: path)?.contents {
                     return true
                 }
                 return false
@@ -193,7 +254,7 @@ public final class InMemoryFileSystem: FileSystem {
     public func isFile(_ path: TSCBasic.AbsolutePath) -> Bool {
         return self.state.withLock { state in
             do {
-                if case .file? = try Self.getNode(state.root, path)?.contents {
+                if case .file? = try state.root.node(at: path)?.contents {
                     return true
                 }
                 return false
@@ -206,7 +267,7 @@ public final class InMemoryFileSystem: FileSystem {
     public func isSymlink(_ path: TSCBasic.AbsolutePath) -> Bool {
         return self.state.withLock { state in
             do {
-                if case .symlink? = try Self.getNode(state.root, path, followSymlink: false)?.contents {
+                if case .symlink? = try state.root.node(at: path, followSymlink: false)?.contents {
                     return true
                 }
                 return false
@@ -226,13 +287,13 @@ public final class InMemoryFileSystem: FileSystem {
 
     public func isExecutableFile(_ path: TSCBasic.AbsolutePath) -> Bool {
         self.state.withLock { state in
-            (try? Self.getNode(state.root, path)?.isExecutable) ?? false
+            (try? state.root.node(at: path)?.isExecutable) ?? false
         }
     }
 
     public func updatePermissions(_ path: AbsolutePath, isExecutable: Bool) throws {
         try self.state.withLock { state in
-            guard let node = try Self.getNode(state.root, path.underlying, followSymlink: true) else {
+            guard let node = try state.root.node(at: path.underlying, followSymlink: true) else {
                 throw FileSystemError(.noEntry, path)
             }
             node.isExecutable = isExecutable
@@ -246,7 +307,7 @@ public final class InMemoryFileSystem: FileSystem {
     public func changeCurrentWorkingDirectory(to path: TSCBasic.AbsolutePath) throws {
         return try self.state.withLock { state in
             // Verify the path exists and is a directory
-            guard let node = try Self.getNode(state.root, path) else {
+            guard let node = try state.root.node(at: path) else {
                 throw FileSystemError(.noEntry, path)
             }
 
@@ -276,7 +337,7 @@ public final class InMemoryFileSystem: FileSystem {
 
     public func getDirectoryContents(_ path: TSCBasic.AbsolutePath) throws -> [String] {
         return try self.state.withLock { state in
-            guard let node = try Self.getNode(state.root, path) else {
+            guard let node = try state.root.node(at: path) else {
                 throw FileSystemError(.noEntry, path)
             }
             guard case .directory(let contents) = node.contents else {
@@ -288,54 +349,9 @@ public final class InMemoryFileSystem: FileSystem {
         }
     }
 
-    /// Not thread-safe; callers must hold the state lock and pass its root in.
-    private static func _createDirectory(_ root: Node, _ path: TSCBasic.AbsolutePath, recursive: Bool) throws {
-        // Ignore if client passes root.
-        guard !path.isRoot else {
-            return
-        }
-        // Get the parent directory node.
-        let parentPath = path.parentDirectory
-        guard let parent = try Self.getNode(root, parentPath) else {
-            // If the parent doesn't exist, and we are recursive, then attempt
-            // to create the parent and retry.
-            if recursive && path != parentPath {
-                // Attempt to create the parent.
-                try Self._createDirectory(root, parentPath, recursive: true)
-
-                // Re-attempt creation, non-recursively.
-                return try Self._createDirectory(root, path, recursive: false)
-            } else {
-                // Otherwise, we failed.
-                throw FileSystemError(.noEntry, parentPath)
-            }
-        }
-
-        // Check that the parent is a directory.
-        guard case .directory(let contents) = parent.contents else {
-            // The parent isn't a directory, this is an error.
-            throw FileSystemError(.notDirectory, parentPath)
-        }
-
-        // Check if the node already exists.
-        if let node = contents.entries[path.basename] {
-            // Verify it is a directory.
-            guard case .directory = node.contents else {
-                // The path itself isn't a directory, this is an error.
-                throw FileSystemError(.notDirectory, path)
-            }
-
-            // We are done.
-            return
-        }
-
-        // Otherwise, the node does not exist, create it.
-        contents.entries[path.basename] = Node(.directory(DirectoryContents()))
-    }
-
     public func createDirectory(_ path: TSCBasic.AbsolutePath, recursive: Bool) throws {
         return try self.state.withLock { state in
-            try Self._createDirectory(state.root, path, recursive: recursive)
+            try state.root.createDirectory(at: path, recursive: recursive)
         }
     }
 
@@ -346,7 +362,7 @@ public final class InMemoryFileSystem: FileSystem {
     ) throws {
         return try self.state.withLock { state in
             // Create directory to destination parent.
-            guard let destinationParent = try Self.getNode(state.root, path.parentDirectory) else {
+            guard let destinationParent = try state.root.node(at: path.parentDirectory) else {
                 throw FileSystemError(.noEntry, path.parentDirectory)
             }
 
@@ -368,7 +384,7 @@ public final class InMemoryFileSystem: FileSystem {
     public func readFileContents(_ path: TSCBasic.AbsolutePath) throws -> ByteString {
         return try self.state.withLock { state in
             // Get the node.
-            guard let node = try Self.getNode(state.root, path) else {
+            guard let node = try state.root.node(at: path) else {
                 throw FileSystemError(.noEntry, path)
             }
 
@@ -392,7 +408,7 @@ public final class InMemoryFileSystem: FileSystem {
             }
 
             // Get the parent node.
-            guard let parent = try Self.getNode(state.root, parentPath) else {
+            guard let parent = try state.root.node(at: parentPath) else {
                 throw FileSystemError(.noEntry, parentPath)
             }
 
@@ -426,7 +442,7 @@ public final class InMemoryFileSystem: FileSystem {
         return self.state.withLock { state in
             // Ignore root and get the parent node's content if its a directory.
             guard !path.isRoot,
-                  let parent = try? Self.getNode(state.root, path.parentDirectory),
+                  let parent = try? state.root.node(at: path.parentDirectory),
                   case .directory(let contents) = parent.contents else {
                       return
                   }
@@ -439,45 +455,16 @@ public final class InMemoryFileSystem: FileSystem {
         // FIXME: We don't have these semantics in InMemoryFileSystem.
     }
 
-    /// Private implementation of core copying function.
-    /// Not thread-safe; callers must hold the state lock and pass its root in.
-    private static func _copy(
-        _ root: Node,
-        from sourcePath: TSCBasic.AbsolutePath,
-        to destinationPath: TSCBasic.AbsolutePath
-    ) throws {
-        // Get the source node.
-        guard let source = try Self.getNode(root, sourcePath) else {
-            throw FileSystemError(.noEntry, sourcePath)
-        }
-
-        // Create directory to destination parent.
-        guard let destinationParent = try Self.getNode(root, destinationPath.parentDirectory) else {
-            throw FileSystemError(.noEntry, destinationPath.parentDirectory)
-        }
-
-        // Check that the parent is a directory.
-        guard case .directory(let contents) = destinationParent.contents else {
-            throw FileSystemError(.notDirectory, destinationPath.parentDirectory)
-        }
-
-        guard contents.entries[destinationPath.basename] == nil else {
-            throw FileSystemError(.alreadyExistsAtDestination, destinationPath)
-        }
-
-        contents.entries[destinationPath.basename] = source
-    }
-
     public func copy(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {
         return try self.state.withLock { state in
-            try Self._copy(state.root, from: sourcePath, to: destinationPath)
+            try state.root.graft(from: sourcePath, to: destinationPath)
         }
     }
 
     public func move(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {
         return try self.state.withLock { state in
             // Get the source parent node.
-            guard let sourceParent = try Self.getNode(state.root, sourcePath.parentDirectory) else {
+            guard let sourceParent = try state.root.node(at: sourcePath.parentDirectory) else {
                 throw FileSystemError(.noEntry, sourcePath.parentDirectory)
             }
 
@@ -486,7 +473,7 @@ public final class InMemoryFileSystem: FileSystem {
                 throw FileSystemError(.notDirectory, sourcePath.parentDirectory)
             }
 
-            try Self._copy(state.root, from: sourcePath, to: destinationPath)
+            try state.root.graft(from: sourcePath, to: destinationPath)
 
             contents.entries[sourcePath.basename] = nil
         }
@@ -498,7 +485,7 @@ public final class InMemoryFileSystem: FileSystem {
         _ body: () throws -> T
     ) throws -> T {
         let resolvedPath: TSCBasic.AbsolutePath = try self.state.withLock { state in
-            if case let .symlink(destination) = try Self.getNode(state.root, path)?.contents {
+            if case let .symlink(destination) = try state.root.node(at: path)?.contents {
                 return try .init(validating: destination, relativeTo: path.parentDirectory)
             } else {
                 return path

--- a/Sources/Basics/FileSystem/InMemoryFileSystem.swift
+++ b/Sources/Basics/FileSystem/InMemoryFileSystem.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import class Foundation.NSLock
 import class Dispatch.DispatchQueue
+import Synchronization
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.ByteString
 import class TSCBasic.FileLock
@@ -79,18 +79,23 @@ public final class InMemoryFileSystem: FileSystem {
         }
     }
 
-    /// The root node of the filesystem.
-    private var root: Node
-
-    /// Protects `root` and everything underneath it.
+    /// The mutable state of the filesystem: the root node and everything underneath it, plus the
+    /// virtualized working directory.
+    ///
     /// FIXME: Using a single lock for this is a performance problem, but in
     /// reality, the only practical use for InMemoryFileSystem is for unit
     /// tests.
-    private let lock = NSLock()
+    /// `@unchecked` because `Node` is a mutable reference type; holding the mutex is what makes
+    /// access to the graph safe.
+    private struct State: @unchecked Sendable {
+        var root: Node
+        var currentWorkingDirectory: TSCBasic.AbsolutePath
+    }
+
+    private let state: Mutex<State>
+
     /// A map that keeps weak references to all locked files.
-    private var lockFiles = Dictionary<TSCBasic.AbsolutePath, WeakReference<DispatchQueue>>()
-    /// Used to access lockFiles in a thread safe manner.
-    private let lockFilesLock = NSLock()
+    private let lockFiles = Mutex<[TSCBasic.AbsolutePath: WeakReference<DispatchQueue>]>([:])
 
     /// Exclusive file system lock vended to clients through `withLock()`.
     /// Used to ensure that DispatchQueues are released when they are no longer in use.
@@ -102,22 +107,30 @@ public final class InMemoryFileSystem: FileSystem {
         }
     }
 
-    public init() {
-        root = Node(.directory(DirectoryContents()))
+    public convenience init() {
+        self.init(root: Node(.directory(DirectoryContents())))
+    }
+
+    private init(root: Node) {
+        self.state = Mutex(
+            State(root: root, currentWorkingDirectory: try! .init(validating: "/"))
+        )
     }
 
     /// Creates deep copy of the object.
     public func copy() -> InMemoryFileSystem {
-        return lock.withLock {
-            let fs = InMemoryFileSystem()
-            fs.root = root.copy()
-            return fs
+        self.state.withLock { state in
+            InMemoryFileSystem(root: state.root.copy())
         }
     }
 
     /// Private function to look up the node corresponding to a path.
-    /// Not thread-safe.
-    private func getNode(_ path: TSCBasic.AbsolutePath, followSymlink: Bool = true) throws -> Node? {
+    /// Not thread-safe; callers must hold the state lock and pass its root in.
+    private func getNode(
+        _ root: Node,
+        _ path: TSCBasic.AbsolutePath,
+        followSymlink: Bool = true
+    ) throws -> Node? {
         func getNodeInternal(_ path: TSCBasic.AbsolutePath) throws -> Node? {
             // If this is the root node, return it.
             if path.isRoot {
@@ -155,9 +168,9 @@ public final class InMemoryFileSystem: FileSystem {
     // MARK: FileSystem Implementation
 
     public func exists(_ path: TSCBasic.AbsolutePath, followSymlink: Bool) -> Bool {
-        return lock.withLock {
+        return self.state.withLock { state in
             do {
-                switch try getNode(path, followSymlink: followSymlink)?.contents {
+                switch try self.getNode(state.root, path, followSymlink: followSymlink)?.contents {
                 case .file, .directory, .symlink: return true
                 case .none: return false
                 }
@@ -168,9 +181,9 @@ public final class InMemoryFileSystem: FileSystem {
     }
 
     public func isDirectory(_ path: TSCBasic.AbsolutePath) -> Bool {
-        return lock.withLock {
+        return self.state.withLock { state in
             do {
-                if case .directory? = try getNode(path)?.contents {
+                if case .directory? = try self.getNode(state.root, path)?.contents {
                     return true
                 }
                 return false
@@ -181,9 +194,9 @@ public final class InMemoryFileSystem: FileSystem {
     }
 
     public func isFile(_ path: TSCBasic.AbsolutePath) -> Bool {
-        return lock.withLock {
+        return self.state.withLock { state in
             do {
-                if case .file? = try getNode(path)?.contents {
+                if case .file? = try self.getNode(state.root, path)?.contents {
                     return true
                 }
                 return false
@@ -194,9 +207,9 @@ public final class InMemoryFileSystem: FileSystem {
     }
 
     public func isSymlink(_ path: TSCBasic.AbsolutePath) -> Bool {
-        return lock.withLock {
+        return self.state.withLock { state in
             do {
-                if case .symlink? = try getNode(path, followSymlink: false)?.contents {
+                if case .symlink? = try self.getNode(state.root, path, followSymlink: false)?.contents {
                     return true
                 }
                 return false
@@ -215,36 +228,35 @@ public final class InMemoryFileSystem: FileSystem {
     }
 
     public func isExecutableFile(_ path: TSCBasic.AbsolutePath) -> Bool {
-        (try? self.getNode(path)?.isExecutable) ?? false
+        self.state.withLock { state in
+            (try? self.getNode(state.root, path)?.isExecutable) ?? false
+        }
     }
 
     public func updatePermissions(_ path: AbsolutePath, isExecutable: Bool) throws {
-        try lock.withLock {
-            guard let node = try self.getNode(path.underlying, followSymlink: true) else {
+        try self.state.withLock { state in
+            guard let node = try self.getNode(state.root, path.underlying, followSymlink: true) else {
                 throw FileSystemError(.noEntry, path)
             }
             node.isExecutable = isExecutable
         }
     }
 
-    /// Virtualized current working directory.
-    private var _currentWorkingDirectory: TSCBasic.AbsolutePath = try! .init(validating: "/")
-
     public var currentWorkingDirectory: TSCBasic.AbsolutePath? {
-        return _currentWorkingDirectory
+        self.state.withLock { $0.currentWorkingDirectory }
     }
 
     public func changeCurrentWorkingDirectory(to path: TSCBasic.AbsolutePath) throws {
-        return try lock.withLock {
+        return try self.state.withLock { state in
             // Verify the path exists and is a directory
-            guard let node = try getNode(path) else {
+            guard let node = try self.getNode(state.root, path) else {
                 throw FileSystemError(.noEntry, path)
             }
 
             guard case .directory = node.contents else {
                 throw FileSystemError(.notDirectory, path)
             }
-            _currentWorkingDirectory = path
+            state.currentWorkingDirectory = path
         }
     }
 
@@ -266,8 +278,8 @@ public final class InMemoryFileSystem: FileSystem {
     }
 
     public func getDirectoryContents(_ path: TSCBasic.AbsolutePath) throws -> [String] {
-        return try lock.withLock {
-            guard let node = try getNode(path) else {
+        return try self.state.withLock { state in
+            guard let node = try self.getNode(state.root, path) else {
                 throw FileSystemError(.noEntry, path)
             }
             guard case .directory(let contents) = node.contents else {
@@ -279,23 +291,23 @@ public final class InMemoryFileSystem: FileSystem {
         }
     }
 
-    /// Not thread-safe.
-    private func _createDirectory(_ path: TSCBasic.AbsolutePath, recursive: Bool) throws {
+    /// Not thread-safe; callers must hold the state lock and pass its root in.
+    private func _createDirectory(_ root: Node, _ path: TSCBasic.AbsolutePath, recursive: Bool) throws {
         // Ignore if client passes root.
         guard !path.isRoot else {
             return
         }
         // Get the parent directory node.
         let parentPath = path.parentDirectory
-        guard let parent = try getNode(parentPath) else {
+        guard let parent = try self.getNode(root, parentPath) else {
             // If the parent doesn't exist, and we are recursive, then attempt
             // to create the parent and retry.
             if recursive && path != parentPath {
                 // Attempt to create the parent.
-                try _createDirectory(parentPath, recursive: true)
+                try self._createDirectory(root, parentPath, recursive: true)
 
                 // Re-attempt creation, non-recursively.
-                return try _createDirectory(path, recursive: false)
+                return try self._createDirectory(root, path, recursive: false)
             } else {
                 // Otherwise, we failed.
                 throw FileSystemError(.noEntry, parentPath)
@@ -325,8 +337,8 @@ public final class InMemoryFileSystem: FileSystem {
     }
 
     public func createDirectory(_ path: TSCBasic.AbsolutePath, recursive: Bool) throws {
-        return try lock.withLock {
-            try _createDirectory(path, recursive: recursive)
+        return try self.state.withLock { state in
+            try self._createDirectory(state.root, path, recursive: recursive)
         }
     }
 
@@ -335,9 +347,9 @@ public final class InMemoryFileSystem: FileSystem {
         pointingAt destination: TSCBasic.AbsolutePath,
         relative: Bool
     ) throws {
-        return try lock.withLock {
+        return try self.state.withLock { state in
             // Create directory to destination parent.
-            guard let destinationParent = try getNode(path.parentDirectory) else {
+            guard let destinationParent = try self.getNode(state.root, path.parentDirectory) else {
                 throw FileSystemError(.noEntry, path.parentDirectory)
             }
 
@@ -357,9 +369,9 @@ public final class InMemoryFileSystem: FileSystem {
     }
 
     public func readFileContents(_ path: TSCBasic.AbsolutePath) throws -> ByteString {
-        return try lock.withLock {
+        return try self.state.withLock { state in
             // Get the node.
-            guard let node = try getNode(path) else {
+            guard let node = try self.getNode(state.root, path) else {
                 throw FileSystemError(.noEntry, path)
             }
 
@@ -375,7 +387,7 @@ public final class InMemoryFileSystem: FileSystem {
     }
 
     public func writeFileContents(_ path: TSCBasic.AbsolutePath, bytes: ByteString) throws {
-        return try lock.withLock {
+        return try self.state.withLock { state in
             // It is an error if this is the root node.
             let parentPath = path.parentDirectory
             guard path != parentPath else {
@@ -383,7 +395,7 @@ public final class InMemoryFileSystem: FileSystem {
             }
 
             // Get the parent node.
-            guard let parent = try getNode(parentPath) else {
+            guard let parent = try self.getNode(state.root, parentPath) else {
                 throw FileSystemError(.noEntry, parentPath)
             }
 
@@ -414,10 +426,10 @@ public final class InMemoryFileSystem: FileSystem {
     }
 
     public func removeFileTree(_ path: TSCBasic.AbsolutePath) throws {
-        return lock.withLock {
+        return self.state.withLock { state in
             // Ignore root and get the parent node's content if its a directory.
             guard !path.isRoot,
-                  let parent = try? getNode(path.parentDirectory),
+                  let parent = try? self.getNode(state.root, path.parentDirectory),
                   case .directory(let contents) = parent.contents else {
                       return
                   }
@@ -431,15 +443,19 @@ public final class InMemoryFileSystem: FileSystem {
     }
 
     /// Private implementation of core copying function.
-    /// Not thread-safe.
-    private func _copy(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {
+    /// Not thread-safe; callers must hold the state lock and pass its root in.
+    private func _copy(
+        _ root: Node,
+        from sourcePath: TSCBasic.AbsolutePath,
+        to destinationPath: TSCBasic.AbsolutePath
+    ) throws {
         // Get the source node.
-        guard let source = try getNode(sourcePath) else {
+        guard let source = try self.getNode(root, sourcePath) else {
             throw FileSystemError(.noEntry, sourcePath)
         }
 
         // Create directory to destination parent.
-        guard let destinationParent = try getNode(destinationPath.parentDirectory) else {
+        guard let destinationParent = try self.getNode(root, destinationPath.parentDirectory) else {
             throw FileSystemError(.noEntry, destinationPath.parentDirectory)
         }
 
@@ -456,15 +472,15 @@ public final class InMemoryFileSystem: FileSystem {
     }
 
     public func copy(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {
-        return try lock.withLock {
-            try _copy(from: sourcePath, to: destinationPath)
+        return try self.state.withLock { state in
+            try self._copy(state.root, from: sourcePath, to: destinationPath)
         }
     }
 
     public func move(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {
-        return try lock.withLock {
+        return try self.state.withLock { state in
             // Get the source parent node.
-            guard let sourceParent = try getNode(sourcePath.parentDirectory) else {
+            guard let sourceParent = try self.getNode(state.root, sourcePath.parentDirectory) else {
                 throw FileSystemError(.noEntry, sourcePath.parentDirectory)
             }
 
@@ -473,7 +489,7 @@ public final class InMemoryFileSystem: FileSystem {
                 throw FileSystemError(.notDirectory, sourcePath.parentDirectory)
             }
 
-            try _copy(from: sourcePath, to: destinationPath)
+            try self._copy(state.root, from: sourcePath, to: destinationPath)
 
             contents.entries[sourcePath.basename] = nil
         }
@@ -484,15 +500,15 @@ public final class InMemoryFileSystem: FileSystem {
         type: FileLock.LockType = .exclusive,
         _ body: () throws -> T
     ) throws -> T {
-        let resolvedPath: TSCBasic.AbsolutePath = try lock.withLock {
-            if case let .symlink(destination) = try getNode(path)?.contents {
+        let resolvedPath: TSCBasic.AbsolutePath = try self.state.withLock { state in
+            if case let .symlink(destination) = try self.getNode(state.root, path)?.contents {
                 return try .init(validating: destination, relativeTo: path.parentDirectory)
             } else {
                 return path
             }
         }
 
-        let fileQueue: DispatchQueue = lockFilesLock.withLock {
+        let fileQueue: DispatchQueue = self.lockFiles.withLock { lockFiles in
             if let queueReference = lockFiles[resolvedPath], let queue = queueReference.reference {
                 return queue
             } else {
@@ -510,5 +526,7 @@ public final class InMemoryFileSystem: FileSystem {
     }
 }
 
-// Internal state of `InMemoryFileSystem` is protected with a lock in all of its `public` methods.
+// Internal state of `InMemoryFileSystem` lives behind a `Mutex`, so it is unreachable without
+// holding the lock. `@unchecked` is still required because the node graph it guards is made of
+// mutable reference types.
 extension InMemoryFileSystem: @unchecked Sendable {}

--- a/Sources/Basics/FileSystem/InMemoryFileSystem.swift
+++ b/Sources/Basics/FileSystem/InMemoryFileSystem.swift
@@ -20,7 +20,10 @@ import struct TSCBasic.FileSystemError
 
 /// Concrete FileSystem implementation which simulates an empty disk.
 public final class InMemoryFileSystem: FileSystem {
-    /// Private internal representation of a file system node.
+    /// Private internal representation of a file system node, and of the tree operations rooted at one.
+    ///
+    /// Not thread-safe. Callers must hold the state lock, and must not let a `Node` outlive the
+    /// `withLock` closure it came from: the compiler does not enforce either rule.
     private class Node {
         /// The actual node data.
         let contents: NodeContents
@@ -183,14 +186,13 @@ public final class InMemoryFileSystem: FileSystem {
 
     /// The mutable state of the filesystem: the root node and everything underneath it, plus the
     /// virtualized working directory.
-    ///
-    /// FIXME: Using a single lock for this is a performance problem, but in
-    /// reality, the only practical use for InMemoryFileSystem is for unit tests.
     private struct State {
-        var root: Node
+        let root: Node
         var currentWorkingDirectory: TSCBasic.AbsolutePath
     }
 
+    /// FIXME: Using a single lock for this is a performance problem, but in
+    /// reality, the only practical use for InMemoryFileSystem is for unit tests.
     private let state: Mutex<State>
 
     /// A map that keeps weak references to all locked files.

--- a/Sources/Basics/FileSystem/InMemoryFileSystem.swift
+++ b/Sources/Basics/FileSystem/InMemoryFileSystem.swift
@@ -35,7 +35,7 @@ public final class InMemoryFileSystem: FileSystem {
         }
 
         /// Creates deep copy of the object.
-        func copy() -> Node {
+        func copy() -> sending Node {
             return Node(contents.copy())
         }
     }
@@ -48,7 +48,7 @@ public final class InMemoryFileSystem: FileSystem {
         case symlink(String)
 
         /// Creates deep copy of the object.
-        func copy() -> NodeContents {
+        func copy() -> sending NodeContents {
             switch self {
             case .file(let bytes):
                 return .file(bytes)
@@ -70,7 +70,7 @@ public final class InMemoryFileSystem: FileSystem {
         }
 
         /// Creates deep copy of the object.
-        func copy() -> DirectoryContents {
+        func copy() -> sending DirectoryContents {
             let contents = DirectoryContents()
             for (key, node) in entries {
                 contents.entries[key] = node.copy()
@@ -83,11 +83,8 @@ public final class InMemoryFileSystem: FileSystem {
     /// virtualized working directory.
     ///
     /// FIXME: Using a single lock for this is a performance problem, but in
-    /// reality, the only practical use for InMemoryFileSystem is for unit
-    /// tests.
-    /// `@unchecked` because `Node` is a mutable reference type; holding the mutex is what makes
-    /// access to the graph safe.
-    private struct State: @unchecked Sendable {
+    /// reality, the only practical use for InMemoryFileSystem is for unit tests.
+    private struct State {
         var root: Node
         var currentWorkingDirectory: TSCBasic.AbsolutePath
     }
@@ -111,7 +108,7 @@ public final class InMemoryFileSystem: FileSystem {
         self.init(root: Node(.directory(DirectoryContents())))
     }
 
-    private init(root: Node) {
+    private init(root: sending Node) {
         self.state = Mutex(
             State(root: root, currentWorkingDirectory: try! .init(validating: "/"))
         )
@@ -126,7 +123,7 @@ public final class InMemoryFileSystem: FileSystem {
 
     /// Private function to look up the node corresponding to a path.
     /// Not thread-safe; callers must hold the state lock and pass its root in.
-    private func getNode(
+    private static func getNode(
         _ root: Node,
         _ path: TSCBasic.AbsolutePath,
         followSymlink: Bool = true
@@ -170,7 +167,7 @@ public final class InMemoryFileSystem: FileSystem {
     public func exists(_ path: TSCBasic.AbsolutePath, followSymlink: Bool) -> Bool {
         return self.state.withLock { state in
             do {
-                switch try self.getNode(state.root, path, followSymlink: followSymlink)?.contents {
+                switch try Self.getNode(state.root, path, followSymlink: followSymlink)?.contents {
                 case .file, .directory, .symlink: return true
                 case .none: return false
                 }
@@ -183,7 +180,7 @@ public final class InMemoryFileSystem: FileSystem {
     public func isDirectory(_ path: TSCBasic.AbsolutePath) -> Bool {
         return self.state.withLock { state in
             do {
-                if case .directory? = try self.getNode(state.root, path)?.contents {
+                if case .directory? = try Self.getNode(state.root, path)?.contents {
                     return true
                 }
                 return false
@@ -196,7 +193,7 @@ public final class InMemoryFileSystem: FileSystem {
     public func isFile(_ path: TSCBasic.AbsolutePath) -> Bool {
         return self.state.withLock { state in
             do {
-                if case .file? = try self.getNode(state.root, path)?.contents {
+                if case .file? = try Self.getNode(state.root, path)?.contents {
                     return true
                 }
                 return false
@@ -209,7 +206,7 @@ public final class InMemoryFileSystem: FileSystem {
     public func isSymlink(_ path: TSCBasic.AbsolutePath) -> Bool {
         return self.state.withLock { state in
             do {
-                if case .symlink? = try self.getNode(state.root, path, followSymlink: false)?.contents {
+                if case .symlink? = try Self.getNode(state.root, path, followSymlink: false)?.contents {
                     return true
                 }
                 return false
@@ -229,13 +226,13 @@ public final class InMemoryFileSystem: FileSystem {
 
     public func isExecutableFile(_ path: TSCBasic.AbsolutePath) -> Bool {
         self.state.withLock { state in
-            (try? self.getNode(state.root, path)?.isExecutable) ?? false
+            (try? Self.getNode(state.root, path)?.isExecutable) ?? false
         }
     }
 
     public func updatePermissions(_ path: AbsolutePath, isExecutable: Bool) throws {
         try self.state.withLock { state in
-            guard let node = try self.getNode(state.root, path.underlying, followSymlink: true) else {
+            guard let node = try Self.getNode(state.root, path.underlying, followSymlink: true) else {
                 throw FileSystemError(.noEntry, path)
             }
             node.isExecutable = isExecutable
@@ -249,7 +246,7 @@ public final class InMemoryFileSystem: FileSystem {
     public func changeCurrentWorkingDirectory(to path: TSCBasic.AbsolutePath) throws {
         return try self.state.withLock { state in
             // Verify the path exists and is a directory
-            guard let node = try self.getNode(state.root, path) else {
+            guard let node = try Self.getNode(state.root, path) else {
                 throw FileSystemError(.noEntry, path)
             }
 
@@ -279,7 +276,7 @@ public final class InMemoryFileSystem: FileSystem {
 
     public func getDirectoryContents(_ path: TSCBasic.AbsolutePath) throws -> [String] {
         return try self.state.withLock { state in
-            guard let node = try self.getNode(state.root, path) else {
+            guard let node = try Self.getNode(state.root, path) else {
                 throw FileSystemError(.noEntry, path)
             }
             guard case .directory(let contents) = node.contents else {
@@ -292,22 +289,22 @@ public final class InMemoryFileSystem: FileSystem {
     }
 
     /// Not thread-safe; callers must hold the state lock and pass its root in.
-    private func _createDirectory(_ root: Node, _ path: TSCBasic.AbsolutePath, recursive: Bool) throws {
+    private static func _createDirectory(_ root: Node, _ path: TSCBasic.AbsolutePath, recursive: Bool) throws {
         // Ignore if client passes root.
         guard !path.isRoot else {
             return
         }
         // Get the parent directory node.
         let parentPath = path.parentDirectory
-        guard let parent = try self.getNode(root, parentPath) else {
+        guard let parent = try Self.getNode(root, parentPath) else {
             // If the parent doesn't exist, and we are recursive, then attempt
             // to create the parent and retry.
             if recursive && path != parentPath {
                 // Attempt to create the parent.
-                try self._createDirectory(root, parentPath, recursive: true)
+                try Self._createDirectory(root, parentPath, recursive: true)
 
                 // Re-attempt creation, non-recursively.
-                return try self._createDirectory(root, path, recursive: false)
+                return try Self._createDirectory(root, path, recursive: false)
             } else {
                 // Otherwise, we failed.
                 throw FileSystemError(.noEntry, parentPath)
@@ -338,7 +335,7 @@ public final class InMemoryFileSystem: FileSystem {
 
     public func createDirectory(_ path: TSCBasic.AbsolutePath, recursive: Bool) throws {
         return try self.state.withLock { state in
-            try self._createDirectory(state.root, path, recursive: recursive)
+            try Self._createDirectory(state.root, path, recursive: recursive)
         }
     }
 
@@ -349,7 +346,7 @@ public final class InMemoryFileSystem: FileSystem {
     ) throws {
         return try self.state.withLock { state in
             // Create directory to destination parent.
-            guard let destinationParent = try self.getNode(state.root, path.parentDirectory) else {
+            guard let destinationParent = try Self.getNode(state.root, path.parentDirectory) else {
                 throw FileSystemError(.noEntry, path.parentDirectory)
             }
 
@@ -371,7 +368,7 @@ public final class InMemoryFileSystem: FileSystem {
     public func readFileContents(_ path: TSCBasic.AbsolutePath) throws -> ByteString {
         return try self.state.withLock { state in
             // Get the node.
-            guard let node = try self.getNode(state.root, path) else {
+            guard let node = try Self.getNode(state.root, path) else {
                 throw FileSystemError(.noEntry, path)
             }
 
@@ -395,7 +392,7 @@ public final class InMemoryFileSystem: FileSystem {
             }
 
             // Get the parent node.
-            guard let parent = try self.getNode(state.root, parentPath) else {
+            guard let parent = try Self.getNode(state.root, parentPath) else {
                 throw FileSystemError(.noEntry, parentPath)
             }
 
@@ -429,7 +426,7 @@ public final class InMemoryFileSystem: FileSystem {
         return self.state.withLock { state in
             // Ignore root and get the parent node's content if its a directory.
             guard !path.isRoot,
-                  let parent = try? self.getNode(state.root, path.parentDirectory),
+                  let parent = try? Self.getNode(state.root, path.parentDirectory),
                   case .directory(let contents) = parent.contents else {
                       return
                   }
@@ -444,18 +441,18 @@ public final class InMemoryFileSystem: FileSystem {
 
     /// Private implementation of core copying function.
     /// Not thread-safe; callers must hold the state lock and pass its root in.
-    private func _copy(
+    private static func _copy(
         _ root: Node,
         from sourcePath: TSCBasic.AbsolutePath,
         to destinationPath: TSCBasic.AbsolutePath
     ) throws {
         // Get the source node.
-        guard let source = try self.getNode(root, sourcePath) else {
+        guard let source = try Self.getNode(root, sourcePath) else {
             throw FileSystemError(.noEntry, sourcePath)
         }
 
         // Create directory to destination parent.
-        guard let destinationParent = try self.getNode(root, destinationPath.parentDirectory) else {
+        guard let destinationParent = try Self.getNode(root, destinationPath.parentDirectory) else {
             throw FileSystemError(.noEntry, destinationPath.parentDirectory)
         }
 
@@ -473,14 +470,14 @@ public final class InMemoryFileSystem: FileSystem {
 
     public func copy(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {
         return try self.state.withLock { state in
-            try self._copy(state.root, from: sourcePath, to: destinationPath)
+            try Self._copy(state.root, from: sourcePath, to: destinationPath)
         }
     }
 
     public func move(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {
         return try self.state.withLock { state in
             // Get the source parent node.
-            guard let sourceParent = try self.getNode(state.root, sourcePath.parentDirectory) else {
+            guard let sourceParent = try Self.getNode(state.root, sourcePath.parentDirectory) else {
                 throw FileSystemError(.noEntry, sourcePath.parentDirectory)
             }
 
@@ -489,7 +486,7 @@ public final class InMemoryFileSystem: FileSystem {
                 throw FileSystemError(.notDirectory, sourcePath.parentDirectory)
             }
 
-            try self._copy(state.root, from: sourcePath, to: destinationPath)
+            try Self._copy(state.root, from: sourcePath, to: destinationPath)
 
             contents.entries[sourcePath.basename] = nil
         }
@@ -501,7 +498,7 @@ public final class InMemoryFileSystem: FileSystem {
         _ body: () throws -> T
     ) throws -> T {
         let resolvedPath: TSCBasic.AbsolutePath = try self.state.withLock { state in
-            if case let .symlink(destination) = try self.getNode(state.root, path)?.contents {
+            if case let .symlink(destination) = try Self.getNode(state.root, path)?.contents {
                 return try .init(validating: destination, relativeTo: path.parentDirectory)
             } else {
                 return path
@@ -525,8 +522,3 @@ public final class InMemoryFileSystem: FileSystem {
         try self.withLock(on: path, type: type, body)
     }
 }
-
-// Internal state of `InMemoryFileSystem` lives behind a `Mutex`, so it is unreachable without
-// holding the lock. `@unchecked` is still required because the node graph it guards is made of
-// mutable reference types.
-extension InMemoryFileSystem: @unchecked Sendable {}

--- a/Sources/Basics/FileSystem/InMemoryFileSystem.swift
+++ b/Sources/Basics/FileSystem/InMemoryFileSystem.swift
@@ -35,7 +35,7 @@ public final class InMemoryFileSystem: FileSystem {
 
         /// Creates deep copy of the object.
         func copy() -> sending Node {
-            return Node(contents.copy())
+            return Node(contents.copy(), isExecutable: isExecutable)
         }
 
         /// Looks up the node corresponding to `path`.

--- a/Tests/BasicsTests/FileSystem/InMemoryFilesSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/InMemoryFilesSystemTests.swift
@@ -121,6 +121,39 @@ struct InMemoryFileSystemTests {
         }
     }
 
+    @Suite(
+        .tags(
+            .TestSize.small,
+        ),
+    )
+    struct CopyTests {
+        @Test
+        func deepCopyPreservesTheExecutableBit() async throws {
+            let fs = InMemoryFileSystem()
+            let pathUnderTest = AbsolutePath("/tool")
+            try fs.writeFileContents(pathUnderTest, bytes: testFileContent)
+            try fs.updatePermissions(pathUnderTest, isExecutable: true)
+
+            let copied = fs.copy()
+
+            #expect(
+                copied.isExecutableFile(pathUnderTest),
+                "Path \(pathUnderTest.pathString) is not executable in the copy when it should be")
+        }
+
+        @Test
+        func deepCopyPreservesFileContents() async throws {
+            let fs = InMemoryFileSystem()
+            let pathUnderTest = AbsolutePath("/nested/myFile.zip")
+            try fs.createDirectory(pathUnderTest.parentDirectory, recursive: true)
+            try fs.writeFileContents(pathUnderTest, bytes: testFileContent)
+
+            let copied = fs.copy()
+
+            #expect(try copied.readFileContents(pathUnderTest) == testFileContent)
+        }
+    }
+
     struct writeFileContentsTests {
 
         @Test


### PR DESCRIPTION
The root node and the virtualized working directory move into a private `State` struct behind a `Mutex`, and `lockFiles` gets a Mutex of its own. `getNode`, `_createDirectory` and `_copy` now take the root explicitly rather than reading `self.root`, since it only exists inside the closure.

There were two potential races where we were reading state without the lock: `isExecutableFile` walked the node graph via `getNode`, and `currentWorkingDirectory` was written under the lock but read without it. Neither is expressible now.
