### PR TITLE
SE-####: Add `swift package report` subcommand

### DIFF
--- a/Fixtures/Miscellaneous/DeprecatedProducts/consumer-transitive/Package.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/consumer-transitive/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:999.0
+import PackageDescription
+
+let package = Package(
+    name: "consumer-transitive",
+    dependencies: [
+        .package(path: "../consumer"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyTransitiveApp",
+            dependencies: [
+                .product(name: "MyLib", package: "consumer"),
+            ],
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/DeprecatedProducts/consumer-transitive/Sources/MyTransitiveApp/main.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/consumer-transitive/Sources/MyTransitiveApp/main.swift
@@ -1,0 +1,8 @@
+import MyLib
+
+@main
+struct MyTransitiveApp {
+    static func main() {
+        print("MyTransitiveApp using MyLib \(myLibExperimentalName())")
+    }
+}

--- a/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Package.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Package.swift
@@ -3,6 +3,15 @@ import PackageDescription
 
 let package = Package(
     name: "consumer",
+    products: [
+        // Expose MyLib as a product so downstream packages (e.g.
+        // `consumer-transitive`) can depend on it and thereby transitively
+        // reach `PaperExperimental` from the producer.
+        .library(
+            name: "MyLib",
+            targets: ["MyLib"],
+        ),
+    ],
     dependencies: [
         .package(path: "../producer"),
     ],

--- a/Sources/Commands/PackageCommands/Audit.swift
+++ b/Sources/Commands/PackageCommands/Audit.swift
@@ -1,0 +1,471 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Basics
+import CoreCommands
+import Foundation
+import PackageGraph
+import PackageModel
+
+struct Audit: AsyncSwiftCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "audit",
+        abstract: "Report deprecated products in the current package graph.",
+        helpNames: [.short, .long, .customLong("help", withSingleDash: true)]
+    )
+
+    @OptionGroup(visibility: .hidden)
+    var globalOptions: GlobalOptions
+
+    @Option(help: "Set the output format ('text' or 'json').")
+    var format: AuditFormat = .text
+
+    @Option(
+        name: .customLong("include-transitive"),
+        defaultAsFlag: IncludeTransitive.reachable,
+        help: ArgumentHelp(
+            "Report deprecated products reached only transitively (via a non-deprecated product's own dependencies).",
+            discussion: "Bare '--include-transitive' selects 'reachable'. Explicit values: 'reachable', 'all', 'non-reachable'.",
+        ),
+    )
+    var includeTransitiveMode: IncludeTransitive? = nil
+
+    @Flag(
+        name: .customLong("allow-deprecations"),
+        help: "Exit with status 0 even when deprecated products are found.",
+    )
+    var allowDeprecations: Bool = false
+
+    func run(_ swiftCommandState: SwiftCommandState) async throws {
+        // Audit produces its own structured deprecation report — suppress the
+        // graph-load-time deprecation warnings/errors so they don't duplicate
+        // (or, when a consumer target has `.treatAllWarnings(.error)`, prevent
+        // the load from completing at all). `exitOnError: false` is likewise
+        // required so a per-target escalation of another consumer's warning
+        // does not halt the load before this command can print its report.
+        let graph = try await swiftCommandState.loadPackageGraph(
+            explicitProduct: nil,
+            enableAllTraits: false,
+            testEntryPointPath: nil,
+            exitOnError: false,
+            emitProductDeprecationDiagnostics: false,
+        )
+        let report = buildAuditReport(
+            graph: graph,
+            includeTransitive: self.includeTransitiveMode ?? .off,
+        )
+
+        switch self.format {
+        case .text:
+            print(renderAuditReportAsText(report))
+        case .json:
+            let encoder = JSONEncoder()
+            encoder.outputFormatting.insert(.sortedKeys)
+            encoder.outputFormatting.insert(.prettyPrinted)
+            let data = try encoder.encode(report)
+            print(String(decoding: data, as: UTF8.self))
+        }
+
+        if report.hasViolations && !self.allowDeprecations {
+            throw ExitCode(1)
+        }
+    }
+
+    // MARK: - Model
+
+    enum AuditFormat: String, RawRepresentable, CustomStringConvertible, ExpressibleByArgument, CaseIterable {
+        case text, json
+
+        init?(rawValue: String) {
+            switch rawValue.lowercased() {
+            case "text":
+                self = .text
+            case "json":
+                self = .json
+            default:
+                return nil
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .text: return "text"
+            case .json: return "json"
+            }
+        }
+    }
+}
+
+// MARK: - `--include-transitive` mode
+
+/// Filter applied to the audit report.
+///
+/// * `.off` (default when the flag is absent) — only direct violations.
+/// * `.reachable` (bare `--include-transitive` or `=reachable`) — direct
+///   plus transitively reachable violations.
+/// * `.all` (`=all`) — direct + reachable + unreachable.
+/// * `.nonReachable` (`=non-reachable`) — unreachable only.
+enum IncludeTransitive: String, CaseIterable, ExpressibleByArgument {
+    case off
+    case reachable
+    case all
+    case nonReachable = "non-reachable"
+
+    // `.off` is an internal-only sentinel — it can never come in from the CLI.
+    static var allValueStrings: [String] {
+        Self.allCases.compactMap { $0 == .off ? nil : $0.rawValue }
+    }
+
+    init?(argument: String) {
+        guard argument != IncludeTransitive.off.rawValue else { return nil }
+        self.init(rawValue: argument)
+    }
+}
+
+// MARK: - Report model (internal so unit tests can construct + assert)
+
+struct AuditReport: Codable, Equatable {
+    struct Deprecated: Codable, Equatable {
+        var products: [DeprecatedProduct]
+    }
+
+    var deprecated: Deprecated
+}
+
+struct DeprecatedProduct: Codable, Equatable {
+    /// Classification of how (or whether) the deprecated product is reached
+    /// from any root-package target. Serialized as a string; matches the JSON
+    /// schema in the proposal.
+    enum Transitive: String, Codable {
+        case direct
+        case transitiveReachable
+        case transitiveUnreachable
+    }
+
+    var message: String?
+    var package: String
+    var product: String
+    var replacement: ProductDeprecation.Replacement?
+    var type: String
+    var usedBy: [String]
+    var transitive: Transitive
+    /// Sequence(s) of hops from a root-package target down to the deprecated
+    /// product. `nil` (omitted from JSON) for `.transitiveUnreachable` entries.
+    var breadcrumb: [[BreadcrumbHop]]?
+}
+
+/// A single step in a breadcrumb path. The first hop of a path always names a
+/// root-package target (`target` populated, `product` nil); every subsequent
+/// hop names a product-boundary crossing (`product` populated, `target` nil).
+struct BreadcrumbHop: Codable, Equatable {
+    var package: String
+    var target: String?
+    var product: String?
+
+    init(package: String, target: String? = nil, product: String? = nil) {
+        self.package = package
+        self.target = target
+        self.product = product
+    }
+}
+
+struct ProductKey: Hashable {
+    let package: String
+    let product: String
+}
+
+// MARK: - Pure report-building logic (internal for testability)
+
+/// Walks the resolved graph and produces an audit report of deprecated products.
+///
+/// - Parameters:
+///   - graph: The resolved package graph to inspect.
+///   - includeTransitive: Filter mode. See `IncludeTransitive` for semantics.
+/// - Returns: An `AuditReport` with products sorted by `(package, product)`
+///   for deterministic output.
+func buildAuditReport(
+    graph: ModulesGraph,
+    includeTransitive: IncludeTransitive,
+) -> AuditReport {
+    // 1. Enumerate every deprecated product in the resolved graph. We match
+    //    them by (packageIdentity, productName) since the same product name
+    //    in two different packages is distinct.
+    var deprecatedProducts: [ProductKey: ResolvedProduct] = [:]
+    for product in graph.allProducts {
+        guard product.underlying.deprecation != nil else { continue }
+        guard auditProductTypeString(product.type) != nil else { continue }
+        let key = ProductKey(
+            package: product.packageIdentity.description,
+            product: product.name,
+        )
+        deprecatedProducts[key] = product
+    }
+
+    // 2. BFS on the target-dependency graph starting from each root-package
+    //    target. Every `.product(...)` edge we traverse contributes a hop to
+    //    the current breadcrumb. When we cross into a deprecated product we
+    //    record the path (and stop — we don't recurse into the deprecated
+    //    product's own dependencies).
+    var reachedPaths: [ProductKey: [[BreadcrumbHop]]] = [:]
+    var reachedRootTargets: [ProductKey: Set<String>] = [:]
+
+    for rootPackage in graph.rootPackages {
+        for rootTarget in rootPackage.modules {
+            let rootHop = BreadcrumbHop(
+                package: rootPackage.identity.description,
+                target: rootTarget.name,
+            )
+            walkFromRootTarget(
+                rootTarget: rootTarget,
+                rootHop: rootHop,
+                rootTargetName: rootTarget.name,
+                deprecatedProducts: deprecatedProducts,
+                reachedPaths: &reachedPaths,
+                reachedRootTargets: &reachedRootTargets,
+            )
+        }
+    }
+
+    // 3. Assemble entries. Classify each product by whether it was reached
+    //    directly (any path of length 2 = root-target-hop +
+    //    deprecated-product-hop) or only transitively (all paths longer than
+    //    2). Products that were never reached are `.transitiveUnreachable`.
+    var entries: [DeprecatedProduct] = []
+    for (key, product) in deprecatedProducts {
+        guard let typeString = auditProductTypeString(product.type) else { continue }
+
+        let deprecation = product.underlying.deprecation
+        let rawPaths = reachedPaths[key] ?? []
+        let paths = deduplicateAndSortBreadcrumbPaths(rawPaths)
+        let usedBy = (reachedRootTargets[key] ?? []).sorted()
+
+        let transitive: DeprecatedProduct.Transitive
+        let breadcrumb: [[BreadcrumbHop]]?
+        if paths.isEmpty {
+            transitive = .transitiveUnreachable
+            breadcrumb = nil
+        } else {
+            transitive = paths.contains(where: { $0.count == 2 }) ? .direct : .transitiveReachable
+            breadcrumb = paths
+        }
+
+        // Apply the filter mode.
+        switch (includeTransitive, transitive) {
+        case (.off, .direct):
+            break
+        case (.off, _):
+            continue
+        case (.reachable, .transitiveUnreachable):
+            continue
+        case (.reachable, _):
+            break
+        case (.nonReachable, .transitiveUnreachable):
+            break
+        case (.nonReachable, _):
+            continue
+        case (.all, _):
+            break
+        }
+
+        entries.append(
+            DeprecatedProduct(
+                message: deprecation?.message,
+                package: key.package,
+                product: key.product,
+                replacement: deprecation?.replacement,
+                type: typeString,
+                usedBy: usedBy,
+                transitive: transitive,
+                breadcrumb: breadcrumb,
+            )
+        )
+    }
+
+    entries.sort { lhs, rhs in
+        if lhs.package != rhs.package {
+            return lhs.package < rhs.package
+        }
+        return lhs.product < rhs.product
+    }
+
+    return AuditReport(deprecated: .init(products: entries))
+}
+
+/// BFS from a single root-package target. Visited-set is on `(target,
+/// breadcrumb-length)` so we don't loop forever, but distinct paths to the
+/// same deprecated product are recorded separately.
+private func walkFromRootTarget(
+    rootTarget: ResolvedModule,
+    rootHop: BreadcrumbHop,
+    rootTargetName: String,
+    deprecatedProducts: [ProductKey: ResolvedProduct],
+    reachedPaths: inout [ProductKey: [[BreadcrumbHop]]],
+    reachedRootTargets: inout [ProductKey: Set<String>],
+) {
+    struct Frame {
+        let module: ResolvedModule
+        let breadcrumb: [BreadcrumbHop]
+    }
+    var queue: [Frame] = [Frame(module: rootTarget, breadcrumb: [rootHop])]
+    // Guard against traversal cycles within the target-dependency graph. A
+    // module can legitimately appear on multiple *distinct* paths (that's
+    // what produces multi-path breadcrumbs), so the visited key is the
+    // (module, breadcrumb-of-product-hops) pair — not just the module.
+    var visited: Set<String> = []
+    while !queue.isEmpty {
+        let frame = queue.removeFirst()
+        let productHopsKey = frame.breadcrumb.dropFirst()
+            .map { "\($0.package)/\($0.product ?? "")" }
+            .joined(separator: "→")
+        let visitKey = "\(frame.module.packageIdentity)/\(frame.module.name)|\(productHopsKey)"
+        if visited.contains(visitKey) { continue }
+        visited.insert(visitKey)
+
+        for dependency in frame.module.dependencies {
+            switch dependency {
+            case .module(let dependee, _):
+                // Same-package target dep: no hop added, just keep walking.
+                queue.append(Frame(module: dependee, breadcrumb: frame.breadcrumb))
+            case .product(let dependeeProduct, _):
+                let key = ProductKey(
+                    package: dependeeProduct.packageIdentity.description,
+                    product: dependeeProduct.name,
+                )
+                let productHop = BreadcrumbHop(
+                    package: dependeeProduct.packageIdentity.description,
+                    product: dependeeProduct.name,
+                )
+                let extendedBreadcrumb = frame.breadcrumb + [productHop]
+
+                if deprecatedProducts[key] != nil {
+                    // Reached a deprecated product — record the path and stop
+                    // descending. (Consumers don't care about deps *of* a
+                    // deprecated product for audit purposes.)
+                    reachedPaths[key, default: []].append(extendedBreadcrumb)
+                    reachedRootTargets[key, default: []].insert(rootTargetName)
+                } else {
+                    // Non-deprecated intermediate — enter each of the
+                    // product's constituent modules with the extended
+                    // breadcrumb.
+                    for member in dependeeProduct.modules {
+                        queue.append(Frame(module: member, breadcrumb: extendedBreadcrumb))
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Order breadcrumb paths deterministically: element-wise by (target-or-product
+/// name) so that a stable sort emerges regardless of graph-walk order.
+private func compareBreadcrumbPaths(_ lhs: [BreadcrumbHop], _ rhs: [BreadcrumbHop]) -> Bool {
+    for (l, r) in zip(lhs, rhs) {
+        let lName = l.target ?? l.product ?? ""
+        let rName = r.target ?? r.product ?? ""
+        if lName != rName { return lName < rName }
+        if l.package != r.package { return l.package < r.package }
+    }
+    return lhs.count < rhs.count
+}
+
+/// The same product can be reached from a single root target via multiple
+/// same-package `.target(...)` chains that collapse to identical product-hop
+/// sequences. Those are indistinguishable in the audit's product-oriented
+/// breadcrumb, so we deduplicate here rather than surface duplicates.
+private func deduplicateAndSortBreadcrumbPaths(_ paths: [[BreadcrumbHop]]) -> [[BreadcrumbHop]] {
+    var seen: Set<String> = []
+    var unique: [[BreadcrumbHop]] = []
+    for path in paths {
+        let key = path
+            .map { "\($0.package)/\($0.target ?? "")|\($0.product ?? "")" }
+            .joined(separator: "→")
+        if seen.insert(key).inserted {
+            unique.append(path)
+        }
+    }
+    return unique.sorted(by: compareBreadcrumbPaths)
+}
+
+/// Renders an `AuditReport` as human-readable text, grouped into three
+/// possible sections by the `transitive` classification. Sections with no
+/// entries are omitted. Returns a fixed "No deprecated products found." line
+/// when the report is empty.
+func renderAuditReportAsText(_ report: AuditReport) -> String {
+    guard !report.deprecated.products.isEmpty else {
+        return "No deprecated products found."
+    }
+
+    var sectionsOutput: [String] = []
+    let sections: [(header: String, kind: DeprecatedProduct.Transitive)] = [
+        ("Directly consumed deprecated products:", .direct),
+        ("Transitively reachable deprecated products:", .transitiveReachable),
+        ("Transitively unreachable deprecated products:", .transitiveUnreachable),
+    ]
+    for section in sections {
+        let entries = report.deprecated.products.filter { $0.transitive == section.kind }
+        guard !entries.isEmpty else { continue }
+        sectionsOutput.append(renderSection(header: section.header, entries: entries))
+    }
+    return sectionsOutput.joined(separator: "\n\n")
+}
+
+/// Formats a single audit section: header line followed by per-package
+/// groupings, each with one indented block per deprecated product.
+private func renderSection(header: String, entries: [DeprecatedProduct]) -> String {
+    var lines: [String] = [header]
+    var currentPackage: String? = nil
+    for entry in entries {
+        if entry.package != currentPackage {
+            lines.append("  package '\(entry.package)':")
+            currentPackage = entry.package
+        }
+        lines.append("    \(entry.type) '\(entry.product)' is unsupported")
+        if let message = entry.message, !message.isEmpty {
+            lines.append("      \(message)")
+        }
+        if let replacement = entry.replacement {
+            lines.append("      \(replacement.formattedInstruction)")
+        }
+        if !entry.usedBy.isEmpty {
+            lines.append("      Used by: \(entry.usedBy.joined(separator: ", "))")
+        }
+    }
+    return lines.joined(separator: "\n")
+}
+
+/// Maps a `ProductType` to the schema-legal string used in the audit JSON
+/// output. Returns `nil` for product kinds that cannot be declared as
+/// deprecated via the public API (test/snippet/macro), so those are silently
+/// filtered out of the report.
+func auditProductTypeString(_ type: ProductType) -> String? {
+    switch type {
+    case .executable:
+        return "executable"
+    case .library:
+        return "library"
+    case .plugin:
+        return "plugin"
+    case .snippet, .test, .macro:
+        return nil
+    }
+}
+
+// MARK: - Report-level helpers
+
+extension AuditReport {
+    /// `true` iff any product in the report should fail the audit (any
+    /// non-empty report has at least one violation).
+    var hasViolations: Bool {
+        !self.deprecated.products.isEmpty
+    }
+}

--- a/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
+++ b/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
@@ -34,6 +34,7 @@ public struct SwiftPackageCommand: AsyncParsableCommand {
             AddTarget.self,
             AddTargetDependency.self,
             AddSetting.self,
+            Audit.self,
             AuditBinaryArtifact.self,
             AddTargetPlugin.self,
             Clean.self,

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -856,12 +856,14 @@ public final class SwiftCommandState {
     @discardableResult
     public func loadPackageGraph(
         explicitProduct: String? = nil,
-        testEntryPointPath: AbsolutePath? = nil
+        testEntryPointPath: AbsolutePath? = nil,
+        emitProductDeprecationDiagnostics: Bool = true,
     ) async throws -> ModulesGraph {
         try await self.loadPackageGraph(
             explicitProduct: explicitProduct,
             enableAllTraits: false,
-            testEntryPointPath: testEntryPointPath
+            testEntryPointPath: testEntryPointPath,
+            emitProductDeprecationDiagnostics: emitProductDeprecationDiagnostics,
         )
     }
 
@@ -871,12 +873,18 @@ public final class SwiftCommandState {
     ///   - explicitProduct: The product specified on the command line to a “swift run” or “swift build” command. This
     /// allows executables from dependencies to be run directly without having to hook them up to any particular target.
     ///   - exitOnError: Whether loading errors should cause this method to throw a failure exit code. Defaults to `true`.
+    ///   - emitProductDeprecationDiagnostics: Whether the graph load should
+    ///     emit warnings/errors when a consumer target depends on a deprecated
+    ///     product. Commands that produce their own structured deprecation
+    ///     report (e.g. `swift package audit`) should pass `false` to suppress
+    ///     redundant graph-load-time diagnostics.
     @discardableResult
     package func loadPackageGraph(
         explicitProduct: String? = nil,
         enableAllTraits: Bool = false,
         testEntryPointPath: AbsolutePath? = nil,
-        exitOnError: Bool = true
+        exitOnError: Bool = true,
+        emitProductDeprecationDiagnostics: Bool = true,
     ) async throws -> ModulesGraph {
         do {
             let workspace = try getActiveWorkspace(enableAllTraits: enableAllTraits)
@@ -902,6 +910,7 @@ public final class SwiftCommandState {
                 testEntryPointPath: testEntryPointPath,
                 observabilityScope: packageGraphObservabilityScope,
                 treatWarningsAsErrors: treatWarningsAsErrors,
+                emitProductDeprecationDiagnostics: emitProductDeprecationDiagnostics,
             )
 
             // Throw if there were errors when loading the graph.

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -42,6 +42,7 @@ extension ModulesGraph {
         modulesFilter: ((Module) -> Bool)? = nil,
         enabledTraitsMap: EnabledTraitsMap,
         treatWarningsAsErrors: Bool = false,
+        emitProductDeprecationDiagnostics: Bool = true,
     ) throws -> ModulesGraph {
         let observabilityScope = observabilityScope.makeChildScope(description: "Loading Package Graph")
 
@@ -214,6 +215,7 @@ extension ModulesGraph {
             productsFilter: productsFilter,
             modulesFilter: modulesFilter,
             treatWarningsAsErrors: treatWarningsAsErrors,
+            emitProductDeprecationDiagnostics: emitProductDeprecationDiagnostics,
         )
 
         let rootPackages = resolvedPackages.filter { root.manifests.values.contains($0.manifest) }
@@ -393,6 +395,7 @@ private func createResolvedPackages(
     productsFilter: ((Product) -> Bool)?,
     modulesFilter: ((Module) -> Bool)?,
     treatWarningsAsErrors: Bool,
+    emitProductDeprecationDiagnostics: Bool,
 ) throws -> IdentifiableSet<ResolvedPackage> {
     // Create package builder objects from the input manifests.
     var packageBuilders: [ResolvedPackageBuilder] = nodes.compactMap { node in
@@ -791,7 +794,11 @@ private func createResolvedPackages(
                 moduleBuilder.dependencies.append(.product(product, conditions: conditions))
 
                 // Emit a diagnostic if the consumed product is deprecated.
-                if let deprecation = product.product.deprecation {
+                // Suppressed when the caller (e.g. `swift package audit`) is
+                // producing its own structured deprecation report and wants
+                // the graph load to remain quiet.
+                if emitProductDeprecationDiagnostics,
+                   let deprecation = product.product.deprecation {
                     let severity: Diagnostic.Severity = shouldEscalateProductDeprecationToError(
                         consumer: moduleBuilder.module,
                         globalTreatWarningsAsErrors: treatWarningsAsErrors,

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -469,6 +469,7 @@ public func loadModulesGraph(
     traitConfiguration: TraitConfiguration = .default,
     enabledTraitsMap: EnabledTraitsMap = .init(),
     treatWarningsAsErrors: Bool = false,
+    emitProductDeprecationDiagnostics: Bool = true,
 ) throws -> ModulesGraph {
     let rootManifests = manifests.filter(\.packageKind.isRoot).spm_createDictionary { ($0.path, $0) }
     let externalManifests = try manifests.filter { !$0.packageKind.isRoot }
@@ -507,5 +508,6 @@ public func loadModulesGraph(
         modulesFilter: nil,
         enabledTraitsMap: enabledTraitsMap,
         treatWarningsAsErrors: treatWarningsAsErrors,
+        emitProductDeprecationDiagnostics: emitProductDeprecationDiagnostics,
     )
 }

--- a/Sources/PackageManagerDocs/Documentation.docc/Dependencies/DeprecatingProducts.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Dependencies/DeprecatingProducts.md
@@ -89,9 +89,9 @@ Swift compiler.
 
 When a consumer package's target depends on a deprecated product, Swift
 Package Manager emits a warning through its diagnostic system during graph
-resolution. `swift build`, `swift test` and `swift package resolve` all
-surface the diagnostic. The warning text is derived from the `message:`
-(if any) and the `replacement:` locator:
+resolution. `swift build`, `swift test`, `swift package resolve`, and
+`swift package audit` all surface the diagnostic. The warning text is
+derived from the `message:` (if any) and the `replacement:` locator:
 
 - Same-package replacement — appended sentence: `Use 'X' instead.`
 - Cross-package replacement — appended sentence:
@@ -107,6 +107,25 @@ Swift build settings, or if the build invocation passes
 `-Xswiftc -warnings-as-errors`, the deprecation diagnostic is escalated
 from a warning to an error, matching how the compiler treats its own
 deprecation diagnostics.
+
+## Surveying deprecated products on demand
+
+Build-time warnings only surface deprecations for products that a package
+currently consumes. To answer questions like "which of my transitive
+dependencies vend an unsupported product?" without triggering a build,
+use <doc:PackageAudit>:
+
+```
+swift package audit
+```
+
+By default the command reports only *directly consumed* deprecated
+products and exits with a non-zero status when it finds any. Use
+`--include-transitive` to also see products reached through intermediate
+non-deprecated products, or `--include-transitive=all` to also see
+deprecated products that exist in the resolved graph but no target
+currently reaches. See <doc:PackageAudit> for a full description of the
+output format, JSON schema, and exit-code semantics.
 
 ## Interaction with `dump-package`
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAudit.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAudit.md
@@ -1,0 +1,207 @@
+# swift package audit
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+    @Available("Swift", introduced: "6.5")
+}
+
+Report deprecated products in the current package graph.
+
+```
+package audit [--package-path=<package-path>]
+  [--cache-path=<cache-path>] [--config-path=<config-path>]
+  [--security-path=<security-path>]
+  [--scratch-path=<scratch-path>]
+  [--swift-sdks-path=<swift-sdks-path>]
+  [--toolset=<toolset>...]
+  [--pkg-config-path=<pkg-config-path>...]
+  [--enable-dependency-cache] [--disable-dependency-cache]
+  [--enable-build-manifest-caching]
+  [--disable-build-manifest-caching]
+  [--manifest-cache=<manifest-cache>]
+  [--enable-experimental-prebuilts]
+  [--disable-experimental-prebuilts] [--verbose]
+  [--very-verbose|vv] [--quiet] [--color-diagnostics]
+  [--no-color-diagnostics] [--disable-sandbox] [--netrc]
+  [--enable-netrc] [--disable-netrc]
+  [--netrc-file=<netrc-file>] [--enable-keychain]
+  [--disable-keychain]
+  [--resolver-fingerprint-checking=<resolver-fingerprint-checking>]
+  [--resolver-signing-entity-checking=<resolver-signing-entity-checking>]
+  [--enable-signature-validation]
+  [--disable-signature-validation] [--enable-prefetching]
+  [--disable-prefetching]
+  [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file]
+  [--skip-update] [--disable-scm-to-registry-transformation]
+  [--use-registry-identity-for-scm]
+  [--replace-scm-with-registry]
+  [--default-registry-url=<default-registry-url>]
+  [--configuration=<configuration>] [--=<Xcc>...]
+  [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]
+  [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]
+  [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...]
+  [--auto-index-store] [--enable-index-store]
+  [--disable-index-store]
+  [--enable-parseable-module-interfaces] [--jobs=<jobs>]
+  [--use-integrated-swift-driver]
+  [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>]
+  [--build-system=<build-system>] [--=<debug-info-format>]
+  [--enable-dead-strip] [--disable-dead-strip]
+  [--disable-local-rpath] [--format=<format>]
+  [--include-transitive[=<mode>]] [--allow-deprecations]
+  [--version] [--help]
+```
+
+## Overview
+
+`swift package audit` inspects the resolved package graph for products that
+their producing packages have marked as unsupported using the
+`deprecated:` parameter on `.library(...)`, `.executable(...)`, or
+`.plugin(...)`. For each such product it reports the producing package, the
+product type, an optional author-supplied message, an optional replacement,
+and the list of root-package targets whose dependency chain reaches the
+product.
+
+Every entry is classified into one of three categories via the `transitive`
+field:
+
+- `direct` — at least one root-package target has a
+  `.product(name:package:)` dependency on the deprecated product.
+- `transitiveReachable` — no root target names the deprecated product
+  directly, but a root target reaches it via another consumed product's
+  internal target chain (for example, `MyApp → MyLib → OldProduct`).
+- `transitiveUnreachable` — the deprecated product exists in the resolved
+  graph but no root-target dependency chain touches it.
+
+Direct violations are always reported. Whether transitive-reachable and
+transitive-unreachable entries appear is controlled by
+`--include-transitive` (see below).
+
+For each `direct` or `transitiveReachable` entry the report includes a
+`breadcrumb` field: one or more paths from a root-package target down to
+the deprecated product. Each hop identifies either a root-package target
+(`{package, target}`) or a product-boundary crossing (`{package, product}`).
+`transitiveUnreachable` entries carry no `breadcrumb` because no reaching
+path exists.
+
+By default the command exits with a non-zero status when any deprecated
+product is reported. Pass `--allow-deprecations` to always exit `0` on a
+successful audit (load failures still exit non-zero). This is intended for
+interactive human use; CI pipelines can rely on the default behavior to
+turn a finding into a failing job.
+
+To silence the graph-load-time deprecation warnings while running an audit,
+`swift package audit` suppresses them internally so its structured report
+is the sole surface for deprecation output. A consumer target's per-target
+`.treatAllWarnings(as: .error)` setting does not prevent the audit from
+completing.
+
+### Output formats
+
+`swift package audit --format text` (the default) groups results into up to
+three sections in fixed order — "Directly consumed deprecated products:",
+"Transitively reachable deprecated products:", "Transitively unreachable
+deprecated products:" — each present only when it has entries. Within a
+section, entries are grouped by producing package.
+
+`swift package audit --format json` emits a structured document with
+alphabetically-sorted keys at every level. Every entry has the fields
+`package`, `product`, `transitive`, `type`, and `usedBy`; optional fields
+`message`, `replacement`, and `breadcrumb` appear when present. The
+`replacement` object always has `kind: "renamed"` and a `product` string;
+a `package` field is included only for cross-package replacements.
+
+For an in-depth guide to declaring deprecations in your own package and
+migrating consumers of deprecated products, see <doc:DeprecatingProducts>.
+
+- term **--format=\<format\>**:
+
+*Set the output format ('text' or 'json'). Defaults to `text`.*
+
+
+- term **--include-transitive[=\<mode\>]**:
+
+*Include transitive violations in the report. When passed without a value,
+selects the `reachable` mode. Accepted explicit values:*
+
+*`reachable` — include direct + transitively-reachable violations (bare
+`--include-transitive` is equivalent to this).*
+
+*`all` — include direct + transitively-reachable + transitively-unreachable
+violations.*
+
+*`non-reachable` — include only transitively-unreachable violations,
+skipping reachable ones (useful for surveying deprecated products that
+are still in the graph but not yet consumed).*
+
+
+- term **--allow-deprecations**:
+
+*Exit with status 0 even when deprecated products are found. Load failures
+still exit non-zero.*
+
+
+- term **--package-path=\<package-path\>**:
+
+*Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
+
+
+- term **--cache-path=\<cache-path\>**:
+
+*Specify the shared cache directory path.*
+
+
+- term **--config-path=\<config-path\>**:
+
+*Specify the shared configuration directory path.*
+
+
+- term **--security-path=\<security-path\>**:
+
+*Specify the shared security directory path.*
+
+
+- term **--scratch-path=\<scratch-path\>**:
+
+*Specify a custom scratch directory path. (default .build)*
+
+
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
+
+*Path to the directory containing installed Swift SDKs.*
+
+
+- term **--verbose**:
+
+*Increase verbosity to include informational output.*
+
+
+- term **--very-verbose|vv**:
+
+*Increase verbosity to include debug output.*
+
+
+- term **--quiet**:
+
+*Decrease verbosity to only include error output.*
+
+
+- term **--color-diagnostics|no-color-diagnostics**:
+
+*Enables or disables color diagnostics when printing to a TTY.
+By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
+
+
+- term **--disable-sandbox**:
+
+*Disable using the sandbox when executing subprocesses.*
+
+
+- term **--version**:
+
+*Show the version.*
+
+
+- term **--help**:
+
+*Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageCommands.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageCommands.md
@@ -38,6 +38,7 @@ Overview of package manager commands here...
 <!-- ref to swift-docc-plugin -->
 
 ### Inspecting packages
+- <doc:PackageAudit>
 - <doc:PackageDescribe>
 - <doc:PackageShowDependencies>
 - <doc:PackageShowExecutables>

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1003,6 +1003,7 @@ extension Workspace {
         expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
         observabilityScope: ObservabilityScope,
         treatWarningsAsErrors: Bool = false,
+        emitProductDeprecationDiagnostics: Bool = true,
     ) async throws -> ModulesGraph {
         let start = DispatchTime.now()
         self.delegate?.willLoadGraph()
@@ -1065,6 +1066,7 @@ extension Workspace {
             observabilityScope: observabilityScope,
             enabledTraitsMap: self.enabledTraitsMap,
             treatWarningsAsErrors: treatWarningsAsErrors,
+            emitProductDeprecationDiagnostics: emitProductDeprecationDiagnostics,
         )
 
         try self.validateSignatures(

--- a/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
@@ -191,6 +191,7 @@ extension Tag.Feature.Command.Package {
     @Tag public static var AddTarget: Tag
     @Tag public static var AddTargetDependency: Tag
     @Tag public static var AddTargetPlugin: Tag
+    @Tag public static var Audit: Tag
     @Tag public static var BuildPlugin: Tag
     @Tag public static var Clean: Tag
     @Tag public static var CommandPlugin: Tag

--- a/Tests/CommandsTests/AuditReporTests.swift
+++ b/Tests/CommandsTests/AuditReporTests.swift
@@ -1,0 +1,1525 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Foundation
+import PackageModel
+import Testing
+import _InternalTestSupport
+
+@_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
+import PackageGraph
+
+@testable import Commands
+
+/// Pure-logic unit tests for the `swift package audit` report-building and
+/// text-rendering helpers. These tests construct in-memory package graphs via
+/// `loadModulesGraph` (no `executeSwiftPackage`, no fixture on disk, no swiftc
+/// invocation) and assert on `AuditReport` values directly. Complements the
+/// end-to-end tests in `PackageCommandTests+Audit.swift`.
+@Suite(
+    .tags(
+        .TestSize.small,
+        .Feature.Command.Package.Audit,
+        .Feature.Deprecation,
+    ),
+)
+struct AuditReportTests {
+
+    // MARK: - buildAuditReport
+    @Suite
+    struct AuditReportBuilderTests {
+
+        // MARK: Empty / no deprecations
+
+        @Test
+        func report_isEmpty_whenNoDeprecatedProducts() throws {
+            let graph = try loadSingleRootGraph(
+                withProducts: [
+                    try ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .off)
+            #expect(report.deprecated.products.isEmpty)
+        }
+
+        // MARK: --include-transitive off
+
+        @Test
+        func report_omitsUnconsumedDeprecatedProduct_whenIncludeTransitiveIsOff() throws {
+            // Root package vends a deprecated product but no target in the root
+            // package consumes it. With .off, the report is empty.
+            let graph = try loadSingleRootGraph(
+                withProducts: [
+                    try ProductDescription(
+                        name: "OldLib",
+                        type: .library(.automatic),
+                        targets: ["OldLib"],
+                        deprecation: ProductDeprecation(
+                            message: "gone",
+                            replacement: .renamed("NewLib"),
+                        ),
+                    ),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .off)
+            #expect(report.deprecated.products.isEmpty)
+        }
+
+        @Test
+        func report_omitsUnreachableDeprecatedProduct_whenIncludeTransitiveIsReachable() throws {
+            // Root package declares a deprecated product but no target
+            // consumes it. Since no root-target dependency chain reaches
+            // the product, it is transitively unreachable — and `.reachable`
+            // mode excludes unreachable entries. Use `.all` (or `.nonReachable`)
+            // to surface it.
+            let graph = try loadSingleRootGraph(
+                withProducts: [
+                    try ProductDescription(
+                        name: "OldLib",
+                        type: .library(.automatic),
+                        targets: ["OldLib"],
+                        deprecation: ProductDeprecation(
+                            message: "gone",
+                            replacement: .renamed("NewLib"),
+                        ),
+                    ),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .reachable)
+            #expect(report.deprecated.products.isEmpty)
+        }
+
+        // MARK: Direct violations
+
+        @Test
+        func report_populatesUsedByAndBreadcrumb_forDirectlyConsumedProduct() throws {
+            let graph = try loadConsumerProducerGraph(
+                producerProducts: [
+                    try ProductDescription(
+                        name: "PaperLegacy",
+                        type: .library(.automatic),
+                        targets: ["PaperLegacy"],
+                        deprecation: ProductDeprecation(
+                            message: "Use Paper instead.",
+                            replacement: .renamed("Paper"),
+                        ),
+                    ),
+                ],
+                producerTargets: [
+                    TargetDescription(name: "PaperLegacy"),
+                ],
+                consumerTargets: [
+                    TargetDescription(
+                        name: "MyApp",
+                        dependencies: [
+                            .product(name: "PaperLegacy", package: "Producer"),
+                        ],
+                    ),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .off)
+            #expect(report.deprecated.products.count == 1)
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.product == "PaperLegacy")
+            #expect(entry.package == "producer")
+            #expect(entry.usedBy == ["MyApp"])
+            #expect(entry.transitive == .direct)
+
+            // Breadcrumb: single path with two hops — [target, product].
+            let breadcrumb = try #require(entry.breadcrumb)
+            #expect(breadcrumb.count == 1)
+            let path = try #require(breadcrumb.first)
+            #expect(path.count == 2)
+            #expect(path[0] == BreadcrumbHop(package: "consumer", target: "MyApp"))
+            #expect(path[1] == BreadcrumbHop(package: "producer", product: "PaperLegacy"))
+        }
+
+        @Test
+        func report_multipleConsumersOfSameProduct_areSortedInUsedBy() throws {
+            let graph = try loadConsumerProducerGraph(
+                producerProducts: [
+                    try ProductDescription(
+                        name: "Old",
+                        type: .library(.automatic),
+                        targets: ["Old"],
+                        deprecation: ProductDeprecation(
+                            message: "gone",
+                            replacement: nil,
+                        ),
+                    ),
+                ],
+                producerTargets: [
+                    TargetDescription(name: "Old"),
+                ],
+                consumerTargets: [
+                    TargetDescription(
+                        name: "ZTarget",
+                        dependencies: [.product(name: "Old", package: "Producer")],
+                    ),
+                    TargetDescription(
+                        name: "ATarget",
+                        dependencies: [.product(name: "Old", package: "Producer")],
+                    ),
+                    TargetDescription(
+                        name: "MTarget",
+                        dependencies: [.product(name: "Old", package: "Producer")],
+                    ),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .off)
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.usedBy == ["ATarget", "MTarget", "ZTarget"])
+            #expect(entry.transitive == .direct)
+            // A single deprecated product consumed by three targets: one path
+            // per consumer, sorted by consumer name.
+            let breadcrumb = try #require(entry.breadcrumb)
+            #expect(breadcrumb.count == 3)
+            #expect(breadcrumb[0].first == BreadcrumbHop(package: "consumer", target: "ATarget"))
+            #expect(breadcrumb[1].first == BreadcrumbHop(package: "consumer", target: "MTarget"))
+            #expect(breadcrumb[2].first == BreadcrumbHop(package: "consumer", target: "ZTarget"))
+        }
+
+        @Test
+        func report_sortsEntriesByPackageThenProduct() throws {
+            let graph = try loadConsumerProducerGraph(
+                producerProducts: [
+                    try ProductDescription(
+                        name: "Zebra",
+                        type: .library(.automatic),
+                        targets: ["Zebra"],
+                        deprecation: ProductDeprecation(message: nil, replacement: nil),
+                    ),
+                    try ProductDescription(
+                        name: "Alpha",
+                        type: .library(.automatic),
+                        targets: ["Alpha"],
+                        deprecation: ProductDeprecation(message: nil, replacement: nil),
+                    ),
+                ],
+                producerTargets: [
+                    TargetDescription(name: "Zebra"),
+                    TargetDescription(name: "Alpha"),
+                ],
+                consumerTargets: [
+                    TargetDescription(
+                        name: "MyApp",
+                        dependencies: [
+                            .product(name: "Zebra", package: "Producer"),
+                            .product(name: "Alpha", package: "Producer"),
+                        ],
+                    ),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .off)
+            #expect(report.deprecated.products.count == 2)
+            #expect(report.deprecated.products.map(\.product) == ["Alpha", "Zebra"])
+            for entry in report.deprecated.products {
+                #expect(
+                    entry.transitive == .direct,
+                    "product \(entry.product) in package \(entry.package) transitive should be direct",
+                )
+            }
+        }
+
+        @Test
+        func report_capturesReplacementInPackageVariant() throws {
+            let graph = try loadConsumerProducerGraph(
+                producerProducts: [
+                    try ProductDescription(
+                        name: "old-tool",
+                        type: .executable,
+                        targets: ["old-tool"],
+                        deprecation: ProductDeprecation(
+                            message: "Migrate to new-tool.",
+                            replacement: .renamed("new-tool", package: "tools"),
+                        ),
+                    ),
+                ],
+                producerTargets: [
+                    TargetDescription(name: "old-tool", type: .executable),
+                ],
+                consumerTargets: [
+                    TargetDescription(
+                        name: "Consumer",
+                        dependencies: [.product(name: "old-tool", package: "Producer")],
+                    ),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .off)
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.type == "executable")
+            #expect(entry.transitive == .direct)
+            #expect(entry.replacement == .renamed("new-tool", package: "tools"))
+        }
+
+        // MARK: --include-transitive reachable
+
+        @Test
+        func report_includesReachableDeprecatedProduct_viaNonDeprecatedIntermediate() throws {
+            // Root consumer has one target that depends on non-deprecated
+            // product 'MidLib' in package 'middle'. MidLib's target depends on
+            // deprecated 'Old' in package 'producer'. The deprecated product is
+            // transitively reachable — must appear with .transitiveReachable
+            // and a breadcrumb of length 3.
+            let graph = try loadThreePackageChain(
+                rootTarget: TargetDescription(
+                    name: "App",
+                    dependencies: [.product(name: "MidLib", package: "middle")],
+                ),
+                middlePackageIdentity: "middle",
+                middleProducts: [
+                    try ProductDescription(
+                        name: "MidLib",
+                        type: .library(.automatic),
+                        targets: ["MidLib"],
+                    ),
+                ],
+                middleTargets: [
+                    TargetDescription(
+                        name: "MidLib",
+                        dependencies: [.product(name: "Old", package: "producer")],
+                    ),
+                ],
+                leafPackageIdentity: "producer",
+                leafProducts: [
+                    try ProductDescription(
+                        name: "Old",
+                        type: .library(.automatic),
+                        targets: ["Old"],
+                        deprecation: ProductDeprecation(
+                            message: "gone",
+                            replacement: .renamed("New"),
+                        ),
+                    ),
+                ],
+                leafTargets: [TargetDescription(name: "Old")],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .reachable)
+            #expect(report.deprecated.products.count == 1)
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.product == "Old")
+            #expect(entry.package == "producer")
+            #expect(entry.transitive == .transitiveReachable)
+            #expect(entry.usedBy == ["App"])
+
+            let breadcrumb = try #require(entry.breadcrumb)
+            #expect(breadcrumb.count == 1)
+            let path = try #require(breadcrumb.first)
+            #expect(path.count == 3)
+            #expect(path[0] == BreadcrumbHop(package: "consumer", target: "App"))
+            #expect(path[1] == BreadcrumbHop(package: "middle", product: "MidLib"))
+            #expect(path[2] == BreadcrumbHop(package: "producer", product: "Old"))
+        }
+
+        @Test
+        func report_reachableMode_omitsUnreachableSiblings() throws {
+            // Producer declares two deprecated products: 'Old' (reachable
+            // through middle.MidLib) and 'Unrelated' (not on any chain from
+            // the root). In .reachable mode, 'Unrelated' must be omitted.
+            let graph = try loadThreePackageChain(
+                rootTarget: TargetDescription(
+                    name: "App",
+                    dependencies: [.product(name: "MidLib", package: "middle")],
+                ),
+                middlePackageIdentity: "middle",
+                middleProducts: [
+                    try ProductDescription(
+                        name: "MidLib",
+                        type: .library(.automatic),
+                        targets: ["MidLib"],
+                    ),
+                ],
+                middleTargets: [
+                    TargetDescription(
+                        name: "MidLib",
+                        dependencies: [.product(name: "Old", package: "producer")],
+                    ),
+                ],
+                leafPackageIdentity: "producer",
+                leafProducts: [
+                    try ProductDescription(
+                        name: "Old",
+                        type: .library(.automatic),
+                        targets: ["Old"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                    try ProductDescription(
+                        name: "Unrelated",
+                        type: .library(.automatic),
+                        targets: ["Unrelated"],
+                        deprecation: ProductDeprecation(message: "also gone", replacement: nil),
+                    ),
+                ],
+                leafTargets: [
+                    TargetDescription(name: "Old"),
+                    TargetDescription(name: "Unrelated"),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .reachable)
+            #expect(report.deprecated.products.map(\.product) == ["Old"])
+        }
+
+        @Test
+        func report_multiplePathsToSameProduct_areAllCapturedInBreadcrumb() throws {
+            // Two root-package targets (AppA and AppB) both depend on
+            // `middle.MidLib`, whose target depends on the deprecated
+            // `producer.Old`. The single deprecated product must be
+            // reported with a breadcrumb containing TWO paths — one per
+            // root consumer — sorted by root target name.
+            let fs = InMemoryFileSystem(emptyFiles: [
+                "/Consumer/Sources/AppA/source.swift",
+                "/Consumer/Sources/AppB/source.swift",
+                "/Middle/Sources/MidLib/source.swift",
+                "/Producer/Sources/Old/source.swift",
+            ])
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Middle",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "AppA",
+                                dependencies: [.product(name: "MidLib", package: "middle")],
+                            ),
+                            TargetDescription(
+                                name: "AppB",
+                                dependencies: [.product(name: "MidLib", package: "middle")],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Middle",
+                        path: "/Middle",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        products: [
+                            try ProductDescription(
+                                name: "MidLib",
+                                type: .library(.automatic),
+                                targets: ["MidLib"],
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "MidLib",
+                                dependencies: [.product(name: "Old", package: "producer")],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                            ),
+                        ],
+                        targets: [TargetDescription(name: "Old")],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .reachable)
+            #expect(report.deprecated.products.count == 1)
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.transitive == .transitiveReachable)
+            #expect(entry.usedBy == ["AppA", "AppB"])
+
+            let breadcrumb = try #require(entry.breadcrumb)
+            #expect(breadcrumb.count == 2)
+            // Paths sorted by root consumer target name.
+            #expect(breadcrumb[0] == [
+                BreadcrumbHop(package: "consumer", target: "AppA"),
+                BreadcrumbHop(package: "middle", product: "MidLib"),
+                BreadcrumbHop(package: "producer", product: "Old"),
+            ])
+            #expect(breadcrumb[1] == [
+                BreadcrumbHop(package: "consumer", target: "AppB"),
+                BreadcrumbHop(package: "middle", product: "MidLib"),
+                BreadcrumbHop(package: "producer", product: "Old"),
+            ])
+        }
+
+        @Test
+        func report_multipleDistinctChains_produceDistinctBreadcrumbPaths() throws {
+            // Single root target `App` depends on two non-deprecated
+            // intermediate products (`middle.LibA` and `middle.LibB`).
+            // Both intermediate targets depend on `producer.Old`
+            // (deprecated). The report must contain a single deprecated
+            // entry whose breadcrumb has TWO distinct paths differing
+            // in the intermediate product hop.
+            let fs = InMemoryFileSystem(emptyFiles: [
+                "/Consumer/Sources/App/source.swift",
+                "/Middle/Sources/LibA/source.swift",
+                "/Middle/Sources/LibB/source.swift",
+                "/Producer/Sources/Old/source.swift",
+            ])
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Middle",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "App",
+                                dependencies: [
+                                    .product(name: "LibA", package: "middle"),
+                                    .product(name: "LibB", package: "middle"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Middle",
+                        path: "/Middle",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        products: [
+                            try ProductDescription(
+                                name: "LibA",
+                                type: .library(.automatic),
+                                targets: ["LibA"],
+                            ),
+                            try ProductDescription(
+                                name: "LibB",
+                                type: .library(.automatic),
+                                targets: ["LibB"],
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "LibA",
+                                dependencies: [.product(name: "Old", package: "producer")],
+                            ),
+                            TargetDescription(
+                                name: "LibB",
+                                dependencies: [.product(name: "Old", package: "producer")],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                            ),
+                        ],
+                        targets: [TargetDescription(name: "Old")],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .reachable)
+            #expect(report.deprecated.products.count == 1)
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.transitive == .transitiveReachable)
+            // The consumer target `App` reaches `Old` via two intermediates,
+            // but `usedBy` deduplicates on the root-target name.
+            #expect(entry.usedBy == ["App"])
+
+            let breadcrumb = try #require(entry.breadcrumb)
+            #expect(breadcrumb.count == 2)
+            // Paths sorted by intermediate product name (LibA before LibB).
+            #expect(breadcrumb[0] == [
+                BreadcrumbHop(package: "consumer", target: "App"),
+                BreadcrumbHop(package: "middle", product: "LibA"),
+                BreadcrumbHop(package: "producer", product: "Old"),
+            ])
+            #expect(breadcrumb[1] == [
+                BreadcrumbHop(package: "consumer", target: "App"),
+                BreadcrumbHop(package: "middle", product: "LibB"),
+                BreadcrumbHop(package: "producer", product: "Old"),
+            ])
+        }
+
+        // MARK: --include-transitive all
+
+        @Test
+        func report_allMode_reportsDirectReachableAndUnreachable() throws {
+            // A direct violation (App → middle.Direct), a reachable
+            // transitive (App → middle.MidLib → producer.Reachable), and
+            // an unreachable deprecated product (producer.Unreachable, not
+            // on any chain from the root).
+            //
+            // Note: root can only reference products from `middle` directly
+            // (the only package it depends on); anything in `producer` must
+            // be reached via a middle product.
+            let graph = try loadThreePackageChain(
+                rootTarget: TargetDescription(
+                    name: "App",
+                    dependencies: [
+                        .product(name: "MidLib", package: "middle"),
+                        .product(name: "Direct", package: "middle"),
+                    ],
+                ),
+                middlePackageIdentity: "middle",
+                middleProducts: [
+                    try ProductDescription(
+                        name: "MidLib",
+                        type: .library(.automatic),
+                        targets: ["MidLib"],
+                    ),
+                    try ProductDescription(
+                        name: "Direct",
+                        type: .library(.automatic),
+                        targets: ["Direct"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                ],
+                middleTargets: [
+                    TargetDescription(
+                        name: "MidLib",
+                        dependencies: [.product(name: "Reachable", package: "producer")],
+                    ),
+                    TargetDescription(name: "Direct"),
+                ],
+                leafPackageIdentity: "producer",
+                leafProducts: [
+                    try ProductDescription(
+                        name: "Reachable",
+                        type: .library(.automatic),
+                        targets: ["Reachable"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                    try ProductDescription(
+                        name: "Unreachable",
+                        type: .library(.automatic),
+                        targets: ["Unreachable"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                ],
+                leafTargets: [
+                    TargetDescription(name: "Reachable"),
+                    TargetDescription(name: "Unreachable"),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .all)
+            let byName = Dictionary(uniqueKeysWithValues: report.deprecated.products.map { ($0.product, $0) })
+            #expect(byName.count == 3)
+
+            let direct = try #require(byName["Direct"])
+            #expect(direct.transitive == .direct)
+            let directCrumb = try #require(direct.breadcrumb?.first)
+            #expect(directCrumb == [
+                BreadcrumbHop(package: "consumer", target: "App"),
+                BreadcrumbHop(package: "middle", product: "Direct"),
+            ])
+
+            let reachable = try #require(byName["Reachable"])
+            #expect(reachable.transitive == .transitiveReachable)
+            let reachableCrumb = try #require(reachable.breadcrumb?.first)
+            #expect(reachableCrumb == [
+                BreadcrumbHop(package: "consumer", target: "App"),
+                BreadcrumbHop(package: "middle", product: "MidLib"),
+                BreadcrumbHop(package: "producer", product: "Reachable"),
+            ])
+
+            let unreachable = try #require(byName["Unreachable"])
+            #expect(unreachable.transitive == .transitiveUnreachable)
+            #expect(unreachable.usedBy == [])
+            // Unreachable entries carry no breadcrumb — no chain to record.
+            #expect(unreachable.breadcrumb == nil)
+        }
+
+        // MARK: --include-transitive nonReachable
+
+        @Test
+        func report_nonReachableMode_omitsDirectAndReachable() throws {
+            // Same graph as `report_allMode_...` above — root reaches a direct
+            // deprecated `middle.Direct` and a transitive-reachable
+            // `producer.Reachable`. `producer.Unreachable` is deprecated but
+            // not on any chain. In `.nonReachable` mode only Unreachable
+            // survives the filter.
+            let graph = try loadThreePackageChain(
+                rootTarget: TargetDescription(
+                    name: "App",
+                    dependencies: [
+                        .product(name: "MidLib", package: "middle"),
+                        .product(name: "Direct", package: "middle"),
+                    ],
+                ),
+                middlePackageIdentity: "middle",
+                middleProducts: [
+                    try ProductDescription(
+                        name: "MidLib",
+                        type: .library(.automatic),
+                        targets: ["MidLib"],
+                    ),
+                    try ProductDescription(
+                        name: "Direct",
+                        type: .library(.automatic),
+                        targets: ["Direct"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                ],
+                middleTargets: [
+                    TargetDescription(
+                        name: "MidLib",
+                        dependencies: [.product(name: "Reachable", package: "producer")],
+                    ),
+                    TargetDescription(name: "Direct"),
+                ],
+                leafPackageIdentity: "producer",
+                leafProducts: [
+                    try ProductDescription(
+                        name: "Reachable",
+                        type: .library(.automatic),
+                        targets: ["Reachable"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                    try ProductDescription(
+                        name: "Unreachable",
+                        type: .library(.automatic),
+                        targets: ["Unreachable"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                ],
+                leafTargets: [
+                    TargetDescription(name: "Reachable"),
+                    TargetDescription(name: "Unreachable"),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .nonReachable)
+            #expect(report.deprecated.products.map(\.product) == ["Unreachable"])
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.transitive == .transitiveUnreachable)
+            #expect(entry.usedBy == [])
+            #expect(entry.breadcrumb == nil)
+        }
+
+        // MARK: - Helpers
+
+        /// Builds a graph containing a single root package with the given products
+        /// and a target for each product. No dependencies.
+        private func loadSingleRootGraph(
+            withProducts products: [ProductDescription],
+        ) throws -> ModulesGraph {
+            var files: [String] = []
+            var targets: [TargetDescription] = []
+            for product in products {
+                for target in product.targets {
+                    files.append("/Root/Sources/\(target)/source.swift")
+                    if !targets.contains(where: { $0.name == target }) {
+                        targets.append(try TargetDescription(name: target))
+                    }
+                }
+            }
+            let fs = InMemoryFileSystem(emptyFiles: files)
+            let observability = ObservabilitySystem.makeForTesting()
+            return try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Root",
+                        path: "/Root",
+                        products: products,
+                        targets: targets,
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+        }
+
+        /// Builds a two-package graph: a `Consumer` root package that depends on
+        /// a `Producer` file-system package. Callers supply the producer's products
+        /// and targets, and the consumer's targets (which can reference producer's
+        /// products via `.product(name:package:)` dependencies).
+        private func loadConsumerProducerGraph(
+            producerProducts: [ProductDescription],
+            producerTargets: [TargetDescription],
+            consumerTargets: [TargetDescription],
+        ) throws -> ModulesGraph {
+            var files: [String] = []
+            for target in producerTargets {
+                files.append("/Producer/Sources/\(target.name)/source.swift")
+            }
+            for target in consumerTargets {
+                files.append("/Consumer/Sources/\(target.name)/source.swift")
+            }
+            let fs = InMemoryFileSystem(emptyFiles: files)
+            let observability = ObservabilitySystem.makeForTesting()
+            return try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: consumerTargets,
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: producerProducts,
+                        targets: producerTargets,
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+        }
+
+        /// Builds a three-package graph:
+        ///   `Consumer` (root) → `middle` → `<leafPackageIdentity>`
+        ///
+        /// The root package depends ONLY on `middle`; the leaf package is
+        /// reachable only transitively via one of the middle's products.
+        /// Callers supply the middle package's products/targets and the leaf
+        /// package's products/targets — this permits scenarios where middle
+        /// has its own deprecated product (a `.direct` violation) alongside a
+        /// non-deprecated product that chains to a deprecated leaf product
+        /// (`.transitiveReachable`).
+        private func loadThreePackageChain(
+            rootTarget: TargetDescription,
+            middlePackageIdentity: String,
+            middleProducts: [ProductDescription],
+            middleTargets: [TargetDescription],
+            leafPackageIdentity: String,
+            leafProducts: [ProductDescription],
+            leafTargets: [TargetDescription],
+        ) throws -> ModulesGraph {
+            let middleDisplay = middlePackageIdentity.capitalized
+            let leafDisplay = leafPackageIdentity.capitalized
+
+            var files: [String] = ["/Consumer/Sources/\(rootTarget.name)/source.swift"]
+            for target in middleTargets {
+                files.append("/\(middleDisplay)/Sources/\(target.name)/source.swift")
+            }
+            for target in leafTargets {
+                files.append("/\(leafDisplay)/Sources/\(target.name)/source.swift")
+            }
+            let fs = InMemoryFileSystem(emptyFiles: files)
+            let observability = ObservabilitySystem.makeForTesting()
+            return try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: AbsolutePath("/\(middleDisplay)"),
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [rootTarget],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: middleDisplay,
+                        path: AbsolutePath("/\(middleDisplay)"),
+                        dependencies: [
+                            .localSourceControl(
+                                path: AbsolutePath("/\(leafDisplay)"),
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        products: middleProducts,
+                        targets: middleTargets,
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: leafDisplay,
+                        path: AbsolutePath("/\(leafDisplay)"),
+                        products: leafProducts,
+                        targets: leafTargets,
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+        }
+    }
+
+    @Suite
+    struct AuditReportProductTypeStringTests {
+
+        @Test
+        func productTypeString_mapsSupportedKinds() async throws {
+            #expect(auditProductTypeString(.executable) == "executable")
+            #expect(auditProductTypeString(.library(.automatic)) == "library")
+            #expect(auditProductTypeString(.library(.static)) == "library")
+            #expect(auditProductTypeString(.library(.dynamic)) == "library")
+            #expect(auditProductTypeString(.plugin) == "plugin")
+        }
+
+        @Test
+        func productTypeString_returnsNilForUnsupportedKinds() async throws {
+            #expect(auditProductTypeString(.test) == nil)
+            #expect(auditProductTypeString(.snippet) == nil)
+            #expect(auditProductTypeString(.macro) == nil)
+        }
+
+    }
+
+
+    @Suite
+    struct AuditReportTextRenderer {
+
+        @Test
+        func text_emptyReport_returnsExplicitMessage() async throws {
+            let empty = AuditReport(deprecated: .init(products: []))
+            #expect(renderAuditReportAsText(empty) == "No deprecated products found.")
+        }
+
+        @Test
+        func text_directOnly_emitsOnlyDirectSection() async throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "Use Paper.",
+                        package: "producer",
+                        product: "PaperLegacy",
+                        replacement: .renamed("Paper"),
+                        type: "library",
+                        usedBy: ["MyApp"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "MyApp"),
+                            BreadcrumbHop(package: "producer", product: "PaperLegacy"),
+                        ]],
+                    ),
+                ]),
+            )
+            let expected = """
+                Directly consumed deprecated products:
+                  package 'producer':
+                    library 'PaperLegacy' is unsupported
+                      Use Paper.
+                      Use 'Paper' instead.
+                      Used by: MyApp
+                """
+            #expect(renderAuditReportAsText(report) == expected)
+        }
+
+        @Test
+        func text_transitiveReachableOnly_emitsOnlyReachableSection() async throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "PaperExperimental",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["MyTransitiveApp"],
+                        transitive: .transitiveReachable,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer-transitive", target: "MyTransitiveApp"),
+                            BreadcrumbHop(package: "consumer", product: "MyLib"),
+                            BreadcrumbHop(package: "producer", product: "PaperExperimental"),
+                        ]],
+                    ),
+                ]),
+            )
+            let rendered = renderAuditReportAsText(report)
+            #expect(rendered.contains("Transitively reachable deprecated products:") == true)
+            #expect(rendered.contains("library 'PaperExperimental' is unsupported") == true)
+            #expect(rendered.contains("Used by: MyTransitiveApp") == true)
+            #expect(rendered.contains("Directly consumed deprecated products:") == false)
+            #expect(rendered.contains("Transitively unreachable") == false)
+        }
+
+        @Test
+        func text_transitiveUnreachableOnly_emitsOnlyUnreachableSection() async throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "Migrate to the standalone paper-tools package.",
+                        package: "producer",
+                        product: "paper-tool-old",
+                        replacement: .renamed("paper-tool", package: "paper-tools"),
+                        type: "executable",
+                        usedBy: [],
+                        transitive: .transitiveUnreachable,
+                        breadcrumb: nil,
+                    ),
+                ]),
+            )
+            let rendered = renderAuditReportAsText(report)
+            #expect(rendered.contains("Transitively unreachable deprecated products:") == true)
+            #expect(rendered.contains("executable 'paper-tool-old' is unsupported") == true)
+            #expect(rendered.contains("Migrate to the standalone paper-tools package.") == true)
+            #expect(rendered.contains("Use 'paper-tool' from package 'paper-tools' instead.") == true)
+            #expect(rendered.contains("Directly consumed deprecated products:") == false)
+            #expect(rendered.contains("Transitively reachable deprecated products:") == false)
+            // Unreachable entries have no 'Used by' line.
+            #expect(rendered.contains("Used by:") == false)
+        }
+
+        @Test
+        func text_allSections_areRenderedInFixedOrder() async throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "Direct",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["App"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "App"),
+                            BreadcrumbHop(package: "producer", product: "Direct"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "Reachable",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["MidLib"],
+                        transitive: .transitiveReachable,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "App"),
+                            BreadcrumbHop(package: "middle", product: "MidLib"),
+                            BreadcrumbHop(package: "producer", product: "Reachable"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "Unreachable",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: [],
+                        transitive: .transitiveUnreachable,
+                        breadcrumb: nil,
+                    ),
+                ]),
+            )
+            let rendered = renderAuditReportAsText(report)
+            let directIdx = try #require(rendered.range(of: "Directly consumed deprecated products:"))
+            let reachableIdx = try #require(rendered.range(of: "Transitively reachable deprecated products:"))
+            let unreachableIdx = try #require(rendered.range(of: "Transitively unreachable deprecated products:"))
+            #expect(directIdx != nil)
+            #expect(reachableIdx != nil)
+            #expect(unreachableIdx != nil)
+
+            #expect(directIdx.lowerBound < reachableIdx.lowerBound)
+            #expect(reachableIdx.lowerBound < unreachableIdx.lowerBound)
+        }
+
+        @Test
+        func text_emptyMessageStringIsSkipped() async throws {
+            // An empty (but non-nil) message string is treated the same as
+            // nil — no message line is emitted.
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "",
+                        package: "producer",
+                        product: "Old",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["Consumer"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "Consumer"),
+                            BreadcrumbHop(package: "producer", product: "Old"),
+                        ]],
+                    ),
+                ]),
+            )
+            let expected = """
+                Directly consumed deprecated products:
+                  package 'producer':
+                    library 'Old' is unsupported
+                      Used by: Consumer
+                """
+            let actual = renderAuditReportAsText(report)
+            #expect(actual == expected)
+        }
+
+        @Test
+        func text_executableAndPluginProductTypeLabelsAppear() async throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "old-tool",
+                        replacement: nil,
+                        type: "executable",
+                        usedBy: ["Consumer"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "Consumer"),
+                            BreadcrumbHop(package: "producer", product: "old-tool"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "OldPlugin",
+                        replacement: nil,
+                        type: "plugin",
+                        usedBy: ["Consumer"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "Consumer"),
+                            BreadcrumbHop(package: "producer", product: "OldPlugin"),
+                        ]],
+                    ),
+                ]),
+            )
+            let rendered = renderAuditReportAsText(report)
+            #expect(rendered.contains("executable 'old-tool' is unsupported") == true)
+            #expect(rendered.contains("plugin 'OldPlugin' is unsupported") == true)
+        }
+
+        @Test
+        func text_multipleEntriesGroupedByPackageWithinSection() async throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "Alpha",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["Consumer"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "Consumer"),
+                            BreadcrumbHop(package: "producer", product: "Alpha"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "Beta",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["Consumer"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "Consumer"),
+                            BreadcrumbHop(package: "producer", product: "Beta"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "third-party",
+                        product: "Gamma",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: [],
+                        transitive: .transitiveUnreachable,
+                        breadcrumb: nil,
+                    ),
+                ]),
+            )
+            let expected = """
+                Directly consumed deprecated products:
+                  package 'producer':
+                    library 'Alpha' is unsupported
+                      Used by: Consumer
+                    library 'Beta' is unsupported
+                      Used by: Consumer
+
+                Transitively unreachable deprecated products:
+                  package 'third-party':
+                    library 'Gamma' is unsupported
+                """
+            let actual = renderAuditReportAsText(report)
+            #expect(actual == expected)
+        }
+    }
+
+    @Suite
+    struct AuditReportCodableTests {
+
+        @Test
+        func report_roundTripsThroughJSON() throws {
+            let original = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "Use New.",
+                        package: "producer",
+                        product: "Old",
+                        replacement: .renamed("New"),
+                        type: "library",
+                        usedBy: ["A", "B"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "A"),
+                            BreadcrumbHop(package: "producer", product: "Old"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: "The message",
+                        package: "thepackage",
+                        product: "deprecatedProductName",
+                        replacement: .renamed("New"),
+                        type: "executable",
+                        usedBy: ["A", "B", "C"],
+                        transitive: .transitiveReachable,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "A"),
+                            BreadcrumbHop(package: "intermediate", product: "Mid"),
+                            BreadcrumbHop(package: "thepackage", product: "deprecatedProductName"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "otherPackage",
+                        product: "otherProduct",
+                        replacement: nil,
+                        type: "plugin",
+                        usedBy: [],
+                        transitive: .transitiveUnreachable,
+                        breadcrumb: nil,
+                    ),
+
+                ]),
+            )
+            let encoded = try JSONEncoder().encode(original)
+            let decoded = try JSONDecoder().decode(AuditReport.self, from: encoded)
+            #expect(decoded == original)
+        }
+
+        @Test
+        func json_emptyReport_hasCanonicalShape() throws {
+            let empty = AuditReport(deprecated: .init(products: []))
+            let encoder = JSONEncoder()
+            encoder.outputFormatting.insert(.sortedKeys)
+            let data = try encoder.encode(empty)
+            let jsonString = String(decoding: data, as: UTF8.self)
+            // Sorted keys → the two keys serialize in stable alphabetical order.
+            #expect(jsonString == #"{"deprecated":{"products":[]}}"#)
+        }
+
+        @Test
+        func json_topLevelHasDeprecatedProductsKey() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "p",
+                        product: "q",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: [],
+                        transitive: .transitiveUnreachable,
+                        breadcrumb: nil,
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let deprecated = try #require(root["deprecated"] as? [String: Any])
+            let products = try #require(deprecated["products"] as? [[String: Any]])
+            #expect(products.count == 1)
+        }
+
+        @Test
+        func json_directEntryEmitsTransitiveDirectAndBreadcrumb() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "m",
+                        package: "producer",
+                        product: "Old",
+                        replacement: .renamed("New"),
+                        type: "library",
+                        usedBy: ["MyApp"],
+                        transitive: .direct,
+                        breadcrumb: [
+                            [
+                                BreadcrumbHop(package: "consumer", target: "MyApp"),
+                                BreadcrumbHop(package: "producer", product: "Old"),
+                            ],
+                        ],
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let entry = try #require(products.first)
+
+            #expect(entry["message"] as? String == "m")
+            #expect(entry["package"] as? String == "producer")
+            #expect(entry["product"] as? String == "Old")
+            #expect(entry["type"] as? String == "library")
+            #expect(entry["usedBy"] as? [String] == ["MyApp"])
+            #expect(entry["transitive"] as? String == "direct")
+
+            let breadcrumb = try #require(entry["breadcrumb"] as? [[[String: Any]]])
+            #expect(breadcrumb.count == 1)
+            let path = try #require(breadcrumb.first)
+            #expect(path.count == 2)
+            #expect(path[0]["package"] as? String == "consumer")
+            #expect(path[0]["target"] as? String == "MyApp")
+            #expect(path[0]["product"] == nil)
+            #expect(path[1]["package"] as? String == "producer")
+            #expect(path[1]["product"] as? String == "Old")
+            #expect(path[1]["target"] == nil)
+
+            let replacement = try #require(entry["replacement"] as? [String: Any])
+            #expect(replacement["kind"] as? String == "renamed")
+            #expect(replacement["product"] as? String == "New")
+        }
+
+        @Test
+        func json_transitiveReachableEntry_hasReachableStringAndBreadcrumb() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "PaperExperimental",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["MyTransitiveApp"],
+                        transitive: .transitiveReachable,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer-transitive", target: "MyTransitiveApp"),
+                            BreadcrumbHop(package: "consumer", product: "MyLib"),
+                            BreadcrumbHop(package: "producer", product: "PaperExperimental"),
+                        ]],
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let entry = try #require(products.first)
+            #expect(entry["transitive"] as? String == "transitiveReachable")
+            let breadcrumb = try #require(entry["breadcrumb"] as? [[[String: Any]]])
+            let path = try #require(breadcrumb.first)
+            #expect(path.count == 3)
+        }
+
+        @Test
+        func json_transitiveUnreachableEntry_omitsBreadcrumbKey() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "paper-tool-old",
+                        replacement: nil,
+                        type: "executable",
+                        usedBy: [],
+                        transitive: .transitiveUnreachable,
+                        breadcrumb: nil,
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let entry = try #require(products.first)
+            #expect(entry["transitive"] as? String == "transitiveUnreachable")
+            #expect(entry["breadcrumb"] == nil)
+            #expect(entry["usedBy"] as? [String] == [])
+        }
+
+        @Test
+        func json_crossPackageReplacementEmitsPackageAndProductFields() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "old-tool",
+                        replacement: .renamed("new-tool", package: "tools"),
+                        type: "executable",
+                        usedBy: ["MyApp"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "MyApp"),
+                            BreadcrumbHop(package: "producer", product: "old-tool"),
+                        ]],
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let entry = try #require(products.first)
+            let replacement = try #require(entry["replacement"] as? [String: Any])
+            #expect(replacement["kind"] as? String == "renamed")
+            #expect(replacement["package"] as? String == "tools")
+            #expect(replacement["product"] as? String == "new-tool")
+        }
+
+        @Test
+        func json_nilReplacementOmitsReplacementKey() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "gone",
+                        package: "producer",
+                        product: "Old",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["MyApp"],
+                        transitive: .direct,
+                        breadcrumb: [
+                            [
+                                BreadcrumbHop(package: "consumer", target: "MyApp"),
+                                BreadcrumbHop(package: "producer", product: "Old"),
+                            ],
+                        ],
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let entry = try #require(products.first)
+            #expect(entry["replacement"] == nil)
+        }
+
+        @Test
+        func json_nilMessageOmitsMessageKey() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "Old",
+                        replacement: .renamed("New"),
+                        type: "library",
+                        usedBy: ["MyApp"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "MyApp"),
+                            BreadcrumbHop(package: "producer", product: "Old"),
+                        ]],
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let entry = try #require(products.first)
+            #expect(entry["message"] == nil)
+        }
+
+        @Test
+        func json_sortedKeysProducesByteStableOutput() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "m",
+                        package: "producer",
+                        product: "Old",
+                        replacement: .renamed("New"),
+                        type: "library",
+                        usedBy: ["MyApp"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "MyApp"),
+                            BreadcrumbHop(package: "producer", product: "Old"),
+                        ]],
+                    ),
+                ]),
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting.insert(.sortedKeys)
+
+            // Two independent encodes with sortedKeys must produce identical bytes,
+            // regardless of dictionary iteration order.
+            let first = try encoder.encode(report)
+            let second = try encoder.encode(report)
+            #expect(first == second)
+
+            // Additionally verify the top-level object's keys are in alphabetical
+            // order (a schema requirement — audit-v1 says sorted keys at every
+            // nesting level).
+            let jsonString = String(decoding: first, as: UTF8.self)
+            let deprecatedIndex = try #require(jsonString.range(of: "\"deprecated\""))
+            #expect(jsonString[..<deprecatedIndex.lowerBound] == "{")
+        }
+
+        @Test
+        func json_multipleEntriesArraySortIsPreserved() throws {
+            // The encoder does not re-sort array elements; whatever order
+            // `buildAuditReport` places entries in is preserved on the wire.
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "aaa",
+                        product: "Alpha",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["C"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "C"),
+                            BreadcrumbHop(package: "aaa", product: "Alpha"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "bbb",
+                        product: "Beta",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["C"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "C"),
+                            BreadcrumbHop(package: "bbb", product: "Beta"),
+                        ]],
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let names = products.compactMap { $0["product"] as? String }
+            #expect(names == ["Alpha", "Beta"])
+        }
+    }
+}

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -2047,7 +2047,6 @@ struct BuildCommandTestCases {
     struct ProductDeprecation {
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func buildEmitsWarningForConsumerOfDeprecatedProduct(
@@ -2078,7 +2077,6 @@ struct BuildCommandTestCases {
         }
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func buildEscalatesToErrorForTargetWithTreatAllWarningsError(
@@ -2110,7 +2108,6 @@ struct BuildCommandTestCases {
         }
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func buildEscalatesToErrorViaXswiftcWarningsAsErrors(
@@ -2139,7 +2136,6 @@ struct BuildCommandTestCases {
         }
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func buildDoesNotWarnForNonConsumingPackage(
@@ -2151,8 +2147,42 @@ struct BuildCommandTestCases {
                     configuration: .debug,
                     buildSystem: buildSystem,
                 )
-                #expect(!stderr.contains("is unsupported"))
-                #expect(!stdout.contains("is unsupported"))
+                #expect(
+                    stderr.contains("is unsupported") == false,
+                    "stdout:\n\(stdout)",
+                )
+                #expect(
+                    stdout.contains("is unsupported") == false,
+                    "stderr:\n\(stderr)",
+                )
+            }
+        }
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func buildDoesNotWarnAboutProducersOwnProducts(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            // Building the producer package should NOT emit a deprecation
+            // diagnostic for any of its OWN products (PaperLegacy,
+            // PaperExperimental, paper-tool-old) because no producer target
+            // depends on them via `.product()`. A diagnostic about
+            // OldThirdParty (which the producer's `Paper` target does consume)
+            // is acceptable — that's the correct behavior for a producer that
+            // consumes a deprecated product from a third-party dependency.
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                let (_, stderr) = try await executeSwiftBuild(
+                    fixturePath.appending("producer"),
+                    configuration: .debug,
+                    buildSystem: buildSystem,
+                )
+                for productName in ["PaperLegacy", "PaperExperimental", "paper-tool-old"] {
+                    #expect(
+                        stderr.contains("product '\(productName)' from package 'producer' is unsupported") == false,
+                        "producer should not warn about its own product '\(productName)'\nstderr:\n\(stderr)",
+                    )
+                }
             }
         }
     }

