### PR TITLE
Only exclude host-only tools from top-level aggregate when cross-compiling

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -89,7 +89,10 @@ package struct PIFBuilderParameters {
     /// reported by the build system for the host `BuildParameters`.
     let hostBuildProductsPath: AbsolutePath
 
-    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRpaths: PackagePIFBuilder.AddLocalRpaths, hostBuildProductsPath: AbsolutePath) {
+    /// The triple of the host on which the build is running, as reported by the host `BuildParameters`.
+    let hostTriple: Basics.Triple
+
+    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRpaths: PackagePIFBuilder.AddLocalRpaths, hostBuildProductsPath: AbsolutePath, hostTriple: Basics.Triple) {
         self.isPackageAccessModifierSupported = isPackageAccessModifierSupported
         self.enableTestability = enableTestability
         self.shouldCreateDylibForDynamicProducts = shouldCreateDylibForDynamicProducts
@@ -104,6 +107,7 @@ package struct PIFBuilderParameters {
         self.additionalFileRules = additionalFileRules
         self.addLocalRpaths = addLocalRpaths
         self.hostBuildProductsPath = hostBuildProductsPath
+        self.hostTriple = hostTriple
     }
 }
 
@@ -263,7 +267,7 @@ public final class PIFBuilder {
             graph: graph,
             buildParameters: buildParameters,
             pluginsPerModule: pluginsPerModule,
-            hostTriple: try pluginScriptRunner.hostTriple
+            hostTriple: self.parameters.hostTriple
         )
 
         let sortedPackages = self.graph.packages
@@ -514,7 +518,8 @@ public final class PIFBuilder {
                     packagesAndProjects: packagesAndPIFProjects,
                     observabilityScope: observabilityScope,
                     modulesGraph: graph,
-                    buildParameters: buildParameters
+                    buildParameters: buildParameters,
+                    hostTriple: self.parameters.hostTriple
                 )
             )
 
