### PR TITLE
Clarify error when local binary target is a ZIP archive ending in .artifactbundle

### DIFF
--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -186,6 +186,20 @@ struct BinaryArtifactsManagerError: Error, CustomStringConvertible {
         .init(description: "local binary target '\(targetName)' at '\(artifactPath)' does not contain a binary artifact.")
     }
 
+    static func localArtifactIsZipArchive(artifactPath: AbsolutePath, targetName: String) -> Self {
+        let ext = artifactPath.extension.map { ".\($0)" } ?? ""
+        return .init(
+            description: "local binary target '\(targetName)' at '\(artifactPath)' is a ZIP archive, but has extension '\(ext)'; ZIP archives must end in '.zip' (e.g. '\(artifactPath.basename).zip'), while '\(ext)' must be an uncompressed directory."
+        )
+    }
+
+    static func localArtifactNotDirectory(artifactPath: AbsolutePath, targetName: String) -> Self {
+        let ext = artifactPath.extension.map { "ending in '.\($0)' " } ?? ""
+        return .init(
+            description: "local binary target '\(targetName)' at '\(artifactPath)' is a file, but binary artifacts \(ext)must be uncompressed directories."
+        )
+    }
+
     static func artifactContainsEscapingSymlink(
         targetName: String,
         symlinkPath: AbsolutePath,

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -106,11 +106,11 @@ extension Workspace {
                                 path: absolutePath,
                                 observabilityScope: observabilityScope
                             ) else {
-                                observabilityScope.emit(
-                                    BinaryArtifactsManagerError.localArtifactNotFound(
-                                        artifactPath: absolutePath,
-                                        targetName: target.name
-                                    )
+                                Self.emitLocalArtifactNotFoundError(
+                                    fileSystem: self.fileSystem,
+                                    artifactPath: absolutePath,
+                                    targetName: target.name,
+                                    observabilityScope: observabilityScope
                                 )
                                 continue
                             }
@@ -792,7 +792,7 @@ extension Workspace.BinaryArtifactsManager {
         path: AbsolutePath,
         observabilityScope: ObservabilityScope
     ) throws -> [(AbsolutePath, BinaryModule.Kind)] {
-        guard fileSystem.exists(path) else {
+        guard fileSystem.exists(path), fileSystem.isDirectory(path) else {
             return []
         }
 
@@ -857,6 +857,64 @@ extension Workspace.BinaryArtifactsManager {
         }
 
         return .none
+    }
+
+    package static func isZipArchive(fileSystem: FileSystem, path: AbsolutePath) -> Bool {
+        guard fileSystem.isFile(path) else {
+            return false
+        }
+        let bytes: [UInt8]
+        if let fileHandle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: path.pathString)) {
+            defer { try? fileHandle.close() }
+            if let data = try? fileHandle.read(upToCount: 4), data.count >= 4 {
+                bytes = [UInt8](data)
+            } else {
+                return false
+            }
+        } else if let contents = try? fileSystem.readFileContents(path) {
+            bytes = Array(contents.contents.prefix(4))
+        } else {
+            return false
+        }
+        guard bytes.count >= 4 else {
+            return false
+        }
+        return bytes[0] == 0x50 && bytes[1] == 0x4B && (
+            (bytes[2] == 0x03 && bytes[3] == 0x04) ||
+            (bytes[2] == 0x05 && bytes[3] == 0x06) ||
+            (bytes[2] == 0x07 && bytes[3] == 0x08)
+        )
+    }
+
+    package static func emitLocalArtifactNotFoundError(
+        fileSystem: FileSystem,
+        artifactPath: AbsolutePath,
+        targetName: String,
+        observabilityScope: ObservabilityScope
+    ) {
+        if !fileSystem.exists(artifactPath) {
+            observabilityScope.emit(BinaryArtifactsManagerError.localArtifactNotFound(
+                artifactPath: artifactPath,
+                targetName: targetName
+            ))
+        } else if fileSystem.isFile(artifactPath) {
+            if Self.isZipArchive(fileSystem: fileSystem, path: artifactPath) {
+                observabilityScope.emit(BinaryArtifactsManagerError.localArtifactIsZipArchive(
+                    artifactPath: artifactPath,
+                    targetName: targetName
+                ))
+            } else {
+                observabilityScope.emit(BinaryArtifactsManagerError.localArtifactNotDirectory(
+                    artifactPath: artifactPath,
+                    targetName: targetName
+                ))
+            }
+        } else {
+            observabilityScope.emit(BinaryArtifactsManagerError.localArtifactNotFound(
+                artifactPath: artifactPath,
+                targetName: targetName
+            ))
+        }
     }
 }
 
