### PR TITLE
updating the README to walk through the CLI docs generation process more explicitly

### DIFF
--- a/Sources/PackageManagerDocs/README.md
+++ b/Sources/PackageManagerDocs/README.md
@@ -3,15 +3,14 @@ code, and needs the binary `generate-docc-reference-tool` to work against locall
 built versions to generate up the docc-flavored markdown files.
 
 This README presumes that you have local dependencies as neighbor enlistments to the package manager repository, such as a local Swift toolchain checkout.
-You can use the version of Swift Argument Parser that SwiftPM manages as a dependency. Using a local build, start by running `swift package resolve` from the root of the SwiftPM project, then:
+Setting `SWIFTCI_USE_LOCAL_DEPS=1` points package dependencies to neighboring `swift-argument-parser` git enlistments (a local path dependency).
 
 ```bash
 export SWIFTCI_USE_LOCAL_DEPS=1
-swift package resolve
-pushd .build/checkouts/swift-argument-parser
+pushd "$(git rev-parse --show-toplevel)/../swift-argument-parser"
 swift build --target generate-docc-reference
 popd
-export DOCC_REF_PATH=".build/checkouts/swift-argument-parser/.build/debug"
+export DOCC_REF_PATH="$(git rev-parse --show-toplevel)/../swift-argument-parser/.build/debug"
 swift build -c release # to generate the CLIs
 ```
 

--- a/Sources/PackageManagerDocs/README.md
+++ b/Sources/PackageManagerDocs/README.md
@@ -1,23 +1,55 @@
-Manually generated the docc content stubs using the swift argument parser tool `generate-docc-reference-tool`:
+The CLI documentation content is generated from the `help` configurations of the 
+code, and needs the binary `generate-docc-reference-tool` to work against locally
+built versions to generate up the docc-flavored markdown files.
 
-The `generate-docc-reference` doesn't work for automatically creating all these because of a quirk in swift-package-manager, which is a driver
-executable and expects to be called with different names. The heurstics in swift-argument-parser's generation tool don't accomodate this use case.
+This README presumes that you have local dependencies as neighbor enlistments to the package manager repository, such as a local Swift toolchain checkout.
+You can use the version of Swift Argument Parser that SwiftPM manages as a dependency. Using a local build, start by running `swift package resolve` from the root of the SwiftPM project, then:
 
 ```bash
-swift build -c release
-.build/debug/generate-docc-reference-tool .build/release/swift-test -o Sources/PackageManagerDocs/Documentation.docc --style docc
-.build/debug/generate-docc-reference-tool .build/release/swift-bootstrap -o Sources/PackageManagerDocs/Documentation.docc --style docc
-.build/debug/generate-docc-reference-tool .build/release/swift-sdk -o Sources/PackageManagerDocs/Documentation.docc --style docc
-.build/debug/generate-docc-reference-tool .build/release/swift-run -o Sources/PackageManagerDocs/Documentation.docc --style docc
-.build/debug/generate-docc-reference-tool .build/release/swift-package -o Sources/PackageManagerDocs/Documentation.docc --style docc
-.build/debug/generate-docc-reference-tool .build/release/swift-package-registry -o Sources/PackageManagerDocs/Documentation.docc --style docc
-.build/debug/generate-docc-reference-tool .build/release/swift-package-collection -o Sources/PackageManagerDocs/Documentation.docc --style docc
-.build/debug/generate-docc-reference-tool .build/release/swift-build -o Sources/PackageManagerDocs/Documentation.docc --style docc
-.build/debug/generate-docc-reference-tool .build/release/swift-build-prebuilts -o Sources/PackageManagerDocs/Documentation.docc --style docc
+export SWIFTCI_USE_LOCAL_DEPS=1
+swift package resolve
+pushd .build/checkouts/swift-argument-parser
+swift build --target generate-docc-reference
+popd
+export DOCC_REF_PATH=".build/checkouts/swift-argument-parser/.build/debug"
+swift build -c release # to generate the CLIs
 ```
 
-As of May 2025, the generation tool generates a single large markdown file in DocC format, which we then split up manually into small pieces
-for the CLI content.
+The `generate-docc-reference` doesn't work for automatically creating all these because
+of a quirk in swift-package-manager, which the driver executable that expects to be
+called with different names rather than as a singular executable binary. 
+The heurstics in swift-argument-parser's generation tool don't accomodate this use case,
+so we invoke it differently to create the raw markdown output:
+
+```bash
+${DOCC_REF_PATH}/generate-docc-reference .build/release/swift-test -o Sources/PackageManagerDocs/Documentation.docc --style docc
+${DOCC_REF_PATH}/generate-docc-reference .build/release/swift-bootstrap -o Sources/PackageManagerDocs/Documentation.docc --style docc
+${DOCC_REF_PATH}/generate-docc-reference .build/release/swift-sdk -o Sources/PackageManagerDocs/Documentation.docc --style docc
+${DOCC_REF_PATH}/generate-docc-reference .build/release/swift-run -o Sources/PackageManagerDocs/Documentation.docc --style docc
+${DOCC_REF_PATH}/generate-docc-reference .build/release/swift-package -o Sources/PackageManagerDocs/Documentation.docc --style docc
+${DOCC_REF_PATH}/generate-docc-reference .build/release/swift-package-registry -o Sources/PackageManagerDocs/Documentation.docc --style docc
+${DOCC_REF_PATH}/generate-docc-reference .build/release/swift-package-collection -o Sources/PackageManagerDocs/Documentation.docc --style docc
+${DOCC_REF_PATH}/generate-docc-reference .build/release/swift-build -o Sources/PackageManagerDocs/Documentation.docc --style docc
+${DOCC_REF_PATH}/generate-docc-reference .build/release/swift-build-prebuilts -o Sources/PackageManagerDocs/Documentation.docc --style docc
+```
+
+The sequence of commands above results in a set of new markdown files that need 
+to be split and moved based on command and subcommand:
+
+```
+Sources/PackageManagerDocs/Documentation.docc/build-prebuilts.md
+Sources/PackageManagerDocs/Documentation.docc/build.md
+Sources/PackageManagerDocs/Documentation.docc/package-collection.md
+Sources/PackageManagerDocs/Documentation.docc/package-registry.md
+Sources/PackageManagerDocs/Documentation.docc/package.md
+Sources/PackageManagerDocs/Documentation.docc/run.md
+Sources/PackageManagerDocs/Documentation.docc/sdk.md
+Sources/PackageManagerDocs/Documentation.docc/swift-bootstrap.md
+Sources/PackageManagerDocs/Documentation.docc/test.md
+```
+
+As of May 2025, the generation tool generates a single large markdown file in DocC
+format, which we then split up manually into small pieces for the CLI content. 
 
 Use the following command to preview documentation changes for this target:
 


### PR DESCRIPTION
updating the README to walk through the CLI docs generation process more explicitly

### Motivation:

the manual process notes for regenerating the CLI documentation was out of date, and missed some key pieces of making the docs-reference-tool from Swift Argument parser available at an expected location. 

### Modifications:

- update the README

### Result:

With a local Swift toolchain checkout, you should be able to follow the steps in the README piece by piece to regenerate all the raw markdown content that can be split into CLI documentation for Package Manager documentation.
