### PR TITLE
Make placeholder PIF construction a type operation

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -298,7 +298,7 @@ public final class PackagePIFBuilder {
 
     /// Build an empty PIF project for the specified `Package`.
 
-    public class func buildEmptyPIF(package: PackageModel.Package) -> ProjectModel.Project {
+    public static func buildEmptyPIF(package: PackageModel.Package) -> ProjectModel.Project {
         self.buildEmptyPIF(
             id: "PACKAGE:\(package.identity)",
             path: package.manifest.path.pathString,
@@ -309,7 +309,7 @@ public final class PackagePIFBuilder {
     }
 
     /// Build an empty PIF project.
-    public class func buildEmptyPIF(
+    public static func buildEmptyPIF(
         id: String,
         path: String,
         projectDir: String,
@@ -346,7 +346,7 @@ public final class PackagePIFBuilder {
     }
 
     /// Build a *placeholder* PIF project for the specified `Package`.
-    public class func buildPlaceholderPIF(
+    public static func buildPlaceholderPIF(
         package: PackageModel.Package
     ) -> (project: ProjectModel.Project, placeholder: ModuleOrProduct) {
         self.buildPlaceholderPIF(
@@ -366,7 +366,7 @@ public final class PackagePIFBuilder {
     /// produces a project with no targets at all.
     ///
     /// Requires no builder instance, and so can be used for a package that failed to load.
-    public class func buildPlaceholderPIF(
+    public static func buildPlaceholderPIF(
         id: String,
         path: String,
         projectDir: String,

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -339,38 +339,79 @@ public final class PackagePIFBuilder {
         return project
     }
 
+    /// Build a *placeholder* PIF project.
     public func buildPlaceholderPIF(id: String, path: String, projectDir: String, name: String) -> ModuleOrProduct {
-        var project = ProjectModel.Project(
+        let (project, placeholderModule) = PackagePIFBuilder.buildPlaceholderPIF(
+            id: id,
+            path: path,
+            projectDir: projectDir,
+            name: name,
+            targetBuildSettings: self.package.underlying.packageBaseBuildSettings,
+            developmentRegion: self.package.manifest.defaultLocalization
+        )
+        self._pifProject = project
+        return placeholderModule
+    }
+
+    /// Build a *placeholder* PIF project for the specified `Package`.
+    public class func buildPlaceholderPIF(
+        package: PackageModel.Package
+    ) -> (project: ProjectModel.Project, placeholder: ModuleOrProduct) {
+        self.buildPlaceholderPIF(
+            id: "PACKAGE:\(package.identity)",
+            path: package.manifest.path.pathString,
+            projectDir: package.path.pathString,
+            name: package.name,
+            targetBuildSettings: package.packageBaseBuildSettings,
+            developmentRegion: package.manifest.defaultLocalization
+        )
+    }
+
+    /// Build a *placeholder* PIF project.
+    ///
+    /// The project contains a single *aggregate* target, `PACKAGE-PLACEHOLDER:<id>`, which has no
+    /// product and no build phases, and so builds nothing. Contrast with `buildEmptyPIF`, which
+    /// produces a project with no targets at all.
+    ///
+    /// Requires no builder instance, and so can be used for a package that failed to load.
+    public class func buildPlaceholderPIF(
+        id: String,
+        path: String,
+        projectDir: String,
+        name: String,
+        targetBuildSettings: ProjectModel.BuildSettings,
+        developmentRegion: String? = nil
+    ) -> (project: ProjectModel.Project, placeholder: ModuleOrProduct) {
+        var packageProject = ProjectModel.Project(
             id: GUID(id),
             path: path,
             projectDir: projectDir,
-            name: name
+            name: name,
+            developmentRegion: developmentRegion
         )
 
         let projectSettings = ProjectModel.BuildSettings()
 
-        project.addBuildConfig { id in ProjectModel.BuildConfig(id: id, name: "Debug", settings: projectSettings) }
-        project.addBuildConfig { id in ProjectModel.BuildConfig(id: id, name: "Release", settings: projectSettings) }
+        packageProject.addBuildConfig { id in ProjectModel.BuildConfig(id: id, name: "Debug", settings: projectSettings) }
+        packageProject.addBuildConfig { id in ProjectModel.BuildConfig(id: id, name: "Release", settings: projectSettings) }
 
-        let targetKeyPath = try! project.addAggregateTarget { _ in
+        // A new project can *not* already contain this target, so adding it cannot fail.
+        let targetKeyPath = try! packageProject.addAggregateTarget { _ in
             ProjectModel.AggregateTarget(id: "PACKAGE-PLACEHOLDER:\(id)", name: id)
         }
-        let targetSettings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
 
-        project[keyPath: targetKeyPath].common.addBuildConfig { id in
-            ProjectModel.BuildConfig(id: id, name: "Debug", settings: targetSettings)
+        packageProject[keyPath: targetKeyPath].common.addBuildConfig { id in
+            ProjectModel.BuildConfig(id: id, name: "Debug", settings: targetBuildSettings)
         }
-        project[keyPath: targetKeyPath].common.addBuildConfig { id in
-            ProjectModel.BuildConfig(id: id, name: "Release", settings: targetSettings)
+        packageProject[keyPath: targetKeyPath].common.addBuildConfig { id in
+            ProjectModel.BuildConfig(id: id, name: "Release", settings: targetBuildSettings)
         }
-
-        self._pifProject = project
 
         let placeholderModule = ModuleOrProduct(
             type: .placeholder,
             name: name,
             moduleName: name,
-            pifTarget: .aggregate(project[keyPath: targetKeyPath]),
+            pifTarget: .aggregate(packageProject[keyPath: targetKeyPath]),
             indexableFileURLs: [],
             headerFiles: [],
             linkedPackageBinaries: [],
@@ -379,7 +420,7 @@ public final class PackagePIFBuilder {
             deploymentTargets: nil,
             toolsVersion: nil
         )
-        return placeholderModule
+        return (packageProject, placeholderModule)
     }
 
     // FIXME: Maybe break this up in a `ArtifactMetadata` protocol and two value types —— Paulo

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -306,7 +306,7 @@ public final class PackagePIFBuilder {
 
     /// Build an empty PIF project for the specified `Package`.
 
-    public class func buildEmptyPIF(package: PackageModel.Package) -> ProjectModel.Project {
+    public static func buildEmptyPIF(package: PackageModel.Package) -> ProjectModel.Project {
         self.buildEmptyPIF(
             id: "PACKAGE:\(package.identity)",
             path: package.manifest.path.pathString,
@@ -317,7 +317,7 @@ public final class PackagePIFBuilder {
     }
 
     /// Build an empty PIF project.
-    public class func buildEmptyPIF(
+    public static func buildEmptyPIF(
         id: String,
         path: String,
         projectDir: String,
@@ -354,7 +354,7 @@ public final class PackagePIFBuilder {
     }
 
     /// Build a *placeholder* PIF project for the specified `Package`.
-    public class func buildPlaceholderPIF(
+    public static func buildPlaceholderPIF(
         package: PackageModel.Package
     ) -> (project: ProjectModel.Project, placeholder: ModuleOrProduct) {
         self.buildPlaceholderPIF(
@@ -374,7 +374,7 @@ public final class PackagePIFBuilder {
     /// produces a project with no targets at all.
     ///
     /// Requires no builder instance, and so can be used for a package that failed to load.
-    public class func buildPlaceholderPIF(
+    public static func buildPlaceholderPIF(
         id: String,
         path: String,
         projectDir: String,

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -331,38 +331,79 @@ public final class PackagePIFBuilder {
         return project
     }
 
+    /// Build a *placeholder* PIF project.
     public func buildPlaceholderPIF(id: String, path: String, projectDir: String, name: String) -> ModuleOrProduct {
-        var project = ProjectModel.Project(
+        let (project, placeholderModule) = PackagePIFBuilder.buildPlaceholderPIF(
+            id: id,
+            path: path,
+            projectDir: projectDir,
+            name: name,
+            targetBuildSettings: self.package.underlying.packageBaseBuildSettings,
+            developmentRegion: self.package.manifest.defaultLocalization
+        )
+        self._pifProject = project
+        return placeholderModule
+    }
+
+    /// Build a *placeholder* PIF project for the specified `Package`.
+    public class func buildPlaceholderPIF(
+        package: PackageModel.Package
+    ) -> (project: ProjectModel.Project, placeholder: ModuleOrProduct) {
+        self.buildPlaceholderPIF(
+            id: "PACKAGE:\(package.identity)",
+            path: package.manifest.path.pathString,
+            projectDir: package.path.pathString,
+            name: package.name,
+            targetBuildSettings: package.packageBaseBuildSettings,
+            developmentRegion: package.manifest.defaultLocalization
+        )
+    }
+
+    /// Build a *placeholder* PIF project.
+    ///
+    /// The project contains a single *aggregate* target, `PACKAGE-PLACEHOLDER:<id>`, which has no
+    /// product and no build phases, and so builds nothing. Contrast with `buildEmptyPIF`, which
+    /// produces a project with no targets at all.
+    ///
+    /// Requires no builder instance, and so can be used for a package that failed to load.
+    public class func buildPlaceholderPIF(
+        id: String,
+        path: String,
+        projectDir: String,
+        name: String,
+        targetBuildSettings: ProjectModel.BuildSettings,
+        developmentRegion: String? = nil
+    ) -> (project: ProjectModel.Project, placeholder: ModuleOrProduct) {
+        var packageProject = ProjectModel.Project(
             id: GUID(id),
             path: path,
             projectDir: projectDir,
-            name: name
+            name: name,
+            developmentRegion: developmentRegion
         )
 
         let projectSettings = ProjectModel.BuildSettings()
 
-        project.addBuildConfig { id in ProjectModel.BuildConfig(id: id, name: "Debug", settings: projectSettings) }
-        project.addBuildConfig { id in ProjectModel.BuildConfig(id: id, name: "Release", settings: projectSettings) }
+        packageProject.addBuildConfig { id in ProjectModel.BuildConfig(id: id, name: "Debug", settings: projectSettings) }
+        packageProject.addBuildConfig { id in ProjectModel.BuildConfig(id: id, name: "Release", settings: projectSettings) }
 
-        let targetKeyPath = try! project.addAggregateTarget { _ in
+        // A new project can *not* already contain this target, so adding it cannot fail.
+        let targetKeyPath = try! packageProject.addAggregateTarget { _ in
             ProjectModel.AggregateTarget(id: "PACKAGE-PLACEHOLDER:\(id)", name: id)
         }
-        let targetSettings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
 
-        project[keyPath: targetKeyPath].common.addBuildConfig { id in
-            ProjectModel.BuildConfig(id: id, name: "Debug", settings: targetSettings)
+        packageProject[keyPath: targetKeyPath].common.addBuildConfig { id in
+            ProjectModel.BuildConfig(id: id, name: "Debug", settings: targetBuildSettings)
         }
-        project[keyPath: targetKeyPath].common.addBuildConfig { id in
-            ProjectModel.BuildConfig(id: id, name: "Release", settings: targetSettings)
+        packageProject[keyPath: targetKeyPath].common.addBuildConfig { id in
+            ProjectModel.BuildConfig(id: id, name: "Release", settings: targetBuildSettings)
         }
-
-        self._pifProject = project
 
         let placeholderModule = ModuleOrProduct(
             type: .placeholder,
             name: name,
             moduleName: name,
-            pifTarget: .aggregate(project[keyPath: targetKeyPath]),
+            pifTarget: .aggregate(packageProject[keyPath: targetKeyPath]),
             indexableFileURLs: [],
             headerFiles: [],
             linkedPackageBinaries: [],
@@ -371,7 +412,7 @@ public final class PackagePIFBuilder {
             deploymentTargets: nil,
             toolsVersion: nil
         )
-        return placeholderModule
+        return (packageProject, placeholderModule)
     }
 
     // FIXME: Maybe break this up in a `ArtifactMetadata` protocol and two value types —— Paulo

--- a/Tests/SwiftBuildSupportTests/PIFPlaceholderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFPlaceholderTests.swift
@@ -1,0 +1,154 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Foundation
+import SwiftBuild
+@testable import SwiftBuildSupport
+import Testing
+
+@Suite(
+    .tags(
+        .TestSize.small,
+        .FunctionalArea.PIF
+    )
+)
+struct PIFPlaceholderTests {
+
+    @Test("Placeholder PIF describes the project it was asked for")
+    func placeholderProjectMirrorsItsArguments() {
+        let (project, _) = PackagePIFBuilder.buildPlaceholderPIF(
+            id: "PACKAGE:example",
+            path: "/tmp/Example/Package.swift",
+            projectDir: "/tmp/Example",
+            name: "Example",
+            targetBuildSettings: ProjectModel.BuildSettings(),
+            developmentRegion: "en"
+        )
+
+        #expect(project.id.value == "PACKAGE:example")
+        #expect(project.path == "/tmp/Example/Package.swift")
+        #expect(project.projectDir == "/tmp/Example")
+        #expect(project.name == "Example")
+        #expect(project.developmentRegion == "en")
+        #expect(project.buildConfigs.map(\.name) == ["Debug", "Release"])
+    }
+
+    @Test("Placeholder PIF has a single aggregate target, unlike an empty PIF")
+    func placeholderHasExactlyOneAggregateTarget() throws {
+        let (project, placeholderModule) = PackagePIFBuilder.buildPlaceholderPIF(
+            id: "PACKAGE:example",
+            path: "/tmp/Example/Package.swift",
+            projectDir: "/tmp/Example",
+            name: "Example",
+            targetBuildSettings: ProjectModel.BuildSettings()
+        )
+
+        // The single aggregate target is what distinguishes a *placeholder* PIF from an *empty* one.
+        let aggregateTarget = try #require(project.targets.only)
+        guard case .aggregate = aggregateTarget else {
+            Issue.record("expected the placeholder target to be an aggregate target")
+            return
+        }
+        #expect(aggregateTarget.id.value == "PACKAGE-PLACEHOLDER:PACKAGE:example")
+        #expect(aggregateTarget.common.buildConfigs.map(\.name) == ["Debug", "Release"])
+
+        // An empty PIF, in contrast, has no targets at all.
+        let emptyProject = PackagePIFBuilder.buildEmptyPIF(
+            id: "PACKAGE:example",
+            path: "/tmp/Example/Package.swift",
+            projectDir: "/tmp/Example",
+            name: "Example"
+        )
+        #expect(emptyProject.targets.count == 0)
+
+        // The returned module describes that same placeholder target.
+        #expect(placeholderModule.type == .placeholder)
+        #expect(placeholderModule.name == "Example")
+        #expect(placeholderModule.moduleName == "Example")
+        #expect(placeholderModule.pifTarget?.id == aggregateTarget.id)
+    }
+
+    @Test("Placeholder PIF applies the given build settings to the target, not to the project")
+    func placeholderAppliesTargetBuildSettings() throws {
+        var targetBuildSettings = ProjectModel.BuildSettings()
+        targetBuildSettings[.SDKROOT] = "auto"
+
+        let (project, _) = PackagePIFBuilder.buildPlaceholderPIF(
+            id: "PACKAGE:example",
+            path: "/tmp/Example/Package.swift",
+            projectDir: "/tmp/Example",
+            name: "Example",
+            targetBuildSettings: targetBuildSettings
+        )
+
+        let aggregateTarget = try #require(project.targets.only)
+        for targetBuildConfig in aggregateTarget.common.buildConfigs {
+            #expect(targetBuildConfig.settings == targetBuildSettings)
+        }
+
+        // The project-level configurations stay empty.
+        for projectBuildConfig in project.buildConfigs {
+            #expect(projectBuildConfig.settings == ProjectModel.BuildSettings())
+        }
+    }
+
+    @Test("Placeholder PIF omits the development region unless one is given")
+    func placeholderDevelopmentRegionIsOptional() {
+        let (project, _) = PackagePIFBuilder.buildPlaceholderPIF(
+            id: "PACKAGE:example",
+            path: "/tmp/Example/Package.swift",
+            projectDir: "/tmp/Example",
+            name: "Example",
+            targetBuildSettings: ProjectModel.BuildSettings()
+        )
+        #expect(project.developmentRegion == nil)
+    }
+
+    /// Checks that a placeholder PIF is well-formed enough that *Swift Build can consume it*:
+    /// signing and serialization are the steps SwiftPM performs before handing a PIF off, so
+    /// they are what would reject a placeholder project that cannot be represented in the PIF.
+    ///
+    /// Note that this stops short of running an actual build over the placeholder PIF.
+    @Test("Placeholder PIF can be signed and serialized without errors")
+    func placeholderPIFCanBeSignedAndSerialized() throws {
+        let (project, _) = PackagePIFBuilder.buildPlaceholderPIF(
+            id: "PACKAGE:example",
+            path: "/tmp/Example/Package.swift",
+            projectDir: "/tmp/Example",
+            name: "Example",
+            targetBuildSettings: ProjectModel.BuildSettings()
+        )
+
+        let workspacePath = try AbsolutePath(validating: "/tmp/Example")
+        let workspace = PIF.Workspace(
+            id: "WORKSPACE:example",
+            name: "Example",
+            path: workspacePath,
+            projects: [project]
+        )
+
+        // Signing encodes the project and each of its targets in turn, so it is the step that
+        // would surface a placeholder project that cannot be represented in the PIF.
+        try PIF.sign(workspace: workspace)
+
+        // A project serializes its targets *by signature*, so the placeholder target is only
+        // representable once signing has given it one.
+        let signedProject = try #require(workspace.projects.only)
+        let placeholderTarget = try #require(signedProject.underlying.targets.only)
+        #expect(placeholderTarget.common.signature != nil)
+
+        // The whole workspace then encodes without throwing.
+        let encodedWorkspace = try JSONEncoder.makeWithDefaults().encode(workspace)
+        #expect(!encodedWorkspace.isEmpty)
+    }
+}

--- a/Tests/SwiftBuildSupportTests/PIFPlaceholderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFPlaceholderTests.swift
@@ -141,8 +141,8 @@ struct PIFPlaceholderTests {
         // would surface a placeholder project that cannot be represented in the PIF.
         try PIF.sign(workspace: workspace)
 
-        // A project serializes its targets *by signature*, so the placeholder target is only
-        // representable once signing has given it one.
+        // A project serializes its targets *by signature*, so the placeholder
+        // target is only representable once signing has given it one.
         let signedProject = try #require(workspace.projects.only)
         let placeholderTarget = try #require(signedProject.underlying.targets.only)
         #expect(placeholderTarget.common.signature != nil)


### PR DESCRIPTION
Make placeholder PIF construction available on the `PackagePIFBuilder` type.

### Motivation:

`buildPlaceholderPIF(id:path:projectDir:name:)` was an instance method, but it only used `self` in two places: to read the package's base build settings, and to store the resulting project in `_pifProject`. Everything else was constructed from its arguments.

That coupling had two costs:

1. A placeholder PIF could only be produced once a `PackagePIFBuilder` had been constructed, which requires a resolved package and a modules graph. 
2. It was effectively untestable, since exercising it meant standing up a full package graph.

An additional motivation is to follow the same three-layer shape `buildEmptyPIF` already uses:.

### Modifications:

Add two helper class functions to build the placeholder PIF.

The instance method keeps its signature and becomes a thin wrapper instead.

I also added some needed unit tests to validate this feature.

Finally, a minor cleanup for the related `buildEmptyPIF`operation.

### Result:

A placeholder PIF can now be built without a `PackagePIFBuilder` instance, which makes it usable for a package that failed to load.

**Development region.** Behavior through the existing instance method is unchanged, with one exception: the placeholder project now carries a development region where it previously carried `nil`. A placeholder has a single aggregate target with no product, no build phases and no files, so there should be nothing for a base localization to affect.

Note that `buildPlaceholderPIF` has no callers within SwiftPM — it is API for clients embedding `SwiftBuildSupport`, like Xcode.

Fixes rdar://185457772