### PR TITLE
Android: link libc++ instead of libstdc++ for C++ targets

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -74,7 +74,7 @@ extension BuildPlan {
             for description in dependencies.staticTargets {
                 if case let target as ClangModule = description.module.underlying, target.isCXX {
                     let triple = buildProduct.buildParameters.triple
-                    if triple.isDarwin() || triple.isFreeBSD() {
+                    if triple.isDarwin() || triple.isFreeBSD() || triple.isAndroid() {
                         buildProduct.additionalFlags += ["-lc++"]
                     } else if triple.isWindows() {
                         // Don't link any C++ library.

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -610,11 +610,11 @@ extension PackagePIFProjectBuilder {
         }
         if sourceModule.isCxx {
             for platform in ProjectModel.BuildSettings.Platform.allCases {
-                // darwin & freebsd
+                // darwin, freebsd & android (bionic only provides libc++)
                 switch platform {
-                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd:
+                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd, .android:
                         impartedSettings[.OTHER_LDFLAGS, platform] = ["-lc++", "$(inherited)"]
-                    case .android, .linux, .wasi, .openbsd:
+                    case .linux, .wasi, .openbsd:
                         impartedSettings[.OTHER_LDFLAGS, platform] = ["-lstdc++", "$(inherited)"]
                     case .windows, ._iOSDevice:
                         break

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2890,6 +2890,21 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         linkArgs = try result.buildProduct(for: "exe").linkArguments()
 
         XCTAssertMatch(linkArgs, ["-lstdc++"])
+
+        // Verify that `-lc++` is passed when cross-compiling to Android,
+        // as the NDK has not shipped libstdc++ since r18.
+        result = try await BuildPlanResult(plan: mockBuildPlan(
+            triple: .arm64Android,
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(2)
+        linkArgs = try result.buildProduct(for: "exe").linkArguments()
+
+        XCTAssertMatch(linkArgs, ["-lc++"])
+        XCTAssertNoMatch(linkArgs, ["-lstdc++"])
     }
 
     func testDynamicProducts() async throws {

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -645,9 +645,9 @@ struct PIFBuilderTests {
             for platform in ProjectModel.BuildSettings.Platform.allCases {
                 let ld_flags = releaseConfig.impartedBuildProperties.settings[.OTHER_LDFLAGS, platform]
                 switch platform {
-                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd:
+                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd, .android:
                          #expect(ld_flags == ["-lc++", "$(inherited)"], "for platform \(platform)")
-                    case .android, .linux, .wasi, .openbsd:
+                    case .linux, .wasi, .openbsd:
                         #expect(ld_flags == ["-lstdc++", "$(inherited)"], "for platform \(platform)")
                     case .windows, ._iOSDevice:
                         #expect(ld_flags == nil, "for platform \(platform)")


### PR DESCRIPTION
## Motivation

The Android NDK has not shipped libstdc++ since r18 — bionic only provides libc++. SwiftPM currently emits `-lstdc++` for Android targets in both build systems, so linking any package with C++ sources against a swift.org Android SDK fails with `cannot find -lstdc++`.

## Modifications

- `BuildPlan+Product.swift` (native build system): add `triple.isAndroid()` to the `-lc++` branch.
- `PackagePIFProjectBuilder+Modules.swift` (SwiftBuild/PIF): move `.android` from the `-lstdc++` case to the `-lc++` case.

## Result

Android cross-compile links of C++-containing packages use `-lc++`.

## Test

- Extended `testCppModule` with an `.arm64Android` cross-compile case asserting `-lc++` and no `-lstdc++`.
- Updated `PIFBuilderTests.platformCCLibrary` so `.android` expects `-lc++`.

Verified on an aarch64 Android host (Termux/proot): the new `.arm64Android` assertions pass and `.arm64Linux` still links `-lstdc++`. (The pre-existing host-triple assertion in `testCppModule` expects `-lstdc++` for non-Darwin hosts and fails only because this device's host triple is itself Android; `platformCCLibrary` cannot run there due to a pre-existing fixture-loading issue affecting all `withGeneratedPIF` tests — the untouched `platformConditionBasics` fails identically.)