### PR TITLE
More granular file tracking for BSP package reload operations

### DIFF
--- a/Sources/SwiftBuildSupport/CMakeLists.txt
+++ b/Sources/SwiftBuildSupport/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(SwiftBuildSupport
   PackagePIFProjectBuilder+Products.swift
   PIF.swift
   PIFBuilder.swift
+  PIFGenerationInputs.swift
   PluginConfiguration.swift
   SwiftBuildSystem.swift
   SwiftBuildSystemMessageHandler.swift)

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -30,6 +30,7 @@ import enum SwiftBuild.ProjectModel
 public struct PIFGenerationResult {
     public var pif: String
     public var accompanyingMetadata: [PackagePIFBuilder.ModuleOrProduct]
+    public var inputs: PIFGenerationInputs
 }
 
 fileprivate func memoize<T>(to cache: inout T?, build: () async throws -> T) async rethrows -> T {
@@ -194,7 +195,16 @@ public final class PIFBuilder {
             throw PIFGenerationError.printedPIFManifestGraphviz
         }
 
-        return PIFGenerationResult(pif: pifString, accompanyingMetadata: modulesAndProducts)
+        return PIFGenerationResult(
+            pif: pifString,
+            accompanyingMetadata: modulesAndProducts,
+            inputs: PIFGenerationInputs(
+                graph: self.graph,
+                modulesAndProducts: modulesAndProducts,
+                pluginWorkingDirectory: self.parameters.pluginWorkingDirectory,
+                pkgConfigDirectories: self.parameters.pkgConfigDirectories
+            )
+        )
     }
 
     private var cachedPIF: (PIF.TopLevelObject, [PackagePIFBuilder.ModuleOrProduct])?

--- a/Sources/SwiftBuildSupport/PIFGenerationInputs.swift
+++ b/Sources/SwiftBuildSupport/PIFGenerationInputs.swift
@@ -1,0 +1,107 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageGraph
+import PackageLoading
+import PackageModel
+
+public struct PIFGenerationInputs: Sendable {
+    private var watchedDirectoryStructures: Set<AbsolutePath>
+    private var watchedFiles: Set<AbsolutePath>
+    private var watchedPackageRootDirectories: Set<AbsolutePath>
+
+    package init(
+        watchedDirectories: Set<AbsolutePath>,
+        watchedFiles: Set<AbsolutePath>,
+        watchedPackageRootDirectories: Set<AbsolutePath>
+    ) {
+        self.watchedDirectoryStructures = watchedDirectories
+        self.watchedFiles = watchedFiles
+        self.watchedPackageRootDirectories = watchedPackageRootDirectories
+    }
+
+    package func creationOrDeletionAffectsPIF(_ path: AbsolutePath) -> Bool {
+        if self.modificationAffectsPIF(path) {
+            return true
+        }
+        return self.watchedDirectoryStructures.contains { path.isDescendantOfOrEqual(to: $0) }
+    }
+
+    package func modificationAffectsPIF(_ path: AbsolutePath) -> Bool {
+        if self.watchedFiles.contains(path) {
+            return true
+        }
+        return self.watchedPackageRootDirectories.contains(path.parentDirectory) && Self.isManifestFileName(path.basename)
+    }
+
+    private static let versionSpecificManifestRegex = #/^Package@swift-(\d+)(?:\.(\d+))?(?:\.(\d+))?\.swift$/#
+    private static func isManifestFileName(_ name: String) -> Bool {
+        name == Manifest.filename || name.wholeMatch(of: versionSpecificManifestRegex) != nil
+    }
+
+    private static let predefinedTargetDirectories: Set<String> = Set(
+        PackageBuilder.predefinedSourceDirectories
+            + PackageBuilder.predefinedTestDirectories
+            + PackageBuilder.predefinedPluginDirectories
+    )
+
+    public static func fallbackInputs(packageRoot: AbsolutePath) -> PIFGenerationInputs {
+        PIFGenerationInputs(
+            watchedDirectories: [packageRoot],
+            watchedFiles: [packageRoot.appending("Package.resolved")],
+            watchedPackageRootDirectories: [packageRoot]
+        )
+    }
+
+    package init(
+        graph: ModulesGraph,
+        modulesAndProducts: [PackagePIFBuilder.ModuleOrProduct],
+        pluginWorkingDirectory: AbsolutePath,
+        pkgConfigDirectories: [AbsolutePath]
+    ) {
+        var directories: Set<AbsolutePath> = []
+        var files: Set<AbsolutePath> = []
+        var packageDirectories: Set<AbsolutePath> = []
+
+        for package in graph.packages {
+            packageDirectories.insert(package.path)
+            files.insert(package.manifest.path)
+
+            if package.manifest.packageKind.isRoot {
+                files.insert(package.path.appending("Package.resolved"))
+            }
+
+            for module in package.modules {
+                directories.insert(module.sources.root)
+            }
+
+            directories.formUnion(Self.predefinedTargetDirectories.map { package.path.appending(component: $0) })
+            for target in package.manifest.targets {
+                guard let path = target.path, let relativePath = try? RelativePath(validating: path) else {
+                    continue
+                }
+                directories.insert(package.path.appending(relativePath))
+            }
+        }
+
+        for moduleOrProduct in modulesAndProducts {
+            files.formUnion(moduleOrProduct.buildToolPluginInputs)
+        }
+        directories.insert(pluginWorkingDirectory.appending("outputs"))
+
+        directories.formUnion(pkgConfigDirectories)
+
+        self.init(watchedDirectories: directories, watchedFiles: files, watchedPackageRootDirectories: packageDirectories)
+    }
+}
+

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -590,6 +590,12 @@ extension PackagePIFProjectBuilder {
             PackagePIFBuilder.LinkedPackageBinary(dependency: $0)
         }
 
