### PR TITLE
Fix module aliases in nested consuming targets

### DIFF
--- a/Fixtures/ModuleAliasing/Executable/App/Sources/App/main.swift
+++ b/Fixtures/ModuleAliasing/Executable/App/Sources/App/main.swift
@@ -3,6 +3,6 @@ import AppUtils
 @main
 struct App {
     static func main() {
-        print(AppUtils.greet())
+        print(AppUtils.Utils.greet())
     }
 }

--- a/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/CoreDependency/Package.swift
+++ b/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/CoreDependency/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "CoreDependency",
+    products: [
+        .library(name: "CoreDependencyV2", targets: ["CoreDependencyV2"]),
+        .library(name: "CoreDependencyV3", targets: ["CoreDependencyV3"]),
+    ],
+    targets: [
+        .target(name: "Common"),
+        .target(name: "CoreDependencyV2", dependencies: ["Common"]),
+        .target(name: "CoreDependencyV3", dependencies: ["Common"]),
+    ]
+)

--- a/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/CoreDependency/Sources/Common/Common.swift
+++ b/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/CoreDependency/Sources/Common/Common.swift
@@ -1,0 +1,7 @@
+public struct CommonValue {
+    public let value: String
+
+    public init(value: String) {
+        self.value = value
+    }
+}

--- a/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/CoreDependency/Sources/CoreDependencyV2/CoreDependencyV2.swift
+++ b/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/CoreDependency/Sources/CoreDependencyV2/CoreDependencyV2.swift
@@ -1,0 +1,3 @@
+import Common
+
+public let value = CommonValue(value: "V2").value

--- a/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/CoreDependency/Sources/CoreDependencyV3/CoreDependencyV3.swift
+++ b/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/CoreDependency/Sources/CoreDependencyV3/CoreDependencyV3.swift
@@ -1,0 +1,3 @@
+import Common
+
+public let value = CommonValue(value: "V3").value

