### PR TITLE
[SBOM] Add regression coverage for SPDX creation timestamps

### DIFF
--- a/Tests/SBOMModelTests/SPDXConverterTests.swift
+++ b/Tests/SBOMModelTests/SPDXConverterTests.swift
@@ -37,6 +37,29 @@ struct SPDXConverterTests {
         #expect(result.isEmpty)
     }
 
+    @Test("convertToAgent does not use the Unix epoch when the metadata timestamp is missing")
+    func convertToAgentWithMissingTimestamp() async throws {
+        let creator = SBOMTool(
+            id: SBOMIdentifier(value: "tool-1"),
+            name: "SwiftPM",
+            version: "3.0.1",
+            purl: PURL(
+                scheme: "pkg",
+                type: "swift",
+                namespace: "github.com/swiftlang",
+                name: "SwiftPM",
+                version: "3.0.1"
+            )
+        )
+        let metadata = SBOMMetadata(timestamp: nil, creators: [creator])
+
+        let result = await SPDXConverter.convertToAgent(from: metadata)
+        let creationInfo = try #require(result.compactMap { $0 as? SPDXCreationInfo }.first)
+
+        #expect(creationInfo.created != "1970-01-01T00:00:00Z")
+        #expect(ISO8601DateFormatter().date(from: creationInfo.created) != nil)
+    }
+
     @Test("convertToAgent with empty creators")
     func convertToAgentWithEmptyCreators() async throws {
         let metadata = SBOMMetadata(


### PR DESCRIPTION
## Summary

Add regression coverage to ensure SPDX agent creation information does not fall back to the Unix epoch when SBOM metadata does not provide a timestamp.

The production fix for this behavior is already present in upstream commit `ae7ed6b6c` (`#10359`). This change adds coverage for the missing-timestamp fallback path so the behavior does not regress.

## Changes

- Add a test for SPDX agent conversion with a missing metadata timestamp.
- Verify the generated timestamp is not `1970-01-01T00:00:00Z`.
- Verify the generated timestamp is a valid ISO 8601 date.

Fixes #10354
