### PR TITLE
Fix broken README documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [SourceKit-LSP](https://github.com/swiftlang/sourcekit-lsp) project leverage
 
 ## Getting Started
 
-Please use [this guide](https://www.swift.org/documentation/package-manager/) for learning package manager basics.
+Please use [this guide](https://docs.swift.org/latest/documentation/packagemanagerdocs/gettingstarted/) for learning package manager basics.
 
 ---
 
@@ -31,13 +31,13 @@ Please use [this guide](https://www.swift.org/documentation/package-manager/) fo
 
 For Quick Help use the `swift package --help` command.
 
-For documentation on using Swift Package Manager, creating packages, and more, see the [Package Manager Docs](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs).
+For documentation on using Swift Package Manager, creating packages, and more, see the [Package Manager Docs](https://docs.swift.org/latest/documentation/packagemanagerdocs/).
 
 For documentation on developing the Swift Package Manager itself, see the [contribution guide](CONTRIBUTING.md).
 
-For detailed documentation on the package manifest API, see [PackageDescription API](https://docs.swift.org/swiftpm/documentation/packagedescription).
+For detailed documentation on the package manifest API, see [PackageDescription API](https://docs.swift.org/latest/documentation/packagedescription/).
 
-For release notes with information about changes between versions, see the [release notes](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/releasenotes).
+For release notes with information about changes between versions, see the [release notes](https://docs.swift.org/latest/documentation/packagemanagerdocs/releasenotes/).
 
 ---
 


### PR DESCRIPTION
Update the README to use the current canonical SwiftPM and PackageDescription documentation URLs.

### Motivation:

Fixes #10463.

The README documentation links use the retired `docs.swift.org/swiftpm/...` routing structure. Those routes now redirect to duplicated paths such as `latest/documentation/packagemanagerdocs/packagemanagerdocs` and return HTTP 404.

The Getting Started link first loads an HTML redirect page that points to the same broken route, so readers cannot reach the guide from the README.

### Modifications:

Updated the four affected README links:

- Getting Started
- Package Manager Docs
- PackageDescription API
- Release notes

Each link now uses its canonical `docs.swift.org/latest/documentation/...` destination with a trailing slash.

### Result:

README visitors are taken directly to the current official Swift documentation instead of a redirect chain ending in a 404 page.

### Validation:

Followed each replacement URL with redirects enabled and confirmed HTTP 200 responses:

- `https://docs.swift.org/latest/documentation/packagemanagerdocs/gettingstarted/`
- `https://docs.swift.org/latest/documentation/packagemanagerdocs/`
- `https://docs.swift.org/latest/documentation/packagedescription/`
- `https://docs.swift.org/latest/documentation/packagemanagerdocs/releasenotes/`

The HTTP checks above validate the link changes. Separately, `git diff --check` passes as a whitespace/conflict-marker sanity check; it does not validate URLs. No Swift source or generated documentation changed.
