### PR TITLE
moves link to Swift Build GH repo down into main content

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
@@ -1,10 +1,10 @@
 # SwiftPM 6.4 Release Notes
 
-Swift Package Manager 6.4 makes [Swift Build](https://github.com/swiftlang/swift-build) the new default build system, providing a unified build experience across all platforms Swift supports. This release also adds first-class support for generating Software Bill of Materials (SBOM) documents.
+Swift Package Manager 6.4 makes Swift Build the new default build system, providing a unified build experience across all platforms Swift supports. This release also adds first-class support for generating Software Bill of Materials (SBOM) documents.
 
 ## Swift Build: the new default build system
 
-SwiftPM has changed its default build system to Swift Build.
+SwiftPM has changed its default build system to [Swift Build](https://github.com/swiftlang/swift-build).
 
 ### Key changes from the native build system
 


### PR DESCRIPTION
Moves the link to the Swift Build GH repo into the main content


### Motivation:

Setting link on the first in-content reference - initial drop was within the abstract for the article page, which doesn't uniformly render as a link (and didn't in this case at https://docs.swift.org/latest/documentation/packagemanagerdocs/6.4/)

### Modifications:

- remove link from abstract
- add link to first in-content reference to Swift Build, directing to the GH repository

### Result:

First in-content reference should include a link to Swift Build (https://github.com/swiftlang/swift-build)
