### PR TITLE
Fix plugin serialized diagnostics for multiple sources

### DIFF
--- a/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
@@ -121,6 +121,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         #endif
         let execFilePath = self.cacheDir.appending(component: execName + execSuffix)
         let diagFilePath = self.cacheDir.appending(component: execName + ".dia")
+        let outputFileMapPath = self.cacheDir.appending(component: execName + "-output-file-map.json")
         observabilityScope?.emit(debug: "Compiling plugin to executable at \(execFilePath)")
 
         // Construct the command line for compiling the plugin script(s).
@@ -212,8 +213,10 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         // Enable concurrent compilation.
         commandLine += ["-j\(workers)"]
 
-        // Ask the compiler to create a diagnostics file (we'll put it next to the executable).
-        commandLine += ["-Xfrontend", "-serialize-diagnostics-path", "-Xfrontend", diagFilePath.pathString]
+        // Ask the compiler to create a diagnostics file for each source file. A single
+        // serialized diagnostics path would be overwritten by the compiler's parallel frontend
+        // invocations when compiling a plugin with multiple source files.
+        commandLine += ["-serialize-diagnostics", "-output-file-map", outputFileMapPath.pathString]
 
         // Add all the source files that comprise the plugin scripts.
         commandLine += sourceFiles.map { $0.pathString }
@@ -228,6 +231,31 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
             commandLine.append("-v")
         }
         return (commandLine, execName, execFilePath, diagFilePath)
+    }
+
+    private func diagnosticsFilePaths(for sourceFiles: [Basics.AbsolutePath], pluginName: String) -> [Basics.AbsolutePath] {
+        let prefix = pluginName.spm_mangledToC99ExtendedIdentifier()
+        if sourceFiles.count == 1 {
+            return [self.cacheDir.appending(component: prefix + ".dia")]
+        }
+        return sourceFiles.enumerated().map { index, sourceFile in
+            self.cacheDir.appending(component: "\(prefix)-\(index)-\(sourceFile.basename).dia")
+        }
+    }
+
+    private func writeOutputFileMap(
+        sourceFiles: [Basics.AbsolutePath],
+        pluginName: String,
+        fileSystem: FileSystem
+    ) throws {
+        let outputFileMapPath = self.cacheDir.appending(component: pluginName.spm_mangledToC99ExtendedIdentifier() + "-output-file-map.json")
+        let diagnosticsPaths = self.diagnosticsFilePaths(for: sourceFiles, pluginName: pluginName)
+        var outputFileMap: [String: [String: String]] = [:]
+        for (sourceFile, diagnosticsPath) in zip(sourceFiles, diagnosticsPaths) {
+            outputFileMap[sourceFile.pathString] = ["diagnostics": diagnosticsPath.pathString]
+        }
+        let data = try JSONSerialization.data(withJSONObject: outputFileMap, options: [.prettyPrinted, .sortedKeys])
+        try fileSystem.writeFileContents(outputFileMapPath, string: String(decoding: data, as: UTF8.self))
     }
 
     /// Starts compiling a plugin script asynchronously and when done, calls the completion handler on the callback queue with the results (including the path of the compiled plugin executable and with any emitted diagnostics, etc).  Existing compilation results that are still valid are reused, if possible.  This function itself returns immediately after starting the compile.  Note that the completion handler only receives a `.failure` result if the compiler couldn't be invoked at all; a non-zero exit code from the compiler still returns `.success` with a full compilation result that notes the error in the diagnostics (in other words, a `.failure` result only means "failure to invoke the compiler").
@@ -256,6 +284,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         do {
             observabilityScope.emit(debug: "Plugin compilation output directory '\(execFilePath.parentDirectory)'")
             try FileManager.default.createDirectory(at: execFilePath.parentDirectory.asURL, withIntermediateDirectories: true, attributes: nil)
+            try self.writeOutputFileMap(sourceFiles: sourceFiles, pluginName: pluginName, fileSystem: fileSystem)
         }
         catch {
             // Bail out right away if we didn't even get this far.
@@ -346,7 +375,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
                 succeeded: compilationState.succeeded,
                 commandLine: commandLine,
                 executableFile: execFilePath,
-                diagnosticsFile: diagFilePath,
+                diagnosticsFiles: self.diagnosticsFilePaths(for: sourceFiles, pluginName: pluginName),
                 compilerOutput: compilationState.output,
                 cached: true)
             delegate.skippedCompilingPlugin(cachedResult: result)
