### PR TITLE
Override MODULE_CACHE_DIR when module cache is overridden via CLI options

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1195,6 +1195,12 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         // swiftCompilerFlags += buildParameters.toolchain.extraFlags.cxxCompilerFlags.rawFlags.asSwiftcCXXCompilerFlags()
         // // User arguments (from -Xcxx) should follow generated arguments to allow user overrides
         // swiftCompilerFlags += buildParameters.flags.cxxCompilerFlags.rawFlags.asSwiftcCXXCompilerFlags()
+
+        // Filter out module cache path flags and override the build setting independently.
+        if let moduleCachePath = Self.extractLastModuleCachePath(from: &swiftCompilerFlags) {
+            settings["MODULE_CACHE_DIR"] = moduleCachePath
+        }
+
         let compilerAndLinkerFlags = [
             "OTHER_CFLAGS": buildParameters.toolchain.extraFlags.cCompilerFlags + buildParameters.flags.cCompilerFlags,
             "OTHER_CPLUSPLUSFLAGS": buildParameters.toolchain.extraFlags.cxxCompilerFlags + buildParameters.flags.cxxCompilerFlags,
@@ -1259,6 +1265,30 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         settings["OTHER_LDFLAGS"] = (settings["OTHER_LDFLAGS"] ?? "$(inherited)") + " $(OTHER_LDFLAGS_SWIFTC_LINKER_DRIVER_$(LINKER_DRIVER))"
 
         return settings
+    }
+
+    private static func extractLastModuleCachePath(from flags: inout [BuildFlag]) -> String? {
+        var remaining: [BuildFlag] = []
+        remaining.reserveCapacity(flags.count)
+        var moduleCachePath: String? = nil
+
+        var index = flags.startIndex
+        while index < flags.endIndex {
+            let flag = flags[index]
+            let nextIndex = flags.index(after: index)
+            if flag.source == .commandLineOptions, flag.value == "-module-cache-path", nextIndex < flags.endIndex {
+                moduleCachePath = flags[nextIndex].value
+                index = flags.index(after: nextIndex)
+                continue
+            }
+            remaining.append(flag)
+            index = nextIndex
+        }
+
+        if moduleCachePath != nil {
+            flags = remaining
+        }
+        return moduleCachePath
     }
 
     private static func constructDebuggingSettingsOverrides(from parameters: BuildParameters.Debugging, for configuration: BuildConfiguration) -> [String: String] {

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -558,6 +558,42 @@ struct SwiftBuildSystemTests {
         }
     }
 
+    @Test
+    func moduleCachePathCLIOverride() async throws {
+        try await withTemporaryDirectory { tempDir in
+            let moduleCachePath = tempDir.appending("shared-module-cache").pathString
+            try await withInstantiatedSwiftBuildSystem(
+                fromFixture: "PIFBuilder/Simple",
+                buildParameters: mockBuildParameters(
+                    destination: .host,
+                    toolchain: try UserToolchain.default,
+                    flags: .init(swiftCompilerFlags: [
+                        BuildFlag(value: "-module-cache-path", source: .commandLineOptions),
+                        BuildFlag(value: moduleCachePath, source: .commandLineOptions),
+                        BuildFlag(value: "-DFoo", source: .commandLineOptions),
+                    ]),
+                    buildSystemKind: .swiftbuild
+                ),
+            ) { swiftBuild, service, session, observabilityScope, buildParameters in
+                let buildRequest = try await swiftBuild.makeBuildRequest(
+                    service: service,
+                    session: session,
+                    configuredTargets: [],
+                    derivedDataPath: tempDir,
+                    symbolGraphOptions: nil,
+                    setToolchainSetting: false,
+                    shouldDisableSandbox: false,
+                )
+
+                let overrides = buildRequest.parameters.overrides.synthesized?.table
+                #expect(overrides?["MODULE_CACHE_DIR"] == moduleCachePath)
+                let otherSwiftFlags = try #require(overrides?["OTHER_SWIFT_FLAGS"])
+                #expect(!otherSwiftFlags.contains("-module-cache-path"))
+                #expect(otherSwiftFlags.contains("-DFoo"))
+            }
+        }
+    }
+
     @Suite
     struct DebuggingSettingsTests {
 


### PR DESCRIPTION
Otherwise, the setting's default value will override the freeform CLI options, defeating the purpose of the override