### PR TITLE
Update the Swift version to 6.4.2

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -58,8 +58,8 @@ public struct SwiftVersion: Sendable {
 extension SwiftVersion {
     /// The current version of the package manager.
     public static let current = SwiftVersion(
-        version: (6, 4, 0),
-        isDevelopment: true,
+        version: (6, 4, 2),
+        isDevelopment: false,
         buildIdentifier: getBuildIdentifier()
     )
 }


### PR DESCRIPTION
- **Explanation**: Update the Swift version to 6.4.2 and set `isDevelopment` to `false` to drop the trailing `-dev` from the version output.
- **Scope**: Change the version of SwiftPM on release/6.4.x branch
- **Issues**: Version expected for release/6.4.x is 6.4.2
- **Original PRs**: N/A
- **Risk**: Low
- **Testing**: CI
- **Reviewers**: