### PR TITLE
Port the docs for module maps to the 6.4.x release branch

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/Documentation.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Documentation.md
@@ -20,25 +20,36 @@ The Swift Package Manager lets you share your code as a package, depend on and u
 - <doc:IntroducingPackages>
 - <doc:PackageSecurity>
 
-### Guides
+### Building Packages
 
 - <doc:CreatingSwiftPackage>
 - <doc:SettingSwiftToolsVersion>
-- <doc:AddingDependencies>
-- <doc:ResolvingPackageVersions>
-- <doc:CreatingCLanguageTargets>
 - <doc:UsingBuildConfigurations>
 - <doc:SwiftVersionSpecificPackaging>
 - <doc:BundlingResources>
 - <doc:ReleasingPublishingAPackage>
 - <doc:GeneratingSBOMs>
 - <doc:ContinuousIntegration>
-- <doc:Plugins>
-- <doc:ModuleAliasing>
-- <doc:UsingSwiftPackageRegistry>
-- <doc:PackageCollections>
 - <doc:UsingShellCompletion>
+
+### Depedencies
+- <doc:AddingDependencies>
+- <doc:UsingSwiftPackageRegistry>
+- <doc:BundlingResources>
+
+### Targets
+- <doc:CreatingCLanguageTargets>
+- <doc:ModuleMaps>
+- <doc:ModuleAliasing>
+
+### Sharing Packages
+- <doc:ReleasingPublishingAPackage>
+- <doc:PackageCollections>
+
+### Extending Package Manager
+- <doc:Plugins>
 - <doc:SwiftPMAsALibrary>
+
 
 <!-- ### Command Plugins -->
 <!-- placeholder for content about swift package manager extensions - command plugins -->

--- a/Sources/PackageManagerDocs/Documentation.docc/ModuleMaps/DebuggingModuleMaps.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/ModuleMaps/DebuggingModuleMaps.md
@@ -1,0 +1,87 @@
+# Debugging Module Maps
+
+Diagnose and resolve issues when Swift can't import your C or C++ libraries.
+
+## Overview
+
+When you create module maps for C libraries, compilation errors or import failures indicate problems with your configuration.
+This article shows you how to test module maps and fix common issues.
+
+Use these techniques when:
+
+- Swift can't find your module
+- Headers fail to import
+- C++ code produces compilation errors
+- You need to verify Swift Package Manager configures your module correctly
+
+## Test your module map
+
+Verify that Swift can import your module before distributing it.
+
+### Create a simple import test
+
+Create a test Swift file that imports your module:
+
+```swift
+// test.swift
+import MyLibrary
+
+print("Module imported successfully")
+```
+
+Build the test file:
+
+```bash
+swiftc -I path/to/module/directory test.swift
+```
+
+If the module map has errors, the compiler produces diagnostic messages that indicates what's wrong.
+
+### Verify build configuration
+
+Use verbose output to verify Swift Package Manager configures your module correctly:
+
+```bash
+swift build --verbose
+```
+
+Look for these compiler flags in the output:
+
+- `-I` flags pointing to your header directories
+- `-fmodule-map-file=` flags pointing to your module map
+- Link flags for binary libraries
+
+## Resolve common issues
+
+When Swift can't find your module or headers, check these common causes.
+
+### Fix module name mismatches
+
+Verify the module name in the module map matches the artifact or target name.
+
+If Swift can't find your module, verify:
+
+- The module name in the module map matches the artifact or target name exactly.
+- The module map file is named `module.modulemap`.
+- The `moduleMapPath` in info.json points to the correct file.
+- For system libraries, the target directory contains the module map.
+
+### Locate missing headers
+
+Verify header paths and file locations when the compiler reports missing headers.
+
+If the compiler reports a missing header:
+
+- Check that the header path in the module map is relative to the module map file.
+- Verify the header file exists at the specified location.
+- Ensure the `headerPaths` array in info.json includes the directory.
+
+### Fix C++ compilation errors
+
+Add C++ language support directives to resolve C++ syntax errors.
+
+If you get errors about C++ syntax:
+
+- Add `requires cplusplus` to your module map.
+- For C++11 or later features, use `requires cplusplus11`.
+- Verify your headers use appropriate `#ifdef __cplusplus` guards for mixed C/C++ code.

