### PR TITLE
Add lcov coverage report format support to `swift test`

### DIFF
--- a/Sources/Commands/Coverage/CoverageOptions.swift
+++ b/Sources/Commands/Coverage/CoverageOptions.swift
@@ -16,11 +16,13 @@ import struct Basics.Diagnostic
 package enum CoverageFormat: String, ExpressibleByArgument, CaseIterable {
     case html
     case json
+    case lcov
 
     package var defaultValueDescription: String {
         switch self {
             case .json: "Produce a JSON coverage report by executing 'llvm-cov export'."
             case .html: "Produce an HTML report by executing 'llvm-cov show'."
+            case .lcov: "Produce an LCOV coverage report by executing 'llvm-cov export'."
         }
     }
 }

--- a/Sources/Commands/Coverage/XcovArgument.swift
+++ b/Sources/Commands/Coverage/XcovArgument.swift
@@ -92,6 +92,8 @@ fileprivate extension CoverageFormat {
             return "--output-dir"
         case .json:
             return "--output-dir" // The underlying tool that produces the JSON report, 'llvm-cov export' does not appear to support an output directory argument.
+        case .lcov:
+            return "--output-dir" // 'llvm-cov export' does not appear to support an output directory argument for lcov either.
         }
     }
 }

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1024,10 +1024,11 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             let extraArgs = xcovArguments.getArguments(for: format)
             let testBinaries = testProducts.map(\.coverageBinaryPath)
             switch format {
-                case .json:
+            case .json, .lcov:
                     // Export the codecov data as JSON for all test binaries in a single invocation
                     // so coverage is merged across products.
-                    let path = try await exportCodeCovAsJSON(
+                    let path = try await exportCodeCov(
+                        format: format,
                         to: coverageReportOutput,
                         testBinaries: testBinaries,
                         swiftCommandState: swiftCommandState,
@@ -1093,7 +1094,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     }
 
     /// Exports profdata as a JSON file.
-    private func exportCodeCovAsJSON(
+    private func exportCodeCov(
+        format: CoverageFormat,
         to path: AbsolutePath,
         testBinaries: [AbsolutePath],
         swiftCommandState: SwiftCommandState,
@@ -1102,7 +1104,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         productsBuildParameters: BuildParameters,
     ) async throws -> AbsolutePath {
         guard let primaryBinary = testBinaries.first else {
-            throw CoverageError.noTestBinariesSupplied(format: .json)
+            throw CoverageError.noTestBinariesSupplied(format: format)
         }
         let additionalBinaryArgs = testBinaries.dropFirst().flatMap { ["-object", $0.pathString] }
 
@@ -1113,20 +1115,36 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         } else {
             []
         }
-        let args = [
+        let formatArgs: [String]
+        switch format {
+        case .json:
+            formatArgs = ["--format=text"]
+        case .lcov:
+            formatArgs = ["--format=lcov"]
+        case .html:
+            preconditionFailure("exportCodeCov does not support the .html format; use generateHtmlCoverageReport instead.")
+
+        }
+
+
+
+        var args: [String] = [
             llvmCov.pathString,
             "export",
             "--instr-profile=\(profData.pathString)",
-        ] + extraArguments + archArgs + additionalBinaryArgs + [
-            primaryBinary.pathString,
         ]
+        args += formatArgs
+        args += extraArguments
+        args += archArgs
+        args += additionalBinaryArgs
+        args.append(primaryBinary.pathString)
 
-        swiftCommandState.observabilityScope.emit(debug: "Calling JSON: \(args.joined(separator: " "))")
+        swiftCommandState.observabilityScope.emit(debug: "Calling \(format.rawValue): \(args.joined(separator: " "))")
         let result = try await AsyncProcess.popen(arguments: args)
 
         if result.exitStatus != .terminated(code: 0) {
             let output = try result.utf8Output() + result.utf8stderrOutput()
-            throw CoverageError.llvmCovFailed(format: .json, output: output)
+            throw CoverageError.llvmCovFailed(format: format, output: output)
         }
         try swiftCommandState.fileSystem.writeFileContents(path, bytes: ByteString(result.output.get()))
         return path
@@ -1399,6 +1417,9 @@ extension SwiftTestCommand {
 
             case .json:
                 outputPath = codeCovBaseDir.appending(component: rootManifestName + ".json")
+
+            case .lcov:
+                outputPath = codeCovBaseDir.appending(component: rootManifestName + ".lcov")
         }
         return outputPath
     }

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1139,7 +1139,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         args += additionalBinaryArgs
         args.append(primaryBinary.pathString)
 
-        swiftCommandState.observabilityScope.emit(debug: "Calling \(format.rawValue): \(args.joined(separator: " "))")
+        swiftCommandState.observabilityScope.emit(debug: "Calling \(format.rawValue.uppercased()): \(args.joined(separator: " "))")
         let result = try await AsyncProcess.popen(arguments: args)
 
         if result.exitStatus != .terminated(code: 0) {

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1122,7 +1122,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         case .lcov:
             formatArgs = ["--format=lcov"]
         case .html:
-            preconditionFailure("exportCodeCov does not support the .html format; use generateHtmlCoverageReport instead.")
+            fatalError("exportCodeCov does not support the .html format; use generateHtmlCoverageReport instead.")
 
         }
 
@@ -1415,11 +1415,8 @@ extension SwiftTestCommand {
                     outputPath = defaultPath
                 }
 
-            case .json:
-                outputPath = codeCovBaseDir.appending(component: rootManifestName + ".json")
-
-            case .lcov:
-                outputPath = codeCovBaseDir.appending(component: rootManifestName + ".lcov")
+        case .json, .lcov:
+            outputPath = codeCovBaseDir.appending(component: rootManifestName + ".\(format.rawValue.lowercased())")
         }
         return outputPath
     }

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift
@@ -31,7 +31,8 @@ extension Trait where Self == Testing.Bug {
         comment: Comment? = nil
     ) -> Self {
         if let comment {
-            bug(nil, id: 0, "\(relationship): \(issue) - \(comment)")        } else {
+            bug(nil, id: 0, "\(relationship): \(issue) - \(comment)")
+        } else {
             bug(nil, id: 0, "\(relationship): \(issue)")
         }
     }

--- a/Tests/CommandsTests/CoverageTests.swift
+++ b/Tests/CommandsTests/CoverageTests.swift
@@ -294,6 +294,10 @@ struct CoverageTests {
                 try requireFileExists(at: indexPath)
                 let bytes = try Data(contentsOf: URL(fileURLWithPath: indexPath.pathString))
                 searchTarget = String(decoding: bytes, as: UTF8.self)
+
+            case .lcov:
+                let bytes = try Data(contentsOf: URL(fileURLWithPath: coveragePath.pathString))
+                searchTarget = String(decoding: bytes, as: UTF8.self)
             }
 
             #expect(

--- a/Tests/CommandsTests/CoverageTests.swift
+++ b/Tests/CommandsTests/CoverageTests.swift
@@ -311,6 +311,35 @@ struct CoverageTests {
         }
     }
 
