### PR TITLE
Improve error message when tools version is missing

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -206,7 +206,11 @@ extension ManifestLoaderProtocol {
             fileSystem: fileSystem,
             currentToolsVersion: currentToolsVersion
         )
-        let manifestToolsVersion = try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: fileSystem)
+        let manifestToolsVersion = try ToolsVersionParser.parse(
+            manifestPath: manifestPath,
+            fileSystem: fileSystem,
+            packageIdentity: packageIdentity
+        )
         // validate the manifest tools-version against the toolchain tools-version
         try manifestToolsVersion.validateToolsVersion(
             currentToolsVersion,

--- a/Sources/PackageLoading/ToolsVersionParser.swift
+++ b/Sources/PackageLoading/ToolsVersionParser.swift
@@ -24,7 +24,17 @@ public struct ToolsVersionParser {
     // designed to be used as a static utility
     private init() {}
 
-    public static func parse(manifestPath: AbsolutePath, fileSystem: FileSystem) throws -> ToolsVersion {
+    /// Parses the Swift tools version specification of the manifest at the given path.
+    ///
+    /// - Parameter packageIdentity: The identity of the package the manifest belongs to, used to
+    ///   report a manifest that carries no specification at all. Omitting it derives one from the
+    ///   manifest's parent directory, which is empty for a file view rooted at `/`, as a repository's
+    ///   and a registry release's are.
+    public static func parse(
+        manifestPath: AbsolutePath,
+        fileSystem: FileSystem,
+        packageIdentity: PackageIdentity? = nil
+    ) throws -> ToolsVersion {
         // FIXME: We should diagnose errors not specific to the tools version specification outside of this function.
         // In order to that, maybe we can restructure the parsing to something like this:
         //     parse(_ manifestContent: String) throws -> Manifest {
@@ -58,7 +68,11 @@ public struct ToolsVersionParser {
         do {
           return try self.parse(utf8String: manifestContentsDecodedWithUTF8)
         } catch Error.malformedToolsVersionSpecification(.commentMarker(.isMissing)) {
-          throw UnsupportedToolsVersion(packageIdentity: .init(path: manifestPath), currentToolsVersion: .current, packageToolsVersion: .v3)
+          throw UnsupportedToolsVersion(
+            packageIdentity: packageIdentity ?? .init(path: manifestPath.parentDirectory),
+            currentToolsVersion: .current,
+            packageToolsVersion: .v3
+          )
         }
     }
 

--- a/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
@@ -79,7 +79,11 @@ public class RegistryPackageContainer: PackageContainer {
             let result = try await self.getAvailableManifestsFilesystem(version: version)
             // find the manifest path and parse it's tools-version
             let manifestPath = try ManifestLoader.findManifest(packagePath: .root, fileSystem: result.fileSystem, currentToolsVersion: self.currentToolsVersion)
-            return try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: result.fileSystem)
+            return try ToolsVersionParser.parse(
+                manifestPath: manifestPath,
+                fileSystem: result.fileSystem,
+                packageIdentity: self.package.identity
+            )
         }
     }
 
@@ -145,7 +149,11 @@ public class RegistryPackageContainer: PackageContainer {
         }
         // find the preferred manifest path and parse it's tools-version
         let preferredToolsVersionManifestPath = try ManifestLoader.findManifest(packagePath: .root, fileSystem: fileSystem, currentToolsVersion: self.currentToolsVersion)
-        let preferredToolsVersion = try ToolsVersionParser.parse(manifestPath: preferredToolsVersionManifestPath, fileSystem: fileSystem)
+        let preferredToolsVersion = try ToolsVersionParser.parse(
+            manifestPath: preferredToolsVersionManifestPath,
+            fileSystem: fileSystem,
+            packageIdentity: self.package.identity
+        )
         // load the manifest content
         let loadManifest = {
             try await self.manifestLoader.load(

--- a/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
@@ -252,7 +252,11 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
                 }
                 let fileSystem = try self.repository.openFileView(tag: tag)
                 let manifestPath = try ManifestLoader.findManifest(packagePath: .root, fileSystem: fileSystem, currentToolsVersion: self.currentToolsVersion)
-                return try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: fileSystem)
+                return try ToolsVersionParser.parse(
+                    manifestPath: manifestPath,
+                    fileSystem: fileSystem,
+                    packageIdentity: self.package.identity
+                )
             }
         }
     }

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -535,7 +535,11 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
         ) async throws -> Manifest {
             let packagePath = try Result { try AbsolutePath(validating: package.locationString) }.mapError({ StringError("Package path \(package.locationString) is not an absolute path. This can be caused by a dependency declared somewhere in the package graph that is using a URL instead of a local path. Original error: \($0)") }).get()
             let manifestPath = packagePath.appending(component: Manifest.filename)
-            let manifestToolsVersion = try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: fileSystem)
+            let manifestToolsVersion = try ToolsVersionParser.parse(
+                manifestPath: manifestPath,
+                fileSystem: fileSystem,
+                packageIdentity: package.identity
+            )
             return try await manifestLoader.load(
                 manifestPath: manifestPath,
                 manifestToolsVersion: manifestToolsVersion,

--- a/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
@@ -234,6 +234,42 @@ final class ToolsVersionParserTests: XCTestCase {
             }
     }
 