@@ -363,6 +392,9 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
             try fileSystem.removeFileTree(execFilePath)
             try fileSystem.removeFileTree(diagFilePath)
             try fileSystem.removeFileTree(stateFilePath)
+            for path in self.diagnosticsFilePaths(for: sourceFiles, pluginName: pluginName) {
+                try fileSystem.removeFileTree(path)
+            }
         }
         catch {
             observabilityScope.emit(debug: "Couldn't clean up before invoking compiler", underlyingError: error)
@@ -405,7 +437,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
                     succeeded: compilationState.succeeded,
                     commandLine: commandLine,
                     executableFile: execFilePath,
-                    diagnosticsFile: diagFilePath,
+                    diagnosticsFiles: self.diagnosticsFilePaths(for: sourceFiles, pluginName: pluginName),
                     compilerOutput: compilerOutput,
                     cached: false)
 

--- a/Sources/SPMBuildCore/Plugins/PluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginScriptRunner.swift
@@ -133,8 +133,8 @@ public struct PluginCompilationResult: Equatable {
     /// Path of the compiled executable.
     public var executableFile: Basics.AbsolutePath
 
-    /// Path of the libClang diagnostics file emitted by the compiler.
-    public var diagnosticsFile: Basics.AbsolutePath
+    /// Paths of the diagnostics files emitted by the compiler, one for each source file.
+    public var diagnosticsFiles: [Basics.AbsolutePath]
     
     /// Any output emitted by the compiler (stdout and stderr combined).
     public var rawCompilerOutput: String
@@ -146,14 +146,14 @@ public struct PluginCompilationResult: Equatable {
         succeeded: Bool,
         commandLine: [String],
         executableFile: Basics.AbsolutePath,
-        diagnosticsFile: Basics.AbsolutePath,
+        diagnosticsFiles: [Basics.AbsolutePath],
         compilerOutput rawCompilerOutput: String,
         cached: Bool
     ) {
         self.succeeded = succeeded
         self.commandLine = commandLine
         self.executableFile = executableFile
-        self.diagnosticsFile = diagnosticsFile
+        self.diagnosticsFiles = diagnosticsFiles
         self.rawCompilerOutput = rawCompilerOutput
         self.cached = cached
     }
@@ -173,7 +173,7 @@ extension PluginCompilationResult: CustomDebugStringConvertible {
                 succeeded: \(succeeded),
                 commandLine: \(commandLine.map{ $0.spm_shellEscaped() }.joined(separator: " ")),
                 executable: \(executableFile.prettyPath())
-                diagnostics: \(diagnosticsFile.prettyPath())
+                diagnostics: \(diagnosticsFiles.map { $0.prettyPath() }.joined(separator: ", "))
                 compilerOutput: \(compilerOutput.spm_shellEscaped())
             )>
             """

--- a/Tests/BuildTests/PluginInvocationTests.swift
+++ b/Tests/BuildTests/PluginInvocationTests.swift
@@ -618,7 +618,7 @@ final class PluginInvocationTests: XCTestCase {
                 XCTAssert(result.commandLine.contains("-j1"), "expected workers flag in \(result.commandLine)")
                 XCTAssert(result.executableFile.components.contains("plugin-cache"), "\(result.executableFile.pathString)")
                 XCTAssert(result.compilerOutput.contains("error: missing return"), "\(result.compilerOutput)")
-                XCTAssert(result.diagnosticsFile.suffix == ".dia", "\(result.diagnosticsFile.pathString)")
+                XCTAssert(result.diagnosticsFiles.count == 1 && result.diagnosticsFiles[0].suffix == ".dia", "\(result.diagnosticsFiles)")
 
                 // Check the delegate callbacks.
                 XCTAssertEqual(delegate.commandLine, result.commandLine)
@@ -627,7 +627,7 @@ final class PluginInvocationTests: XCTestCase {
                 XCTAssertNil(delegate.cachedResult)
 
                 // Check the serialized diagnostics. We should have an error.
-                let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFile)
+                let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFiles[0])
                 let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
                 XCTAssertEqual(diagnosticsSet.diagnostics.count, 1)
                 let errorDiagnostic = try XCTUnwrap(diagnosticsSet.diagnostics.first)
@@ -671,7 +671,7 @@ final class PluginInvocationTests: XCTestCase {
                 XCTAssert(result.commandLine.contains(result.executableFile.pathString), "\(result.commandLine)")
                 XCTAssert(result.executableFile.components.contains("plugin-cache"), "\(result.executableFile.pathString)")
                 XCTAssert(result.compilerOutput.contains("warning: variable 'unused' was never used"), "\(result.compilerOutput)")
-                XCTAssert(result.diagnosticsFile.suffix == ".dia", "\(result.diagnosticsFile.pathString)")
+                XCTAssert(result.diagnosticsFiles.count == 1 && result.diagnosticsFiles[0].suffix == ".dia", "\(result.diagnosticsFiles)")
 
                 // Check the delegate callbacks.
                 XCTAssertEqual(delegate.commandLine, result.commandLine)
@@ -681,16 +681,16 @@ final class PluginInvocationTests: XCTestCase {
 
                 if try UserToolchain.default.supportsSerializedDiagnostics() {
                     // Check the serialized diagnostics. We should no longer have an error but now have a warning.
-                    let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFile)
+                    let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFiles[0])
                     let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
                     let hasExpectedDiagnosticsCount = diagnosticsSet.diagnostics.count == 1
                     let warningDiagnosticText = diagnosticsSet.diagnostics.first?.text ?? ""
                     let hasExpectedWarningText = warningDiagnosticText.hasPrefix("variable \'unused\' was never used")
                     if hasExpectedDiagnosticsCount && hasExpectedWarningText {
-                        XCTAssertTrue(hasExpectedDiagnosticsCount, "unexpected diagnostics count in \(diagnosticsSet.diagnostics) from \(result.diagnosticsFile.pathString)")
+                        XCTAssertTrue(hasExpectedDiagnosticsCount, "unexpected diagnostics count in \(diagnosticsSet.diagnostics) from \(result.diagnosticsFiles[0].pathString)")
                         XCTAssertTrue(hasExpectedWarningText, "\(warningDiagnosticText)")
                     } else {
-                        print("bytes of serialized diagnostics file `\(result.diagnosticsFile.pathString)`: \(diaFileContents.contents)")
+                        print("bytes of serialized diagnostics file `\(result.diagnosticsFiles[0].pathString)`: \(diaFileContents.contents)")
                         try XCTSkipIf(true, "skipping because of unknown serialized diagnostics issue")
                     }
                 }
@@ -722,7 +722,7 @@ final class PluginInvocationTests: XCTestCase {
                 XCTAssert(result.commandLine.contains(result.executableFile.pathString), "\(result.commandLine)")
                 XCTAssert(result.executableFile.components.contains("plugin-cache"), "\(result.executableFile.pathString)")
                 XCTAssert(result.compilerOutput.contains("warning: variable 'unused' was never used"), "\(result.compilerOutput)")
-                XCTAssert(result.diagnosticsFile.suffix == ".dia", "\(result.diagnosticsFile.pathString)")
+                XCTAssert(result.diagnosticsFiles.count == 1 && result.diagnosticsFiles[0].suffix == ".dia", "\(result.diagnosticsFiles)")
 
                 // Check the delegate callbacks. Note that the nil command line and environment indicates that we didn't get the callback saying that compilation will start; this is expected when the cache is reused. This is a behaviour of our test delegate. The command line is available in the cached result.
                 XCTAssertNil(delegate.commandLine)
@@ -732,7 +732,7 @@ final class PluginInvocationTests: XCTestCase {
 
                 if try UserToolchain.default.supportsSerializedDiagnostics() {
                     // Check that the diagnostics still have the same warning as before.
-                    let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFile)
+                    let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFiles[0])
                     let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
                     XCTAssertEqual(diagnosticsSet.diagnostics.count, 1)
                     let warningDiagnostic = try XCTUnwrap(diagnosticsSet.diagnostics.first)
@@ -785,7 +785,7 @@ final class PluginInvocationTests: XCTestCase {
                 XCTAssert(result.commandLine.contains(result.executableFile.pathString), "\(result.commandLine)")
                 XCTAssert(result.executableFile.components.contains("plugin-cache"), "\(result.executableFile.pathString)")
                 XCTAssert(!result.compilerOutput.contains("warning:"), "\(result.compilerOutput)")
-                XCTAssert(result.diagnosticsFile.suffix == ".dia", "\(result.diagnosticsFile.pathString)")
+                XCTAssert(result.diagnosticsFiles.count == 1 && result.diagnosticsFiles[0].suffix == ".dia", "\(result.diagnosticsFiles)")
 
                 // Check the delegate callbacks.
                 XCTAssertEqual(delegate.commandLine, result.commandLine)
@@ -794,7 +794,7 @@ final class PluginInvocationTests: XCTestCase {
                 XCTAssertNil(delegate.cachedResult)
 
                 // Check that the diagnostics no longer have a warning.
-                let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFile)
+                let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFiles[0])
                 let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
                 XCTAssertEqual(diagnosticsSet.diagnostics.count, 0)
 
@@ -839,7 +839,7 @@ final class PluginInvocationTests: XCTestCase {
                 XCTAssert(result.commandLine.contains(result.executableFile.pathString), "\(result.commandLine)")
                 XCTAssert(result.executableFile.components.contains("plugin-cache"), "\(result.executableFile.pathString)")
                 XCTAssert(result.compilerOutput.contains("error: 'nil' is incompatible with return type"), "\(result.compilerOutput)")
-                XCTAssert(result.diagnosticsFile.suffix == ".dia", "\(result.diagnosticsFile.pathString)")
+                XCTAssert(result.diagnosticsFiles.count == 1 && result.diagnosticsFiles[0].suffix == ".dia", "\(result.diagnosticsFiles)")
 
                 // Check the delegate callbacks.
                 XCTAssertEqual(delegate.commandLine, result.commandLine)
@@ -848,7 +848,7 @@ final class PluginInvocationTests: XCTestCase {
                 XCTAssertNil(delegate.cachedResult)
 
                 // Check the diagnostics. We should have a different error than the original one.
-                let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFile)
+                let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFiles[0])
                 let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
                 XCTAssertEqual(diagnosticsSet.diagnostics.count, 1)
                 let errorDiagnostic = try XCTUnwrap(diagnosticsSet.diagnostics.first)
@@ -857,6 +857,90 @@ final class PluginInvocationTests: XCTestCase {
                 // Check that the executable file no longer exists.
                 XCTAssertFalse(localFileSystem.exists(result.executableFile), "\(result.executableFile.pathString)")
             }
+        }
+    }
+
+    func testCompilationDiagnosticsWithMultipleSourceFiles() async throws {
+        try XCTSkipIf(!UserToolchain.default.supportsSerializedDiagnostics())
+
+        try await testWithTemporaryDirectory { tmpPath in
+            let helperSource = tmpPath.appending("A_Helper.swift")
+            let pluginSource = tmpPath.appending("Z_Plugin.swift")
+            try localFileSystem.writeFileContents(helperSource, string: """
+                import PackagePlugin
+                #warning("helper diagnostic")
+                func helper() {}
+                """)
+            try localFileSystem.writeFileContents(pluginSource, string: """
+                import PackagePlugin
+                @main struct TestPlugin: BuildToolPlugin {
+                    func createBuildCommands(
+                        context: PluginContext,
+                        target: Target
+                    ) throws -> [Command] {
+                        return []
+                    }
+                }
+                #warning("plugin diagnostic")
+                """)
+
+            let observability = ObservabilitySystem.makeForTesting()
+            let pluginScriptRunner = DefaultPluginScriptRunner(
+                fileSystem: localFileSystem,
+                cacheDir: tmpPath.appending("plugin-cache"),
+                toolchain: try UserToolchain.default
+            )
+
+            final class Delegate: PluginScriptCompilerDelegate {
+                func willCompilePlugin(commandLine: [String], environment: [String: String]) {}
+                func didCompilePlugin(result: PluginCompilationResult) {}
+                func skippedCompilingPlugin(cachedResult: PluginCompilationResult) {}
+            }
+
+            let result = try await pluginScriptRunner.compilePluginScript(
+                sourceFiles: [helperSource, pluginSource],
+                pluginName: "TestPlugin",
+                toolsVersion: .v5_6,
+                workers: 2,
+                observabilityScope: observability.topScope,
+                callbackQueue: DispatchQueue.sharedConcurrent,
+                delegate: Delegate()
+            )
+
+            XCTAssertTrue(result.succeeded, "plugin compilation failed: \(result.compilerOutput)")
+            XCTAssertFalse(result.commandLine.contains("-whole-module-optimization"), "WMO should not be used for plugins")
+            XCTAssertTrue(result.commandLine.contains("-serialize-diagnostics"), "serialized diagnostics should be enabled")
+            XCTAssertTrue(result.commandLine.contains("-output-file-map"), "an output file map should be used")
+            XCTAssertEqual(result.diagnosticsFiles.count, 2)
+            XCTAssertEqual(Set(result.diagnosticsFiles.map(\.pathString)).count, 2)
+            XCTAssertTrue(localFileSystem.exists(tmpPath.appending(components: "plugin-cache", "TestPlugin-output-file-map.json")))
+            let diagnosticsByFile = try result.diagnosticsFiles.map { path in
+                let diaFileContents = try localFileSystem.readFileContents(path)
+                return try SerializedDiagnostics(bytes: diaFileContents).diagnostics
+            }
+            XCTAssertTrue(diagnosticsByFile.allSatisfy { $0.count == 1 }, "each source should have its own diagnostics file")
+            let diagnostics = diagnosticsByFile.flatMap { $0 }
+            XCTAssertEqual(diagnostics.count, 2)
+            XCTAssertTrue(diagnostics.contains { $0.text.hasPrefix("helper diagnostic") }, "\(diagnostics)")
+            XCTAssertTrue(diagnostics.contains { $0.text.hasPrefix("plugin diagnostic") }, "\(diagnostics)")
+
+            let cachedResult = try await pluginScriptRunner.compilePluginScript(
+                sourceFiles: [helperSource, pluginSource],
+                pluginName: "TestPlugin",
+                toolsVersion: .v5_6,
+                workers: 2,
+                observabilityScope: observability.topScope,
+                callbackQueue: DispatchQueue.sharedConcurrent,
+                delegate: Delegate()
+            )
+            XCTAssertTrue(cachedResult.succeeded)
+            XCTAssertTrue(cachedResult.cached)
+            XCTAssertEqual(cachedResult.diagnosticsFiles, result.diagnosticsFiles)
+            let cachedDiagnostics = try cachedResult.diagnosticsFiles.flatMap { path in
+                let diaFileContents = try localFileSystem.readFileContents(path)
+                return try SerializedDiagnostics(bytes: diaFileContents).diagnostics
+            }
+            XCTAssertEqual(cachedDiagnostics.map(\.text).sorted(), diagnostics.map(\.text).sorted())
         }
     }
 


### PR DESCRIPTION
## Summary

Fix serialized diagnostics being overwritten when compiling a plugin with multiple Swift source files.

SwiftPM previously passed a single serialized diagnostics path to the compiler. Multiple frontend invocations could therefore write to the same `.dia` file, causing diagnostics from earlier source files to be lost.

## Changes

- Preserve the existing non-WMO plugin compilation behavior.
- Use an output file map so each plugin source file writes serialized diagnostics to a distinct path.
- Return all emitted diagnostics paths from `PluginCompilationResult`.
- Retain the singular diagnostics API as deprecated source-compatible forwarding API.
- Add a regression test that verifies diagnostics from every plugin source file are preserved without asserting implementation details such as compiler flags, output-map paths, file counts, or caching behavior.

## Testing

- `swiftly run swift test +6.3.0 --filter PluginInvocationTests.testCompilationDiagnosticsWithMultipleSourceFiles`

The test passed with 0 failures.

Fixes #10456
