### PR TITLE
[🍒main] Only exclude host-only tools from top-level aggregate when cross-compiling

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -93,7 +93,10 @@ package struct PIFBuilderParameters {
     /// real path.
     let shouldPreserveSymlinks: Bool
 
-    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRpaths: PackagePIFBuilder.AddLocalRpaths, hostBuildProductsPath: AbsolutePath, shouldPreserveSymlinks: Bool) {
+    /// The triple of the host on which the build is running, as reported by the host `BuildParameters`.
+    let hostTriple: Basics.Triple
+
+    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRpaths: PackagePIFBuilder.AddLocalRpaths, hostBuildProductsPath: AbsolutePath, shouldPreserveSymlinks: Bool, hostTriple: Basics.Triple) {
         self.isPackageAccessModifierSupported = isPackageAccessModifierSupported
         self.enableTestability = enableTestability
         self.shouldCreateDylibForDynamicProducts = shouldCreateDylibForDynamicProducts
@@ -109,6 +112,7 @@ package struct PIFBuilderParameters {
         self.addLocalRpaths = addLocalRpaths
         self.hostBuildProductsPath = hostBuildProductsPath
         self.shouldPreserveSymlinks = shouldPreserveSymlinks
+        self.hostTriple = hostTriple
     }
 }
 
@@ -268,7 +272,7 @@ public final class PIFBuilder {
             graph: graph,
             buildParameters: buildParameters,
             pluginsPerModule: pluginsPerModule,
-            hostTriple: try pluginScriptRunner.hostTriple
+            hostTriple: self.parameters.hostTriple
         )
 
         let sortedPackages = self.graph.packages
@@ -520,7 +524,8 @@ public final class PIFBuilder {
                     packagesAndProjects: packagesAndPIFProjects,
                     observabilityScope: observabilityScope,
                     modulesGraph: graph,
-                    buildParameters: buildParameters
+                    buildParameters: buildParameters,
+                    hostTriple: self.parameters.hostTriple
                 )
             )
 
