### PR TITLE
Remove unused TSCUtility.Versioning import

### DIFF
--- a/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
@@ -12,7 +12,6 @@
 
 import _Concurrency
 import Foundation
-import struct TSCUtility.Versioning
 #if canImport(FoundationNetworking)
 // FIXME: this brings OpenSSL dependency on Linux and needs to be replaced with `swift-server/async-http-client` package
 import FoundationNetworking


### PR DESCRIPTION
This is unused and the last reference to another small chunk of TSCUtility