### PR TITLE
PIFBuilder: Enable automatic library promotion

### DIFF
--- a/Fixtures/Miscellaneous/DynamicLibraryDiamond/Exec/Package.swift
+++ b/Fixtures/Miscellaneous/DynamicLibraryDiamond/Exec/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "Exec",
+    dependencies: [
+        .package(path: "../First"),
+        .package(path: "../Second"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "Exec",
+            dependencies: [
+                .product(name: "First", package: "First"),
+                .product(name: "Second", package: "Second"),
+            ])
+    ]
+)

--- a/Fixtures/Miscellaneous/DynamicLibraryDiamond/Exec/Sources/Exec/main.swift
+++ b/Fixtures/Miscellaneous/DynamicLibraryDiamond/Exec/Sources/Exec/main.swift
@@ -1,0 +1,7 @@
+import First
+import Second
+
+// Both dynamic libraries call into the same `Shared` module. If `Shared` was linked
+// into each of them separately there will be two copies of its global state and both
+// calls return 1; if it was linked once they share it and return 1 then 2.
+print("first=\(firstBump()) second=\(secondBump())")

--- a/Fixtures/Miscellaneous/DynamicLibraryDiamond/First/Package.swift
+++ b/Fixtures/Miscellaneous/DynamicLibraryDiamond/First/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "First",
+    products: [
+        .library(
+            name: "First",
+            type: .dynamic,
+            targets: ["First"])
+    ],
+    dependencies: [
+        .package(path: "../Shared")
+    ],
+    targets: [
+        .target(
+            name: "First",
+            dependencies: [
+                .product(name: "Shared", package: "Shared")
+            ])
+    ]
+)

--- a/Fixtures/Miscellaneous/DynamicLibraryDiamond/First/Sources/First/First.swift
+++ b/Fixtures/Miscellaneous/DynamicLibraryDiamond/First/Sources/First/First.swift
@@ -1,0 +1,5 @@
+import Shared
+
+public func firstBump() -> Int {
+    bump()
+}

--- a/Fixtures/Miscellaneous/DynamicLibraryDiamond/Second/Package.swift
+++ b/Fixtures/Miscellaneous/DynamicLibraryDiamond/Second/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "Second",
+    products: [
+        .library(
+            name: "Second",
+            type: .dynamic,
+            targets: ["Second"])
+    ],
+    dependencies: [
+        .package(path: "../Shared")
+    ],
+    targets: [
+        .target(
+            name: "Second",
+            dependencies: [
+                .product(name: "Shared", package: "Shared")
+            ])
+    ]
+)

--- a/Fixtures/Miscellaneous/DynamicLibraryDiamond/Second/Sources/Second/Second.swift
+++ b/Fixtures/Miscellaneous/DynamicLibraryDiamond/Second/Sources/Second/Second.swift
@@ -1,0 +1,5 @@
+import Shared
+
+public func secondBump() -> Int {
+    bump()
+}

--- a/Fixtures/Miscellaneous/DynamicLibraryDiamond/Shared/Package.swift
+++ b/Fixtures/Miscellaneous/DynamicLibraryDiamond/Shared/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "Shared",
+    products: [
+        .library(
+            name: "Shared",
+            targets: ["Shared"])
+    ],
+    targets: [
+        .target(
+            name: "Shared")
+    ]
+)