--- a/Sources/PackageManagerDocs/Documentation.docc/ModuleMaps/ModuleMapReference.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/ModuleMaps/ModuleMapReference.md
@@ -1,0 +1,565 @@
+# Module Map Syntax Reference
+
+A reference of module map directives, attributes, and syntax for defining C and C++ module interfaces.
+
+## Overview
+
+Module maps use a domain-specific language to describe how C, Objective-C, and C++ headers are organized into modules.
+This reference documents the syntax and semantics of module map declarations.
+
+For instructions on creating module maps, see <doc:ModuleMaps>.
+For troubleshooting and testing module maps, see <doc:DebuggingModuleMaps>.
+
+The [Clang Modules documentation](https://clang.llvm.org/docs/Modules.html) is the official specification for module maps.
+The content below summarizes that reference for common Swift use cases.
+
+## Module declarations
+
+A module declaration defines a named module and specifies its contents.
+
+### Basic syntax
+
+```
+module ModuleName {
+    declarations
+}
+```
+
+The module name must be a valid identifier.
+It can contain letters, numbers, and underscores, but can't start with a number.
+The module name must match the product or target name in Swift Package Manager.
+
+### Framework modules
+
+<!-- REVIEWER QUESTION - Is this section relevant outside of Apple? -->
+
+Framework modules use a specialized syntax for macOS and iOS frameworks:
+
+```
+framework module FrameworkName {
+    umbrella header "FrameworkName.h"
+    export *
+    module * { export * }
+}
+```
+
+The `framework` keyword indicates the module represents a framework bundle.
+The `module * { export * }` pattern automatically creates and exports submodules for all headers.
+
+### Explicit submodules
+
+Submodules divide a module into smaller units:
+
+```
+module ParentModule {
+    explicit module SubmoduleA {
+        header "SubA.h"
+        export *
+    }
+
+    explicit module SubmoduleB {
+        header "SubB.h"
+        export *
+    }
+}
+```
+
+The `explicit` keyword requires clients to explicitly import the submodule.
+Code imports explicit submodules with `import ParentModule.SubmoduleA`.
+
+Without the `explicit` keyword, the submodule is imported automatically when the parent module is imported.
+
+### Header declarations
+
+Header declarations specify which header files belong to a module.
+
+#### header
+
+Includes a header file in the module:
+
+```
+header "HeaderName.h"
+```
+
+The path is relative to the module map file's location.
+The compiler parses the header and makes its declarations available when the module is imported.
+
+<!-- REVIEWER QUESTION - Examples all seem to line up with a single header import, but it looks like you *could* list more than one, assuming there weren't overlaps or such. What are the actual constraints on importing multiple different headers in your library exposes more than one? -->
+
+#### umbrella header
+
+Includes a header that itself includes all other public headers:
+
+```
+umbrella header "ModuleName.h"
+```
+
+Umbrella headers provide a single entry point for all module functionality.
+The header typically includes all other public headers with `#include` directives.
+
+#### private header
+
+Includes a header that's only visible within the module implementation:
+
+```
+private header "InternalAPI.h"
+```
+
+Private headers aren't visible to clients that import the module.
+Use private headers for implementation details that other files within the module need to access.
+
+#### textual header
+
+Includes a header that's textually included rather than compiled as part of the module:
+
+```
+textual header "Macros.h"
+```
+
+Textual headers are typically used for macro-only headers or headers that can't be parsed in isolation.
+The compiler includes the header's contents directly into each translation unit rather than precompiling it as part of the module.
+
+#### exclude header
+
+Explicitly excludes a header from an umbrella:
+
+```
+umbrella header "Module.h"
+exclude header "Internal.h"
+```
+
+When using an umbrella header that includes files you don't want in the module, use `exclude header` to omit specific headers.
+
+#### umbrella directory
+
+Includes all headers in a directory:
+
+```
+umbrella "include"
+```
+
+The compiler includes all headers found in the specified directory and its subdirectories.
+This is less common than umbrella headers because it provides less control over which headers are public.
+
+### Export declarations
+
+Export declarations control which modules are re-exported to clients.
+
+#### export *
+
+Re-exports all imported modules:
+
+```
+export *
+```
+
+When a client imports your module, they also see declarations from modules your module imports.
+This is the most common export pattern for C libraries.
+
+#### Selective exports
+
+Re-exports specific modules:
+
+```
+module MyModule {
+    header "MyModule.h"
+    export Foundation
+    export Darwin
+}
+```
+
+Only the specified modules are visible to clients.
+Modules imported but not exported remain private implementation details.
+
+### Link declarations
+
+Link declarations specify libraries the linker should include.
+
+#### Basic syntax
+
+```
+link "libraryname"
+```
+
+Specify the library name without the `lib` prefix or file extension.
+For example, use `link "z"` for `libz.a` or `libz.dylib`.
+
+The build system passes this information to the linker automatically.
+
+#### Framework links
+
+<!-- REVIEWER QUESTION - Is this section relevant outside of Apple? -->
+
+For macOS and iOS frameworks:
+
+```
+link framework "FrameworkName"
+```
+
+This tells the linker to link against the specified framework.
+
+### Requirements
+
+Requirements specify conditions that must be met for the module to be available.
+
+#### Language requirements
+
+- term cplusplus: Requires C++ language support
+- term cplusplus11: Requires C++11 or later
+- term cplusplus14: Requires C++14 or later
+- term cplusplus17: Requires C++17 or later
+- term cplusplus20: Requires C++20 or later
+- term objc: Requires Objective-C language support
+- term opencl: Requires OpenCL support
+
+Example:
+
+```
+module CppLibrary {
+    header "CppLibrary.h"
+    requires cplusplus11
+    export *
+}
+```
+
+The compiler rejects the module if the build doesn't satisfy the requirements.
+
+#### Feature requirements
+
+- term blocks: Requires blocks (closures) support
+- term gnuinlineasm: Requires GNU inline assembly support
+
+Use the negation operator to exclude features:
+
+```
+requires !gnuinlineasm
+```
+
+#### Combining requirements
+
+Combine multiple requirements with commas:
+
+```
+requires cplusplus, !blocks
+```
+
+All requirements must be satisfied for the module to be available.
+
+### Module attributes
+
+Attributes modify module behavior and semantics.
+
+#### [system]
+
+<!-- REVIEWER QUESTION - Is this section relevant outside of Apple? -->
+
+Marks a module as a system module:
+
+```
+module SystemLibrary [system] {
+    header "system.h"
+    export *
+}
+```
+
+System modules receive special treatment:
+
+- Compiler warnings in system headers are suppressed
+- Swift imports certain Objective-C types differently (`NSUInteger` becomes `Int` instead of `UInt`)
+- The attribute ensures consistent behavior between local builds and client builds
+
+Use `[system]` for SDK-provided libraries and system headers.
+
+#### [extern_c]
+
+Indicates C linkage for C++ code:
+
+```
+module [extern_c] CLibrary {
+    header "clib.h"
+    export *
+}
+```
+
+This is useful when wrapping C libraries in C++ contexts.
+
+#### [no_undeclared_includes]
+
+Prevents implicit inclusion of headers:
+
+```
+module StrictModule [no_undeclared_includes] {
+    header "StrictModule.h"
+    export *
+}
+```
+
+Clients must explicitly import all modules they use.
+This makes dependencies explicit and prevents accidental reliance on transitive includes.
+
+### Configuration macros
+
+Configuration macros allow different module variants based on preprocessor definitions.
+
+#### config_macros
+
+Declares macros that affect the module's interface:
+
+```
+module ConfigurableModule {
+    header "ConfigurableModule.h"
+    config_macros exhaustive DEBUG_MODE, FEATURE_X
+    export *
+}
+```
+
+The `exhaustive` keyword lists all macros that affect the module's API.
+The compiler creates separate module variants for different macro combinations.
+
+Without configuration macros declared, the compiler assumes the module's interface is independent of preprocessor state.
+
+### Conflict declarations
+
+Conflict declarations specify incompatible modules.
+
+#### conflict
+
+Declares that a module conflicts with another:
+
+```
+module NewModule {
+    header "NewModule.h"
+    conflict OldModule, "Use NewModule instead"
+    export *
+}
+```
+
+The compiler produces an error if both modules are imported in the same translation unit.
+The message explains why the modules conflict, and what to do instead.
+
+### Extern modules
+
+Extern modules reference module maps in other files.
+
+#### extern module
+
+References a module defined in another module map:
+
+```
+extern module ExternalModule "path/to/other.modulemap"
+```
+
+This allows organizing large module hierarchies across multiple files.
+The path is relative to the current module map file.
+
+### Use declarations
+
+Use declarations specify dependencies between modules.
+
+#### use
+
+Declares that a module depends on another:
+
+```
+module DependentModule {
+    header "DependentModule.h"
+    use Foundation
+    export *
+}
+```
+
+This is informational and helps document module dependencies.
+Most module maps don't need explicit `use` declarations.
+
+## Complete syntax example
+
+A comprehensive module map demonstrating multiple features:
+
+```
+module CompleteExample [system] {
+    // Main module
+    umbrella header "CompleteExample.h"
+    export *
+
+    // Configuration
+    config_macros exhaustive DEBUG, LOGGING_ENABLED
+
+    // Linking
+    link "example"
+
+    // Requirements
+    requires !gnuinlineasm
+
+    // Explicit submodule
+    explicit module Utilities {
+        header "Utilities.h"
+        export *
+    }
+
+    // Private implementation submodule
+    explicit module Private {
+        private header "CompleteExample_Private.h"
+        export *
+    }
+
+    // C++ submodule
+    explicit module CPP {
+        header "CompleteExample_CPP.hpp"
+        requires cplusplus11
+        export *
+    }
+}
+
+// Backward compatibility module
+module CompleteExampleOld {
+    header "CompleteExample_Old.h"
+    conflict CompleteExample, "Use CompleteExample instead of CompleteExampleOld"
+    export *
+}
+```
+
+## Module map file naming
+
+Module map files must follow specific naming conventions:
+
+- term module.modulemap: Standard public module map
+- term module.private.modulemap: Private module map for implementation details
+
+Swift Package Manager looks for `module.modulemap` by default.
+
+### System library wrapper
+
+```
+module SystemLib [system] {
+    header "shim.h"
+    link "systemlib"
+    export *
+}
+```
+
+The shim header includes the actual system header, allowing the compiler to find it through search paths.
+
+### C++ library
+
+```
+module CppLib {
+    header "CppLib.hpp"
+    requires cplusplus11
+    export *
+}
+```
+
+The `requires cplusplus11` directive ensures the module is only available in C++11 mode or later.
+
+### Framework with submodules
+
+```
+framework module MyFramework {
+    umbrella header "MyFramework.h"
+    export *
+    module * { export * }
+
+    explicit module Private {
+        private header "MyFramework_Private.h"
+        export *
+    }
+}
+```
+
+Public headers are automatically modularized, while private headers require explicit import.
+
+### Multiple libraries
+
+```
+module CompositeLib {
+    module Core {
+        header "Core.h"
+        link "core"
+        export *
+    }
+
+    module Utils {
+        header "Utils.h"
+        link "utils"
+        export *
+    }
+}
+```
+
+Each submodule can link to its own library.
+
+## Diagnostic directives
+
+Module maps don't support preprocessor directives like `#if` or `#ifdef`.
+All content in a module map is always active.
+
+To handle platform-specific headers, use separate module maps for each platform or use requirements:
+
+```
+module CrossPlatform {
+    // Common headers
+    header "Common.h"
+
+    // Platform-specific via requirements
+    module Darwin {
+        requires objc
+        header "Darwin.h"
+        export *
+    }
+
+    export *
+}
+```
+
+## Module map parsing
+
+The compiler parses module maps with these characteristics:
+
+- Comments use C++ style (`//`) or C style (`/* */`).
+- Identifiers follow C naming rules (letters, digits, underscores).
+- String literals use double quotes.
+- Paths in string literals are relative to the module map file.
+- Whitespace is insignificant outside string literals.
+- Module map files must be valid UTF-8.
+
+## Limitations and constraints
+
+Module maps have several limitations:
+
+- Module names can't contain periods (use submodules instead).
+- Header paths must be relative to the module map file.
+- Circular dependencies between modules aren't supported.
+- Conditional compilation directives aren't supported in module maps.
+- Module maps assume headers are well-formed and can be parsed in isolation.
+
+## Integration with Swift Package Manager
+
+Swift Package Manager uses module maps to bridge C and C++ libraries:
+
+- The `moduleMapPath` field in artifact bundles specifies the module map location.
+- System library targets place module maps in the target directory.
+- The build system automatically adds `-fmodule-map-file=` flags.
+- Module names must match binary target or system library target names.
+
+For instructions on creating a module map, see <doc:ModuleMaps>.
+
+## Best practices
+
+Follow these practices when writing module maps:
+
+- Use `[system]` for SDK and system library modules.
+- Specify `requires cplusplus` for any C++ code.
+- Use umbrella headers for multi-header libraries.
+- Keep module names simple and descriptive.
+- Match module names to artifact names exactly.
+- Use relative paths for all header references.
+- Document configuration macros with `exhaustive`.
+- Test module maps on all target platforms.
+- Use explicit submodules for optional functionality.
+- Keep module maps minimal and focused.
+
+## See Also
+
+- [Clang Modules Documentation](https://clang.llvm.org/docs/Modules.html)
+- <doc:DebuggingModuleMaps>
+

--- a/Sources/PackageManagerDocs/Documentation.docc/ModuleMaps/ModuleMaps.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/ModuleMaps/ModuleMaps.md
@@ -1,0 +1,223 @@
+# Creating Module Maps
+
+Define how C and C++ headers are exposed to Swift for system library targets, precompiled libraries, or C Language targets.
+
+## Overview
+
+Module maps bridge C and C++ libraries with Swift code.
+They define how the Clang module system organizes headers so Swift can import them.
+When you wrap a C library for use in Swift Package Manager, you create a module map that describes the library's public interface.
+
+Create a module map when you:
+
+- Wrap a C or C++ library for Swift Package Manager.
+- Define a system library target that references pre-installed libraries.
+- Package a binary library in an artifact bundle.
+- Need to control which headers Swift can import.
+
+Swift Package Manager automatically configures the build system when it finds your module map:
+
+- Adds the module map to compiler search paths.
+- Configures header include directories.
+- Links binary libraries specified in the module map.
+- Selects platform-specific variants from artifact bundles.
+
+You don't need to manually configure compiler flags or search paths.
+
+This article shows you how to create module maps for libraries you're wrapping.
+For complete syntax details, see <doc:ModuleMapReference>.
+To diagnose import failures and compilation errors, see <doc:DebuggingModuleMaps>.
+
+### Create a basic module map
+
+To show how to create a module map, this example starts with a simple module map that exposes a single header.
+
+Create a file named `module.modulemap` in your library's include directory:
+
+```
+module MyLibrary {
+    header "MyLibrary.h"
+    export *
+}
+```
+
+This module map defines a module named `MyLibrary` that includes one header file.
+The `export *` directive makes all symbols from the header available to code that imports the module.
+
+#### Use relative paths for headers
+
+Specify header paths relative to the module map file's location.
+If your module map is in `include/module.modulemap`, the header directive `header "MyLibrary.h"` looks for `include/MyLibrary.h`.
+
+Don't use absolute paths or parent directory references (`../`) when referencing headers.
+Relative paths ensure your module map works across different systems and build configurations.
+
+#### Match the module name to your artifact
+
+The module name in your module map must match the artifact name in Swift Package Manager.
+If your Package.swift defines a binary target named `MyLibrary`, your module map must declare `module MyLibrary`.
+
+When you use the functions exposed in a module map in Swift, you get access to them using `import`.
+For the example above, use the following to access the C functions you exposed in the module map:
+
+```swift
+import MyLibrary
+```
+
+### Create a module map for C++
+
+C++ libraries require an additional directive to enable C++ language support.
+Add the `requires cplusplus` directive to your module map:
+
+```
+module MyCppLibrary {
+    header "MyCppLibrary.h"
+    requires cplusplus
+    export *
+}
+```
+
+Without this directive, the compiler treats the header as C code and produces errors when it encounters C++ syntax.
+
+You can require a specific C++ standard version:
+
+```
+module ModernCppLibrary {
+    header "ModernCppLibrary.h"
+    requires cplusplus11
+    export *
+}
+```
+
+Use `cplusplus11` for C++11 or later.
+The compiler rejects the module if the build doesn't enable the required C++ standard.
+
+### Organize multiple headers with umbrella headers
+
+When your library has multiple headers, use an umbrella header to include them all.
+
+Create a main header file that includes your other headers:
+
+```c
+// MyLibrary.h
+#ifndef MYLIBRARY_H
+#define MYLIBRARY_H
+
+#include "Core.h"
+#include "Utils.h"
+#include "Types.h"
+
+#endif
+```
+
+Then reference it in your module map with the `umbrella header` directive:
+
+```
+module MyLibrary {
+    umbrella header "MyLibrary.h"
+    export *
+}
+```
+
+The umbrella header pattern is common for libraries with multiple public headers.
+It provides a single include point for all functionality and clearly defines the public API.
+
+### Mark system libraries
+
+<!-- REVIEWER QUESTION - Is this commonly used, or should we leave this to reference content? -->
+
+When wrapping system libraries (libraries that are built in or pre-installed on the system), add the `[system]` attribute:
+
+```
+module SystemLib [system] {
+    header "systemlib.h"
+    link "systemlib"
+    export *
+}
+```
+
+The `[system]` attribute ensures consistent behavior between local builds and client builds.
+It affects how Swift imports certain Objective-C types, particularly `NSUInteger`, which maps to `Int` for system modules and `UInt` for non-system modules.
+
+<!-- REVIEWER QUESTION - Is this section relevant outside of Apple exposing internal libraries? -->
+
+### Link binary libraries
+
+<!-- REVIEWER QUESTION - Is this commonly used, or should we leave this to reference content? -->
+
+Use the `link` directive to specify libraries the linker should include:
+
+```
+module ZLib [system] {
+    header "zlib.h"
+    link "z"
+    export *
+}
+```
+
+Swift Package Manager passes this information to the linker automatically.
+You specify the library name without the `lib` prefix or file extension.
+For example write `"z"` for `libz.a` or `libz.dylib`.
+
+<!-- REVIEWER QUESTION - keep the example that shows dylib or drop it? -->
+
+### Add a module map to a system library target
+
+Create a system library target when you wrap a library that users install separately on their systems.
+The common convention for exposing system libraries is to prefix the name of the library with `C`.
+This allows you to create a Swift module with the name of the C library that provides a more idiomatic Swift interface. 
+
+#### Create the target directory
+
+Make a directory for your system library target in your package's root:
+
+```bash
+mkdir -p SystemLibraries/CSystemLib
+```
+
+#### Create the module map file
+
+Add a `module.modulemap` file in the target directory:
+
+```
+module CSystemLib [system] {
+    header "shim.h"
+    link "systemlib"
+    export *
+}
+```
+
+#### Create a shim header
+
+Add a shim header that includes the actual system header:
+
+```c
+// shim.h
+#include <systemlib.h>
+```
+
+The shim header allows the compiler to find the actual header through search paths, avoiding hardcoded absolute paths that break portability.
+
+#### Declare the target
+
+Add a system library target to your Package.swift:
+
+```swift
+.systemLibrary(
+    name: "CSystemLib",
+    pkgConfig: "systemlib",
+    providers: [
+        .apt(["libsystemlib-dev"]),
+        .brew(["systemlib"])
+    ]
+)
+```
+
+Users who build your package need to install the library first.
+The package manager uses `pkg-config` to locate the library and configure search paths.
+
+## Topics
+
+- <doc:ModuleMapReference>
+- <doc:DebuggingModuleMaps>
+


### PR DESCRIPTION
back-ports the module maps documentation from the `main` branch for Swift Package Manager documentation to the 6.4.x release branch for versioned content.

### Motivation:

With the docs.swift.org site, there's now a distinction between latest `main` content and latest release, the the 6.4 release (built from `release/6.4.x` being used to present that content). This back-ports docs that aren't specific to main features (about module maps and how to use them) so that they're reflected in the latest release docs.

### Modifications:

Backport cherry pick of 71363ff8f

### Result:

module maps will be included in latest release docs:
```
https://docs.swift.org/latest/documentation/packagemanagerdocs/modulemaps/
```