--- a/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/Package.swift
+++ b/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "AppPkg",
+    products: [
+        .library(name: "App", targets: ["App"]),
+    ],
+    dependencies: [
+        .package(path: "./CoreDependency"),
+    ],
+    targets: [
+        .target(
+            name: "App",
+            dependencies: ["AppCore"]
+        ),
+        .target(
+            name: "AppCore",
+            dependencies: [
+                .product(
+                    name: "CoreDependencyV3",
+                    package: "CoreDependency",
+                    moduleAliases: ["CoreDependencyV3": "CoreDependency"]
+                ),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/Sources/App/App.swift
+++ b/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/Sources/App/App.swift
@@ -1,0 +1,5 @@
+import AppCore
+
+public struct App {
+    public let core = AppCore.Service()
+}

--- a/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/Sources/AppCore/AppCore.swift
+++ b/Fixtures/ModuleAliasing/NestedConsumingTarget/AppPkg/Sources/AppCore/AppCore.swift
@@ -1,0 +1,7 @@
+import CoreDependency
+
+public struct Service {
+    public let value = CoreDependency.value
+
+    public init() {}
+}

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -177,7 +177,7 @@ extension LLBuildManifestBuilder {
             outputs: cmdOutputs,
             executable: target.buildParameters.toolchain.swiftCompilerPath,
             moduleName: target.target.c99name,
-            moduleAliases: target.target.moduleAliases,
+            moduleAliases: target.target.moduleAliasesForCompilation,
             moduleOutputPath: target.moduleOutputPath,
             importPath: target.modulesPath,
             tempsPath: target.tempsPath,

--- a/Sources/PackageGraph/Resolution/ResolvedModule.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedModule.swift
@@ -137,6 +137,20 @@ public struct ResolvedModule {
         self.underlying.moduleAliases
     }
 
+    /// Module aliases that need to be passed to the compiler when building this module.
+    /// Aliases declared by this module are referenced directly in its source code.
+    package var moduleAliasesForCompilation: [String: String]? {
+        guard var aliases = self.moduleAliases else { return nil }
+        for dependency in self.underlying.dependencies {
+            guard case .product(let product, _) = dependency,
+                  let declaredAliases = product.moduleAliases else { continue }
+            for (originalName, alias) in declaredAliases where aliases[originalName] == alias {
+                aliases.removeValue(forKey: originalName)
+            }
+        }
+        return aliases.isEmpty ? nil : aliases
+    }
+
     /// Allows access to package symbols from other modules in the package
     public var packageAccess: Bool {
         self.underlying.packageAccess

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -547,7 +547,7 @@ extension PackagePIFProjectBuilder {
                 }
             }
 
-            if let aliases = sourceModule.moduleAliases {
+            if let aliases = sourceModule.moduleAliasesForCompilation {
                 // Format each entry as "original_name=alias"
                 let list = aliases.map { $0.0 + "=" + $0.1 }
                 settings[.SWIFT_MODULE_ALIASES] = list.isEmpty ? nil : list

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -121,7 +121,7 @@ extension PackagePIFProjectBuilder {
         // We must use the main module name here instead of the product name, because they're not guranteed to be the same, and the users may have authored e.g. tests which rely on an executable's module name.
         settings[.PRODUCT_MODULE_NAME] = mainModule.c99name
 
-        if let aliases = mainModule.moduleAliases {
+        if let aliases = mainModule.moduleAliasesForCompilation {
             let list = aliases.map { $0.0 + "=" + $0.1 }
             settings[.SWIFT_MODULE_ALIASES] = list.isEmpty ? nil : list
         }

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -650,7 +650,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         // Disable code coverage linker flags since we're producing .o files. Otherwise, we will run into duplicated
         // symbols when there are more than one targets that produce .o as their product.
         settings[.CLANG_COVERAGE_MAPPING_LINKER_ARGS] = "NO"
-        if let aliases = target.moduleAliases {
+        if let aliases = target.moduleAliasesForCompilation {
             settings[.SWIFT_MODULE_ALIASES] = aliases.map { $0.key + "=" + $0.value }
         }
 

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -48,7 +48,7 @@ struct ModuleAliasingFixtureTests {
     }
 
     @Test(
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/10417", "Module aliases are propagated within the consuming package"),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10417", relationship: .verifies),
         .tags(
             Tag.Feature.Command.Build,
         ),

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -29,6 +29,26 @@ import Testing
 )
 struct ModuleAliasingFixtureTests {
     @Test(
+        .bug("https://github.com/swiftlang/swift-package-manager/issues/10417", "Module aliases are propagated within the consuming package"),
+        .tags(
+            Tag.Feature.Command.Build,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func moduleAliasInNestedConsumingTarget(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "ModuleAliasing/NestedConsumingTarget") { fixturePath in
+            let pkgPath = fixturePath.appending(component: "AppPkg")
+            try await executeSwiftBuild(
+                pkgPath,
+                configuration: .debug,
+                buildSystem: buildSystem,
+            )
+        }
+    }
+
+    @Test(
         .tags(
             Tag.Feature.Command.Build,
         ),

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -29,6 +29,25 @@ import Testing
 )
 struct ModuleAliasingFixtureTests {
     @Test(
+        .tags(
+            Tag.Feature.Command.Build,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func moduleAliasInExecutableTarget(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "ModuleAliasing/Executable") { fixturePath in
+            let pkgPath = fixturePath.appending(component: "App")
+            try await executeSwiftBuild(
+                pkgPath,
+                configuration: .debug,
+                buildSystem: buildSystem,
+            )
+        }
+    }
+
+    @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/10417", "Module aliases are propagated within the consuming package"),
         .tags(
             Tag.Feature.Command.Build,

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -439,7 +439,7 @@ struct PIFBuilderTests {
 
         struct Verify {
             let targetName: String
-            let expectedAliases: [String]
+            let expectedAliases: [String]?
         }
     }
     @Test(
@@ -451,13 +451,13 @@ struct PIFBuilderTests {
                 verify: [
                     ModuleAliasTestData.Verify(
                         targetName: "App-product",
-                        expectedAliases: ["Utils=AppUtils"],
+                        expectedAliases: nil,
                     ),
                 ],
             ),
         ]
     )
-    func moduleAliasesPropagateToExecutableProduct(
+    func directlyDeclaredModuleAliasesAreOmittedFromExecutableProduct(
         data: ModuleAliasTestData,
     ) async throws {
         try await withGeneratedPIF(


### PR DESCRIPTION
Fixes #10417.

Targets that declare a product module alias reference the aliased name directly in their source. SwiftPM was also passing that same mapping back to the compiler for the declaring target, which caused the compiler to reject the aliased import.

This keeps the complete alias information in the package graph while excluding directly declared aliases when generating compiler settings for that target.

Tests:
- Added a nested consuming-target regression fixture.
- Verified with the native and Swift Build systems.
- Existing ModuleAliasingBuildTests pass (40 tests).