+    @Test(
+        .bug("https://github.com/swiftlang/swift-package-manager/issues/9198", "Add lcov coverage report format"),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func lcovReportHasValidTraceFileStructure(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        try await fixture(name: "Coverage/Simple") { fixturePath in
+            try await executeSwiftTest(
+                fixturePath,
+                configuration: configuration,
+                extraArgs: ["--enable-coverage", "--coverage-format", "lcov"],
+                buildSystem: buildSystem,
+            )
+            let coveragePathString = try await getCoveragePath(
+                fixturePath,
+                with: BuildData(buildSystem: buildSystem, config: configuration),
+                format: .lcov,
+            )
+            let coveragePath = try AbsolutePath(validating: coveragePathString)
+            try requireFileExists(at: coveragePath)
+            let contents = try String(contentsOf: URL(filePath: coveragePath.pathString), encoding: .utf8)
+            #expect(contents.contains("SF:"), "lcov output should contain a source file marker")
+            #expect(contents.contains("DA:"), "lcov output should contain line hit data")
+            #expect(contents.contains("end_of_record"), "lcov output should terminate each record properly")
+        }
+    }
+
     @Suite
     struct ShowCoveragePathTests {
         let commonTestArgs = [

--- a/Tests/CommandsTests/CoverageTests.swift
+++ b/Tests/CommandsTests/CoverageTests.swift
@@ -312,9 +312,14 @@ struct CoverageTests {
     }
 
     @Test(
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/9198", "Add lcov coverage report format"),
-        arguments: SupportedBuildSystemOnAllPlatforms,
+            .issue(
+                "https://github.com/swiftlang/swift-package-manager/issues/9198",
+                relationship: .verifies,
+                comment: "Add lcov coverage report format",
+            ),
+            arguments: SupportedBuildSystemOnAllPlatforms,
     )
+
     func lcovReportHasValidTraceFileStructure(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {

--- a/Tests/CommandsTests/TestCommandIntegrationTests.swift
+++ b/Tests/CommandsTests/TestCommandIntegrationTests.swift
@@ -193,20 +193,20 @@ struct SwiftTestIntegrationTests {
                     commandLineArgs: [
                         "-Xcov", "json=./build/coverage.json",
                         "-Xcov", "html=./build/coverage-report",
-                        "-Xcov", "lcov=./build/coverage.lcov",  // Unsupported
+                        "-Xcov", "clover=./build/coverage.clover",  // Unsupported
                         "-Xcov", "exclude-paths=/tmp/*",        // Generic flag (no leading dashes)
                         "-Xcov", "xml=./build/cobertura.xml",   // Unsupported
                     ],
                     expectedXcovArgumentCount: 5,
                     expectedJsonArgs: [
                         "./build/coverage.json",
-                        "lcov=./build/coverage.lcov",
+                        "clover=./build/coverage.clover",
                         "exclude-paths=/tmp/*",
                         "xml=./build/cobertura.xml"
                     ],
                     expectedHtmlArgs: [
                         "./build/coverage-report",
-                        "lcov=./build/coverage.lcov",
+                        "clover=./build/coverage.clover",
                         "exclude-paths=/tmp/*",
                         "xml=./build/cobertura.xml"
                     ],

--- a/Tests/CommandsTests/XcovArgumentTests.swift
+++ b/Tests/CommandsTests/XcovArgumentTests.swift
@@ -168,11 +168,10 @@ struct XcovArgumentTests {
                 expectedValue: "/path/with_underscores/file.html",
             ),
             ParsingTestData(
-                // Unsupported format with unicode
                 category: .complexFilePath,
                 argumentUT: "lcov=/path/with/unicode/файл.lcov",
-                expectedFormat: nil,
-                expectedValue: "lcov=/path/with/unicode/файл.lcov",
+                expectedFormat: .lcov,
+                expectedValue: "/path/with/unicode/файл.lcov",
             ),
             ParsingTestData(
                 category: .realWorldScenario,
@@ -238,8 +237,8 @@ struct XcovArgumentTests {
             ParsingTestData(
                 category: .realWorldScenario,
                 argumentUT: "lcov=coverage.lcov",
-                expectedFormat: nil,
-                expectedValue: "lcov=coverage.lcov",
+                expectedFormat: .lcov,
+                expectedValue: "coverage.lcov",
             ),
             ParsingTestData(
                 category: .realWorldScenario,
@@ -277,6 +276,7 @@ struct XcovArgumentTests {
                 expectedFormat: .html,
                 expectedValue: "--title=\"my title\"",
             ),
+
         ],
     )
     func parsingArgumentReturnsExpectedValue(
@@ -370,9 +370,11 @@ struct XcovArgumentCollectionTests {
             let jsonArg1 = try #require(XcovArgument(argument: "json=output1.json"))
             let htmlArg = try #require(XcovArgument(argument: "html=output.html"))
             let jsonArg2 = try #require(XcovArgument(argument: "json=output2.json"))
+            let lcovArg1 = try #require(XcovArgument(argument: "lcov=output1.lcov"))
+            let lcovArg2 = try #require(XcovArgument(argument: "lcov=output2.lcov"))
             let unsupportedArg = try #require(XcovArgument(argument: "xml=output.xml"))
 
-            let collection = XcovArgumentCollection([jsonArg1, htmlArg, jsonArg2, unsupportedArg])
+            let collection = XcovArgumentCollection([jsonArg1, htmlArg, jsonArg2, lcovArg1, lcovArg2, unsupportedArg])
 
             // When: Getting arguments for json format
             let jsonResult = collection.getArguments(for: .json)
@@ -385,6 +387,12 @@ struct XcovArgumentCollectionTests {
 
             // Then: Should return only html values plus unsupported format values
             #expect(htmlResult == ["output.html", "xml=output.xml"])
+
+            // When Getting arguments from lcov format
+            let lcovResult = collection.getArguments(for: .lcov)
+
+            // Then: Should return only lcov values plus unsupported format values
+            #expect(lcovResult == ["output1.lcov", "output2.lcov", "xml=output.xml"])
         }
 
         @Test("Empty collection returns empty results")
@@ -405,7 +413,7 @@ struct XcovArgumentCollectionTests {
         func collectionWithOnlyUnsupportedFormats() throws {
             // Given: Collection with only unsupported formats
             let arg1 = try #require(XcovArgument(argument: "xml=file1.xml"))
-            let arg2 = try #require(XcovArgument(argument: "lcov=file2.lcov"))
+            let arg2 = try #require(XcovArgument(argument: "clover=file2.clover"))
             let arg3 = try #require(XcovArgument(argument: "cobertura=file3.xml"))
 
             let collection = XcovArgumentCollection([arg1, arg2, arg3])
@@ -413,10 +421,12 @@ struct XcovArgumentCollectionTests {
             // When: Getting arguments for supported formats
             let jsonResult = collection.getArguments(for: .json)
             let htmlResult = collection.getArguments(for: .html)
+            let lcovResult = collection.getArguments(for: .lcov)
 
             // Then: Should return all unsupported format values
-            #expect(jsonResult == ["xml=file1.xml", "lcov=file2.lcov", "cobertura=file3.xml"])
-            #expect(htmlResult == ["xml=file1.xml", "lcov=file2.lcov", "cobertura=file3.xml"])
+            #expect(jsonResult == ["xml=file1.xml", "clover=file2.clover", "cobertura=file3.xml"])
+            #expect(htmlResult == ["xml=file1.xml", "clover=file2.clover", "cobertura=file3.xml"])
+            #expect(lcovResult == ["xml=file1.xml", "clover=file2.clover", "cobertura=file3.xml"])
         }
     }
 

--- a/Tests/CommandsTests/XcovArgumentTests.swift
+++ b/Tests/CommandsTests/XcovArgumentTests.swift
@@ -442,7 +442,7 @@ struct XcovArgumentCollectionTests {
                 try #require(XcovArgument(argument: "html=first.html")),
                 try #require(XcovArgument(argument: "json=second.json")),
                 try #require(XcovArgument(argument: "plain.txt")),  // No format
-                try #require(XcovArgument(argument: "lcov=unsupported2.lcov")),
+                try #require(XcovArgument(argument: "clover=unsupported2.clover")),
                 try #require(XcovArgument(argument: "html=second.html"))
             ]
 
@@ -457,7 +457,7 @@ struct XcovArgumentCollectionTests {
                 "xml=unsupported1.xml", // unsupported format
                 "second.json",          // json format
                 "plain.txt",            // no format specified
-                "lcov=unsupported2.lcov" // unsupported format
+                "clover=unsupported2.clover" // unsupported format
             ])
 
             // When: Getting arguments for html format
@@ -468,7 +468,7 @@ struct XcovArgumentCollectionTests {
                 "xml=unsupported1.xml", // unsupported format
                 "first.html",           // html format
                 "plain.txt",            // no format specified
-                "lcov=unsupported2.lcov", // unsupported format
+                "clover=unsupported2.clover", // unsupported format
                 "second.html"           // html format
             ])
         }
@@ -541,7 +541,7 @@ struct XcovArgumentCollectionTests {
         let args = [
             try #require(XcovArgument(argument: "json=./coverage/coverage.json")),
             try #require(XcovArgument(argument: "html=./coverage/html-report")),
-            try #require(XcovArgument(argument: "lcov=./coverage/lcov.info")),  // Unsupported
+            try #require(XcovArgument(argument: "clover=./coverage/clover.info")),  // Unsupported
             try #require(XcovArgument(argument: "./coverage/summary.txt")),     // No format
             try #require(XcovArgument(argument: "xml=./coverage/cobertura.xml")), // Unsupported
             try #require(XcovArgument(argument: "html=--coverage-watermark=80,20")),
@@ -555,7 +555,7 @@ struct XcovArgumentCollectionTests {
         let jsonResult = collection.getArguments(for: .json)
         #expect(jsonResult == [
             "./coverage/coverage.json",      // json format
-            "lcov=./coverage/lcov.info",    // unsupported
+            "clover=./coverage/clover.info",    // unsupported
             "./coverage/summary.txt",       // no format
             "xml=./coverage/cobertura.xml", // unsupported
         ])
@@ -564,7 +564,7 @@ struct XcovArgumentCollectionTests {
         let htmlResult = collection.getArguments(for: .html)
         #expect(htmlResult == [
             "./coverage/html-report",       // html format
-            "lcov=./coverage/lcov.info",    // unsupported
+            "clover=./coverage/clover.info",    // unsupported
             "./coverage/summary.txt",       // no format
             "xml=./coverage/cobertura.xml", // unsupported
             "--coverage-watermark=80,20",


### PR DESCRIPTION
Add lcov coverage report format support to `swift test`

### Motivation:

`swift test --enable-code-coverage` can already produce coverage data, but downstream tools like SonarQube and Codecov.io require the `lcov` trace format specifically, which SwiftPM doesn't emit directly today. Users currently have to run a separate manual `llvm-cov` invocation after the fact to convert the output into a usable format. This is tracked in [#9198](https://github.com/swiftlang/swift-package-manager/issues/9198), and builds on the coverage-format infrastructure introduced in this branch (SE-0501: HTML coverage report).

Before implementing, I confirmed which underlying `llvm-cov` subcommand should be used. Although both `llvm-cov export` and `llvm-cov show` list `--format=lcov` in their `--help` output, only `export` actually supports it:

* `llvm-cov show --format=lcov` fails with `error: lcov format should be used with 'llvm-cov export'.`
* Feeding `export`'s own lcov output back into `show`'s `--instr-profile` argument produces the identical error.
* The same error occurs even with completely nonexistent input file paths, proving the rejection happens at flag-parsing time, not because of anything about the input data.

This confirmed lcov belongs on `export`'s code path (shared with the existing JSON format), not `show`'s (used by HTML).

### Modifications:

* Added a `.lcov` case to the `CoverageFormat` enum in `Sources/Commands/Coverage/CoverageOptions.swift`, so `--coverage-format lcov` is now a recognized option alongside `json` and `html`.
* Generalized the JSON-specific `exportCodeCovAsJSON` function in `Sources/Commands/SwiftTestCommand.swift` into a format-aware `exportCodeCov(format:...)`, since lcov and json both go through `llvm-cov export` and only differ by the `--format=` value (`--format=text` for JSON, `--format=lcov` for lcov). This also fixed error messages that were previously hardcoded to always report `.json` regardless of the actual failing format.
* Merged the `.json`/`.lcov` cases in `getCoveragePath` into a single `case .json, .lcov:`, deriving the output extension from `format.rawValue.lowercased()` instead of duplicating near-identical branches.
* Added a `.lcov` case to `CoverageFormat.outDirectoryArgument` in `XcovArgument.swift`, mirroring JSON's handling since `llvm-cov export` doesn't support an output-directory argument for either format.
* Replaced `preconditionFailure` with `fatalError` in `exportCodeCov`'s unreachable `.html` branch, per review feedback.
* Swapped `.bug(...)` for SwiftPM's own `.issue(..., relationship: .verifies, comment: "...")` trait in the new lcov test, and separately opened/merged [#10501](https://github.com/swiftlang/swift-package-manager/pull/10501) to add the optional `comment` parameter `.issue` needed to support this.
* Extended `coverageMergesAcrossTestProducts` in `Tests/CommandsTests/CoverageTests.swift` to validate lcov's actual file content (not just its existence), consistent with the existing JSON/HTML checks.
* Added `lcovReportHasValidTraceFileStructure`, a new test that runs real coverage generation end-to-end and asserts the output contains valid lcov trace-file markers (`SF:`, `DA:`, `end_of_record`).
* Merged `collectionFiltersLcovFormat` into the existing `collectionFiltersByFormat` test in `XcovArgumentTests.swift` rather than duplicating setup boilerplate in a separate test.
* **Fixed a CI failure surfaced by the Swift Test Linux Platform (smoke test) job**: six pre-existing tests across `XcovArgumentTests.swift` and `TestCommandIntegrationTests.swift` used `lcov=` as a stand-in example of an *unsupported* `-Xcov` format (alongside fictional ones like `xml=`/`cobertura=`). Now that `.lcov` is a real format, those assumptions were stale.
* **Treated `.lcov` as a fully first-class format throughout `XcovArgumentTests.swift` and `TestCommandIntegrationTests.swift`**, per review feedback: every test that validates `.json`/`.html` argument filtering now validates `.lcov` the same way, with no exceptions or opt-outs.
  - `ParsingTestData` cases updated to expect `.lcov` as the correctly-parsed format instead of `nil`.
  - `collectionWithOnlyUnsupportedFormats`, `collectionPreservesOrderWithMixedFormats`, and `mixedRealWorldScenario` now use genuine `lcov=` arguments (not a fictional placeholder), with their `json`/`html` expectations updated to correctly exclude the now-recognized lcov-tagged value, and explicit `lcovResult`/`expectedLcovArgs` checks added everywhere `.json`/`.html` already had one.
  - `IntegrationTestData.expectedLcovArgs` is a required field (no default), so every test entry in `TestCommandIntegrationTests.swift` must explicitly state its lcov expectation rather than silently skip it.
* Removed an accidentally-committed toolchain installer binary (`swiftly.pkg`) from git history and added it to `.gitignore`.

### Result:

`swift test --enable-code-coverage --coverage-format lcov` now produces a valid, standard lcov trace file directly. Verified by:

* Manual inspection of real output (correct `SF:`/`FN:`/`DA:`/`end_of_record` structure).
* The full existing `CoverageTests` suite, which now automatically covers `lcov` via `CoverageFormat.allCases` with no changes needed for the format-agnostic tests.
* A new dedicated test (`lcovReportHasValidTraceFileStructure`) that explicitly validates lcov's trace-file structure on every future run.
* `XcovArgumentTests` (23 tests, 7 suites) and `TestCommandIntegrationTests` — all passing, with `.lcov` now validated as thoroughly as `.json`/`.html` everywhere in both files.

Fixes [#9198](https://github.com/swiftlang/swift-package-manager/issues/9198)