### PR TITLE
Build a traitless package with its default traits

### DIFF
--- a/Sources/PackageModel/EnabledTrait.swift
+++ b/Sources/PackageModel/EnabledTrait.swift
@@ -166,6 +166,12 @@ public struct EnabledTraitsMap {
     // for packages that can be versioned.
     public subscript(manifest: Manifest) -> EnabledTraits {
         get {
+            // A package that declares no traits can only be built with its defaults, whatever its parents
+            // or a trait configuration asked of it.
+            guard manifest.supportsTraits else {
+                return .defaults
+            }
+
             // use manifest version to acquire per-version traits
             let identity = manifest.packageIdentity
             guard let version = manifest.version else {

--- a/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
@@ -2648,4 +2648,48 @@ extension WorkspaceTests {
             }
         }
     }
+
+    /// A traitless package must be built with its default traits, not with the traits that were requested
+    /// of it. The warning alone isn't enough: the request has to be cleared out of the enabled traits map,
+    /// which unions its writes and would otherwise carry the request through to the graph.
+    func testDependencyWithoutTraits_ResolvesToDefaultTraits() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "RootTarget",
+                            dependencies: [.product(name: "TraitlessProduct", package: "TraitlessPackage")]
+                        ),
+                    ],
+                    dependencies: [
+                        .sourceControl(
+                            path: "./TraitlessPackage",
+                            requirement: .upToNextMajor(from: "1.0.0"),
+                            traits: ["Logging"]
+                        ),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "TraitlessPackage",
+                    targets: [MockTarget(name: "TraitlessTarget")],
+                    products: [MockProduct(name: "TraitlessProduct", modules: ["TraitlessTarget"])],
+                    versions: ["1.0.0"]
+                ),
+            ]
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Root"], deps: []) { graph, _ in
+            let traitlessPackage = graph.packages.first { $0.identity == .plain("traitlesspackage") }
+            XCTAssertEqual(traitlessPackage?.enabledTraits, ["default"])
+        }
+    }
 }


### PR DESCRIPTION
A dependency asked for traits it doesn't declare gets a warning and falls back to its defaults, but the fallback never reached the graph. The request recorded by a parent manifest or a trait configuration stayed in EnabledTraitsMap, which unions its writes, so it was carried along into ResolvedPackage.enabledTraits and the package was built with traits it doesn't have.

Simply check if the manifest declares traits, and if it doesn't then short-circuit and immediately return `.default`.

Follow-up to #10499
