### PR TITLE
Update the Swift version to 6.3.4

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -58,7 +58,7 @@ public struct SwiftVersion: Sendable {
 extension SwiftVersion {
     /// The current version of the package manager.
     public static let current = SwiftVersion(
-        version: (6, 3, 3),
+        version: (6, 3, 4),
         isDevelopment: false,
         buildIdentifier: getBuildIdentifier()
     )


### PR DESCRIPTION
- **Explanation**: Update the Swift version to 6.3.4
- **Scope**: Change the version of SwiftPM on release/6.3 branch
- **Issues**: Version expected for release/6.3 is 6.3.4, currently reporting 6.3.3
- **Original PRs**: N/A
- **Risk**: Low
- **Testing**: CI
- **Reviewers**: