### PR TITLE
Fix explicit enablement of index-while-building in release configs

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1066,12 +1066,18 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                 settings[setting.enableVariableName] = "YES"
                 settings[setting.pathVariable] = try await self.indexStore(for: self.buildParameters).pathStringWithPosixSlashes
             }
+            // When indexing is explicitly enabled, set COMPILER_INDEX_STORE_ENABLE explicitly to allow index-while-building
+            // with optimizations enabled.
+            settings["COMPILER_INDEX_STORE_ENABLE"] = "YES"
         case .off:
             for setting in indexStoreSettingNames {
                 settings[setting.enableVariableName] = "NO"
             }
         case .auto:
-            // The settings are handles in the PIF builder
+            // The enablement settings are handled in the PIF builder
+            for setting in indexStoreSettingNames {
+                settings[setting.pathVariable] = try await self.indexStore(for: self.buildParameters).pathStringWithPosixSlashes
+            }
             break
         }
 
@@ -1144,6 +1150,14 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         let ddPathPrefix = derivedDataPath.pathString
         #endif
 
+        let indexEnableDataStore: Bool
+        switch buildParameters.indexStoreMode {
+        case .off:
+            indexEnableDataStore = false
+        case .on, .auto:
+            indexEnableDataStore = true
+        }
+
         let arenaInfo = SWBArenaInfo(
             derivedDataPath: ddPathPrefix,
             buildProductsPath: ddPathPrefix + "/Products",
@@ -1153,7 +1167,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             indexRegularBuildIntermediatesPath: nil,
             indexPCHPath: ddPathPrefix,
             indexDataStoreFolderPath: ddPathPrefix,
-            indexEnableDataStore: request.parameters.arenaInfo?.indexEnableDataStore ?? false
+            indexEnableDataStore: request.parameters.arenaInfo?.indexEnableDataStore ?? indexEnableDataStore
         )
 
         request.parameters.arenaInfo = arenaInfo

--- a/Tests/CommandsTests/IndexStoreTests.swift
+++ b/Tests/CommandsTests/IndexStoreTests.swift
@@ -1,0 +1,121 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import _InternalTestSupport
+
+import struct Basics.AbsolutePath
+import var Basics.localFileSystem
+import typealias Basics.TSCAbsolutePath
+import enum PackageModel.BuildConfiguration
+import struct SPMBuildCore.BuildSystemProvider
+
+@Suite(
+    .tags(
+        .TestSize.large,
+        .Feature.Command.Build,
+    ),
+)
+struct IndexStoreIntegrationTests {
+    @Test(
+        arguments: SupportedBuildSystemOnAllPlatforms,
+        BuildConfiguration.allCases,
+    )
+    func explicitlyEnabled(
+        buildSystem: BuildSystemProvider.Kind,
+        configuration: BuildConfiguration,
+    ) async throws {
+        try await fixture(name: "CFamilyTargets/SwiftCMixed") { fixturePath in
+            try await executeSwiftBuild(
+                fixturePath,
+                configuration: configuration,
+                extraArgs: ["--enable-index-store"],
+                buildSystem: buildSystem,
+            )
+            let binPath = try await getBinPath(
+                fixturePath,
+                configuration: configuration,
+                buildSystem: buildSystem,
+            )
+            let storePath = binPath.appending(components: "index", "store")
+            #expect(try !localFileSystem.getDirectoryContents(storePath).isEmpty)
+        }
+    }
+
+    @Test(
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func implicitlyEnabledViaBuildConfig(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "CFamilyTargets/SwiftCMixed") { fixturePath in
+            try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                buildSystem: buildSystem,
+            )
+            let binPath = try await getBinPath(
+                fixturePath,
+                configuration: .debug,
+                buildSystem: buildSystem,
+            )
+            let storePath = binPath.appending(components: "index", "store")
+            #expect(try !localFileSystem.getDirectoryContents(storePath).isEmpty)
+        }
+    }
+
+    @Test(
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func implicitlyDisabledViaBuildConfig(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "CFamilyTargets/SwiftCMixed") { fixturePath in
+            try await executeSwiftBuild(
+                fixturePath,
+                configuration: .release,
+                buildSystem: buildSystem,
+            )
+            let binPath = try await getBinPath(
+                fixturePath,
+                configuration: .release,
+                buildSystem: buildSystem,
+            )
+            let storePath = binPath.appending(components: "index", "store")
+            #expect(!localFileSystem.exists(storePath))
+        }
+    }
+
+    @Test(
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func explicitlyDisabled(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "CFamilyTargets/SwiftCMixed") { fixturePath in
+            try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                extraArgs: ["--disable-index-store"],
+                buildSystem: buildSystem,
+            )
+            let binPath = try await getBinPath(
+                fixturePath,
+                configuration: .debug,
+                buildSystem: buildSystem,
+            )
+            let storePath = binPath.appending(components: "index", "store")
+            #expect(!localFileSystem.exists(storePath))
+        }
+    }
+}

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -188,6 +188,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     buildSystemKind: .swiftbuild,
                     sanitizers: [sanitizer],
                 ),
@@ -218,6 +219,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     buildSystemKind: .swiftbuild,
                     sanitizers: [sanitizer],
                 ),