@@ -929,10 +987,12 @@ extension Workspace {
                     path: artifact.path,
                     observabilityScope: observabilityScope
                 ) else {
-                    observabilityScope.emit(BinaryArtifactsManagerError.localArtifactNotFound(
+                    BinaryArtifactsManager.emitLocalArtifactNotFoundError(
+                        fileSystem: self.fileSystem,
                         artifactPath: artifact.path,
-                        targetName: artifact.targetName
-                    ))
+                        targetName: artifact.targetName,
+                        observabilityScope: observabilityScope
+                    )
                     continue
                 }
                 artifactsToAdd.append(artifact)

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -7273,6 +7273,82 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    func testLocalArtifactIsZipArchive() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "ReproTarget",
+                            type: .binary,
+                            path: "ArtifactBundles/Repro.artifactbundle"
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        let rootPath = try workspace.pathToRoot(withName: "Root")
+        let a1Path = rootPath.appending(components: "ArtifactBundles", "Repro.artifactbundle")
+        try fs.createDirectory(a1Path.parentDirectory, recursive: true)
+        try fs.writeFileContents(a1Path, bytes: ByteString([0x50, 0x4B, 0x03, 0x04, 0x00, 0x00]))
+
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+            testDiagnostics(diagnostics) { result in
+                result.check(
+                    diagnostic: .contains(
+                        "local binary target 'ReproTarget' at '\(a1Path)' is a ZIP archive, but has extension '.artifactbundle'; ZIP archives must end in '.zip' (e.g. 'Repro.artifactbundle.zip'), while '.artifactbundle' must be an uncompressed directory."
+                    ),
+                    severity: .error
+                )
+            }
+        }
+    }
+
+    func testLocalArtifactIsFileNotDirectory() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "ReproTarget",
+                            type: .binary,
+                            path: "ArtifactBundles/NotZip.artifactbundle"
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        let rootPath = try workspace.pathToRoot(withName: "Root")
+        let a1Path = rootPath.appending(components: "ArtifactBundles", "NotZip.artifactbundle")
+        try fs.createDirectory(a1Path.parentDirectory, recursive: true)
+        try fs.writeFileContents(a1Path, bytes: ByteString([0x00, 0x01, 0x02, 0x03]))
+
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+            testDiagnostics(diagnostics) { result in
+                result.check(
+                    diagnostic: .contains(
+                        "local binary target 'ReproTarget' at '\(a1Path)' is a file, but binary artifacts ending in '.artifactbundle' must be uncompressed directories."
+                    ),
+                    severity: .error
+                )
+            }
+        }
+    }
+
     func testArtifactDownloadHappyPath() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()


### PR DESCRIPTION
Clarify error when local binary target is a ZIP archive ending in .artifactbundle

Resolves #10077

### Motivation:

When referencing a local binary target pointing to a path ending in `.artifactbundle` or `.xcframework` that happens to be a ZIP archive on disk (or any file rather than an uncompressed directory), SwiftPM previously attempted to traverse it as a directory without checking whether it was a directory. This caused an unhandled `FileSystemError(.notDirectory, path)` to escape or a generic `does not contain a binary artifact` message, leaving users confused about why a `.artifactbundle` file was rejected.

### Modifications:

- In `Workspace.BinaryArtifactsManager.deriveBinaryArtifacts`, ensured `fileSystem.isDirectory(path)` is verified before trying to read directory contents, avoiding unhandled `FileSystemError(.notDirectory)`.
- Added helper `isZipArchive` to check for ZIP header magic bytes (`PK\x03\x04`, `PK\x05\x06`, `PK\x07\x08`).
- Added `localArtifactIsZipArchive` and `localArtifactNotDirectory` diagnostics in `WorkspaceDiagnostics` (`BinaryArtifactsManagerError`) explaining:
  - If it is a ZIP archive: archives must end in `.zip` (suggesting `<name>.zip`), while `.artifactbundle` / `.xcframework` must be uncompressed directories.
  - If it is a non-archive file: binary artifacts must be uncompressed directories.
- Added unit tests in `WorkspaceTests.swift` covering both cases (`testLocalArtifactIsZipArchive`, `testLocalArtifactIsFileNotDirectory`).

### Result:

Users pointing `.binaryTarget(path:)` at a ZIP archive ending in `.artifactbundle` receive an informative, actionable diagnostic explaining why the archive cannot be read and how to address it.