--- a/Fixtures/Miscellaneous/DynamicLibraryDiamond/Shared/Sources/Shared/Shared.swift
+++ b/Fixtures/Miscellaneous/DynamicLibraryDiamond/Shared/Sources/Shared/Shared.swift
@@ -1,0 +1,6 @@
+nonisolated(unsafe) private var counter = 0
+
+public func bump() -> Int {
+    counter += 1
+    return counter
+}

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -501,10 +501,19 @@ extension PackagePIFProjectBuilder {
 
             settings[.SWIFT_PACKAGE_NAME] = sourceModule.packageName
 
-            // On Windows, disable static linking mode when this module is a dependency of a dynamic library.
-            // This ensures the module is compiled correctly for linking into a dynamic library.
+            // On Windows, disable static linking mode when this module is a dependency of a dynamic library,
+            // or conditionally disable it when this module is a dependency of an automatic libray which can
+            // be promoted to dynamic. This ensures the module is compiled correctly for linking into a
+            // dynamic library.
             if self.modulesInDynamicLibraries.contains(sourceModule.name) {
                 settings[.SWIFT_COMPILE_FOR_STATIC_LINKING, .windows] = "NO"
+            }
+
+            if let promotableProductTargetIds = self.modulesInPromotableAutomaticLibraries[sourceModule.name] {
+                settings[
+                    .SWIFT_DISABLE_COMPILATION_FOR_STATIC_LINKING_WHEN_ANY_TARGET_IS_PROMOTED_TO_DYNAMIC,
+                    .windows
+                ] = promotableProductTargetIds.map(\.value).sorted()
             }
 
             // This entrypoint is only used for the testable variant of executable and macro targets. The primary PIF generation

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -651,6 +651,10 @@ extension PackagePIFProjectBuilder {
                 fatalError("Could not assign dynamic PIF target")
             }
             self.project[keyPath: pifTargetKeyPath].dynamicTargetVariantId = dynamicPifTarget.id
+
+            for module in libraryProduct.modules where module.isSourceModule {
+                self.modulesInPromotableAutomaticLibraries[module.name, default: []].insert(pifTarget.id)
+            }
         }
     }
 
@@ -781,8 +785,13 @@ extension PackagePIFProjectBuilder {
             // For dynamic libraries, track which source modules are DIRECT dependencies so we can set
             // SWIFT_COMPILE_FOR_STATIC_LINKING=NO on Windows for those modules.
             // Collect only DIRECT module dependencies (not recursive)
-            for module in product.modules where module.isSourceModule {
-                self.modulesInDynamicLibraries.insert(module.name)
+            //
+            // Skip the synthesized dynamic variant of an `.automatic` product: its modules are still
+            // linked statically by default, so flagging them here would compile them incorrectly.
+            if targetSuffix != .dynamic {
+                for module in product.modules where module.isSourceModule {
+                    self.modulesInDynamicLibraries.insert(module.name)
+                }
             }
         } else if productType == .staticArchive {
             settings[.TARGET_NAME] = product.targetName()

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -68,6 +68,11 @@ struct PackagePIFProjectBuilder {
     /// These modules should be compiled without static linking on Windows.
     var modulesInDynamicLibraries: Set<String> = []
 
+    /// Module names that are direct dependencies of automatic libraries which may be
+    /// promoted to dynamic. These modules should be compiled without static linking on Windows
+    /// if the corresponding target builds dynamically.
+    var modulesInPromotableAutomaticLibraries: [String: Set<GUID>] = [:]
+
     /// FIXME: We should eventually clean this up but right now we have to carry over this
     /// bit of information from processing the *products* to processing the *targets*.
     var mainModuleTargetNamesWithResources: Set<String> = []

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1390,7 +1390,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                     additionalFileRules: additionalFileRules,
                     addLocalRpaths: self.buildParameters.linkingParameters.shouldDisableLocalRpath ? .never : .always,
                     materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
-                    createDynamicVariantsForLibraryProducts: false,
+                    createDynamicVariantsForLibraryProducts: true,
                     hostBuildProductsPath: try await self.buildProductsPath(for: self.hostBuildParameters)
                 ),
                 fileSystem: self.fileSystem,

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -1609,6 +1609,22 @@ struct MiscellaneousTestCase {
             ProcessInfo.isHostAmazonLinux2() // libFuzzer link issues occur on AL2
         }
     }
+
+    @Test(
+        .tags(
+            .Feature.Command.Run,
+        )
+    )
+    func diamondLinkagePromotesAutomaticLibraryToDynamic() async throws {
+        try await fixture(name: "Miscellaneous/DynamicLibraryDiamond") { fixturePath in
+            let (stdout, _) = try await executeSwiftRun(
+                fixturePath.appending("Exec"),
+                "Exec",
+                buildSystem: .swiftbuild,
+            )
+            #expect(stdout.contains("first=1 second=2"))
+        }
+    }
 }
 
 @Suite

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1906,6 +1906,96 @@ struct PIFBuilderTests {
         }
     }
 