@@ -281,6 +283,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     buildSystemKind: .swiftbuild,
                     shouldLinkStaticSwiftStdlib: shouldLinkStaticSwiftStdlib,
                     triple: triple,
@@ -325,6 +328,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     buildSystemKind: .swiftbuild,
                     shouldLinkStaticSwiftStdlib: shouldLinkStaticSwiftStdlib,
                     triple: nonDarwinTriple,
@@ -354,7 +358,6 @@ struct SwiftBuildSystemTests {
 
     @Test(
         arguments: BuildParameters.IndexStoreMode.allCases,
-        // arguments: [BuildParameters.IndexStoreMode.on],
     )
     func indexModeSettingSetCorrectBuildRequest(
         indexStoreSettingUT: BuildParameters.IndexStoreMode
@@ -383,13 +386,17 @@ struct SwiftBuildSystemTests {
                 case .auto: nil
             }
             let expectedPathValue: AbsolutePath? = switch indexStoreSettingUT {
-                case .on: try await swiftBuild.indexStore(for: buildParameters)
+                case .on, .auto: try await swiftBuild.indexStore(for: buildParameters)
                 case .off: nil
-                case .auto: nil
+            }
+            let expectedCompilerIndexStoreValue: String? = switch indexStoreSettingUT {
+                case .on: "YES"
+                case .off, .auto: nil
             }
 
             #expect(synthesizedArgs.table["SWIFT_INDEX_STORE_ENABLE"] == expectedSettingValue)
             #expect(synthesizedArgs.table["CLANG_INDEX_STORE_ENABLE"] == expectedSettingValue)
+            #expect(synthesizedArgs.table["COMPILER_INDEX_STORE_ENABLE"] == expectedCompilerIndexStoreValue)
             if let expectedPathValue {
                 let swiftPath = try #require(
                     synthesizedArgs.table["SWIFT_INDEX_STORE_PATH"],
@@ -424,6 +431,7 @@ struct SwiftBuildSystemTests {
             fromFixture: "PIFBuilder/Simple",
             buildParameters: mockBuildParameters(
                 destination: .host,
+                toolchain: try UserToolchain.default,
                 buildSystemKind: .swiftbuild,
                 stripProducts: stripProductsSettingUT,
             ),
@@ -461,6 +469,7 @@ struct SwiftBuildSystemTests {
             fromFixture: "PIFBuilder/Simple",
             buildParameters: mockBuildParameters(
                 destination: .host,
+                toolchain: try UserToolchain.default,
                 buildSystemKind: .swiftbuild,
                 linkerDeadStrip: linkerDeadStripUT,
             ),
@@ -501,6 +510,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     buildSystemKind: .swiftbuild,
                     numberOfWorkers: expectedNumberOfWorkers,
                 ),
@@ -527,6 +537,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     flags: .init(cCompilerFlags: [BuildFlag(value: "-DFoo", source: .commandLineOptions)]),
                     buildSystemKind: .swiftbuild
                 ),
@@ -571,6 +582,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     buildSystemKind: .swiftbuild,
                     triple: .x86_64MacOS,
                     shouldEnableDebuggingEntitlement: shouldEnableDebuggingEntitlement
@@ -609,6 +621,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     buildSystemKind: .swiftbuild,
                     debugInfoFormat: debugInfoFormat
                 ),
@@ -633,6 +646,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     buildSystemKind: .swiftbuild,
                     triple: .windows,
                     debugInfoFormat: .codeview
@@ -665,6 +679,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     buildSystemKind: .swiftbuild,
                     omitFramePointers: omitFramePointers
                 ),
@@ -689,6 +704,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     buildSystemKind: .swiftbuild,
                     omitFramePointers: nil
                 ),
@@ -722,6 +738,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     buildSystemKind: .swiftbuild,
                     debugInfoFormat: .dwarf,
                     shouldEnableDebuggingEntitlement: true,
@@ -780,6 +797,7 @@ struct SwiftBuildSystemTests {
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(
                     destination: .host,
+                    toolchain: try UserToolchain.default,
                     flags: flags,
                     buildSystemKind: .swiftbuild,
                     debugInfoFormat: .dwarf,
@@ -857,6 +875,7 @@ struct SwiftBuildSystemTests {
             fromFixture: "PIFBuilder/Simple",
             buildParameters: mockBuildParameters(
                 destination: .host,
+                toolchain: try UserToolchain.default,
                 flags: flags,
                 buildSystemKind: .swiftbuild,
             ),
@@ -886,6 +905,7 @@ struct SwiftBuildSystemTests {
             fromFixture: "PIFBuilder/Simple",
             buildParameters: mockBuildParameters(
                 destination: .host,
+                toolchain: try UserToolchain.default,
                 buildSystemKind: .swiftbuild,
                 sdkRootOverride: sdkRoot,
             ),


### PR DESCRIPTION
A couple settings were missing to allow index-while-building to be properly enabled in all configs. Additionally, ensure we use the same index store path when enabling it explicitly vs implicitly for the sake of consistency. Add some end to end tests which verify the index store is at the expected location and non-empty when enabled in various ways.