### PR TITLE
Fix authentication credential leak on cross-host redirect in DataTaskManager

### DIFF
--- a/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
@@ -209,15 +209,15 @@ private final class DataTaskManager: NSObject, URLSessionDataDelegate {
             return
         }
 
-        var request = request
-        // Set `Authorization` header for the redirected request
-        if let redirectURL = request.url, let authorization = task.authorizationProvider?(redirectURL),
-           request.value(forHTTPHeaderField: "Authorization") == nil
-        {
-            request.addValue(authorization, forHTTPHeaderField: "Authorization")
+        // Add new authorization header for a redirect if there is one, otherwise remove
+        var redirectRequest = request
+        if let redirectURL = request.url, let authorization = task.authorizationProvider?(redirectURL) {
+            redirectRequest.setValue(authorization, forHTTPHeaderField: "Authorization")
+        } else {
+            redirectRequest.setValue(nil, forHTTPHeaderField: "Authorization")
         }
 
-        completionHandler(request)
+        completionHandler(redirectRequest)
     }
 
     struct DataTask: Sendable {

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -835,7 +835,12 @@ final class URLSessionHTTPClientTest: XCTestCase {
         MockURLProtocol.onRequest(request) { request in
             XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], testAuthHeader)
             MockURLProtocol.sendResponse(statusCode: 302, headers: ["Location": redirectURL.absoluteString], for: request)
-            MockURLProtocol.sendRedirect(for: request, to: URLRequest(url: redirectURL))
+            // URLSession carries the original request's headers (including `Authorization`) onto
+            // the redirected request it hands to the delegate, so mirror that here to actually
+            // exercise the delegate's header-stripping logic.
+            var redirectURLRequest = URLRequest(url: redirectURL)
+            redirectURLRequest.allHTTPHeaderFields = request.allHTTPHeaderFields
+            MockURLProtocol.sendRedirect(for: request, to: redirectURLRequest)
         }
         MockURLProtocol.onRequest(redirectedRequest) { request in
             XCTAssertNil(request.allHTTPHeaderFields?["Authorization"])

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -808,6 +808,45 @@ final class URLSessionHTTPClientTest: XCTestCase {
         }
     }
 
+    func testAsyncAuthenticateWithRedirectedRemovesAuthorizationForUnknownHost() async throws {
+        let netrcContent = "machine async-redirect-tests.com login anonymous password qwerty"
+        let netrc = try NetrcAuthorizationWrapper(underlying: NetrcParser.parse(netrcContent))
+        let authData = Data("anonymous:qwerty".utf8)
+        let testAuthHeader = "Basic \(authData.base64EncodedString())"
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSessionHTTPClient(configuration: configuration)
+        let httpClient = HTTPClient(implementation: urlSession.execute)
+
+        let url = URL("https://async-redirect-tests.com/resource")
+        // The redirect target is a different host that `netrc` has no credentials for, so the
+        // `Authorization` header from the original request must not be forwarded to it.
+        let redirectURL = URL("https://cdn-async-redirect-tests.com/resource")
+
+        var options = HTTPClientRequest.Options()
+        options.authorizationProvider = netrc.httpAuthorizationHeader(for:)
+        let request = HTTPClientRequest(method: .get, url: url, options: options)
+        let redirectedRequest = HTTPClientRequest(method: .get, url: redirectURL, options: options)
+
+        let responseStatus = 200
+        let responseBody = Data(UUID().uuidString.utf8)
+
+        MockURLProtocol.onRequest(request) { request in
+            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], testAuthHeader)
+            MockURLProtocol.sendResponse(statusCode: 302, headers: ["Location": redirectURL.absoluteString], for: request)
+            MockURLProtocol.sendRedirect(for: request, to: URLRequest(url: redirectURL))
+        }
+        MockURLProtocol.onRequest(redirectedRequest) { request in
+            XCTAssertNil(request.allHTTPHeaderFields?["Authorization"])
+            MockURLProtocol.respond(request, statusCode: responseStatus, body: responseBody)
+        }
+
+        let response = try await httpClient.execute(request)
+        XCTAssertEqual(response.statusCode, responseStatus)
+        XCTAssertEqual(response.body, responseBody)
+    }
+
     func testAsyncDownloadAuthenticateWithRedirectedSuccess() async throws {
         #if !os(macOS)
         // URLSession Download tests can only run on macOS

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -809,6 +809,15 @@ final class URLSessionHTTPClientTest: XCTestCase {
     }
 
     func testAsyncAuthenticateWithRedirectedRemovesAuthorizationForUnknownHost() async throws {
+        #if !os(macOS)
+        // swift-corelibs-foundation's URLSessionTask does not implement redirect handling: it
+        // calls `URLProtocolClient.urlProtocol(_:wasRedirectedTo:redirectResponse:)` but then hits
+        // "The URLSession swift-corelibs-foundation implementation doesn't currently handle
+        // redirects directly" as a fatal error before the delegate the fix in this PR touches is
+        // ever consulted.
+        // https://github.com/apple/swift-corelibs-foundation/pull/2593 tries to address this.
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let netrcContent = "machine async-redirect-tests.com login anonymous password qwerty"
         let netrc = try NetrcAuthorizationWrapper(underlying: NetrcParser.parse(netrcContent))
         let authData = Data("anonymous:qwerty".utf8)


### PR DESCRIPTION
Fix authentication credential leak on cross-host redirect in `DataTaskManager`

### Motivation:

`DataTaskManager`'s `urlSession(_:task:willPerformHTTPRedirection:newRequest:completionHandler:)` delegate only *added* an `Authorization` header to the redirected request when one was missing (`request.value(forHTTPHeaderField: "Authorization") == nil`); it never *removed* an existing one.

`URLSession`'s default redirect handling carries headers from the original request into the `newRequest` it hands to this delegate. So if a request to a host with saved credentials (netrc, registry auth, etc.) is redirected to a different host that the `authorizationProvider` has no credentials for, the original `Authorization` header is preserved on `newRequest` and this delegate does nothing to strip it — leaking the original host's credentials to the redirect target.

This is the same class of bug fixed in #8947 for `DownloadTaskManager` (see #8946: private GitHub artifact bundle downloads leaking a GitHub `Authorization` header to an Azure Storage redirect target). That fix only touched `DownloadTaskManager`; `DataTaskManager`, used for all other (non-download) HTTP requests, still has the old behavior.

### Modifications:

Apply the same fix `DownloadTaskManager` already has: on redirect, always set a fresh `Authorization` header from `authorizationProvider` for the redirect target's URL, and explicitly clear the header (`setValue(nil, ...)`) when the provider has no credentials for that target, instead of only conditionally adding one.

### Result:

`DataTaskManager` no longer forwards a stale `Authorization` header to a redirect target the `authorizationProvider` doesn't recognize, closing the same credential-exfiltration path #8947 closed for downloads.

### Test scope:

Added `testAsyncAuthenticateWithRedirectedRemovesAuthorizationForUnknownHost`, mirroring the pattern of #8947's `testAsyncDownloadAuthenticateWithRedirectedSuccess`: a request to a host with `netrc` credentials gets redirected via `MockURLProtocol` to a different host with no configured credentials, and the test asserts the redirected request carries no `Authorization` header.