+    @Test func swiftCompileForStaticLinkingInPromotableAutomaticLibraries() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/Root/Sources/ModuleA/ModuleA.swift",
+            "/Root/Sources/ModuleB/ModuleB.swift",
+            "/Root/Sources/ModuleC/ModuleC.swift",
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v6_0,
+                    products: [
+                        ProductDescription(name: "AutomaticLib", type: .library(.automatic), targets: ["ModuleA", "ModuleB"]),
+                        ProductDescription(name: "StaticLib", type: .library(.static), targets: ["ModuleC"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "ModuleA"),
+                        TargetDescription(name: "ModuleB"),
+                        TargetDescription(name: "ModuleC"),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: .always,
+                createDynamicVariantsForLibraryProducts: true
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let project = try pif.workspace.project(named: "Root")
+
+        let automaticLibTarget = try project.target(named: "AutomaticLib-product")
+        guard case .target(let automaticLibStandardTarget) = automaticLibTarget else {
+            Issue.record("Expected 'AutomaticLib-product' to be a standard target")
+            return
+        }
+        #expect(automaticLibStandardTarget.dynamicTargetVariantId != nil)
+
+        for moduleName in ["ModuleA", "ModuleB"] {
+            let moduleTarget = try project.target(named: moduleName)
+            let config = try moduleTarget.buildConfig(named: .release)
+
+            #expect(
+                config.settings[
+                    .SWIFT_DISABLE_COMPILATION_FOR_STATIC_LINKING_WHEN_ANY_TARGET_IS_PROMOTED_TO_DYNAMIC,
+                    .windows
+                ] == [automaticLibTarget.id.value]
+            )
+            #expect(
+                config.settings[.SWIFT_COMPILE_FOR_STATIC_LINKING, .windows] == nil,
+                "Module \(moduleName) should not disable static linking mode unconditionally"
+            )
+
+            for platform in SwiftBuild.ProjectModel.BuildSettings.Platform.allCases where platform != .windows {
+                #expect(
+                    config.settings[
+                        .SWIFT_DISABLE_COMPILATION_FOR_STATIC_LINKING_WHEN_ANY_TARGET_IS_PROMOTED_TO_DYNAMIC,
+                        platform
+                    ] == nil
+                )
+            }
+        }
+
+        let moduleCConfig = try project.target(named: "ModuleC").buildConfig(named: .release)
+        for platform in ProjectModel.BuildSettings.Platform.allCases {
+            #expect(
+                moduleCConfig.settings[
+                    .SWIFT_DISABLE_COMPILATION_FOR_STATIC_LINKING_WHEN_ANY_TARGET_IS_PROMOTED_TO_DYNAMIC,
+                    platform
+                ] == nil
+            )
+        }
+    }
+
     @Test func macroPackageSupportedPlatforms() async throws {
         try await withGeneratedPIF(fromFixture: "Macros/MinimalMacroPackage") { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)


### PR DESCRIPTION
https://github.com/swiftlang/swift-package-manager/pull/9831 disabled creation of dynamic variants for automatic library products, preventing diamond linkage resolution from kicking in as expected. Reenable this flag, and adopt the new setting in the underlying build system to conditionally disable compilation for static linking for targets in promoted products.

Depends on https://github.com/swiftlang/swift-build/pull/1679
Closes https://github.com/swiftlang/swift-package-manager/issues/10460