+    /// Verifies that a manifest with no Swift tools version specification is reported against the package it belongs to, rather than against the name of the manifest file.
+    func testMissingSpecificationInManifestFileNamesThePackage() throws {
+        let fs = InMemoryFileSystem()
+
+        let packageRoot = AbsolutePath("/lorem/ipsum/dolor")
+        try fs.createDirectory(packageRoot, recursive: true)
+
+        /// Manifests without a specification, the identity their package is known by, if any, and the identity the diagnostic should name.
+        let manifestsWithoutSpecification: [(manifestName: String, givenIdentity: PackageIdentity?, reportedIdentity: PackageIdentity)] = [
+            ("Package.swift", nil, PackageIdentity(path: packageRoot)),
+            ("Package@swift-5.5.swift", nil, PackageIdentity(path: packageRoot)),
+            ("Package.swift", .plain("mona.linkedlist"), .plain("mona.linkedlist")),
+        ]
+
+        for (manifestName, givenIdentity, reportedIdentity) in manifestsWithoutSpecification {
+            let manifestPath = packageRoot.appending(manifestName)
+            try fs.writeFileContents(manifestPath, bytes: "import PackageDescription\n")
+
+            XCTAssertThrowsError(
+                try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: fs, packageIdentity: givenIdentity),
+                "an 'UnsupportedToolsVersion' should've been thrown, because '\(manifestName)' has no Swift tools version specification"
+            ) { error in
+                guard let error = error as? UnsupportedToolsVersion else {
+                    XCTFail("'UnsupportedToolsVersion' should've been thrown, but a different error is thrown")
+                    return
+                }
+
+                XCTAssertEqual(error.packageIdentity, reportedIdentity)
+                XCTAssertEqual(
+                    error.description,
+                    "package '\(reportedIdentity)' is using Swift tools version 3.1.0 which is no longer supported; consider using '\(ToolsVersion.current.specification(roundedTo: .minor))' to specify the current tools version"
+                )
+            }
+        }
+    }
+
     /// Verifies that the correct error is thrown for each non-empty manifest missing its Swift tools version specification.
     func testMissingSpecifications() throws {
         /// Leading snippets of manifest files that don't have Swift tools version specifications.

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -273,6 +273,60 @@ final class SourceControlPackageContainerTests: XCTestCase {
         }
     }
 
+    /// A dependency whose manifest has no Swift tools version specification is reported against the package, rather than against the name of its manifest file.
+    func testUnsupportedToolsVersionNamesThePackage() async throws {
+        try XCTSkipOnWindows(because: """
+        https://github.com/swiftlang/swift-package-manager/issues/8578
+        """)
+
+        let fs = InMemoryFileSystem()
+        try fs.createMockToolchain()
+
+        let repoPath = AbsolutePath.root
+        let filePath = repoPath.appending("Package.swift")
+
+        let specifier = RepositorySpecifier(path: repoPath)
+        let repo = InMemoryGitRepository(path: repoPath, fs: fs)
+
+        try repo.createDirectory(repoPath, recursive: true)
+
+        try repo.writeFileContents(filePath, bytes: "import PackageDescription\n")
+        try repo.commit()
+        try repo.tag(name: "1.0.0")
+
+        let inMemRepoProvider = InMemoryGitRepositoryProvider()
+        inMemRepoProvider.add(specifier: specifier, repository: repo)
+
+        let p = AbsolutePath.root.appending("repoManager")
+        try fs.createDirectory(p, recursive: true)
+        let repositoryManager = RepositoryManager(
+            fileSystem: fs,
+            path: p,
+            provider: inMemRepoProvider,
+            delegate: MockRepositoryManagerDelegate()
+        )
+
+        let provider = try Workspace._init(
+            fileSystem: fs,
+            environment: .mockEnvironment,
+            location: .init(forRootPackage: repoPath, fileSystem: fs),
+            customToolsVersion: ToolsVersion(version: "4.0.0"),
+            customHostToolchain: .mockHostToolchain(fs),
+            customManifestLoader: MockManifestLoader(manifests: [:]),
+            customRepositoryManager: repositoryManager
+        )
+
+        let ref = PackageReference.localSourceControl(identity: .plain("dolor"), path: repoPath)
+        let container = try await provider.getContainer(for: ref) as! SourceControlPackageContainer
+        await XCTAssertAsyncThrowsError(try await container.toolsVersion(for: "1.0.0")) { error in
+            guard let error = error as? UnsupportedToolsVersion else {
+                XCTFail("'UnsupportedToolsVersion' should've been thrown, but '\(error)' is thrown")
+                return
+            }
+            XCTAssertEqual(error.packageIdentity, .plain("dolor"))
+        }
+    }
+
     func testPreReleaseVersions() async throws {
         try XCTSkipOnWindows(because: """
         https://github.com/swiftlang/swift-package-manager/issues/8578


### PR DESCRIPTION
A package that didn't have a tools-version specified at the top of the manifest produced the following error:

```
error: 'toolsversion-identity': package 'package.swift' is using Swift
tools version 3.1.0 which is no longer supported; consider using '//
swift-tools-version: 6.4' to specify the current tools version
```

It misidentifies the package identitiy as being "package.swift" instead of the actual name of the package.

This is reproducible by running `swift package dump-package` on a very simple package, just a Package.swift in an otherwise empty folder that looks like:

```
import PackageDescription

let package = Package(name: "ToolsVersionIdentity")
```

After this change, the error now contains the package's actual identity instead of `package.swift`:

```
error: 'toolsversion-identity': package 'toolsversion-identity' is using
Swift tools version 3.1.0 which is no longer supported; consider using '//
swift-tools-version: 6.5' to specify the current tools version
```
