### PR TITLE
Fixup arena info index data path to match build request overrides

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1151,11 +1151,14 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         #endif
 
         let indexEnableDataStore: Bool
+        let indexDataStoreFolderPath: String?
         switch buildParameters.indexStoreMode {
         case .off:
             indexEnableDataStore = false
+            indexDataStoreFolderPath = nil
         case .on, .auto:
             indexEnableDataStore = true
+            indexDataStoreFolderPath = try await self.indexStore(for: buildParameters).pathStringWithPosixSlashes
         }
 
         let arenaInfo = SWBArenaInfo(
@@ -1166,7 +1169,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             indexRegularBuildProductsPath: nil,
             indexRegularBuildIntermediatesPath: nil,
             indexPCHPath: ddPathPrefix,
-            indexDataStoreFolderPath: ddPathPrefix,
+            indexDataStoreFolderPath: indexDataStoreFolderPath,
             indexEnableDataStore: request.parameters.arenaInfo?.indexEnableDataStore ?? indexEnableDataStore
         )
 

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -412,6 +412,19 @@ struct SwiftBuildSystemTests {
                 #expect(synthesizedArgs.table["SWIFT_INDEX_STORE_PATH"] == nil)
                 #expect(synthesizedArgs.table["CLANG_INDEX_STORE_PATH"] == nil)
             }
+
+            let buildRequest = try await swiftBuild.makeBuildRequest(
+                service: service,
+                session: session,
+                configuredTargets: [],
+                derivedDataPath: buildParameters.dataPath,
+                symbolGraphOptions: nil,
+                setToolchainSetting: false,
+                shouldDisableSandbox: false,
+            )
+            let arenaInfo = try #require(buildRequest.parameters.arenaInfo)
+            #expect(arenaInfo.indexEnableDataStore == (indexStoreSettingUT != .off))
+            #expect(arenaInfo.indexDataStoreFolderPath == expectedPathValue?.pathString)
         }
     }
 


### PR DESCRIPTION
One more indexing fix to ensure the arena info always contains the right path to the index store. This allows BSP clients to correctly load the data when relying on index-while-building