### PR TITLE
[🍒6.4.1] Fix infinite loop in pub grub when repairing decision node (#10479)

### DIFF
--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -74,10 +74,11 @@ public struct PubGrubDependencyResolver {
                         let identity = package.package.identity
                         let previousDecisionEnabledTraits = self.enabledTraitsMap[identity]
                         self.enabledTraitsMap[identity] = package.enabledTraits
+                        let currentEnabledTraits = self.enabledTraitsMap[identity]
                         // If a decision has already been made for this package but a change in enabled traits
                         // is detected, flag it so the resolver can repair the shape of the package graph below
                         // it (if applicable due to trait-guarded dependencies).
-                        if !package.enabledTraits.isSubset(of: previousDecisionEnabledTraits)
+                        if !currentEnabledTraits.isSubset(of: previousDecisionEnabledTraits)
                         {
                             self.decisionsToRepair.formUnion(self.solution.decisions(for: identity))
                         }
@@ -546,9 +547,6 @@ public struct PubGrubDependencyResolver {
             // initiate prefetch of known packages that will be used to make the decision on the next step
             self.provider.prefetch(containers: state.solution.undecided.map(\.node.package))
 
-            // If decision making determines that no more decisions are to be
-            // made, it returns nil to signal that version solving is done.
-
             // Ensure that decisions that need repairing are prioritized.
             if let repairNode = state.decisionsToRepair.popFirst(),
                let version = state.solution.decisions[repairNode] {
@@ -566,6 +564,8 @@ public struct PubGrubDependencyResolver {
                     state.addIncompatibility(incompatibility, at: .decisionMaking)
                 }
             } else {
+                // If decision making determines that no more decisions are to be
+                // made, it returns nil to signal that version solving is done.
                 next = try await self.makeDecision(state: state)
             }
         }

--- a/Sources/PackageModel/EnabledTrait.swift
+++ b/Sources/PackageModel/EnabledTrait.swift
@@ -85,9 +85,8 @@ public struct EnabledTraitsMap {
         var map: [Version: EnabledTraits] = [:]
 
         /// Returns the named traits explicitly recorded for this version, or `nil` if none have
-        /// been recorded for it yet. Unlike the old `at(_:)`, this never substitutes a fallback
-        /// sentinel, so callers can distinguish "nothing recorded" from "recorded as empty".
-        public func namedTraits(at version: Version) -> EnabledTraits? {
+        /// been recorded for it yet.
+        public func traits(at version: Version) -> EnabledTraits? {
             self.map[version]
         }
 
@@ -134,7 +133,8 @@ public struct EnabledTraitsMap {
         ///
         /// Priority:
         /// 1. Explicit named traits, if any, always win outright - an explicit selection by any
-        ///    parent must override other parents' mere requests for defaults.
+        ///    parent must be unioned with other parents' request for defaults (whether implicit or explicit).
+        ///    At this stage, default traits will have been flattened out into a list of explicit traits.
         /// 2. Otherwise, if any parent requested defaults (explicitly, or implicitly by not
         ///    specifying traits), that request wins over a coexisting disabler: disablers and
         ///    default-setters are meant to coexist, with the default-setter's request winning if
@@ -173,7 +173,7 @@ public struct EnabledTraitsMap {
             }
 
             let state = self.storage.get()
-            let named = state.versionedTraits[identity]?.namedTraits(at: version)
+            let named = state.versionedTraits[identity]?.traits(at: version)
             return state.resolvedExplicitTraits(named: named, for: identity) ?? .defaults
         }
         set {

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -304,6 +304,69 @@ final class PubGrubTests: XCTestCase {
         ])
     }
 
+    /// Reproduces the mismatch that used to make `addIncompatibility` perpetually flag an
+    /// already-decided package for repair: `d` is reached by one edge that explicitly names a real
+    /// trait (`Trait1`, e.g. from `a`'s manifest naming it directly) and, separately, by an edge
+    /// that only ever requests the implicit `default` trait (e.g. from a manifest dependency with
+    /// no `traits:` at all).
+    func testResolverAddIncompatibilityDoesNotRepairDecisionForImplicitDefaultTraitEdge() async throws {
+        let dRef: PackageReference = "d"
+        let namedTraitNode = DependencyResolutionNode.product(
+            "d", package: dRef,
+            enabledTraits: EnabledTraits(["Trait1"], setBy: .package("a"))
+        )
+        // No `enabledTraits:` provided - this is the literal, unresolved `["default"]` value that a
+        // manifest dependency with no `traits:` at all produces.
+        let implicitDefaultNode = DependencyResolutionNode.product("d", package: dRef)
+
+        let state = PubGrubDependencyResolver.State(root: rootNode)
+
+        // `a` explicitly names `Trait1` on `d`, and `d` gets decided on the strength of that edge.
+        state.addIncompatibility(try Incompatibility(Term(namedTraitNode, .exact(v1)), root: rootNode), at: .topLevel)
+        state.decide(namedTraitNode, at: v1)
+        XCTAssertTrue(state.decisionsToRepair.isEmpty)
+
+        // Some other, unrelated edge to `d` (e.g. a transitively-discovered manifest dependency with
+        // no `traits:`) gets processed - repeatedly, as would happen if that edge's owning package
+        // were re-decided across backtracking. Nothing about `d`'s actual trait requirements ever
+        // changes, so this must never flag `d`'s decision for repair.
+        for _ in 0 ..< 25 {
+            state.addIncompatibility(try Incompatibility(Term(implicitDefaultNode, .exact(v1)), root: rootNode), at: .topLevel)
+        }
+
+        XCTAssertTrue(
+            state.decisionsToRepair.isEmpty,
+            "d's already-made decision was incorrectly flagged for repair by an implicit-default edge that never changed anything."
+        )
+    }
+
+    /// Check for the fix above: a *genuinely new* named trait request for an already-decided
+    /// package must still flag it for repair - the fix should stop false positives without silencing
+    /// real ones.
+    func testResolverAddIncompatibilityStillRepairsDecisionForGenuinelyNewTrait() async throws {
+        let dRef: PackageReference = "d"
+        let namedTraitNode = DependencyResolutionNode.product(
+            "d", package: dRef,
+            enabledTraits: EnabledTraits(["Trait1"], setBy: .package("a"))
+        )
+        let secondNamedTraitNode = DependencyResolutionNode.product(
+            "d", package: dRef,
+            enabledTraits: EnabledTraits(["Trait2"], setBy: .package("b"))
+        )
+
+        let state = PubGrubDependencyResolver.State(root: rootNode)
+
+        state.addIncompatibility(try Incompatibility(Term(namedTraitNode, .exact(v1)), root: rootNode), at: .topLevel)
+        state.decide(namedTraitNode, at: v1)
+        XCTAssertTrue(state.decisionsToRepair.isEmpty)
+
+        // `b` explicitly names a *different* real trait on `d` - this genuinely widens what's
+        // enabled and must still trigger a repair.
+        state.addIncompatibility(try Incompatibility(Term(secondNamedTraitNode, .exact(v1)), root: rootNode), at: .topLevel)
+
+        XCTAssertEqual(state.decisionsToRepair, [namedTraitNode])
+    }
+
     func testUpdatePackageIdentifierAfterResolution() async throws {
         let fooURL = SourceControlURL("https://example.com/foo")
         let fooRef = PackageReference.remoteSourceControl(identity: PackageIdentity(url: fooURL), url: fooURL)


### PR DESCRIPTION
Cherry-pick of #10479 

Ensure that when comparing against enabled traits state for a decided dependency node, SwiftPM fetches from the enabled traits map rather than directly from the `DependencyResolutionNode` itself. This is due to the fact that the map is set up to handle special "default" trait cases.
