### PR TITLE
Allow optional comment in Testing.Bug.issue trait

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift
@@ -28,10 +28,13 @@ extension Trait where Self == Testing.Bug {
     public static func issue(
         _ issue: _const String,
         relationship: Relationship,
+        comment: Comment? = nil
     ) -> Self {
-        bug(nil, id: 0, "\(relationship): \(issue)")
+        if let comment {
+            bug(nil, id: 0, "\(relationship): \(issue) - \(comment)")        } else {
+            bug(nil, id: 0, "\(relationship): \(issue)")
+        }
     }
-
     public static var IssueWindowsRelativePathAssert: Self {
         // TSCBasic/Path.swift:969: Assertion failed
         issue(

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift
@@ -35,6 +35,7 @@ extension Trait where Self == Testing.Bug {
             bug(nil, id: 0, "\(relationship): \(issue)")
         }
     }
+    
     public static var IssueWindowsRelativePathAssert: Self {
         // TSCBasic/Path.swift:969: Assertion failed
         issue(


### PR DESCRIPTION
Allow `Trait.issue` to optionally accept a descriptive comment

### Motivation:

While reviewing #10497, bkhouri suggested using SwiftPM's own custom `.issue(_:relationship:)` trait instead of Swift Testing's built-in `.bug(_:_:)`, since `.issue` is more readable and already carries relationship semantics (`.verifies`, `.defect`, `.fixedBy`). However, `.issue` currently has no way to attach a free-text description the way `.bug(_:_:)` could — it only accepts the issue URL and a relationship. This makes it a strictly weaker replacement for `.bug` as-is.

### Modifications:

- Added an optional `comment: Comment? = nil` parameter to `issue(_:relationship:)` in `Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift`.
- When a comment is provided, it's appended to the generated bug title as `"\(relationship): \(issue) - \(comment)"`; when omitted, behavior is unchanged from before (`"\(relationship): \(issue)"`).
- The new parameter defaults to `nil` and is purely additive, so all existing call sites in this file (`IssueWindowsRelativePathAssert`, `IssueWindowsPathNoEntry`, etc.) continue to compile and behave identically without modification.

### Result:

`.issue(...)` can now fully replace `.bug(...)` at call sites that want both a relationship and a descriptive comment, e.g.:
```swift
.issue(
    "https://github.com/swiftlang/swift-package-manager/issues/9198",
    relationship: .verifies,
    comment: "Add lcov coverage report format",
),