### PR TITLE
Warn and prefer --swift-sdk over an SDKROOT/-sdk override when both are provided

### DIFF
--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -1043,6 +1043,23 @@ public final class SwiftCommandState {
     when building on macOS.
     """
 
+    package func computeSDKRootOverride() -> AbsolutePath? {
+        let sdkRootOverride = self.options.build.customCompileSDK
+            ?? self.environment["SDKROOT"].flatMap { try? AbsolutePath(validating: $0) }
+        guard let sdkRootOverride else {
+            return nil
+        }
+        if let swiftSDKSelector = self.options.build.swiftSDKSelector {
+            let source = self.options.build.customCompileSDK != nil
+                ? "'--sdk'"
+                : "the 'SDKROOT' environment variable"
+            self.observabilityScope.emit(warning: "ignoring the SDK '\(sdkRootOverride)' specified using \(source) because the Swift SDK '\(swiftSDKSelector)' was selected with '--swift-sdk'")
+            return nil
+        } else {
+            return sdkRootOverride
+        }
+    }
+
     private func _buildParams(
         toolchain: UserToolchain,
         destination: BuildParameters.Destination,
@@ -1071,7 +1088,7 @@ public final class SwiftCommandState {
             configuration: self.options.build.configuration ?? self.preferredBuildConfiguration,
             toolchain: toolchain,
             triple: triple,
-            sdkRootOverride: self.options.build.customCompileSDK ?? self.environment["SDKROOT"].flatMap({ try? AbsolutePath(validating: $0) }),
+            sdkRootOverride: self.computeSDKRootOverride(),
             flags: options.build.buildFlags,
             buildSystemKind: options.build.buildSystem,
             pkgConfigDirectories: options.locations.pkgConfigDirectories,

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -96,6 +96,121 @@ struct SwiftCommandStateTestSuites {
         )
     }
 
+    private static func makeSDKRootOverrideState(
+        arguments: [String],
+        environment: Environment,
+    ) throws -> (state: SwiftCommandState, output: BufferedOutputByteStream) {
+        let fs = InMemoryFileSystem(emptyFiles: ["/Pkg/Sources/exe/main.swift"])
+        let outputStream = BufferedOutputByteStream()
+        let state = try SwiftCommandState.makeMockState(
+            outputStream: outputStream,
+            options: GlobalOptions.parse(arguments),
+            fileSystem: fs,
+            environment: environment,
+        )
+        return (state, outputStream)
+    }
+
+    @Test(
+        .tags(
+            .TestSize.small,
+        ),
+    )
+    func sdkRootOverrideDefaultsToUnset() throws {
+        let (state, output) = try Self.makeSDKRootOverrideState(arguments: [], environment: [:])
+
+        #expect(state.computeSDKRootOverride() == nil)
+
+        state.waitForObservabilityEvents(timeout: .now() + .seconds(1))
+        #expect(!output.bytes.validDescription!.contains("warning:"))
+    }
+
+    @Test(
+        .tags(
+            .TestSize.small,
+        ),
+    )
+    func sdkRootOverrideComesFromSDKOption() throws {
+        let (state, _) = try Self.makeSDKRootOverrideState(
+            arguments: ["--sdk", "/fake/sdk"],
+            environment: [:],
+        )
+
+        #expect(state.computeSDKRootOverride() == AbsolutePath("/fake/sdk"))
+    }
+
+    @Test(
+        .tags(
+            .TestSize.small,
+        ),
+    )
+    func sdkRootOverrideComesFromSDKROOTEnvironmentVariable() throws {
+        let (state, _) = try Self.makeSDKRootOverrideState(
+            arguments: [],
+            environment: ["SDKROOT": "/fake/env/sdk"],
+        )
+
+        #expect(state.computeSDKRootOverride() == AbsolutePath("/fake/env/sdk"))
+    }
+
+    @Test(
+        .tags(
+            .TestSize.small,
+        ),
+    )
+    func sdkOptionTakesPrecedenceOverSDKROOTEnvironmentVariable() throws {
+        let (state, _) = try Self.makeSDKRootOverrideState(
+            arguments: ["--sdk", "/fake/sdk"],
+            environment: ["SDKROOT": "/fake/env/sdk"],
+        )
+
+        #expect(state.computeSDKRootOverride() == AbsolutePath("/fake/sdk"))
+    }
+
+    @Test(
+        .tags(
+            .TestSize.small,
+        ),
+    )
+    func swiftSDKSuppressesSDKOptionWithWarning() throws {
+        let (state, output) = try Self.makeSDKRootOverrideState(
+            arguments: ["--sdk", "/fake/sdk", "--swift-sdk", "my-swift-sdk"],
+            environment: [:],
+        )
+
+        #expect(state.computeSDKRootOverride() == nil)
+
+        state.waitForObservabilityEvents(timeout: .now() + .seconds(1))
+        let contents = try #require(output.bytes.validDescription)
+        #expect(
+            contents.contains(
+                "warning: ignoring the SDK '/fake/sdk' specified using '--sdk' because the Swift SDK 'my-swift-sdk' was selected with '--swift-sdk'"
+            ),
+        )
+    }
+
+    @Test(
+        .tags(
+            .TestSize.small,
+        ),
+    )
+    func swiftSDKSuppressesSDKROOTEnvironmentVariableWithWarning() throws {
+        let (state, output) = try Self.makeSDKRootOverrideState(
+            arguments: ["--swift-sdk", "my-swift-sdk"],
+            environment: ["SDKROOT": "/fake/env/sdk"],
+        )
+
+        #expect(state.computeSDKRootOverride() == nil)
+
+        state.waitForObservabilityEvents(timeout: .now() + .seconds(1))
+        let contents = try #require(output.bytes.validDescription)
+        #expect(
+            contents.contains(
+                "warning: ignoring the SDK '/fake/env/sdk' specified using the 'SDKROOT' environment variable because the Swift SDK 'my-swift-sdk' was selected with '--swift-sdk'"
+            ),
+        )
+    }
+
     @Test(
         .tags(
             .TestSize.small,


### PR DESCRIPTION
Most often this happens when someone is using a Swift SDK and accidentally has SDKROOT in the environment. We might consider elevating this to an error in the future, but at the moment some tests in projects like sourcekit-lsp depend on us choosing a winner.