--- a/Tests/CommandsTests/PackageCommandTests+Audit.swift
+++ b/Tests/CommandsTests/PackageCommandTests+Audit.swift
@@ -1,0 +1,658 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import _InternalTestSupport
+
+import struct SPMBuildCore.BuildSystemProvider
+
+extension PackageCommandTests.PackageAuditCommandTests {
+
+    @Suite(
+        .tags(
+            .Feature.Deprecation,
+        ),
+    )
+    struct ProductDeprecation {
+
+        // MARK: - Direct violations (transitive == "direct")
+
+        @Suite
+        struct DirectViolationsTests {
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditReportsDirectDeprecatedProductsInJson(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "json",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        let data = Data(error.stdout.utf8)
+                        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                              let deprecated = root["deprecated"] as? [String: Any],
+                              let products = deprecated["products"] as? [[String: Any]] else {
+                            Issue.record("audit output is not valid JSON. stdout:\n\(error.stdout)")
+                            return
+                        }
+                        // consumer's MyApp directly consumes PaperLegacy;
+                        // MyLib directly consumes PaperExperimental. Both are
+                        // deprecated. Nothing else is reachable, so no
+                        // transitive entries appear (--include-transitive not
+                        // passed).
+                        #expect(products.count == 2, "unexpected products: \(products.map { $0["product"] as? String ?? "?" })")
+
+                        let byProduct = Dictionary(uniqueKeysWithValues: products.compactMap {
+                            (product) -> (String, [String: Any])? in
+                            guard let name = product["product"] as? String else { return nil }
+                            return (name, product)
+                        })
+
+                        let paperLegacy = try #require(byProduct["PaperLegacy"])
+                        #expect(paperLegacy["package"] as? String == "producer")
+                        #expect(paperLegacy["type"] as? String == "library")
+                        #expect(paperLegacy["transitive"] as? String == "direct")
+                        #expect(paperLegacy["message"] as? String == "PaperLegacy is superseded by Paper.")
+                        let paperLegacyReplacement = try #require(paperLegacy["replacement"] as? [String: Any])
+                        #expect(paperLegacyReplacement["kind"] as? String == "renamed")
+                        #expect(paperLegacyReplacement["product"] as? String == "Paper")
+                        #expect(paperLegacy["usedBy"] as? [String] == ["MyApp"])
+                        // Direct entries carry a breadcrumb: [target-hop, product-hop].
+                        let paperLegacyBreadcrumb = try #require(paperLegacy["breadcrumb"] as? [[[String: Any]]])
+                        #expect(paperLegacyBreadcrumb.count == 1)
+                        let paperLegacyPath = try #require(paperLegacyBreadcrumb.first)
+                        #expect(paperLegacyPath.count == 2)
+                        #expect(paperLegacyPath[0]["package"] as? String == "consumer")
+                        #expect(paperLegacyPath[0]["target"] as? String == "MyApp")
+                        #expect(paperLegacyPath[1]["package"] as? String == "producer")
+                        #expect(paperLegacyPath[1]["product"] as? String == "PaperLegacy")
+
+                        let experimental = try #require(byProduct["PaperExperimental"])
+                        #expect(experimental["type"] as? String == "library")
+                        #expect(experimental["transitive"] as? String == "direct")
+                        #expect(experimental["message"] as? String == "PaperExperimental is going away with no replacement.")
+                        #expect(experimental["replacement"] == nil)
+                        #expect(experimental["usedBy"] as? [String] == ["MyLib"])
+                        let experimentalBreadcrumb = try #require(experimental["breadcrumb"] as? [[[String: Any]]])
+                        #expect(experimentalBreadcrumb.count == 1)
+                        let experimentalPath = try #require(experimentalBreadcrumb.first)
+                        #expect(experimentalPath.count == 2)
+                        #expect(experimentalPath[0]["package"] as? String == "consumer")
+                        #expect(experimentalPath[0]["target"] as? String == "MyLib")
+                        #expect(experimentalPath[1]["package"] as? String == "producer")
+                        #expect(experimentalPath[1]["product"] as? String == "PaperExperimental")
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditReportsDirectDeprecatedProductsInText(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "text",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        #expect(
+                            error.stdout.contains("Directly consumed deprecated products:") == true,
+                            "stderr:\n\(error.stderr)",
+                        )
+                        #expect(
+                            error.stdout.contains("PaperLegacy") == true,
+                            "stderr:\n\(error.stderr)",
+                        )
+                        #expect(
+                            error.stdout.contains("PaperLegacy is superseded by Paper.") == true,
+                            "stderr:\n\(error.stderr)",
+                        )
+                        #expect(
+                            error.stdout.contains("Use 'Paper' instead.") == true,
+                            "stderr:\n\(error.stderr)",
+                        )
+                        #expect(
+                            error.stdout.contains("PaperExperimental") == true,
+                            "stderr:\n\(error.stderr)",
+                        )
+                        #expect(
+                            error.stdout.contains("PaperExperimental is going away with no replacement.") == true,
+                            "stderr:\n\(error.stderr)",
+                        )
+                        // Nothing transitively reachable or unreachable is
+                        // included without --include-transitive.
+                        #expect(
+                            error.stdout.contains("Transitively reachable") == false,
+                            "unexpected transitive-reachable section:\n\(error.stderr)",
+                        )
+                        #expect(
+                            error.stdout.contains("Transitively unreachable") == false,
+                            "unexpected transitive-unreachable section:\n\(error.stderr)",
+                        )
+                    }
+                }
+            }
+        }
+
+        // MARK: - Exit-code semantics
+
+        @Suite
+        struct ExitCodeSemanticsTests {
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditExitsNonZeroWhenDeprecatedProductsFound(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await #expect(throws: (any Error).self) {
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: ["audit"],
+                            buildSystem: buildSystem,
+                        )
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditExitsZeroWithAllowDeprecationsFlag(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await #expect(throws: Never.self) {
+                        let (_, _) = try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--allow-deprecations",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditRejectsInvalidFormat(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await #expect(throws: (any Error).self) {
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "invalid",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditRejectsInvalidIncludeTransitiveMode(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await #expect(throws: (any Error).self) {
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--include-transitive=bogus",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    }
+                }
+            }
+        }
+
+        // MARK: - Clean package (empty report)
+
+        @Suite
+        struct CleanPackageTests {
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditOnCleanPackageEmitsEmptyReport(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // Auditing `producer` directly: no producer target has a
+                // `.product(...)` dependency on any deprecated product, so
+                // there are no direct violations. Its own deprecated products
+                // (paper-tool-old, PaperLegacy, PaperExperimental) exist in the
+                // graph but are unreachable — without --include-transitive
+                // they're omitted.
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    let (stdout, _) = try await executeSwiftPackage(
+                        fixturePath.appending("producer"),
+                        configuration: .debug,
+                        extraArgs: [
+                            "audit",
+                            "--format", "json",
+                        ],
+                        buildSystem: buildSystem,
+                    )
+                    let data = Data(stdout.utf8)
+                    let root = try #require(
+                        try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                    )
+                    let deprecated = try #require(root["deprecated"] as? [String: Any])
+                    let products = try #require(deprecated["products"] as? [[String: Any]])
+                    #expect(products.isEmpty, "unexpected products: \(products)")
+                }
+            }
+        }
+
+        // MARK: - Transitive reachable violations (transitive == "transitiveReachable")
+
+        @Suite
+        struct TransitiveReachableViolationsTests {
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditOnConsumerTransitiveReportsNothingByDefault(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // `consumer-transitive` has one target (MyTransitiveApp) that
+                // depends on `.product("MyLib", package: "consumer")`. `MyLib`
+                // is NOT deprecated, so no direct violations. Without
+                // --include-transitive, its transitively-reachable deprecated
+                // product (PaperExperimental) is omitted → empty report.
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    let (stdout, _) = try await executeSwiftPackage(
+                        fixturePath.appending("consumer-transitive"),
+                        configuration: .debug,
+                        extraArgs: [
+                            "audit",
+                            "--format", "json",
+                        ],
+                        buildSystem: buildSystem,
+                    )
+                    let data = Data(stdout.utf8)
+                    let root = try #require(
+                        try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                    )
+                    let deprecated = try #require(root["deprecated"] as? [String: Any])
+                    let products = try #require(deprecated["products"] as? [[String: Any]])
+                    #expect(products.isEmpty, "unexpected products: \(products)")
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditOnConsumerTransitiveWithBareIncludeTransitiveReportsReachable(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // Bare `--include-transitive` (no value) defaults to
+                // "reachable" mode. PaperExperimental is transitively
+                // reachable via MyTransitiveApp → MyLib →
+                // .product(PaperExperimental, ...).
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer-transitive"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "json",
+                                "--include-transitive",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        let data = Data(error.stdout.utf8)
+                        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                              let deprecated = root["deprecated"] as? [String: Any],
+                              let products = deprecated["products"] as? [[String: Any]] else {
+                            Issue.record("audit output is not valid JSON. stdout:\n\(error.stdout)")
+                            return
+                        }
+                        #expect(products.count == 1, "unexpected products: \(products.map { $0["product"] as? String ?? "?" })")
+
+                        let entry = try #require(products.first)
+                        #expect(entry["product"] as? String == "PaperExperimental")
+                        #expect(entry["package"] as? String == "producer")
+                        #expect(entry["transitive"] as? String == "transitiveReachable")
+                        #expect(entry["usedBy"] as? [String] == ["MyTransitiveApp"])
+                        // Breadcrumb: MyTransitiveApp (target) → consumer.MyLib
+                        // (product) → producer.PaperExperimental (product).
+                        let breadcrumb = try #require(entry["breadcrumb"] as? [[[String: Any]]])
+                        let path = try #require(breadcrumb.first)
+                        #expect(path.count == 3)
+                        #expect(path[0]["package"] as? String == "consumer-transitive")
+                        #expect(path[0]["target"] as? String == "MyTransitiveApp")
+                        #expect(path[1]["package"] as? String == "consumer")
+                        #expect(path[1]["product"] as? String == "MyLib")
+                        #expect(path[2]["package"] as? String == "producer")
+                        #expect(path[2]["product"] as? String == "PaperExperimental")
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditIncludeTransitiveEqualsReachableIsSameAsBare(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // `--include-transitive=reachable` is the explicit form of the
+                // bare flag; must produce the same report.
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer-transitive"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "json",
+                                "--include-transitive=reachable",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        let data = Data(error.stdout.utf8)
+                        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                              let deprecated = root["deprecated"] as? [String: Any],
+                              let products = deprecated["products"] as? [[String: Any]] else {
+                            Issue.record("audit output is not valid JSON. stdout:\n\(error.stdout)")
+                            return
+                        }
+                        #expect(products.count == 1)
+                        let entry = try #require(products.first)
+                        #expect(entry["transitive"] as? String == "transitiveReachable")
+                        #expect(entry["product"] as? String == "PaperExperimental")
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditOnConsumerTransitiveTextEmitsReachableSection(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer-transitive"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "text",
+                                "--include-transitive",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        #expect(
+                            error.stdout.contains("Transitively reachable deprecated products:"),
+                            "stdout:\n\(error.stdout)",
+                        )
+                        #expect(
+                            error.stdout.contains("PaperExperimental"),
+                            "stdout:\n\(error.stdout)",
+                        )
+                        // No direct violations on consumer-transitive.
+                        #expect(
+                            !error.stdout.contains("Directly consumed deprecated products:"),
+                            "unexpected direct section:\n\(error.stdout)",
+                        )
+                        // Not in "all" mode → no unreachable section.
+                        #expect(
+                            !error.stdout.contains("Transitively unreachable"),
+                            "unexpected unreachable section:\n\(error.stdout)",
+                        )
+                    }
+                }
+            }
+        }
+
+        // MARK: - Transitive unreachable violations (transitive == "transitiveUnreachable")
+
+        @Suite
+        struct TransitiveUnreachableViolationsTests {
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditWithIncludeTransitiveAllReportsUnreachableOnConsumer(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // Auditing `consumer` with --include-transitive=all: MyApp and
+                // MyLib produce direct violations for PaperLegacy and
+                // PaperExperimental. `paper-tool-old` is deprecated in
+                // producer, is in the resolved graph, and no consumer target
+                // reaches it → surfaces as "transitiveUnreachable".
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "json",
+                                "--include-transitive=all",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        let data = Data(error.stdout.utf8)
+                        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                              let deprecated = root["deprecated"] as? [String: Any],
+                              let products = deprecated["products"] as? [[String: Any]] else {
+                            Issue.record("audit output is not valid JSON. stdout:\n\(error.stdout)")
+                            return
+                        }
+                        let byProduct = Dictionary(uniqueKeysWithValues: products.compactMap {
+                            (product) -> (String, [String: Any])? in
+                            guard let name = product["product"] as? String else { return nil }
+                            return (name, product)
+                        })
+                        #expect(byProduct.count == 3, "unexpected products: \(byProduct.keys.sorted())")
+
+                        let legacy = try #require(byProduct["PaperLegacy"])
+                        #expect(legacy["transitive"] as? String == "direct")
+
+                        let experimental = try #require(byProduct["PaperExperimental"])
+                        #expect(experimental["transitive"] as? String == "direct")
+
+                        let tool = try #require(byProduct["paper-tool-old"])
+                        #expect(tool["transitive"] as? String == "transitiveUnreachable")
+                        #expect(tool["package"] as? String == "producer")
+                        #expect(tool["type"] as? String == "executable")
+                        #expect(tool["message"] as? String == "Migrate to the standalone paper-tools package.")
+                        let toolReplacement = try #require(tool["replacement"] as? [String: Any])
+                        #expect(toolReplacement["kind"] as? String == "renamed")
+                        #expect(toolReplacement["package"] as? String == "paper-tools")
+                        #expect(toolReplacement["product"] as? String == "paper-tool")
+                        // Empty usedBy for unreachable entries.
+                        #expect(tool["usedBy"] as? [String] == [])
+                        // Unreachable entries have no breadcrumb.
+                        #expect(tool["breadcrumb"] == nil)
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditWithIncludeTransitiveNonReachableSkipsReachable(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // Auditing `consumer-transitive` with
+                // --include-transitive=non-reachable: PaperExperimental is
+                // reachable via MyTransitiveApp → consumer.MyLib → producer.
+                // PaperExperimental, so it MUST be omitted. paper-tool-old
+                // and PaperLegacy are unreachable from consumer-transitive
+                // (PaperLegacy is only consumed by consumer.MyApp, which is
+                // not on any chain from consumer-transitive), so both MUST
+                // be included as `transitiveUnreachable`.
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer-transitive"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "json",
+                                "--include-transitive=non-reachable",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        let data = Data(error.stdout.utf8)
+                        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                              let deprecated = root["deprecated"] as? [String: Any],
+                              let products = deprecated["products"] as? [[String: Any]] else {
+                            Issue.record("audit output is not valid JSON. stdout:\n\(error.stdout)")
+                            return
+                        }
+                        let byProduct = Dictionary(uniqueKeysWithValues: products.compactMap {
+                            (product) -> (String, [String: Any])? in
+                            guard let name = product["product"] as? String else { return nil }
+                            return (name, product)
+                        })
+
+                        let names = Set(products.compactMap { $0["product"] as? String })
+                        #expect(
+                            names == ["paper-tool-old", "PaperLegacy"],
+                            "unexpected names: \(names)",
+                        )
+
+                        // PaperExperimental is reachable — skipped.
+                        #expect(byProduct["PaperExperimental"] == nil)
+                        // paper-tool-old is unreachable — included.
+                        let tool = try #require(byProduct["paper-tool-old"])
+                        #expect(tool["transitive"] as? String == "transitiveUnreachable")
+                        #expect(tool["usedBy"] as? [String] == [])
+                        #expect(tool["breadcrumb"] == nil)
+                        // PaperLegacy is also unreachable from consumer-transitive
+                        // (only consumer.MyApp reaches it, and MyApp isn't on
+                        // any chain from consumer-transitive).
+                        let legacy = try #require(byProduct["PaperLegacy"])
+                        #expect(legacy["transitive"] as? String == "transitiveUnreachable")
+                        #expect(legacy["usedBy"] as? [String] == [])
+                        #expect(legacy["breadcrumb"] == nil)
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditIncludeTransitiveReachableOmitsUnreachable(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // Auditing `consumer-transitive` with
+                // --include-transitive=reachable: only `PaperExperimental`
+                // is reachable (via MyTransitiveApp → consumer.MyLib →
+                // producer.PaperExperimental). PaperLegacy and paper-tool-old
+                // are unreachable from consumer-transitive and MUST be
+                // omitted. MyLib is not deprecated so it doesn't appear at all.
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer-transitive"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "json",
+                                "--include-transitive=reachable",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        let data = Data(error.stdout.utf8)
+                        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                              let deprecated = root["deprecated"] as? [String: Any],
+                              let products = deprecated["products"] as? [[String: Any]] else {
+                            Issue.record("audit output is not valid JSON. stdout:\n\(error.stdout)")
+                            return
+                        }
+                        let names = Set(products.compactMap { $0["product"] as? String })
+                        #expect(
+                            names == ["PaperExperimental"],
+                            "unexpected products: \(names)",
+                        )
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditWithIncludeTransitiveAllTextEmitsUnreachableSection(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "text",
+                                "--include-transitive=all",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        #expect(
+                            error.stdout.contains("Directly consumed deprecated products:") == true,
+                            "stdout:\n\(error.stdout)",
+                        )
+                        #expect(
+                            error.stdout.contains("Transitively unreachable deprecated products:") == true,
+                            "stdout:\n\(error.stdout)",
+                        )
+                        #expect(
+                            error.stdout.contains("paper-tool-old") == true,
+                            "stdout:\n\(error.stdout)",
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -106,6 +106,14 @@ struct PackageCommandTests {
     )
     enum PackageResolveCommandTests { }
 
+    @Suite(
+        .tags(
+            .TestSize.large,
+            .Feature.Command.Package.Audit,
+        ),
+    )
+    enum PackageAuditCommandTests { }
+
     @Test(
         arguments: SupportedBuildSystemOnAllPlatforms,
     )

--- a/Tests/CommandsTests/PackageCommandtests+Resolve.swift
+++ b/Tests/CommandsTests/PackageCommandtests+Resolve.swift
@@ -25,7 +25,6 @@ extension PackageCommandTests.PackageResolveCommandTests {
     struct ProductDeprecation {
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func resolveEmitsWarningForConsumerOfDeprecatedProduct(
@@ -56,7 +55,6 @@ extension PackageCommandTests.PackageResolveCommandTests {
         }
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func resolveEscalatesToErrorViaXswiftcWarningsAsErrors(
@@ -85,20 +83,53 @@ extension PackageCommandTests.PackageResolveCommandTests {
         }
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func resolveDoesNotWarnForNonConsumingPackage(
             buildSystem: BuildSystemProvider.Kind,
         ) async throws {
             try await fixture(name: "Miscellaneous/DeprecatedProducts/producer") { fixturePath in
-                let (_, stderr) = try await executeSwiftPackage(
+                let (stdout, stderr) = try await executeSwiftPackage(
                     fixturePath,
                     configuration: .debug,
                     extraArgs: ["resolve"],
                     buildSystem: buildSystem,
                 )
-                #expect(!stderr.contains("is unsupported"))
+                #expect(
+                    stderr.contains("is unsupported") == false,
+                    "stderr:\n\(stdout)",
+                )
+                #expect(
+                    stdout.contains("is unsupported") == false,
+                    "stderr:\n\(stderr)",
+                )
+            }
+        }
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func resolveDoesNotWarnAboutProducersOwnProducts(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            // Resolving the producer package should NOT emit a deprecation
+            // diagnostic for any of its OWN products because no producer target
+            // depends on them via `.product()`. A diagnostic about
+            // OldThirdParty (which the producer's `Paper` target does consume)
+            // is acceptable.
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                let (_, stderr) = try await executeSwiftPackage(
+                    fixturePath.appending("producer"),
+                    configuration: .debug,
+                    extraArgs: ["resolve"],
+                    buildSystem: buildSystem,
+                )
+                for productName in ["PaperLegacy", "PaperExperimental", "paper-tool-old"] {
+                    #expect(
+                        stderr.contains("product '\(productName)' from package 'producer' is unsupported") == false,
+                        "producer should not warn about its own product '\(productName)'\nstderr:\n\(stderr)",
+                    )
+                }
             }
         }
     }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -2681,5 +2681,43 @@ struct TestCommandTests {
             #expect(XCTestCaseSpecifier.specific("SomeTests/testFoo").normalizedForXCTest() == .specific("SomeTests/testFoo"))
         }
     }
