### PR TITLE
Warn instead of failing when a dependency declares no traits

### DIFF
--- a/Sources/PackageModel/EnabledTrait.swift
+++ b/Sources/PackageModel/EnabledTrait.swift
@@ -737,7 +737,7 @@ extension Collection where Element == EnabledTrait {
     }
 
     public func joined(separator: String = "") -> String {
-        names.joined(separator: separator)
+        names.sorted().joined(separator: separator)
     }
 }
 

--- a/Sources/PackageModel/Manifest/Manifest+Traits.swift
+++ b/Sources/PackageModel/Manifest/Manifest+Traits.swift
@@ -87,38 +87,40 @@ extension Manifest {
         }
     }
 
+    /// The reason this manifest cannot honour `explicitlyEnabledTraits` because it declares no traits at all,
+    /// or `nil` if that is not the problem.
+    ///
+    /// This is exposed separately from `validateEnabledTraits` because callers disagree on how severe it is.
+    /// A request naming traits this package no longer declares is not something the requesting package can
+    /// fix, so `Workspace` downgrades that case to a warning; see `Workspace.validateEnabledTraits(_:for:observabilityScope:)`.
+    public func unsupportedTraitsError(_ explicitlyEnabledTraits: EnabledTraits) -> TraitError? {
+        guard !self.supportsTraits, explicitlyEnabledTraits != ["default"] else {
+            return nil
+        }
+
+        return .traitsNotSupported(
+            package: .init(self),
+            explicitlyEnabledTraits: explicitlyEnabledTraits
+        )
+    }
+
     /// Validates a set of traits that is intended to be enabled for the manifest; if there are any discrepencies in the
     /// set of enabled traits and whether the manifest defines these traits (or if it defines any traits at all), then an
     /// error indicating the issue will be thrown.
     public func validateEnabledTraits(_ explicitlyEnabledTraits: EnabledTraits) throws {
-        guard supportsTraits else {
-            if explicitlyEnabledTraits != ["default"] {
-                throw TraitError.traitsNotSupported(
-                    package: .init(self),
-                    explicitlyEnabledTraits: explicitlyEnabledTraits
-                )
-            }
+        if let error = self.unsupportedTraitsError(explicitlyEnabledTraits) {
+            throw error
+        }
 
+        // A manifest that declares no traits has nothing left to check: the only set it can be asked for
+        // is `["default"]`, which `unsupportedTraitsError` has already let through.
+        guard self.supportsTraits else {
             return
         }
 
-        let enabledTraits = explicitlyEnabledTraits
-
         // Validate each trait to assure it's defined in the current package.
-        for trait in enabledTraits {
+        for trait in explicitlyEnabledTraits {
            try validateTrait(trait)
-        }
-
-        let areDefaultsEnabled = enabledTraits.contains("default")
-
-        // Ensure that disabling default traits is disallowed for packages that don't define any traits.
-        if !areDefaultsEnabled && !self.supportsTraits {
-            // We throw an error when default traits are disabled for a package without any traits
-            // This allows packages to initially move new API behind traits once.
-            throw TraitError.traitsNotSupported(
-                package: .init(self),
-                explicitlyEnabledTraits: enabledTraits
-            )
         }
     }
 

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -72,8 +72,6 @@ extension Workspace {
             self.delegate?.didUpdateDependencies(duration: start.distance(to: .now()))
         }
 
-//        self.enabledTraitsMap = [:]
-
         // Create cache directories.
         self.createCacheDirectories(observabilityScope: observabilityScope)
 

--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -683,6 +683,10 @@ extension Workspace {
             try await updateEnabledTraits(for: manifest, observabilityScope: observabilityScope)
         }
 
+        // Now that every parent has registered its edges, each package's enabled traits are final
+        // and can be reported on.
+        self.reportTraitFallbacks(for: allManifests.values, observabilityScope: observabilityScope)
+
         let dependencyManifests = allNodes.filter { !$0.value.manifest.packageKind.isRoot }
 
         // TODO: this check should go away when introducing explicit overrides

--- a/Sources/Workspace/Workspace+Traits.swift
+++ b/Sources/Workspace/Workspace+Traits.swift
@@ -17,6 +17,7 @@ import enum PackageModel.ProductFilter
 import enum PackageModel.PackageDependency
 import struct PackageModel.EnabledTrait
 import struct PackageModel.EnabledTraits
+import enum PackageModel.TraitError
 import class Basics.ObservabilityScope
 import Basics
 
@@ -41,7 +42,7 @@ extension Workspace {
         // for a no-trait package it discards that information and returns ["default"].
         // Root packages are validated separately through the trait configuration path.
         if !manifest.packageKind.isRoot {
-            try manifest.validateEnabledTraits(explicitlyEnabledTraits)
+            try self.validateEnabledTraits(explicitlyEnabledTraits, for: manifest)
         }
 
         var enabledTraits = try manifest.enabledTraits(using: explicitlyEnabledTraits)
@@ -96,6 +97,97 @@ extension Workspace {
             self.enabledTraitsMap[dependency.identity] = defaultTraits
         }
     }
+
+    /// Validates the traits enabled for a non-root `Manifest`, throwing only for a request that must fail
+    /// package resolution.
+    ///
+    /// A parent manifest asking a traitless package to *disable* its defaults is an error. This rule is in place
+    /// to protect the ability of a package to move existing API behind a default trait without breaking its consumers.
+    /// The parent's author owns the manifest that made the request, so they can act on the error.
+    ///
+    /// Everything else falls back to the package's defaults, which is what `enabledTraits(using:)` returns for
+    /// a traitless package anyway, and `reportTraitFallbacks` warns about it. That covers naming traits the
+    /// package no longer declares, and disabling defaults from a stored trait configuration: in both cases the
+    /// dependency is the thing that changed, and there is nothing the consumer can do about it short of
+    /// editing a manifest they may not own.
+    func validateEnabledTraits(_ enabledTraits: EnabledTraits, for manifest: Manifest) throws {
+        guard let unsupportedTraits = manifest.unsupportedTraitsError(enabledTraits) else {
+            try manifest.validateEnabledTraits(enabledTraits)
+            return
+        }
+
+        if enabledTraits.isEmpty, !self.defaultsDisabledOnlyByTraitConfiguration(manifest) {
+            throw unsupportedTraits
+        }
+    }
+
+    /// Whether every setter that disabled this package's default traits was a stored trait configuration.
+    ///
+    /// `EnabledTraits.disabledBy` reports one setter picked arbitrarily out of the recorded disablers, so it
+    /// can't answer this when a package was disabled by more than one thing. Ask the map for all of them
+    /// instead: a parent manifest among them is a request its author can fix, and stays an error.
+    private func defaultsDisabledOnlyByTraitConfiguration(_ manifest: Manifest) -> Bool {
+        guard let disablers = self.enabledTraitsMap[disablersFor: manifest.packageIdentity],
+              !disablers.isEmpty
+        else {
+            return false
+        }
+
+        return disablers.allSatisfy { $0 == .traitConfiguration }
+    }
+
+    /// Warns about packages that were asked for traits they don't declare and will fall back to their defaults.
+    ///
+    /// This runs over the whole manifest set rather than from `updateEnabledTraits`, because a single
+    /// manifest's enabled traits aren't final until every parent has registered its edges. Warning as each
+    /// manifest loads would report a request that is still being assembled, and report it once per loading
+    /// pass rather than once per package.
+    func reportTraitFallbacks(
+        for manifests: some Sequence<Manifest>,
+        observabilityScope: ObservabilityScope
+    ) {
+        for manifest in manifests where !manifest.packageKind.isRoot {
+            // Report only the named traits, `default` is always present.
+            var requestedTraits = self.enabledTraitsMap[manifest.packageIdentity]
+            _ = requestedTraits.remove("default")
+
+            // If all that is left is an empty map, the request is to disable defaults. This is only tolerated
+            // (and so we only warn about it) when every disabler was a stored trait configuration.
+            // An empty map with no disablers at all means nothing was requested of this package, so there is nothing to report.
+            guard !requestedTraits.isEmpty || self.defaultsDisabledOnlyByTraitConfiguration(manifest),
+                  let unsupportedTraits = manifest.unsupportedTraitsError(requestedTraits)
+            else {
+                continue
+            }
+
+            observabilityScope.emit(
+                warning: """
+                \(self.traitFallbackReason(unsupportedTraits, requestedTraits, manifest)) The package will \
+                be built with its default traits.
+                """
+            )
+        }
+    }
+
+    /// Describes why a package can't honour what was asked of it, for use in a warning.
+    ///
+    /// `TraitError`'s own prose ends by explaining why the request is normally rejected, which contradicts a
+    /// warning saying we went ahead regardless. That only applies to disabling defaults, so reuse the error's
+    /// wording for a request naming traits and describe the disable case here.
+    private func traitFallbackReason(
+        _ unsupportedTraits: TraitError,
+        _ requestedTraits: EnabledTraits,
+        _ manifest: Manifest
+    ) -> String {
+        guard requestedTraits.isEmpty else {
+            return "\(unsupportedTraits)"
+        }
+
+        return """
+        The trait configuration disables the default traits of package \
+        \(Manifest.PackageIdentifier(manifest)), which declares no traits.
+        """
+    }
 }
 
 extension Workspace {
@@ -112,7 +204,7 @@ extension Workspace {
             let enabledTraits = self.enabledTraitsMap[manifest]
 
             // Validate traits on update.
-            try manifest.validateEnabledTraits(enabledTraits)
+            try self.validateEnabledTraits(enabledTraits, for: manifest)
         }
     }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
@@ -2468,4 +2468,184 @@ extension WorkspaceTests {
             result.check(dependency: "guardedleaf", at: .checkout(.version("1.0.0")))
         }
     }
