### PR TITLE
Make `PackageDescription.Trait` sendable

### DIFF
--- a/Sources/Runtimes/PackageDescription/Trait.swift
+++ b/Sources/Runtimes/PackageDescription/Trait.swift
@@ -55,7 +55,7 @@
 /// #endif // Trait1
 /// ```
 @available(_PackageDescription, introduced: 6.1)
-public struct Trait: Hashable, ExpressibleByStringLiteral {
+public struct Trait: Hashable, Sendable, ExpressibleByStringLiteral {
     /// Declares the default traits for this package.
     public static func `default`(enabledTraits: Set<String>) -> Self {
         .init(


### PR DESCRIPTION
Add `Sendable` to `PackageDescription.Trait` conformances.

This will allow users to extend the `PackageDescription.Trait` to create `static` trait variables.

Issue: rdar://185500887