+        let buildToolPluginInputs = Set(
+            (pifBuilder.buildToolPluginResultsByTargetName[mainModule.name] ?? [])
+                .flatMap(\.buildCommands)
+                .flatMap(\.inputPaths)
+        )
+
         let moduleOrProduct = PackagePIFBuilder.ModuleOrProduct(
             type: moduleOrProductType,
             name: product.name,
@@ -597,6 +603,7 @@ extension PackagePIFProjectBuilder {
             pifTarget: .target(self.project[keyPath: mainModuleTargetKeyPath]),
             indexableFileURLs: indexableFileURLs,
             headerFiles: headerFiles,
+            buildToolPluginInputs: buildToolPluginInputs,
             doccCatalogs: doccCatalogs,
             linkedPackageBinaries: linkedPackageBinaries,
             swiftLanguageVersion: mainModule.packageSwiftLanguageVersion(manifest: packageManifest),

--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -140,6 +140,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
     private var headersByTargetGUID: [String: Set<Basics.AbsolutePath>] = [:]
     private var doccCatalogsByTargetGUID: [String: Set<Basics.AbsolutePath>] = [:]
     private var buildToolPluginInputsByTargetGUID: [String: Set<Basics.AbsolutePath>] = [:]
+    private var pifGenerationInputs: PIFGenerationInputs
 
     private struct PluginInfo {
         var name: String
@@ -155,6 +156,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
         self.packageRoot = packageRoot
         self.buildSystem = buildSystem
         self.workspace = workspace
+        self.pifGenerationInputs = PIFGenerationInputs.fallbackInputs(packageRoot: packageRoot)
         self.defaultScratchDirectory = Workspace.DefaultLocations.scratchDirectory(forRootPackage: packageRoot)
         self.connectionToClient = connectionToClient
         self.exitHandler = exitHandler
@@ -607,21 +609,21 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
         return false
     }
 
-    /// An event is relevant if it modifies a file that matches one of the file rules used by the SwiftPM workspace.
+    /// An event is relevant if it touches a file or directory which is a PIF input.
     private func fileEventShouldTriggerPackageReload(event: FileEvent) -> Bool {
-        guard let fileURL = event.uri.fileURL else {
+        guard let fileURL = event.uri.fileURL, let filePath = try? fileURL.filePath else {
             return false
         }
         if isInScratchDirectory(fileURL) {
             return false
         }
+
+        let candidatePaths = [filePath, (try? resolveSymlinks(filePath))].compactMap { $0 }
         switch event.type {
         case .created, .deleted:
-            // This is overly conservative, we may want to consider restricting it to file types which will be built.
-            // However, the possibility of a plugin which might process an arbitrary file type makes this difficult.
-            return true
+            return candidatePaths.contains { pifGenerationInputs.creationOrDeletionAffectsPIF($0) }
         case .changed:
-            return fileURL.lastPathComponent == "Package.swift" || fileURL.lastPathComponent == "Package.resolved" ||  fileURL.lastPathComponent.wholeMatch(of: versionSpecificManifestRegex) != nil
+            return candidatePaths.contains { pifGenerationInputs.modificationAffectsPIF($0) }
         default:
             logToClient(.warning, "received unknown file event type: '\(event.type)'")
             return false
@@ -629,7 +631,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
     }
 
     public func scheduleRegeneratingBuildDescription() {
-        packageLoadingQueue.async { [buildSystem] in
+        packageLoadingQueue.async { [buildSystem, packageRoot] in
             let reloadingTaskID = TaskId(id: "package-reloading")
             do {
                 self.connectionToClient.send(
@@ -640,6 +642,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
                 )
                 let result = try await buildSystem.generatePIFAndAccompanyingMetadata(preserveStructure: false)
                 try localFileSystem.writeIfChanged(path: buildSystem.buildParameters.pifManifest, string: result.pif)
+                self.pifGenerationInputs = result.inputs
                 await self.rebuildHeaderMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
                 await self.rebuildBuildToolPluginInputsMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
                 await self.rebuildDocCCatalogMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
@@ -652,6 +655,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
                     TaskFinishNotification(taskId: reloadingTaskID, status: .ok)
                 )
             } catch {
+                self.pifGenerationInputs = PIFGenerationInputs.fallbackInputs(packageRoot: packageRoot)
                 self.logToClient(.warning, "error regenerating build description: \(error)")
                 self.connectionToClient.send(
                     TaskFinishNotification(taskId: reloadingTaskID, status: .error)

--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -36,43 +36,41 @@ final fileprivate class NotificationCollectingMessageHandler: MessageHandler, @u
 }
 
 fileprivate func withSwiftPMBSP(packagePath: AbsolutePath, extraBSPArgs: [String] = [], body: (Connection, NotificationCollectingMessageHandler) async throws -> Void) async throws {
-    await withKnownIssue("Tests occasionally fail to load build description in CI", isIntermittent: true) {
-        let inPipe = Pipe()
-        let outPipe = Pipe()
-        let connection = JSONRPCConnection(
-            name: "bsp-connection",
-            protocol: MessageRegistry.bspProtocol,
-            receiveFD: inPipe.fileHandleForReading,
-            sendFD: outPipe.fileHandleForWriting
-        )
-        defer {
-            connection.close()
-        }
-        let bspProcess = Process()
-        bspProcess.standardOutputPipe = inPipe
-        bspProcess.standardInput = outPipe
-        let execPath = SwiftPM.xctestBinaryPath(for: "swift-package").pathString
-        bspProcess.executableURL = URL(filePath: execPath)
-        bspProcess.arguments = ["--package-path", packagePath.pathString] + ["experimental-build-server", "--build-system", "swiftbuild"] + extraBSPArgs
-        async let terminationPromise: Void = try await bspProcess.run()
-        let notificationCollector = NotificationCollectingMessageHandler()
-        connection.start(receiveHandler: notificationCollector)
-        _ = try await connection.send(
-            InitializeBuildRequest(
-                displayName: "test-bsp-client",
-                version: "1.0.0",
-                bspVersion: "2.2.0",
-                rootUri: URI(URL(filePath: packagePath.pathString)),
-                capabilities: .init(languageIds: [.swift, .c, .objective_c, .cpp, .objective_cpp])
-            )
-        )
-        connection.send(OnBuildInitializedNotification())
-        _ = try await connection.send(WorkspaceWaitForBuildSystemUpdatesRequest())
-        try await body(connection, notificationCollector)
-        _ = try await connection.send(BuildShutdownRequest())
-        connection.send(OnBuildExitNotification())
-        try await terminationPromise
+    let inPipe = Pipe()
+    let outPipe = Pipe()
+    let connection = JSONRPCConnection(
+        name: "bsp-connection",
+        protocol: MessageRegistry.bspProtocol,
+        receiveFD: inPipe.fileHandleForReading,
+        sendFD: outPipe.fileHandleForWriting
+    )
+    defer {
+        connection.close()
     }
+    let bspProcess = Process()
+    bspProcess.standardOutputPipe = inPipe
+    bspProcess.standardInput = outPipe
+    let execPath = SwiftPM.xctestBinaryPath(for: "swift-package").pathString
+    bspProcess.executableURL = URL(filePath: execPath)
+    bspProcess.arguments = ["--package-path", packagePath.pathString] + ["experimental-build-server", "--build-system", "swiftbuild"] + extraBSPArgs
+    async let terminationPromise: Void = try await bspProcess.run()
+    let notificationCollector = NotificationCollectingMessageHandler()
+    connection.start(receiveHandler: notificationCollector)
+    _ = try await connection.send(
+        InitializeBuildRequest(
+            displayName: "test-bsp-client",
+            version: "1.0.0",
+            bspVersion: "2.2.0",
+            rootUri: URI(URL(filePath: packagePath.pathString)),
+            capabilities: .init(languageIds: [.swift, .c, .objective_c, .cpp, .objective_cpp])
+        )
+    )
+    connection.send(OnBuildInitializedNotification())
+    _ = try await connection.send(WorkspaceWaitForBuildSystemUpdatesRequest())
+    try await body(connection, notificationCollector)
+    _ = try await connection.send(BuildShutdownRequest())
+    connection.send(OnBuildExitNotification())
+    try await terminationPromise
 }
 
 fileprivate func withSwiftPMBSP(fixtureName: String, extraBSPArgs: [String] = [], body: (Connection, NotificationCollectingMessageHandler, AbsolutePath) async throws -> Void) async throws {
@@ -100,7 +98,7 @@ struct SwiftPMBuildServerTests {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, _, _ in
             let response = try await connection.send(WorkspaceBuildTargetsRequest())
             #expect(response.targets.count == 3)
-            #expect(response.targets.map(\.displayName).sorted() == ["Foo", "Foo-product", "Package Manifest"])
+            #expect(response.targets.map(\.displayName).sorted() == ["Foo", "Foo", "Package Manifest"])
         }
     }
 
@@ -113,7 +111,7 @@ struct SwiftPMBuildServerTests {
             #expect(!myLib.tags.contains(.dependency))
             #expect(!myLib.tags.contains(.test))
 
-            let myLibTests = try #require(response.targets.first(where: { $0.displayName == "MyLibTests-product" }))
+            let myLibTests = try #require(response.targets.first(where: { $0.displayName == "MyLibTests" }))
             #expect(!myLibTests.tags.contains(.dependency))
             #expect(myLibTests.tags.contains(.test))
 
@@ -128,9 +126,9 @@ struct SwiftPMBuildServerTests {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, _, _ in
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
             #expect(targetResponse.targets.count == 3)
-            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo-product", "Package Manifest"])
+            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo", "Package Manifest"])
 
-            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" })).id
+            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" && !$0.id.uri.stringValue.contains("product")  })).id
             let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [fooID]))
             let item = try #require(sourcesResponse.items.only?.sources.only)
             #expect(item.kind == .file)
@@ -189,9 +187,9 @@ struct SwiftPMBuildServerTests {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, _, _ in
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
             #expect(targetResponse.targets.count == 3)
-            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo-product", "Package Manifest"])
+            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo", "Package Manifest"])
 
-            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" })).id
+            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" && !$0.id.uri.stringValue.contains("product") })).id
             let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [fooID]))
             let item = try #require(sourcesResponse.items.only?.sources.only)
             #expect(item.kind == .file)
@@ -210,9 +208,9 @@ struct SwiftPMBuildServerTests {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, _, fixturePath in
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
             #expect(targetResponse.targets.count == 3)
-            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo-product", "Package Manifest"])
+            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo", "Package Manifest"])
 
-            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" })).id
+            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" && !$0.id.uri.stringValue.contains("product") })).id
             let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [fooID]))
             let sourcesItem = try #require(sourcesResponse.items.only)
             #expect(sourcesItem.sources.count == 1)
@@ -301,6 +299,53 @@ struct SwiftPMBuildServerTests {
     }
 
     @Test
+    func onlyFileEventsAffectingPIFInputsTriggerPackageReload() async throws {
+        try await withSwiftPMBSP(fixtureName: "Miscellaneous/LibraryWithTestAndDep") { connection, notificationCollector, fixturePath in
+            func packageReloadCount() -> Int {
+                notificationCollector.notifications(of: TaskStartNotification.self)
+                    .filter { $0.taskId.id == "package-reloading" }
+                    .count
+            }
+
+            func sendFileEvent(_ path: AbsolutePath, type: FileChangeType) async throws {
+                connection.send(OnWatchedFilesDidChangeNotification(changes: [
+                    .init(uri: .init(.init(filePath: path.pathString)), type: type)
+                ]))
+                _ = try await connection.send(WorkspaceWaitForBuildSystemUpdatesRequest())
+            }
+
+            #expect(packageReloadCount() == 1)
+
+            let unrelatedFile = fixturePath.appending(component: "notes.txt")
+            try localFileSystem.writeFileContents(unrelatedFile, string: "hello")
+            try await sendFileEvent(unrelatedFile, type: .created)
+            #expect(packageReloadCount() == 1)
+
+            try localFileSystem.removeFileTree(unrelatedFile)
+            try await sendFileEvent(unrelatedFile, type: .deleted)
+            #expect(packageReloadCount() == 1)
+
+            try await sendFileEvent(fixturePath.appending(components: "Sources", "MyLib", "MyLib.swift"), type: .changed)
+            #expect(packageReloadCount() == 1)
+
+            let newSource = fixturePath.appending(components: "Sources", "MyLib", "Extra.swift")
+            try localFileSystem.writeFileContents(newSource, string: "public let extra = 1\n")
+            try await sendFileEvent(newSource, type: .created)
+            #expect(packageReloadCount() == 2)
+
+            let newDepSource = fixturePath.appending(components: "MyDep", "Sources", "MyDep", "Extra.swift")
+            try localFileSystem.writeFileContents(newDepSource, string: "public let extra = 1\n")
+            try await sendFileEvent(newDepSource, type: .created)
+            #expect(packageReloadCount() == 3)
+
+            let versionSpecificManifest = fixturePath.appending(component: "Package@swift-6.0.swift")
+            try localFileSystem.copy(from: fixturePath.appending(component: "Package.swift"), to: versionSpecificManifest)
+            try await sendFileEvent(versionSpecificManifest, type: .created)
+            #expect(packageReloadCount() == 4)
+        }
+    }
+
+    @Test
     func underlyingBuildServerNotificationsAreForwarded() async throws {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, notificationCollector, fixturePath in
             let initialChangeCount = notificationCollector.notifications(of: OnBuildTargetDidChangeNotification.self).count
@@ -326,9 +371,9 @@ struct SwiftPMBuildServerTests {
 
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
             #expect(targetResponse.targets.count == 3)
-            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo-product", "Package Manifest"])
+            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo", "Package Manifest"])
 
-            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" })).id
+            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" && !$0.id.uri.stringValue.contains("product") })).id
             let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [fooID]))
             let item = try #require(sourcesResponse.items.only?.sources.only)
             #expect(item.kind == .file)
@@ -375,7 +420,7 @@ struct SwiftPMBuildServerTests {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/VersionSpecificManifest") { connection, _, _ in
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
             #expect(targetResponse.targets.count == 3)
-            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo-product", "Package Manifest"])
+            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo", "Package Manifest"])
 
             let manifestTarget = try #require(targetResponse.targets.first(where: { $0.displayName == "Package Manifest" }))
             #expect(manifestTarget.tags.contains(.notBuildable))
@@ -394,7 +439,7 @@ struct SwiftPMBuildServerTests {
     func extraSwiftcArgs() async throws {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple", extraBSPArgs: ["-Xswiftc", "-DFoo", "-Xcc", "-DBar"]) { connection, _, _ in
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
-            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" })).id
+            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" && !$0.id.uri.stringValue.contains("product") })).id
             let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [fooID]))
             let item = try #require(sourcesResponse.items.only?.sources.only)
 
@@ -559,7 +604,7 @@ struct SwiftPMBuildServerTests {
     func skipResolvingPackagePathsPreservesSymlinkedSourcePaths() async throws {
         func testSourcePath(_ connection: Connection) async throws -> AbsolutePath {
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
-            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" })).id
+            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" && !$0.id.uri.stringValue.contains("product") })).id
             let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [fooID]))
             let item = try #require(sourcesResponse.items.only?.sources.only)
             let fileURL = try #require(item.uri.fileURL)


### PR DESCRIPTION
More closely match sourcekit-lsp's existing behavior of only reloading the package when receiving notice of a file change which impacts the build plan. We collect the relevant paths during PIF construction for tracking, and otherwise fallback to a more conservative heuristic (e.g. if the manifest is completely broken when the package is initially opened).

I also fixed up a few minor issues in some related tests.