### PR TITLE
Exclude scratch directory from Time Machine backups

### DIFF
--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -15,6 +15,8 @@ import ArgumentParser
 import Basics
 import Dispatch
 import class Foundation.ProcessInfo
+import struct Foundation.URL
+import struct Foundation.URLResourceValues
 import PackageFingerprint
 import PackageGraph
 import PackageLoading
@@ -180,12 +182,31 @@ package func createCacheDirFile(
             #.   http://www.brynosaurus.com/cachedir/
             """
         try fileSystem.createDirectory(path.parentDirectory, recursive: true)
+        _ = excludeFromBackups(directory: directory)
         try fileSystem.writeFileContents(path, string: contents)
         return path
     } catch {
         // Don't error out if we fail to create the CACHEDIR.TAG file, as this is not critical to the functioning of the tool.
         return nil
     }
+}
+
+/// Marks a directory as excluded from backups, for example for Time Machine.
+package func excludeFromBackups(directory: AbsolutePath) -> Bool {
+    #if os(macOS)
+    do {
+        var url = directory.asURL
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        try url.setResourceValues(resourceValues)
+        return true
+    } catch {
+        // Don't error out if we fail to create the file, as this is not critical to the functioning of the tool.
+        return false
+    }
+    #else
+    return false
+    #endif
 }
 
 package func createBuildSystemFile(

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -24,6 +24,7 @@ import _InternalTestSupport
 import XCTest
 
 import ArgumentParser
+import Foundation
 import class TSCBasic.BufferedOutputByteStream
 import protocol TSCBasic.OutputByteStream
 import enum TSCBasic.SystemError
@@ -93,6 +94,24 @@ struct SwiftCommandStateTestSuites {
             contents == "\(buildData.buildSystem)",
             "Actual is not as expected",
         )
+    }
+
+    @Test(
+        .tags(
+            .TestSize.small,
+        ),
+        .enabled(if: ProcessInfo.hostOperatingSystem == .macOS),
+    )
+    func excludeFromBackupMarksDirectoryAsExcluded() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let scratchDirectory = tmpDir.appending(".build")
+            try localFileSystem.createDirectory(scratchDirectory, recursive: true)
+
+            #expect(excludeFromBackups(directory: scratchDirectory))
+
+            let resourceValues = try scratchDirectory.asURL.resourceValues(forKeys: [.isExcludedFromBackupKey])
+            #expect(resourceValues.isExcludedFromBackup == true)
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation:

`.build` dir (scratch directory) contains artifacts reproducible from the source code.
It can get quite chunky.
Considering pretty much all artifacts are reproducible, it should be excluded from backups to not waste backup storage.

Software like Time Machine don't allow any ways of just telling it "don't backup any dir named .build".

### Modifications:

Exclude `.build` from backups, for example for Time Machine.

### Result:

Backup storage of users will no longer be wasted.