+
+    // MARK: - Product deprecation (SE-NNNN)
+
+    /// Confirms that graph-load-time product-deprecation diagnostics fire
+    /// during `swift test` just as they do during `swift build` / `swift
+    /// package resolve`. This is a smoke test — the detailed matrix of
+    /// severity behavior is covered by `BuildCommandTestCases.ProductDeprecation`
+    /// and `PackageCommandTests.PackageResolveCommandTests.ProductDeprecation`.
+    @Suite(
+        .tags(
+            .Feature.Deprecation,
+        ),
+    )
+    struct ProductDeprecation {
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func warningIsEmittedForConsumerOfDeprecatedProduct(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                let fixturePath = fixturePath.appending("consumer")
+                let (_, stderr) = try await executeSwiftTest(
+                    fixturePath,
+                    configuration: .debug,
+                    buildSystem: buildSystem,
+                    throwIfCommandFails: false,
+                )
+                #expect(
+                    stderr.contains(
+                        "warning: 'consumer': product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead.",
+                    ),
+                    "stderr:\n\(stderr)",
+                )
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
- [Swift Evolution Proposal](https://github.com/swiftlang/swift-evolution/pull/3401)
- [Pitch thread](https://forums.swift.org/t/pitch-deprecating-package-products-in-the-package-manifest/88468)

Completes SE-NNNN by adding the on-demand reporting surface. Builds on
the plumbing and build-time warning from the previous commit.

The new `swift package report` command loads the resolved package graph
and reports every deprecated product it finds, grouped by producing
package. Output is human-readable by default and can be switched to JSON
for tooling. The report includes which of the current package's targets
consume each deprecated product; `--include-transitive` also lists
deprecated products that are reachable through the graph but not
directly consumed. The command exits with a non-zero status when
findings exist, which is convenient for CI, unless `--allow-deprecations`
is passed for interactive use.

Along the way, this commit adds a way to suppress the graph-load-time
deprecation diagnostics that were introduced in the previous commit,
threaded through the workspace and graph-loading APIs. The report command
opts out of those diagnostics because it produces its own structured
report, and because a consumer target with `.treatAllWarnings(as: .error)`
in the graph would otherwise escalate a deprecation to a hard error and
prevent the report from completing.

The `DeprecatedProducts` fixture is extended with a `third-party`
sub-package that vends its own deprecated product, and the `producer`
sub-package now depends on it. That gives every test — build, resolve,
report, and `dump-package` — a realistic three-package graph to exercise
including the transitive path, without needing a separate fixture per
scenario. A few existing "producer doesn't warn about its own products"
tests were updated to match the new fixture shape.

A smoke test also confirms that `swift test` emits deprecation
diagnostics during graph load, matching what `swift build` and
`swift package resolve` already do.

--- 
Blocked on: #10400
Blocked on: #10437 