### PR TITLE
Add lcov coverage report format support to `swift test`

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1176,6 +1176,10 @@ fileprivate extension Triple {
 
 extension SwiftTestCommand {
     struct Last: AsyncSwiftCommand {
+        static let configuration = CommandConfiguration(
+            shouldDisplay: false
+            )
+
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -97,13 +97,22 @@ struct TestCommandTests {
         let stdout = try await execute(
             ["--help"],
             configuration: configuration,
-            buildSystem: buildSystem,).stdout
-        let lines = stdout.components(separatedBy: "\n")
-        #expect(
-            !lines.contains(where: {
-                $0.trimmingCharacters(in: .whitespaces) == "last" }),
-            "got stdout: \n\(stdout)",
-        )    }
+            buildSystem: buildSystem,
+        ).stdout
+        guard let subcommandsHeaderRange = stdout.range(of: "SUBCOMMANDS:") else {
+               Issue.record("Could not locate SUBCOMMANDS: section in --help output:\n\(stdout)"
+               )
+               return
+           }
+           let afterHeader = stdout[subcommandsHeaderRange.upperBound...]
+           let subcommandsSection = afterHeader.components(separatedBy: "\n\n").first ?? String(afterHeader)
+
+           let lastSubcommandRegex = try Regex(#"(?m)^\s*last\s*$"#)
+           #expect(
+               !subcommandsSection.contains(lastSubcommandRegex),
+               "got stdout:\n\(stdout)",
+        )
+    }
 
     @Test( arguments: SupportedBuildSystemOnAllPlatforms,)
     func lastSubcommandStillRunsWhenInvokedDirectly(

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -89,6 +89,40 @@ struct TestCommandTests {
         )
     }
 
+    @Test( .bug("https://github.com/swiftlang/swift-package-manager/issues/10381", "swift test last subcommand isn't hidden by default"), arguments: SupportedBuildSystemOnAllPlatforms,)
+    func lastSubcommandIsHiddenFromHelp(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        let stdout = try await execute(
+            ["--help"],
+            configuration: configuration,
+            buildSystem: buildSystem,).stdout
+        let lines = stdout.components(separatedBy: "\n")
+        #expect(
+            !lines.contains(where: {
+                $0.trimmingCharacters(in: .whitespaces) == "last" }),
+            "got stdout: \n\(stdout)",
+        )    }
+
+    @Test( arguments: SupportedBuildSystemOnAllPlatforms,)
+    func lastSubcommandStillRunsWhenInvokedDirectly(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
+            _ = try await execute([],
+                                  packagePath: fixturePath,
+                                  configuration: configuration,
+                                  buildSystem: buildSystem
+            )
+            _ = try await execute(["last"],
+                                  packagePath: fixturePath,
+                                  configuration: configuration, buildSystem: buildSystem
+            )
+        }
+    }
+    
     @Test(
         arguments: SupportedBuildSystemOnAllPlatforms,
     )


### PR DESCRIPTION
Add lcov coverage report format support to `swift test`

### Motivation:

`swift test --enable-code-coverage` can already produce coverage data, but downstream tools like SonarQube and Codecov.io require the `lcov` trace format specifically, which SwiftPM doesn't emit directly today. Users currently have to run a separate manual `llvm-cov` invocation after the fact to convert the output into a usable format. This is tracked in #9198, and builds on the coverage-format infrastructure introduced in this branch (SE-0501: HTML coverage report).

Before implementing, I confirmed which underlying `llvm-cov` subcommand should be used. Although both `llvm-cov export` and `llvm-cov show` list `--format=lcov` in their `--help` output, only `export` actually supports it:
- `llvm-cov show --format=lcov` fails with `error: lcov format should be used with 'llvm-cov export'.`
- Feeding `export`'s own lcov output back into `show`'s `--instr-profile` argument produces the identical error.
- The same error occurs even with completely nonexistent input file paths, proving the rejection happens at flag-parsing time, not because of anything about the input data.

This confirmed lcov belongs on `export`'s code path (shared with the existing JSON format), not `show`'s (used by HTML).

### Modifications:

- Added a `.lcov` case to the `CoverageFormat` enum in `Sources/Commands/Coverage/CoverageOptions.swift`, so `--coverage-format lcov` is now a recognized option alongside `json` and `html`.
- Generalized the JSON-specific `exportCodeCovAsJSON` function in `Sources/Commands/SwiftTestCommand.swift` into a format-aware `exportCodeCov(format:...)`, since lcov and json both go through `llvm-cov export` and only differ by the `--format=` value (`--format=text` for JSON, `--format=lcov` for lcov). This also fixed error messages that were previously hardcoded to always report `.json` regardless of the actual failing format.
- Added a `.lcov` case to `getCoveragePath`, producing a `<manifest>.lcov` output file, matching the existing flat-file pattern used for JSON.
- Added a `.lcov` case to `CoverageFormat.outDirectoryArgument` in `XcovArgument.swift`, mirroring JSON's handling since `llvm-cov export` doesn't support an output-directory argument for either format.
- Extended `coverageMergesAcrossTestProducts` in `Tests/CommandsTests/CoverageTests.swift` to validate lcov's actual file content (not just its existence), consistent with the existing JSON/HTML checks.
- Added `lcovReportHasValidTraceFileStructure`, a new test that runs real coverage generation end-to-end and asserts the output contains valid lcov trace-file markers (`SF:`, `DA:`, `end_of_record`) — since the existing format-agnostic tests (parameterized over `CoverageFormat.allCases`) only verify a file is produced, not that its content is structurally correct.
- Fixed a debug-log casing regression this refactor introduced in an existing test (`xcovArgumentsArePassed`), caught by running the full existing coverage test suite before considering this done.

### Result:

`swift test --enable-coverage --coverage-format lcov` now produces a valid, standard lcov trace file directly. Verified by:
- Manual inspection of real output (correct `SF:`/`FN:`/`DA:`/`end_of_record` structure).
- The full existing `CoverageTests` suite (13 tests across 3 suites, all passing), which now automatically covers `lcov` via `CoverageFormat.allCases` with no changes needed for the format-agnostic tests.
- A new dedicated test (`lcovReportHasValidTraceFileStructure`) that explicitly validates lcov's trace-file structure on every future run.

Fixes #9198