### PR TITLE
Respect an explicit trait configuration when dumping symbol graphs

### DIFF
--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -62,8 +62,8 @@ struct DumpSymbolGraph: AsyncSwiftCommand {
         //
         // We turn build manifest caching off because we need the build plan.
         let buildSystem = try await swiftCommandState.createBuildSystem(
-            // We are enabling all traits for dumping the symbol graph.
-            enableAllTraits: true,
+            // If no traits are defined enable all for dumping the symbol graph.
+            enableAllTraits: swiftCommandState.traitConfiguration == .default,
             cacheBuildManifest: false
         )
         let buildResult = try await buildSystem.build(subset: .allExcludingTests, buildOutputs: [.symbolGraph(

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -377,7 +377,8 @@ final class PluginDelegate: PluginInvocationDelegate {
         // Create a build system for building the target., skipping the the cache because we need the build plan.
         let buildSystem = try await swiftCommandState.createBuildSystem(
             explicitBuildSystem: buildSystem,
-            enableAllTraits: true,
+            // If no traits are defined enable all for dumping the symbol graph.
+            enableAllTraits: swiftCommandState.traitConfiguration == .default,
             cacheBuildManifest: false
         )
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -1310,6 +1310,115 @@ struct PackageCommandTests {
                     #expect(JSONText.components(separatedBy: .newlines).count == 1)
                 }
             }
+    }
+
+    @Test(
+        .requiresSymbolgraphExtract,
+        .tags(
+            .Feature.Command.Package.CommandPlugin
+        ),
+        arguments:
+        SupportedBuildSystemOnAllPlatforms,
+        [
+            (["--traits", "Package10Trait1"], false, "TypeGatedByPackage10Trait1", "TypeGatedByPackage10Trait2"),
+            (["--traits", "Package10Trait2"], false, "TypeGatedByPackage10Trait2", "TypeGatedByPackage10Trait1"),
+            (["--disable-default-traits"], false, "hello", "TypeGatedByPackage10Trait1"),
+            (["--traits", "NonExistentTrait"], true, nil, nil),
+        ]
+    )
+    func dumpSymbolGraph_respectsEnabledTraits(
+        buildSystem: BuildSystemProvider.Kind,
+        testCase: (arguments: [String], errorOut: Bool, expected: String?, unexpected: String?)
+    ) async throws {
+        let config = BuildConfiguration.debug
+        try await fixture(
+            name: "Traits",
+            removeFixturePathOnDeinit: true
+        ) { fixturePath in
+            let packagePath = fixturePath.appending("Package10")
+            let symbolGraphExtractorPath = try UserToolchain.default.getSymbolGraphExtract()
+
+            let symbolGraphOutputDir = fixturePath.appending("symbolgraph")
+            if testCase.errorOut {
+                // Enabling a trait the package doesn't define is an error.
+                await #expect(throws: SwiftPMError.self) {
+                    try await execute(
+                        ["dump-symbol-graph"] + testCase.arguments + ["--output-dir", symbolGraphOutputDir.pathString],
+                        packagePath: packagePath,
+                        env: ["SWIFT_SYMBOLGRAPH_EXTRACT": symbolGraphExtractorPath.pathString],
+                        configuration: config,
+                        buildSystem: BuildSystemProvider.Kind.swiftbuild
+                    )
+                }
+                return
+            }
+            await #expect(throws: Never.self) {
+                try await execute(
+                    ["dump-symbol-graph"] + testCase.arguments + ["--output-dir", symbolGraphOutputDir.pathString],
+                    packagePath: packagePath,
+                    env: ["SWIFT_SYMBOLGRAPH_EXTRACT": symbolGraphExtractorPath.pathString],
+                    configuration: config,
+                    buildSystem: BuildSystemProvider.Kind.swiftbuild
+                )
+            }
+            let symbolGraphPath = symbolGraphOutputDir.appending(component: "Package10Library1.symbols.json")
+            try #require(
+                localFileSystem.exists(symbolGraphPath),
+                "Failed to extract symbol graph"
+            )
+            let symbolGraphData = try Data(contentsOf: URL(fileURLWithPath: symbolGraphPath.pathString))
+            #expect(throws: Never.self) {
+                try JSONSerialization.jsonObject(with: symbolGraphData)
+            }
+            let JSONText = String(decoding: symbolGraphData, as: UTF8.self)
+            let expectedTrait = try #require(testCase.expected)
+            let nonExpectedTrait = try #require(testCase.unexpected)
+            #expect(JSONText.contains(expectedTrait))
+            #expect(!JSONText.contains(nonExpectedTrait))
+        }
+    }
+
+    @Test(
+        .requiresSymbolgraphExtract,
+        .tags(
+            .Feature.Command.Package.CommandPlugin
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms
+    )
+    func commandPluginSymbolGraph_respectsEnabledTraits(
+        buildSystem: BuildSystemProvider.Kind
+    ) async throws {
+        let config = BuildConfiguration.debug
+        try await fixture(
+            name: "Traits",
+            removeFixturePathOnDeinit: true
+        ) { fixturePath in
+            let packagePath = fixturePath.appending("Package10")
+
+            let (stdout, _) = try await execute(
+                ["--traits", "Package10Trait1", "extract"],
+                packagePath: packagePath,
+                configuration: config,
+                buildSystem: buildSystem
+            )
+
+            // The plugin prints the symbol graph directory of the first target.
+            let line = try #require(
+                stdout.split(whereSeparator: \.isNewline).first,
+                "no symbol graph directory in output"
+            )
+            let symbolGraphDirectory = try AbsolutePath(
+                validating: String(line).trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            let symbolGraphPath = symbolGraphDirectory.appending(component: "Package10Library1.symbols.json")
+            let symbolGraphData = try Data(contentsOf: URL(fileURLWithPath: symbolGraphPath.pathString))
+            #expect(throws: Never.self) {
+                try JSONSerialization.jsonObject(with: symbolGraphData)
+            }
+            let JSONText = String(decoding: symbolGraphData, as: UTF8.self)
+            #expect(JSONText.contains("TypeGatedByPackage10Trait1"))
+            #expect(!JSONText.contains("TypeGatedByPackage10Trait2"))
+        }
     }
 
     @Test(


### PR DESCRIPTION
Respect an explicit trait configuration when dumping symbol graphs

### Motivation:

`DumpSymbolGraph` and `PluginDelegate.createSymbolGraphForPlugin` unconditionally enabled every trait so that a symbol graph would cover all trait-gated API. That is a sensible default when the caller expresses no preference, but it also discarded any configuration the caller did provide.

185313176

### Modifications:

Instead of enabling all traits, check if any trait has been enabled first.

### Result:

The default behaviour stays the same, but if the caller passes a specific list of traits, only those are used when generating the symbol graphs.
