### PR TITLE
Stop resuming continuations while holding the pending lookup mutex in RegistryDownloadsManager/RepositoryManager

### DIFF
--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -69,45 +69,43 @@ public class RegistryDownloadsManager: AsyncCancellable {
         }
 
         let lookupId = PackageLookup(package: package, version: version)
-        let task = await withCheckedContinuation { continuation in
-            self.pendingLookups.withLock { pendingLookups in
-                // Check if we've already resolved/are in the process of resolving for this package.
-                if let inFlight = pendingLookups[lookupId] {
-                    continuation.resume(returning: inFlight)
-                } else {
-                    let lookupTask = Task {
-                        // inform delegate that we are starting to fetch
-                        // calculate if cached (for delegate call) outside queue as it may change while queue is processing
-                        let isCached = self.cachePath.map { self.fileSystem.exists($0.appending(packageRelativePath)) } ?? false
-                        let details = FetchDetails(fromCache: isCached, updatedCache: false)
-                        delegate?.emit { $0.willFetch(package: package, version: version, fetchDetails: details) }
-
-                        // make sure destination is free.
-                        try? self.fileSystem.removeFileTree(packagePath)
-
-                        let start = DispatchTime.now()
-                        do {
-                            let result = try await self.downloadAndPopulateCache(
-                                package: package,
-                                version: version,
-                                packagePath: packagePath,
-                                observabilityScope: observabilityScope
-                            )
-                            // inform delegate that we finished to fetch
-                            let duration = start.distance(to: .now())
-                            delegate?.emit { $0.didFetch(package: package, version: version, result: .success(result), duration: duration) }
-                        } catch {
-                            let duration = start.distance(to: .now())
-                            delegate?.emit { $0.didFetch(package: package, version: version, result: .failure(error), duration: duration) }
-                            throw error
-                        }
-                        return packagePath
-                    }
-
-                    pendingLookups[lookupId] = lookupTask
-                    continuation.resume(returning: lookupTask)
-                }
+        let task = self.pendingLookups.withLock { pendingLookups -> Task<Basics.AbsolutePath, Error> in
+            // Check if we've already resolved/are in the process of resolving for this package.
+            if let inFlight = pendingLookups[lookupId] {
+                return inFlight
             }
+
+            let lookupTask = Task {
+                // inform delegate that we are starting to fetch
+                // calculate if cached (for delegate call) outside queue as it may change while queue is processing
+                let isCached = self.cachePath.map { self.fileSystem.exists($0.appending(packageRelativePath)) } ?? false
+                let details = FetchDetails(fromCache: isCached, updatedCache: false)
+                delegate?.emit { $0.willFetch(package: package, version: version, fetchDetails: details) }
+
+                // make sure destination is free.
+                try? self.fileSystem.removeFileTree(packagePath)
+
+                let start = DispatchTime.now()
+                do {
+                    let result = try await self.downloadAndPopulateCache(
+                        package: package,
+                        version: version,
+                        packagePath: packagePath,
+                        observabilityScope: observabilityScope
+                    )
+                    // inform delegate that we finished to fetch
+                    let duration = start.distance(to: .now())
+                    delegate?.emit { $0.didFetch(package: package, version: version, result: .success(result), duration: duration) }
+                } catch {
+                    let duration = start.distance(to: .now())
+                    delegate?.emit { $0.didFetch(package: package, version: version, result: .failure(error), duration: duration) }
+                    throw error
+                }
+                return packagePath
+            }
+
+            pendingLookups[lookupId] = lookupTask
+            return lookupTask
         }
         return try await task.value
     }

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -130,43 +130,40 @@ public class RepositoryManager: Cancellable {
         observabilityScope: ObservabilityScope
     ) async throws -> RepositoryHandle {
         return try await self.asyncOperationQueue.withOperation {
-            let task = await withCheckedContinuation { continuation in
-                self.pendingLookups.withLock { pendingLookups in
-                    // Identifies this lookup so that, on completion, it only removes
-                    // its own entry from `pendingLookups`.
-                    let lookupID = UUID()
-                    let inFlight = pendingLookups[repositorySpecifier]?.task
+            let task = self.pendingLookups.withLock { pendingLookups -> Task<RepositoryManager.RepositoryHandle, Error> in
+                // Identifies this lookup so that, on completion, it only removes its own entry from `pendingLookups`.
+                let lookupID = UUID()
+                let inFlight = pendingLookups[repositorySpecifier]?.task
 
-                    // Serialize lookups per repository, but each caller runs its own `performLookup` to honor its own `updateStrategy`.
-                    let lookupTask = Task { () throws -> RepositoryManager.RepositoryHandle in
-                        defer { self.removePendingLookup(for: repositorySpecifier, id: lookupID) }
+                // Serialize lookups per repository, but each caller runs its own `performLookup` to honor its own `updateStrategy`.
+                let lookupTask = Task { () throws -> RepositoryManager.RepositoryHandle in
+                    defer { self.removePendingLookup(for: repositorySpecifier, id: lookupID) }
 
-                        // Let the existing in-flight task finish before queuing up the new one
-                        if let inFlight {
-                            _ = try? await inFlight.value
-                        }
-
-                        if Task.isCancelled {
-                            throw CancellationError()
-                        }
-
-                        let result = try await self.performLookup(
-                            package: package,
-                            repository: repositorySpecifier,
-                            updateStrategy: updateStrategy,
-                            observabilityScope: observabilityScope
-                        )
-
-                        if Task.isCancelled {
-                            throw CancellationError()
-                        }
-
-                        return result
+                    // Let the existing in-flight task finish before queuing up the new one
+                    if let inFlight {
+                        _ = try? await inFlight.value
                     }
 
-                    pendingLookups[repositorySpecifier] = (id: lookupID, task: lookupTask)
-                    continuation.resume(returning: lookupTask)
+                    if Task.isCancelled {
+                        throw CancellationError()
+                    }
+
+                    let result = try await self.performLookup(
+                        package: package,
+                        repository: repositorySpecifier,
+                        updateStrategy: updateStrategy,
+                        observabilityScope: observabilityScope
+                    )
+
+                    if Task.isCancelled {
+                        throw CancellationError()
+                    }
+
+                    return result
                 }
+
+                pendingLookups[repositorySpecifier] = (id: lookupID, task: lookupTask)
+                return lookupTask
             }
 
             return try await task.value


### PR DESCRIPTION
`RegistryDownloadsManager.lookup` and `RepositoryManager.lookup` both wrapped a `Mutex.withLock` in `withCheckedContinuation` and then resumed the continuation inside the lock.

This is a common way to end up with deadlocked code. The code that runs after the continuation is resumed but before the lock is released can end up trying to acquire the same lock again, which will deadlock.

The section inside `withCheckedContinuation` was already synchronous, so the continuation wasn't even required. We can just return the value directly from `withLock` directly.