@@ -603,7 +608,8 @@ public final class PIFBuilder {
         addLocalRpaths: PackagePIFBuilder.AddLocalRpaths,
         materializeStaticArchiveProductsForRootPackages: Bool,
         createDynamicVariantsForLibraryProducts: Bool,
-        hostBuildProductsPath: AbsolutePath
+        hostBuildProductsPath: AbsolutePath,
+        hostTriple: Basics.Triple
     ) async throws -> PIFGenerationResult {
         let parameters = PIFBuilderParameters(
             buildParameters,
@@ -615,7 +621,8 @@ public final class PIFBuilder {
             addLocalRpaths: addLocalRpaths,
             materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
             createDynamicVariantsForLibraryProducts: createDynamicVariantsForLibraryProducts,
-            hostBuildProductsPath: hostBuildProductsPath
+            hostBuildProductsPath: hostBuildProductsPath,
+            hostTriple: hostTriple
         )
         let builder = Self(
             graph: packageGraph,
@@ -865,7 +872,8 @@ fileprivate func buildAggregatePIFProject(
     packagesAndProjects: [(package: ResolvedPackage, project: ProjectModel.Project)],
     observabilityScope: ObservabilityScope,
     modulesGraph: ModulesGraph,
-    buildParameters: BuildParameters
+    buildParameters: BuildParameters,
+    hostTriple: Basics.Triple
 ) throws -> ProjectModel.Project {
     precondition(!packagesAndProjects.isEmpty)
 
@@ -916,7 +924,8 @@ fileprivate func buildAggregatePIFProject(
     addEmptyBuildConfig(to: allExcludingTestsTargetKeyPath, name: "Debug")
     addEmptyBuildConfig(to: allExcludingTestsTargetKeyPath, name: "Release")
 
-    let hostOnlyModuleIDs = computeHostOnlyModuleIDsInRootPackages(in: modulesGraph)
+    let isCrossCompiling = !hostTriple.isRuntimeCompatible(with: buildParameters.triple)
+    let hostOnlyModuleIDs = isCrossCompiling ? computeHostOnlyModuleIDsInRootPackages(in: modulesGraph) : []
 
     for (package, packageProject) in packagesAndProjects where package.manifest.packageKind.isRoot {
         for target in packageProject.targets {
@@ -1026,7 +1035,8 @@ extension PIFBuilderParameters {
         addLocalRpaths: PackagePIFBuilder.AddLocalRpaths,
         materializeStaticArchiveProductsForRootPackages: Bool,
         createDynamicVariantsForLibraryProducts: Bool,
-        hostBuildProductsPath: AbsolutePath
+        hostBuildProductsPath: AbsolutePath,
+        hostTriple: Basics.Triple
     ) {
         self.init(
             isPackageAccessModifierSupported: buildParameters.driverParameters.isPackageAccessModifierSupported,
@@ -1042,7 +1052,8 @@ extension PIFBuilderParameters {
             pluginWorkingDirectory: pluginWorkingDirectory,
             additionalFileRules: additionalFileRules,
             addLocalRpaths: addLocalRpaths,
-            hostBuildProductsPath: hostBuildProductsPath
+            hostBuildProductsPath: hostBuildProductsPath,
+            hostTriple: hostTriple
         )
     }
 }

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1391,7 +1391,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                     addLocalRpaths: self.buildParameters.linkingParameters.shouldDisableLocalRpath ? .never : .always,
                     materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
                     createDynamicVariantsForLibraryProducts: false,
-                    hostBuildProductsPath: try await self.buildProductsPath(for: self.hostBuildParameters)
+                    hostBuildProductsPath: try await self.buildProductsPath(for: self.hostBuildParameters),
+                    hostTriple: self.hostBuildParameters.triple
                 ),
                 fileSystem: self.fileSystem,
                 observabilityScope: self.observabilityScope,

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -33,7 +33,8 @@ extension PIFBuilderParameters {
         shouldCreateDylibForDynamicProducts: Bool = false,
         createDynamicVariantsForLibraryProducts: Bool = false,
         pluginScriptRunner: PluginScriptRunner? = nil,
-        hostBuildProductsPath: Basics.AbsolutePath? = nil
+        hostBuildProductsPath: Basics.AbsolutePath? = nil,
+        hostTriple: Basics.Triple? = nil
     ) throws -> Self {
         try self.init(
             isPackageAccessModifierSupported: true,
@@ -53,7 +54,8 @@ extension PIFBuilderParameters {
             pluginWorkingDirectory: temporaryDirectory.appending(component: "plugin-working-dir"),
             additionalFileRules: [],
             addLocalRpaths: addLocalRpaths,
-            hostBuildProductsPath: hostBuildProductsPath ?? temporaryDirectory.appending(component: "host-build-products")
+            hostBuildProductsPath: hostBuildProductsPath ?? temporaryDirectory.appending(component: "host-build-products"),
+            hostTriple: try hostTriple ?? UserToolchain.default.targetTriple
         )
     }
 }
@@ -2180,7 +2182,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, triple: .wasi)
         )
 
         let errors = observability.diagnostics.filter { $0.severity == .error }
@@ -2246,7 +2248,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, triple: .wasi)
         )
 
         let errors = observability.diagnostics.filter { $0.severity == .error }
@@ -2317,7 +2319,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, triple: .wasi)
         )
 
         let errors = observability.diagnostics.filter { $0.severity == .error }
@@ -2388,7 +2390,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, triple: .wasi)
         )
 
         let errors = observability.diagnostics.filter { $0.severity == .error }
@@ -2460,7 +2462,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, triple: .wasi)
         )
 
         let errors = observability.diagnostics.filter { $0.severity == .error }
@@ -2532,7 +2534,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, triple: .wasi)
         )
 
         let errors = observability.diagnostics.filter { $0.severity == .error }


### PR DESCRIPTION
Only exclude host-only tools from top-level aggregate when cross-compiling

### Motivation:

https://github.com/swiftlang/swift-package-manager/pull/10348 caused host-only build tool dependencies to be excluded  for every build.  This change makes that exclusion conditional, only when cross-compiling.  

### Modifications:

Gate the host-only exclusion on a check if we are cross-compiling.

### Result:

Cross compilation behaviour is unchanged, host build tools are still excluded as in https://github.com/swiftlang/swift-package-manager/pull/10348.  For host builds, executables that are plugin dependencies are again built.