@@ -609,7 +614,8 @@ public final class PIFBuilder {
         addLocalRpaths: PackagePIFBuilder.AddLocalRpaths,
         materializeStaticArchiveProductsForRootPackages: Bool,
         createDynamicVariantsForLibraryProducts: Bool,
-        hostBuildProductsPath: AbsolutePath
+        hostBuildProductsPath: AbsolutePath,
+        hostTriple: Basics.Triple
     ) async throws -> PIFGenerationResult {
         let parameters = PIFBuilderParameters(
             buildParameters,
@@ -621,7 +627,8 @@ public final class PIFBuilder {
             addLocalRpaths: addLocalRpaths,
             materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
             createDynamicVariantsForLibraryProducts: createDynamicVariantsForLibraryProducts,
-            hostBuildProductsPath: hostBuildProductsPath
+            hostBuildProductsPath: hostBuildProductsPath,
+            hostTriple: hostTriple
         )
         let builder = Self(
             graph: packageGraph,
@@ -871,7 +878,8 @@ fileprivate func buildAggregatePIFProject(
     packagesAndProjects: [(package: ResolvedPackage, project: ProjectModel.Project)],
     observabilityScope: ObservabilityScope,
     modulesGraph: ModulesGraph,
-    buildParameters: BuildParameters
+    buildParameters: BuildParameters,
+    hostTriple: Basics.Triple
 ) throws -> ProjectModel.Project {
     precondition(!packagesAndProjects.isEmpty)
 
@@ -922,7 +930,8 @@ fileprivate func buildAggregatePIFProject(
     addEmptyBuildConfig(to: allExcludingTestsTargetKeyPath, name: "Debug")
     addEmptyBuildConfig(to: allExcludingTestsTargetKeyPath, name: "Release")
 
-    let hostOnlyModuleIDs = computeHostOnlyModuleIDsInRootPackages(in: modulesGraph)
+    let isCrossCompiling = !hostTriple.isRuntimeCompatible(with: buildParameters.triple)
+    let hostOnlyModuleIDs = isCrossCompiling ? computeHostOnlyModuleIDsInRootPackages(in: modulesGraph) : []
 
     for (package, packageProject) in packagesAndProjects where package.manifest.packageKind.isRoot {
         for target in packageProject.targets {
@@ -1032,7 +1041,8 @@ extension PIFBuilderParameters {
         addLocalRpaths: PackagePIFBuilder.AddLocalRpaths,
         materializeStaticArchiveProductsForRootPackages: Bool,
         createDynamicVariantsForLibraryProducts: Bool,
-        hostBuildProductsPath: AbsolutePath
+        hostBuildProductsPath: AbsolutePath,
+        hostTriple: Basics.Triple
     ) {
         self.init(
             isPackageAccessModifierSupported: buildParameters.driverParameters.isPackageAccessModifierSupported,
@@ -1049,7 +1059,8 @@ extension PIFBuilderParameters {
             additionalFileRules: additionalFileRules,
             addLocalRpaths: addLocalRpaths,
             hostBuildProductsPath: hostBuildProductsPath,
-            shouldPreserveSymlinks: buildParameters.shouldPreserveSymlinks
+            shouldPreserveSymlinks: buildParameters.shouldPreserveSymlinks,
+            hostTriple: hostTriple
         )
     }
 }

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1391,7 +1391,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                     addLocalRpaths: self.buildParameters.linkingParameters.shouldDisableLocalRpath ? .never : .always,
                     materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
                     createDynamicVariantsForLibraryProducts: true,
-                    hostBuildProductsPath: try await self.buildProductsPath(for: self.hostBuildParameters)
+                    hostBuildProductsPath: try await self.buildProductsPath(for: self.hostBuildParameters),
+                    hostTriple: self.hostBuildParameters.triple
                 ),
                 fileSystem: self.fileSystem,
                 observabilityScope: self.observabilityScope,

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -33,7 +33,8 @@ extension PIFBuilderParameters {
         shouldCreateDylibForDynamicProducts: Bool = false,
         createDynamicVariantsForLibraryProducts: Bool = false,
         pluginScriptRunner: PluginScriptRunner? = nil,
-        hostBuildProductsPath: Basics.AbsolutePath? = nil
+        hostBuildProductsPath: Basics.AbsolutePath? = nil,
+        hostTriple: Basics.Triple? = nil
     ) throws -> Self {
         try self.init(
             isPackageAccessModifierSupported: true,
@@ -54,7 +55,8 @@ extension PIFBuilderParameters {
             additionalFileRules: [],
             addLocalRpaths: addLocalRpaths,
             hostBuildProductsPath: hostBuildProductsPath ?? temporaryDirectory.appending(component: "host-build-products"),
-            shouldPreserveSymlinks: false
+            shouldPreserveSymlinks: false,
+            hostTriple: try hostTriple ?? UserToolchain.default.targetTriple
         )
     }
 }
@@ -2392,7 +2394,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, triple: .wasi)
         )
 
         let errors = observability.diagnostics.filter { $0.severity == .error }
@@ -2458,7 +2460,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, triple: .wasi)
         )
 
         let errors = observability.diagnostics.filter { $0.severity == .error }
@@ -2529,7 +2531,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, triple: .wasi)
         )
 
         let errors = observability.diagnostics.filter { $0.severity == .error }
@@ -2600,7 +2602,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, triple: .wasi)
         )
 
         let errors = observability.diagnostics.filter { $0.severity == .error }
@@ -2672,7 +2674,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, triple: .wasi)
         )
 
         let errors = observability.diagnostics.filter { $0.severity == .error }
@@ -2744,7 +2746,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, triple: .wasi)
         )
 
         let errors = observability.diagnostics.filter { $0.severity == .error }


### PR DESCRIPTION
Only exclude host-only tools from top-level aggregate when cross-compiling

cherry picked from commit da0267ae6ddb44de6b29a4674b5c28dda500f3c9