+
+    /// A dependency that declared a trait in one version and declares none in the next.
+    func testDependencyDropsTraitsInNewVersion_WarnsOnUpdate() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "RootTarget",
+                            dependencies: [.product(name: "TraitfulProduct", package: "TraitfulPackage")]
+                        ),
+                    ],
+                    dependencies: [
+                        .sourceControl(
+                            path: "./TraitfulPackage",
+                            requirement: .range("1.0.0" ..< "3.0.0"),
+                            traits: ["Logging"]
+                        ),
+                    ]
+                ),
+            ],
+            packages: [
+                // Declares the trait the root asks for.
+                MockPackage(
+                    name: "TraitfulPackage",
+                    targets: [MockTarget(name: "TraitfulTarget")],
+                    products: [MockProduct(name: "TraitfulProduct", modules: ["TraitfulTarget"])],
+                    traits: ["Logging"],
+                    versions: ["1.0.0", "1.0.1"]
+                ),
+                // Same package, next major, with the trait removed.
+                MockPackage(
+                    name: "TraitfulPackage",
+                    targets: [MockTarget(name: "TraitfulTarget")],
+                    products: [MockProduct(name: "TraitfulProduct", modules: ["TraitfulTarget"])],
+                    versions: ["2.0.0"]
+                ),
+            ]
+        )
+
+        // Hold the first resolution at 1.x, where the root's request is still honourable.
+        let deps: [MockDependency] = [
+            .sourceControl(path: "./TraitfulPackage", requirement: .upToNextMajor(from: "1.0.0")),
+        ]
+
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+            PackageGraphTesterXCTest(graph) { result in
+                result.check(roots: "Root")
+                result.check(packages: "Root", "TraitfulPackage")
+            }
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "traitfulpackage", at: .checkout(.version("1.0.1")))
+        }
+
+        // Updating moves to 2.0.0, which declares no traits at all.
+        try await workspace.checkUpdate(roots: ["Root"]) { diagnostics in
+            testDiagnostics(diagnostics) { result in
+                result.check(
+                    diagnostic: .contains(
+                        "Package 'root' (Root) enables traits [Logging] on package 'traitfulpackage' (TraitfulPackage) that declares no traits. The package will be built with its default traits."
+                    ),
+                    severity: .warning
+                )
+            }
+        }
+
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "traitfulpackage", at: .checkout(.version("2.0.0")))
+        }
+    }
+
+    /// Disabling a traitless package's defaults is a hard error.
+    func testDependencyWithoutTraits_ParentDisablesDefaults_IsError() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "RootTarget",
+                            dependencies: [.product(name: "TraitlessProduct", package: "TraitlessPackage")]
+                        ),
+                    ],
+                    dependencies: [
+                        .sourceControl(
+                            path: "./TraitlessPackage",
+                            requirement: .upToNextMajor(from: "1.0.0"),
+                            traits: []
+                        ),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "TraitlessPackage",
+                    targets: [MockTarget(name: "TraitlessTarget")],
+                    products: [MockProduct(name: "TraitlessProduct", modules: ["TraitlessTarget"])],
+                    versions: ["1.0.0"]
+                ),
+            ]
+        )
+
+        try await workspace.checkPackageGraphFailure(roots: ["Root"], deps: []) { diagnostics in
+            testDiagnostics(diagnostics) { result in
+                result.check(
+                    diagnostic: .contains("Disabled default traits by package 'root' (Root) on package 'traitlesspackage' (TraitlessPackage) that declares no traits."),
+                    severity: .error
+                )
+            }
+        }
+    }
+
+    /// The fallback warning is suppressed per package so a single resolution doesn't repeat it on every
+    /// manifest-loading pass. That suppression must not outlive the resolution. This ensures a `Workspace`
+    /// can be reused across resolutions.
+    func testDependencyWithoutTraits_WarnsOnEveryResolution() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "RootTarget",
+                            dependencies: [.product(name: "TraitlessProduct", package: "TraitlessPackage")]
+                        ),
+                    ],
+                    dependencies: [
+                        .sourceControl(
+                            path: "./TraitlessPackage",
+                            requirement: .upToNextMajor(from: "1.0.0"),
+                            traits: ["Logging"]
+                        ),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "TraitlessPackage",
+                    targets: [MockTarget(name: "TraitlessTarget")],
+                    products: [MockProduct(name: "TraitlessProduct", modules: ["TraitlessTarget"])],
+                    versions: ["1.0.0"]
+                ),
+            ]
+        )
+
+        for _ in 0 ..< 2 {
+            try await workspace.checkPackageGraph(roots: ["Root"], deps: []) { graph, diagnostics in
+                PackageGraphTesterXCTest(graph) { result in
+                    result.check(packages: "Root", "TraitlessPackage")
+                }
+                testDiagnostics(diagnostics) { result in
+                    result.check(
+                        diagnostic: .contains(
+                            "on package 'traitlesspackage' (TraitlessPackage) that declares no traits. The package will be built with its default traits."
+                        ),
+                        severity: .warning
+                    )
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
If a client has traits persisted for a dependency, and that dependency drops its traits in a new version, loading the package graph fails:

`Traits [Bar] have been enabled on package 'baz' (Baz) that declares no traits.`

The consumer changed nothing, and can't fix the dependency's manifest, but resolution now errors.

Warn and fall back to the package's defaults instead. Asking a traitless package to disable its defaults is still an error when a parent manifest requests it.
